### PR TITLE
Add crafting data resources and sample data

### DIFF
--- a/auto-battler/data/professions/SampleProfessions.gd
+++ b/auto-battler/data/professions/SampleProfessions.gd
@@ -1,0 +1,32 @@
+extends Node
+class_name SampleProfessions
+
+static func get_professions() -> Array[ProfessionData]:
+    var list: Array[ProfessionData] = []
+
+    var cooking := ProfessionData.new()
+    cooking.profession_name = "Cooking"
+    cooking.description = "Creates food and drink cards"
+    cooking.current_level = 1
+    cooking.known_recipes = [SampleRecipes.mushroom_soup()]
+    cooking.crafted_by_tag = "Chef"
+    list.append(cooking)
+
+    var smithing := ProfessionData.new()
+    smithing.profession_name = "Smithing"
+    smithing.description = "Creates and upgrades equipment"
+    smithing.current_level = 1
+    smithing.known_recipes = [SampleRecipes.reinforced_sword()]
+    smithing.crafted_by_tag = "Blacksmith"
+    list.append(smithing)
+
+    var alchemy := ProfessionData.new()
+    alchemy.profession_name = "Alchemy"
+    alchemy.description = "Brews elixirs and utility items"
+    alchemy.current_level = 1
+    alchemy.known_recipes = [SampleRecipes.healing_elixir()]
+    alchemy.crafted_by_tag = "Alchemist"
+    list.append(alchemy)
+
+    return list
+

--- a/auto-battler/data/recipes/SampleRecipes.gd
+++ b/auto-battler/data/recipes/SampleRecipes.gd
@@ -1,0 +1,56 @@
+extends Node
+class_name SampleRecipes
+
+static func _create_card(name: String, desc: String) -> CardData:
+    var c := CardData.new()
+    c.card_name = name
+    c.description = desc
+    c.card_type = CardData.CardType.Utility
+    return c
+
+static func get_recipes() -> Array[RecipeData]:
+    var recipes: Array[RecipeData] = []
+    recipes.append(mushroom_soup())
+    recipes.append(reinforced_sword())
+    recipes.append(healing_elixir())
+    return recipes
+
+static func get_recipe_by_name(name: String) -> RecipeData:
+    for r in get_recipes():
+        if r.recipe_name == name:
+            return r
+    return null
+
+static func mushroom_soup() -> RecipeData:
+    var r := RecipeData.new()
+    r.recipe_name = "Mushroom Soup"
+    r.input_cards = ["Mushroom", "Water"]
+    r.output_card = _create_card("Mushroom Soup", "Warm soup made from mushrooms.")
+    r.profession_required = "Cooking"
+    r.level_required = 1
+    r.synergy_tags = []
+    r.discovered = true
+    return r
+
+static func reinforced_sword() -> RecipeData:
+    var r := RecipeData.new()
+    r.recipe_name = "Reinforced Sword"
+    r.input_cards = ["Iron Ore", "Wood"]
+    r.output_card = _create_card("Reinforced Sword", "Sturdier than a basic blade.")
+    r.profession_required = "Smithing"
+    r.level_required = 1
+    r.synergy_tags = []
+    r.discovered = true
+    return r
+
+static func healing_elixir() -> RecipeData:
+    var r := RecipeData.new()
+    r.recipe_name = "Healing Elixir"
+    r.input_cards = ["Herb", "Water"]
+    r.output_card = _create_card("Healing Elixir", "Restores a small amount of health.")
+    r.profession_required = "Alchemy"
+    r.level_required = 1
+    r.synergy_tags = []
+    r.discovered = true
+    return r
+

--- a/auto-battler/scripts/data/ProfessionData.gd
+++ b/auto-battler/scripts/data/ProfessionData.gd
@@ -7,7 +7,7 @@ class_name ProfessionData
 @export var description: String = ""
 @export var max_level: int = 10
 @export var current_level: int = 1
-@export var known_recipes: Array = []
+@export var known_recipes: Array[RecipeData] = []
 @export var crafting_bonus: float = 0.0
 @export var exclusive_cards: Array[CardData] = []
 @export var crafted_by_tag: String = ""
@@ -25,12 +25,14 @@ func grant_xp(amount: int, crafted_card: CardData) -> void:
         level_up()
 
 func level_up() -> void:
+    ## Increase profession level and unlock new recipes.
     if current_level < max_level:
         current_level += 1
         unlock_new_recipes()
 
 func unlock_new_recipes() -> void:
     ## Unlock additional recipes when leveling up.
+    ## Actual recipe lists are provided elsewhere.
     pass
 
 func _apply_crafted_by(card: CardData) -> void:

--- a/auto-battler/scripts/data/RecipeData.gd
+++ b/auto-battler/scripts/data/RecipeData.gd
@@ -4,7 +4,7 @@ class_name RecipeData
 ## Resource representing a crafting recipe.
 
 @export var recipe_name: String = ""
