### PR TITLE
Add UI scene scaffolds

### DIFF
--- a/auto-battler/scenes/CombatScene.tscn
+++ b/auto-battler/scenes/CombatScene.tscn
@@ -1,0 +1,20 @@
+[gd_scene format=3]
+
+[ext_resource path="res://auto-battler/scripts/ui/CombatScene.gd" type="Script" id=1]
+[ext_resource path="res://auto-battler/ui/PartyMemberPanel.tscn" type="PackedScene" id=2]
+[ext_resource path="res://auto-battler/ui/EnemyPanel.tscn" type="PackedScene" id=3]
+
+[node name="CombatScene" type="Node2D"]
+script = ExtResource(1)
+
+[node name="PartyPanel" parent="." instance=ExtResource(2)]
+[node name="EnemyPanel" parent="." instance=ExtResource(3)]
+
+[node name="CardRow" type="HBoxContainer" parent="."]
+[node name="CombatLog" type="VBoxContainer" parent="."]
+
+[node name="Controls" type="HBoxContainer" parent="."]
+[node name="SpeedButton" type="Button" parent="Controls"]
+text = "Speed"
+[node name="PauseButton" type="Button" parent="Controls"]
+text = "Pause"

--- a/auto-battler/scenes/DungeonMap.tscn
+++ b/auto-battler/scenes/DungeonMap.tscn
@@ -1,0 +1,10 @@
+[gd_scene format=3]
+
+[ext_resource path="res://auto-battler/scripts/ui/DungeonMap.gd" type="Script" id=1]
+
+[node name="DungeonMap" type="Node2D"]
+script = ExtResource(1)
+
+[node name="MapContainer" type="Node2D" parent="."]
+
+[node name="PartyStatus" type="Control" parent="."]

--- a/auto-battler/scenes/InventoryCrafting.tscn
+++ b/auto-battler/scenes/InventoryCrafting.tscn
@@ -1,0 +1,23 @@
+[gd_scene format=3]
+
+[ext_resource path="res://auto-battler/scripts/ui/InventoryCrafting.gd" type="Script" id=1]
+[ext_resource path="res://auto-battler/ui/CardViewer.tscn" type="PackedScene" id=2]
+
+[node name="InventoryCrafting" type="Control"]
+anchor_right = 1.0
+anchor_bottom = 1.0
+script = ExtResource(1)
+
+[node name="Grid" type="GridContainer" parent="."]
+
+[node name="Pouch" type="HBoxContainer" parent="."]
+[node name="Slot1" parent="Pouch" instance=ExtResource(2)]
+[node name="Slot2" parent="Pouch" instance=ExtResource(2)]
+[node name="Slot3" parent="Pouch" instance=ExtResource(2)]
+[node name="Slot4" parent="Pouch" instance=ExtResource(2)]
+[node name="Slot5" parent="Pouch" instance=ExtResource(2)]
+
+[node name="CraftButton" type="Button" parent="."]
+text = "Craft"
+
+[node name="CraftLog" type="VBoxContainer" parent="."]

--- a/auto-battler/scenes/LootPanel.tscn
+++ b/auto-battler/scenes/LootPanel.tscn
@@ -1,0 +1,10 @@
+[gd_scene format=3]
+
+[ext_resource path="res://auto-battler/scripts/ui/LootPanel.gd" type="Script" id=1]
+
+[node name="LootPanel" type="Control"]
+script = ExtResource(1)
+
+[node name="Grid" type="GridContainer" parent="."]
+
+[node name="Log" type="VBoxContainer" parent="."]

