### PR TITLE
Add sample profession, recipe, and card resources

### DIFF
--- a/auto-battler/data/cards/HealingElixir.tres
+++ b/auto-battler/data/cards/HealingElixir.tres
@@ -1,0 +1,15 @@
+[gd_resource type="CardData" load_steps=2 format=3]
+
+[resource]
+card_name = "Healing Elixir"
+description = "Brewed concoction that restores health."
+card_type = 4
+role_restriction = ""
+class_restriction = ""
+effect_description = "Heals a small amount when used."
+rarity = 0
+icon_path = ""
+synergy_tags = []
+energy_cost = 0
+is_combo_starter = false
+is_combo_finisher = false

--- a/auto-battler/data/cards/MushroomSoup.tres
+++ b/auto-battler/data/cards/MushroomSoup.tres
@@ -1,0 +1,15 @@
+[gd_resource type="CardData" load_steps=2 format=3]
+
+[resource]
+card_name = "Mushroom Soup"
+description = "A hearty soup that eases hunger."
+card_type = 3
+role_restriction = ""
+class_restriction = ""
+effect_description = "Restores a small amount of hunger and thirst."
+rarity = 0
+icon_path = ""
+synergy_tags = []
+energy_cost = 0
+is_combo_starter = false
+is_combo_finisher = false

--- a/auto-battler/data/cards/ReinforcedSword.tres
+++ b/auto-battler/data/cards/ReinforcedSword.tres
@@ -1,0 +1,15 @@
+[gd_resource type="CardData" load_steps=2 format=3]
+
+[resource]
+card_name = "Reinforced Sword"
+description = "A sturdy sword with extra durability."
+card_type = 1
+role_restriction = ""
+class_restriction = ""
+effect_description = "Grants +1 attack while equipped."
+rarity = 0
+icon_path = ""
+synergy_tags = []
+energy_cost = 0
+is_combo_starter = false
+is_combo_finisher = false

--- a/auto-battler/data/professions/Alchemy.tres
+++ b/auto-battler/data/professions/Alchemy.tres
@@ -1,0 +1,13 @@
+[gd_resource type="ProfessionData" load_steps=2 format=3]
+
+[ext_resource path="res://auto-battler/data/recipes/HealingElixir.tres" type="RecipeData" id=1]
+
+[resource]
+profession_name = "Alchemy"
+description = "Brew elixirs and utility items."
+max_level = 10
+current_level = 1
+known_recipes = [ExtResource(1)]
+crafting_bonus = 0.0
+exclusive_cards = []
+crafted_by_tag = ""

--- a/auto-battler/data/professions/Cooking.tres
+++ b/auto-battler/data/professions/Cooking.tres
@@ -1,0 +1,13 @@
+[gd_resource type="ProfessionData" load_steps=2 format=3]
+
+[ext_resource path="res://auto-battler/data/recipes/MushroomSoup.tres" type="RecipeData" id=1]
+
+[resource]
+profession_name = "Cooking"
+description = "Prepare food and drink cards."
+max_level = 10
+current_level = 1
+known_recipes = [ExtResource(1)]
+crafting_bonus = 0.0
+exclusive_cards = []
+crafted_by_tag = ""

--- a/auto-battler/data/professions/Smithing.tres
+++ b/auto-battler/data/professions/Smithing.tres
@@ -1,0 +1,13 @@
+[gd_resource type="ProfessionData" load_steps=2 format=3]
+
+[ext_resource path="res://auto-battler/data/recipes/ReinforcedSword.tres" type="RecipeData" id=1]
+
+[resource]
+profession_name = "Smithing"
+description = "Forge and upgrade equipment."
+max_level = 10
+current_level = 1
+known_recipes = [ExtResource(1)]
+crafting_bonus = 0.0
+exclusive_cards = []
+crafted_by_tag = ""

--- a/auto-battler/data/recipes/HealingElixir.tres
+++ b/auto-battler/data/recipes/HealingElixir.tres
@@ -1,0 +1,12 @@
+[gd_resource type="RecipeData" load_steps=2 format=3]
+
+[ext_resource path="res://auto-battler/data/cards/HealingElixir.tres" type="CardData" id=1]
+
+[resource]
+recipe_name = "Healing Elixir"
+description = "Brew a basic healing elixir."
+profession = "Alchemy"
+required_level = 1
+ingredients = ["Healing Herb", "Crystal Vial"]
+output_card = ExtResource(1)
+success_rate = 1.0

--- a/auto-battler/data/recipes/MushroomSoup.tres
+++ b/auto-battler/data/recipes/MushroomSoup.tres
@@ -1,0 +1,12 @@
+[gd_resource type="RecipeData" load_steps=2 format=3]
+
+[ext_resource path="res://auto-battler/data/cards/MushroomSoup.tres" type="CardData" id=1]
+
+[resource]
+recipe_name = "Mushroom Soup"
+description = "Simple soup using common mushrooms."
+profession = "Cooking"
+required_level = 1
+ingredients = ["Mushroom", "Water", "Herbs"]
+output_card = ExtResource(1)
+success_rate = 1.0

--- a/auto-battler/data/recipes/ReinforcedSword.tres
+++ b/auto-battler/data/recipes/ReinforcedSword.tres
@@ -1,0 +1,12 @@
+[gd_resource type="RecipeData" load_steps=2 format=3]
+
+[ext_resource path="res://auto-battler/data/cards/ReinforcedSword.tres" type="CardData" id=1]
+
+[resource]
+recipe_name = "Reinforced Sword"
+description = "Forge a sword with reinforced blade."
+profession = "Smithing"
+required_level = 1
+ingredients = ["Iron Ingot", "Leather Strips"]
+output_card = ExtResource(1)
+success_rate = 1.0

--- a/auto-battler/scripts/data/RecipeData.gd
+++ b/auto-battler/scripts/data/RecipeData.gd
@@ -1,0 +1,12 @@
+extends Resource
+class_name RecipeData
+
+## Resource representing a crafting recipe.
+
+@export var recipe_name: String = ""
+@export var description: String = ""
+@export var profession: String = "" # e.g., Cooking, Smithing, Alchemy
+@export var required_level: int = 1
+@export var ingredients: Array = [] # Array[CardData] or String names
+@export var output_card: CardData
+@export var success_rate: float = 1.0


### PR DESCRIPTION
## Summary
- add RecipeData resource script
- create card resources for Mushroom Soup, Reinforced Sword, and Healing Elixir
- add crafting recipes for the sample cards
- initialize Cooking, Smithing, and Alchemy ProfessionData resources

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_683f51741e308327aabd4861f263fec1