-@export var input_cards: Array = []      ## Array[CardData] or String identifiers
+@export var input_cards: Array = []      ## Array[CardData] or card name Strings
 @export var output_card: CardData
 @export var profession_required: String = ""
 @export var level_required: int = 1
@@ -13,12 +13,21 @@ class_name RecipeData
 
 func matches_inputs(inputs: Array) -> bool:
     ## Return true if the given input cards match this recipe.
+    ## Allows comparison by CardData resource or card name String.
     if inputs.size() != input_cards.size():
         return false
     var remaining := inputs.duplicate()
     for expected in input_cards:
-        var idx := remaining.find(expected)
-        if idx == -1:
+        var matched := false
+        var expected_name = expected if typeof(expected) == TYPE_STRING else expected.card_name
+        for i in range(remaining.size()):
+            var check = remaining[i]
+            var check_name = check if typeof(check) == TYPE_STRING else check.card_name
+            if check_name == expected_name:
+                remaining.remove_at(i)
+                matched = true
+                break
+        if not matched:
             return false
-        remaining.remove_at(idx)
     return remaining.is_empty()
+

--- a/auto-battler/scripts/systems/CraftingSystem.gd
+++ b/auto-battler/scripts/systems/CraftingSystem.gd
@@ -9,12 +9,12 @@ signal crafted(result)
 func craft_item(profession: ProfessionData, ingredients: Array) -> CardData:
     ## Main entry point for crafting cards.
     var inputs := ingredients.slice(0, 5)
-    var recipe = _find_recipe(inputs)
+    var recipe: RecipeData = _find_recipe(profession, inputs)
     var output: CardData
     var success := false
 
-    if recipe and profession.current_level >= recipe.required_level:
-        output = recipe.result.duplicate()
+    if recipe and profession.current_level >= recipe.level_required:
+        output = recipe.output_card.duplicate()
         success = true
     else:
         output = _generate_failure_item()
@@ -22,40 +22,50 @@ func craft_item(profession: ProfessionData, ingredients: Array) -> CardData:
     if _has_synergy(inputs):
         _upgrade_output(output)
 
-    _apply_crafted_by_tag(output, profession)
-    _grant_profession_xp(profession, success)
+    _grant_profession_xp(profession, output, success)
     _log_result(output, success)
 
     emit_signal("crafted", output)
     return output
 
-func _find_recipe(inputs: Array):
-    ## Placeholder for recipe lookup/discovery logic.
-    ## Should check known and hidden recipes.
+func _find_recipe(profession: ProfessionData, inputs: Array) -> RecipeData:
+    ## Basic recipe lookup using profession's known recipes.
+    for recipe in profession.known_recipes:
+        if recipe.matches_inputs(inputs):
+            return recipe
+    ## Placeholder: also search hidden recipes here.
     return null
 
 func _generate_failure_item() -> CardData:
-    ## Placeholder for returning a Scrap or other low-value card.
-    return CardData.new()
+    ## Return a generic Scrap card when no recipe matches.
+    var scrap := CardData.new()
+    scrap.card_name = "Scrap"
+    scrap.description = "Leftover debris from failed crafting."
+    scrap.card_type = CardData.CardType.Utility
+    return scrap
 
 func _has_synergy(inputs: Array) -> bool:
-    ## Placeholder for detecting synergy tags like "Rare Spice".
+    ## Check for synergy tags such as "Rare Spice".
+    for item in inputs:
+        if item is CardData and "Rare Spice" in item.synergy_tags:
+            return true
+        elif typeof(item) == TYPE_STRING and item == "Rare Spice":
+            return true
     return false
 
 func _upgrade_output(card: CardData) -> void:
-    ## Placeholder for improving card rarity or stats when synergy detected.
-    pass
+    ## Improve output rarity when synergy is detected.
+    if card.rarity < CardData.Rarity.Legendary:
+        card.rarity += 1
 
 func _apply_crafted_by_tag(card: CardData, profession: ProfessionData) -> void:
-    if card.synergy_tags == null:
-        card.synergy_tags = []
-    card.synergy_tags.append("crafted_by")
     if profession.crafted_by_tag != "":
-        card.synergy_tags.append(profession.crafted_by_tag)
+        card.set("crafted_by", profession.crafted_by_tag)
 
-func _grant_profession_xp(profession: ProfessionData, success: bool) -> void:
-    ## Placeholder for XP gain and level up handling.
-    pass
+func _grant_profession_xp(profession: ProfessionData, card: CardData, success: bool) -> void:
+    ## Grant profession XP based on crafting success.
+    var xp := success ? 10 : 2
+    profession.grant_xp(xp, card)
 
 func _log_result(card: CardData, success: bool) -> void:
     var outcome = "Crafted" if success else "Failed, produced"


### PR DESCRIPTION
## Summary
- expand profession script to type known recipes and add docs
- improve recipe matching logic for string or resource inputs
- flesh out crafting system for recipe lookups and synergy
- provide sample professions and recipes for Cooking, Smithing, and Alchemy

## Testing
- `godot --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f531e800c8327aac5f0497c01b2e8