--- a/auto-battler/scenes/MainMenu.tscn
+++ b/auto-battler/scenes/MainMenu.tscn
@@ -1,0 +1,32 @@
+[gd_scene format=3]
+
+[ext_resource path="res://auto-battler/scripts/ui/MainMenu.gd" type="Script" id=1]
+
+[node name="MainMenu" type="Control"]
+anchor_right = 1.0
+anchor_bottom = 1.0
+script = ExtResource(1)
+
+[node name="CenterContainer" type="CenterContainer" parent="."]
+anchor_right = 1.0
+anchor_bottom = 1.0
+
+[node name="VBoxContainer" type="VBoxContainer" parent="CenterContainer"]
+
+[node name="Title" type="Label" parent="CenterContainer/VBoxContainer"]
+text = "Survival Dungeon"
+
+[node name="StartButton" type="Button" parent="CenterContainer/VBoxContainer"]
+text = "Start Game"
+
+[node name="ContinueButton" type="Button" parent="CenterContainer/VBoxContainer"]
+text = "Continue"
+
+[node name="SettingsButton" type="Button" parent="CenterContainer/VBoxContainer"]
+text = "Settings"
+
+[node name="CreditsButton" type="Button" parent="CenterContainer/VBoxContainer"]
+text = "Credits"
+
+[node name="ExitButton" type="Button" parent="CenterContainer/VBoxContainer"]
+text = "Exit"

--- a/auto-battler/scenes/PartySetup.tscn
+++ b/auto-battler/scenes/PartySetup.tscn
@@ -1,0 +1,21 @@
+[gd_scene format=3]
+
+[ext_resource path="res://auto-battler/scripts/ui/PartySetup.gd" type="Script" id=1]
+[ext_resource path="res://auto-battler/ui/PartyMemberPanel.tscn" type="PackedScene" id=2]
+
+[node name="PartySetup" type="Control"]
+anchor_right = 1.0
+anchor_bottom = 1.0
+script = ExtResource(1)
+
+[node name="VBoxContainer" type="VBoxContainer" parent="."]
+
+[node name="PartyContainer" type="HBoxContainer" parent="VBoxContainer"]
+[node name="Member1" parent="VBoxContainer/PartyContainer" instance=ExtResource(2)]
+[node name="Member2" parent="VBoxContainer/PartyContainer" instance=ExtResource(2)]
+[node name="Member3" parent="VBoxContainer/PartyContainer" instance=ExtResource(2)]
+[node name="Member4" parent="VBoxContainer/PartyContainer" instance=ExtResource(2)]
+[node name="Member5" parent="VBoxContainer/PartyContainer" instance=ExtResource(2)]
+
+[node name="ReadyButton" type="Button" parent="VBoxContainer"]
+text = "Ready"

--- a/auto-battler/scenes/RestScene.tscn
+++ b/auto-battler/scenes/RestScene.tscn
@@ -1,0 +1,13 @@
+[gd_scene format=3]
+
+[ext_resource path="res://auto-battler/scripts/ui/RestScene.gd" type="Script" id=1]
+
+[node name="RestScene" type="Control"]
+anchor_right = 1.0
+anchor_bottom = 1.0
+script = ExtResource(1)
+
+[node name="PartyStatus" type="Control" parent="."]
+
+[node name="ContinueButton" type="Button" parent="."]
+text = "Continue"

--- a/auto-battler/scripts/ui/CardViewer.gd
+++ b/auto-battler/scripts/ui/CardViewer.gd
@@ -1,0 +1,18 @@
+extends Control
+
+signal hovered
+signal selected
+
+var item
+
+func set_item(p_item):
+    item = p_item
+
+func get_item():
+    return item
+
+func _unhandled_input(event):
+    if event is InputEventMouseButton and event.pressed:
+        emit_signal("selected")
+    elif event is InputEventMouseMotion:
+        emit_signal("hovered")

--- a/auto-battler/scripts/ui/CombatScene.gd
+++ b/auto-battler/scripts/ui/CombatScene.gd
@@ -1,0 +1,18 @@
+extends Node2D
+
+signal combat_finished
+
+var combat_speed := 1.0
+var paused := false
+
+func _ready():
+    if has_node("Controls/SpeedButton"):
+        $Controls/SpeedButton.pressed.connect(_on_speed_button)
+    if has_node("Controls/PauseButton"):
+        $Controls/PauseButton.pressed.connect(_on_pause_button)
+
+func _on_speed_button():
+    combat_speed = clamp(combat_speed + 1, 1, 4)
+
+func _on_pause_button():
+    paused = !paused

--- a/auto-battler/scripts/ui/DungeonMap.gd
+++ b/auto-battler/scripts/ui/DungeonMap.gd
@@ -1,0 +1,18 @@
+extends Node2D
+
+signal node_selected(index)
+
+var nodes := []
+
+func _ready():
+    _generate_nodes()
+
+func _generate_nodes():
+    var container = $MapContainer
+    for i in range(5):
+        var btn = Button.new()
+        btn.text = "Room %d" % i
+        btn.position = Vector2(i * 120, 0)
+        container.add_child(btn)
+        btn.pressed.connect(func(): emit_signal("node_selected", i))
+        nodes.append(btn)

--- a/auto-battler/scripts/ui/EnemyPanel.gd
+++ b/auto-battler/scripts/ui/EnemyPanel.gd
@@ -1,0 +1,9 @@
+extends Panel
+
+var enemy
+
+func set_enemy(enemy_data):
+    enemy = enemy_data
+
+func update_stats():
+    pass

--- a/auto-battler/scripts/ui/InventoryCrafting.gd
+++ b/auto-battler/scripts/ui/InventoryCrafting.gd
@@ -1,0 +1,15 @@
+extends Control
+
+signal craft_requested(items)
+
+func _ready():
+    $CraftButton.pressed.connect(_on_craft_pressed)
+
+func _on_craft_pressed():
+    var items: Array = []
+    for child in $Pouch.get_children():
+        if child.has_method("get_item"):
+            var item = child.get_item()
+            if item != null:
+                items.append(item)
+    emit_signal("craft_requested", items)

--- a/auto-battler/scripts/ui/LootPanel.gd
+++ b/auto-battler/scripts/ui/LootPanel.gd
@@ -1,0 +1,12 @@
+extends Control
+
+signal item_added(item)
+
+func show_loot(items:Array):
+    var grid = $Grid
+    grid.queue_free_children()
+    for item in items:
+        var btn = Button.new()
+        btn.text = str(item)
+        grid.add_child(btn)
+        btn.pressed.connect(func(): emit_signal("item_added", item))

--- a/auto-battler/scripts/ui/MainMenu.gd
+++ b/auto-battler/scripts/ui/MainMenu.gd
@@ -1,0 +1,31 @@
+extends Control
+
+signal start_game
+signal continue_game
+signal open_settings
+signal open_credits
+signal exit_game
+
+func _ready():
+    $CenterContainer/VBoxContainer/StartButton.pressed.connect(_on_start_pressed)
+    $CenterContainer/VBoxContainer/ContinueButton.pressed.connect(_on_continue_pressed)
+    $CenterContainer/VBoxContainer/ExitButton.pressed.connect(_on_exit_pressed)
+    if $CenterContainer/VBoxContainer.has_node("SettingsButton"):
+        $CenterContainer/VBoxContainer/SettingsButton.pressed.connect(_on_settings_pressed)
+    if $CenterContainer/VBoxContainer.has_node("CreditsButton"):
+        $CenterContainer/VBoxContainer/CreditsButton.pressed.connect(_on_credits_pressed)
+
+func _on_start_pressed():
+    emit_signal("start_game")
+
+func _on_continue_pressed():
+    emit_signal("continue_game")
+
+func _on_settings_pressed():
+    emit_signal("open_settings")
+
+func _on_credits_pressed():
+    emit_signal("open_credits")
+
+func _on_exit_pressed():
+    emit_signal("exit_game")

--- a/auto-battler/scripts/ui/PartyMemberPanel.gd
+++ b/auto-battler/scripts/ui/PartyMemberPanel.gd
@@ -1,0 +1,14 @@
+extends Panel
+
+signal card_assigned(card)
+signal gear_changed(gear)
+
+var assigned_cards: Array = []
+
+func assign_card(card):
+    if assigned_cards.size() < 4:
+        assigned_cards.append(card)
+        emit_signal("card_assigned", card)
+
+func change_gear(gear):
+    emit_signal("gear_changed", gear)

--- a/auto-battler/scripts/ui/PartySetup.gd
+++ b/auto-battler/scripts/ui/PartySetup.gd
@@ -1,0 +1,9 @@
+extends Control
+
+signal ready_pressed
+
+func _ready():
+    $VBoxContainer/ReadyButton.pressed.connect(_on_ready_button)
+
+func _on_ready_button():
+    emit_signal("ready_pressed")

--- a/auto-battler/scripts/ui/RestScene.gd
+++ b/auto-battler/scripts/ui/RestScene.gd
@@ -1,0 +1,9 @@
+extends Control
+
+signal continue_pressed
+
+func _ready():
+    $ContinueButton.pressed.connect(_on_continue_pressed)
+
+func _on_continue_pressed():
+    emit_signal("continue_pressed")

--- a/auto-battler/ui/CardDetailPanel.tscn
+++ b/auto-battler/ui/CardDetailPanel.tscn
@@ -1,0 +1,2 @@
+[gd_scene format=3]
+[node name="CardDetailPanel" type="Panel"]

--- a/auto-battler/ui/CardViewer.tscn
+++ b/auto-battler/ui/CardViewer.tscn
@@ -1,0 +1,9 @@
+[gd_scene format=3]
+
+[ext_resource path="res://auto-battler/scripts/ui/CardViewer.gd" type="Script" id=1]
+
+[node name="CardViewer" type="Control"]
+script = ExtResource(1)
+
+[node name="Icon" type="TextureRect" parent="."]
+[node name="CardName" type="Label" parent="."]

--- a/auto-battler/ui/EnemyPanel.tscn
+++ b/auto-battler/ui/EnemyPanel.tscn
@@ -1,0 +1,11 @@
+[gd_scene format=3]
+
+[ext_resource path="res://auto-battler/scripts/ui/EnemyPanel.gd" type="Script" id=1]
+
+[node name="EnemyPanel" type="Panel"]
+script = ExtResource(1)
+
+[node name="VBoxContainer" type="VBoxContainer" parent="."]
+[node name="Icon" type="TextureRect" parent="VBoxContainer"]
+[node name="NameLabel" type="Label" parent="VBoxContainer"]
+[node name="HPBar" type="ProgressBar" parent="VBoxContainer"]

--- a/auto-battler/ui/PartyMemberPanel.tscn
+++ b/auto-battler/ui/PartyMemberPanel.tscn
@@ -1,0 +1,18 @@
+[gd_scene format=3]
+
+[ext_resource path="res://auto-battler/scripts/ui/PartyMemberPanel.gd" type="Script" id=1]
+[ext_resource path="res://auto-battler/ui/CardViewer.tscn" type="PackedScene" id=2]
+
+[node name="PartyMemberPanel" type="Panel"]
+script = ExtResource(1)
+
+[node name="VBoxContainer" type="VBoxContainer" parent="."]
+
+[node name="Portrait" type="TextureRect" parent="VBoxContainer"]
+[node name="NameLabel" type="Label" parent="VBoxContainer"]
+[node name="Stats" type="VBoxContainer" parent="VBoxContainer"]
+[node name="Cards" type="HBoxContainer" parent="VBoxContainer"]
+[node name="Card1" parent="VBoxContainer/Cards" instance=ExtResource(2)]
+[node name="Card2" parent="VBoxContainer/Cards" instance=ExtResource(2)]
+[node name="Card3" parent="VBoxContainer/Cards" instance=ExtResource(2)]
+[node name="Card4" parent="VBoxContainer/Cards" instance=ExtResource(2)]

--- a/auto-battler/ui/PartyStatsPanel.tscn
+++ b/auto-battler/ui/PartyStatsPanel.tscn
@@ -1,0 +1,2 @@
+[gd_scene format=3]
+[node name="PartyStatsPanel" type="Panel"]


### PR DESCRIPTION
## Summary
- scaffold MainMenu, PartySetup, DungeonMap, CombatScene, InventoryCrafting, RestScene, and LootPanel scenes
- create reusable CardViewer, PartyMemberPanel, and EnemyPanel components
- add minimal scripts hooking up buttons and placeholder logic

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_683f535fe0688327a8833d89464c37a6