### PR TITLE
Add initial UI scene and script scaffolding

### DIFF
--- a/auto-battler/project.godot
+++ b/auto-battler/project.godot
@@ -1,0 +1,16 @@
+; Engine configuration file.
+; It's best edited using the editor UI and not directly,
+; since the parameters that go here are not all obvious.
+;
+; Format:
+;   [section] ; section goes between []
+;   param=value ; assign values to parameters
+
+config_version=5
+
+[application]
+
+config/name="Auto Battler"
+run/main_scene="res://scenes/MainMenu.tscn"
+config/features=PackedStringArray("4.2", "GL Compatibility")
+config/icon="res://icon.svg"

--- a/auto-battler/scenes/CombatScene.tscn
+++ b/auto-battler/scenes/CombatScene.tscn
@@ -1,0 +1,125 @@
+[gd_scene load_steps=2 format=3 uid="uid://cqx705wscy5vt"]
+
+[ext_resource type="Script" path="res://scripts/combat/CombatScene.gd" id="1_klmno"]
+
+[node name="CombatScene" type="Control"]
+layout_mode = 3
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+script = ExtResource("1_klmno")
+
+[node name="Main 전투 Layout" type="VBoxContainer" parent="."]
+layout_mode = 1
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+
+[node name="TopBar" type="HBoxContainer" parent="Main 전투 Layout"]
+layout_mode = 2
+alignment = 2 # Align to the right for pause/speed buttons
+
+[node name="PauseButton" type="Button" parent="Main 전투 Layout/TopBar"]
+layout_mode = 2
+text = "Pause"
+
+[node name="SpeedUpButton" type="Button" parent="Main 전투 Layout/TopBar"]
+layout_mode = 2
+text = "Speed Up x1"
+
+
+[node name="BattleArea" type="HBoxContainer" parent="Main 전투 Layout"]
+layout_mode = 2
+size_flags_vertical = 3 # Make this area take most of the vertical space
+alignment = 1 # Center children
+
+[node name="PartyPanel" type="VBoxContainer" parent="Main 전투 Layout/BattleArea"]
+layout_mode = 2
+size_flags_horizontal = 3 # Party takes up some space
+alignment = 1
+# Placeholder for PartyMemberPanel instances
+
+[node name="PartyMember1" type="PanelContainer" parent="Main 전투 Layout/BattleArea/PartyPanel"]
+layout_mode = 2
+# child will be PartyMemberPanel.tscn instance
+[node name="Label" type="Label" parent="Main 전투 Layout/BattleArea/PartyPanel/PartyMember1"]
+layout_mode = 2
+text = "Party Member 1\nHP: 100/100\nFatigue: 0"
+horizontal_alignment = 1
+vertical_alignment = 1
+
+[node name="EnemyPanel" type="VBoxContainer" parent="Main 전투 Layout/BattleArea"]
+layout_mode = 2
+size_flags_horizontal = 3 # Enemies take up some space
+alignment = 1
+# Placeholder for EnemyPanel.tscn instances
+
+[node name="Enemy1" type="PanelContainer" parent="Main 전투 Layout/BattleArea/EnemyPanel"]
+layout_mode = 2
+# child will be EnemyPanel.tscn instance
+[node name="Label" type="Label" parent="Main 전투 Layout/BattleArea/EnemyPanel/Enemy1"]
+layout_mode = 2
+text = "Enemy 1\nHP: 50/50"
+horizontal_alignment = 1
+vertical_alignment = 1
+
+
+[node name="CharacterCardsArea" type="HBoxContainer" parent="Main 전투 Layout"]
+layout_mode = 2
+custom_minimum_size = Vector2(0, 100) # Min height for card display area
+alignment = 1
+# Placeholder for active character's cards (CardViewer.tscn instances)
+
+[node name="Card1" type="PanelContainer" parent="Main 전투 Layout/CharacterCardsArea"]
+layout_mode = 2
+# child will be CardViewer.tscn instance
+[node name="Label" type="Label" parent="Main 전투 Layout/CharacterCardsArea/Card1"]
+layout_mode = 2
+text = "Card 1 Name"
+horizontal_alignment = 1
+vertical_alignment = 1
+
+
+[node name="CombatLogPanel" type="PanelContainer" parent="Main 전투 Layout"]
+layout_mode = 2
+custom_minimum_size = Vector2(0, 150) # Min height for combat log
+
+[node name="CombatLogScroll" type="ScrollContainer" parent="Main 전투 Layout/CombatLogPanel"]
+layout_mode = 2
+horizontal_scroll_mode = 0 # Disable horizontal scroll
+
+[node name="CombatLog" type="VBoxContainer" parent="Main 전투 Layout/CombatLogPanel/CombatLogScroll"]
+layout_mode = 2
+size_flags_horizontal = 3 # Expand to fill scroll container width
+
+[node name="LogEntry1" type="Label" parent="Main 전투 Layout/CombatLogPanel/CombatLogScroll/CombatLog"]
+layout_mode = 2
+text = "Combat Started!"
+autowrap_mode = 3 # Word wrap
+
+[node name="VisualFeedbackLabel" type="Label" parent="."]
+# This label can be used for temporary feedback like "Damage!", "Heal!"
+# Position it in the center of the screen or over characters
+layout_mode = 1
+anchors_preset = 8
+anchor_left = 0.5
+anchor_top = 0.5
+anchor_right = 0.5
+anchor_bottom = 0.5
+offset_left = -50.0
+offset_top = -15.0
+offset_right = 50.0
+offset_bottom = 15.0
+grow_horizontal = 2
+grow_vertical = 2
+text = "Feedback!"
+horizontal_alignment = 1
+vertical_alignment = 1
+visible = false # Initially hidden
+
+[connection signal="pressed" from="Main 전투 Layout/TopBar/PauseButton" to="." method="_on_pause_button_pressed"]
+[connection signal="pressed" from="Main 전투 Layout/TopBar/SpeedUpButton" to="." method="_on_speed_up_button_pressed"]

--- a/auto-battler/scenes/DungeonMap.tscn
+++ b/auto-battler/scenes/DungeonMap.tscn
@@ -1,0 +1,72 @@
+[gd_scene load_steps=2 format=3 uid="uid://dqvcn7p4j7x0y"]
+
+[ext_resource type="Script" path="res://scripts/ui/DungeonMap.gd" id="1_fghij"]
+
+[node name="DungeonMap" type="Control"]
+layout_mode = 3
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+script = ExtResource("1_fghij")
+
+[node name="MapNodesContainer" type="HBoxContainer" parent="."]
+layout_mode = 1
+anchors_preset = 8
+anchor_left = 0.5
+anchor_top = 0.5
+anchor_right = 0.5
+anchor_bottom = 0.5
+offset_left = -200.0
+offset_top = -50.0
+offset_right = 200.0
+offset_bottom = 50.0
+grow_horizontal = 2
+grow_vertical = 2
+alignment = 1
+
+[node name="Node1Button" type="Button" parent="MapNodesContainer"]
+layout_mode = 2
+size_flags_horizontal = 3
+text = "Room 1"
+
+[node name="Node2Button" type="Button" parent="MapNodesContainer"]
+layout_mode = 2
+size_flags_horizontal = 3
+text = "Event A"
+
+[node name="Node3Button" type="Button" parent="MapNodesContainer"]
+layout_mode = 2
+size_flags_horizontal = 3
+text = "Room 2"
+
+[node name="PartyStatusOverlay" type="VBoxContainer" parent="."]
+layout_mode = 0
+offset_right = 150.0
+offset_bottom = 200.0
+# Position it on the screen, e.g., top-left
+
+[node name="Member1Status" type="Label" parent="PartyStatusOverlay"]
+layout_mode = 2
+text = "Member 1: HP 100/100, F:100, W:100, E:100"
+
+[node name="Member2Status" type="Label" parent="PartyStatusOverlay"]
+layout_mode = 2
+text = "Member 2: HP 100/100, F:100, W:100, E:100"
+
+[node name="Member3Status" type="Label" parent="PartyStatusOverlay"]
+layout_mode = 2
+text = "Member 3: HP 100/100, F:100, W:100, E:100"
+
+[node name="Member4Status" type="Label" parent="PartyStatusOverlay"]
+layout_mode = 2
+text = "Member 4: HP 100/100, F:100, W:100, E:100"
+
+[node name="Member5Status" type="Label" parent="PartyStatusOverlay"]
+layout_mode = 2
+text = "Member 5: HP 100/100, F:100, W:100, E:100"
+
+[connection signal="pressed" from="MapNodesContainer/Node1Button" to="." method="_on_map_node_selected" binds= [0]]
+[connection signal="pressed" from="MapNodesContainer/Node2Button" to="." method="_on_map_node_selected" binds= [1]]
+[connection signal="pressed" from="MapNodesContainer/Node3Button" to="." method="_on_map_node_selected" binds= [2]]

--- a/auto-battler/scenes/InventoryCrafting.tscn
+++ b/auto-battler/scenes/InventoryCrafting.tscn
@@ -1,0 +1,162 @@
+[gd_scene load_steps=2 format=3 uid="uid://b5y1o2x7w7x0x"]
+
+[ext_resource type="Script" path="res://scripts/ui/InventoryCrafting.gd" id="1_pqrst"]
+
+[node name="InventoryCrafting" type="Control"]
+layout_mode = 3
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+script = ExtResource("1_pqrst")
+
+[node name="MainHBox" type="HBoxContainer" parent="."]
+layout_mode = 1
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+
+[node name="InventoryPanel" type="VBoxContainer" parent="MainHBox"]
+layout_mode = 2
+size_flags_horizontal = 3 # Inventory takes up space
+
+[node name="InventoryLabel" type="Label" parent="MainHBox/InventoryPanel"]
+layout_mode = 2
+text = "Inventory"
+horizontal_alignment = 1
+
+[node name="InventoryGrid" type="GridContainer" parent="MainHBox/InventoryPanel"]
+layout_mode = 2
+size_flags_vertical = 3
+columns = 4 # Example: 4 columns
+# Add placeholder items (e.g., Panels or Buttons) to the grid
+[node name="Item1" type="PanelContainer" parent="MainHBox/InventoryPanel/InventoryGrid"] # Changed to PanelContainer for consistency
+custom_minimum_size = Vector2(50, 50)
+layout_mode = 2
+[node name="Label" type="Label" parent="MainHBox/InventoryPanel/InventoryGrid/Item1"]
+layout_mode = 1
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+text = "Item A"
+horizontal_alignment = 1
+vertical_alignment = 1
+
+
+[node name="CraftingPanel" type="VBoxContainer" parent="MainHBox"]
+layout_mode = 2
+size_flags_horizontal = 3 # Crafting area takes up space
+alignment = 1
+
+[node name="CraftingAreaLabel" type="Label" parent="MainHBox/CraftingPanel"]
+layout_mode = 2
+text = "Magical Pouch (Crafting Slots)"
+horizontal_alignment = 1
+
+[node name="CraftingSlots" type="HBoxContainer" parent="MainHBox/CraftingPanel"]
+layout_mode = 2
+alignment = 1
+# Add 5 placeholder slots (e.g., Panels)
+[node name="Slot1" type="PanelContainer" parent="MainHBox/CraftingPanel/CraftingSlots"] # Changed to PanelContainer
+custom_minimum_size = Vector2(60, 60)
+layout_mode = 2
+[node name="Label" type="Label" parent="MainHBox/CraftingPanel/CraftingSlots/Slot1"] # Added Label for display
+layout_mode = 1
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+text = "[Empty]"
+horizontal_alignment = 1
+vertical_alignment = 1
+
+[node name="Slot2" type="PanelContainer" parent="MainHBox/CraftingPanel/CraftingSlots"] # Changed to PanelContainer
+custom_minimum_size = Vector2(60, 60)
+layout_mode = 2
+[node name="Label" type="Label" parent="MainHBox/CraftingPanel/CraftingSlots/Slot2"] # Added Label for display
+layout_mode = 1
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+text = "[Empty]"
+horizontal_alignment = 1
+vertical_alignment = 1
+
+[node name="Slot3" type="PanelContainer" parent="MainHBox/CraftingPanel/CraftingSlots"] # Added Slot3
+custom_minimum_size = Vector2(60, 60)
+layout_mode = 2
+[node name="Label" type="Label" parent="MainHBox/CraftingPanel/CraftingSlots/Slot3"] # Added Label for display
+layout_mode = 1
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+text = "[Empty]"
+horizontal_alignment = 1
+vertical_alignment = 1
+
+[node name="Slot4" type="PanelContainer" parent="MainHBox/CraftingPanel/CraftingSlots"] # Added Slot4
+custom_minimum_size = Vector2(60, 60)
+layout_mode = 2
+[node name="Label" type="Label" parent="MainHBox/CraftingPanel/CraftingSlots/Slot4"] # Added Label for display
+layout_mode = 1
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+text = "[Empty]"
+horizontal_alignment = 1
+vertical_alignment = 1
+
+[node name="Slot5" type="PanelContainer" parent="MainHBox/CraftingPanel/CraftingSlots"] # Added Slot5
+custom_minimum_size = Vector2(60, 60)
+layout_mode = 2
+[node name="Label" type="Label" parent="MainHBox/CraftingPanel/CraftingSlots/Slot5"] # Added Label for display
+layout_mode = 1
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+text = "[Empty]"
+horizontal_alignment = 1
+vertical_alignment = 1
+
+
+[node name="ProfessionLabel" type="Label" parent="MainHBox/CraftingPanel"]
+layout_mode = 2
+text = "Profession: Alchemy Lvl 5"
+horizontal_alignment = 1
+
+[node name="KnownRecipesLabel" type="Label" parent="MainHBox/CraftingPanel"]
+layout_mode = 2
+text = "Recipes: Potion A, Scroll B"
+horizontal_alignment = 1
+
+[node name="CraftingPreviewLabel" type="Label" parent="MainHBox/CraftingPanel"]
+layout_mode = 2
+text = "Output Preview: Minor Healing Potion"
+horizontal_alignment = 1
+
+[node name="CraftButton" type="Button" parent="MainHBox/CraftingPanel"]
+layout_mode = 2
+text = "Craft"
+
+[node name="CraftingLogLabel" type="Label" parent="MainHBox/CraftingPanel"]
+layout_mode = 2
+text = "Log: Crafted Minor Healing Potion."
+horizontal_alignment = 1
+autowrap_mode = 3
+
+[connection signal="pressed" from="MainHBox/CraftingPanel/CraftButton" to="." method="_on_craft_button_pressed"]
+# Connections for drag-and-drop will be set up in script or dynamically

--- a/auto-battler/scenes/LootPanel.tscn
+++ b/auto-battler/scenes/LootPanel.tscn
@@ -1,0 +1,77 @@
+[gd_scene load_steps=2 format=3 uid="uid://dxylqx7w7x0x2"]
+
+[ext_resource type="Script" path="res://scripts/ui/LootPanel.gd" id="1_yzabc"]
+
+[node name="LootPanel" type="PanelContainer"] # Changed root to PanelContainer for better theming/background
+layout_mode = 3
+anchors_preset = 15
+anchor_left = 0.25 # Example: Center it a bit more
+anchor_top = 0.25
+anchor_right = 0.75
+anchor_bottom = 0.75
+grow_horizontal = 2
+grow_vertical = 2
+script = ExtResource("1_yzabc")
+
+[node name="VBoxContainer" type="VBoxContainer" parent="."]
+layout_mode = 2
+alignment = 1
+
+[node name="TitleLabel" type="Label" parent="VBoxContainer"]
+layout_mode = 2
+text = "Loot & Rewards"
+horizontal_alignment = 1
+theme_override_font_sizes/font_size = 24 # Make title bigger
+
+[node name="LootScrollContainer" type="ScrollContainer" parent="VBoxContainer"]
+layout_mode = 2
+size_flags_vertical = 3 # Make scroll container take available vertical space
+horizontal_scroll_mode = 0 # Disable horizontal scroll if items are stacked vertically
+custom_minimum_size = Vector2(0, 150) # Ensure it has some min height
+
+[node name="LootList" type="VBoxContainer" parent="VBoxContainer/LootScrollContainer"]
+layout_mode = 2
+size_flags_horizontal = 3 # Loot items will fill width
+
+# Example Loot Item Entry (This would ideally be a reusable scene instance)
+# The script will populate this area dynamically.
+# Keeping one example for structure reference, though script will clear it.
+[node name="LootItemEntry1" type="HBoxContainer" parent="VBoxContainer/LootScrollContainer/LootList"]
+layout_mode = 2
+custom_minimum_size = Vector2(0, 50) # Min height for an item entry
+visible = false # Initially invisible, script will handle population
+
+[node name="ItemIcon" type="TextureRect" parent="VBoxContainer/LootScrollContainer/LootList/LootItemEntry1"]
+# Placeholder for item icon
+custom_minimum_size = Vector2(40, 40)
+layout_mode = 2
+expand_mode = 1 # Or keep aspect ratio if needed
+stretch_mode = 5 # Scale to fit
+color = Color(0.5, 0.5, 0.5, 1) # Placeholder color
+
+[node name="ItemDetails" type="VBoxContainer" parent="VBoxContainer/LootScrollContainer/LootList/LootItemEntry1"]
+layout_mode = 2
+size_flags_horizontal = 3 # Details take remaining space
+
+[node name="ItemNameLabel" type="Label" parent="VBoxContainer/LootScrollContainer/LootList/LootItemEntry1/ItemDetails"]
+layout_mode = 2
+text = "Magic Sword (Rare)"
+
+[node name="ItemTagsLabel" type="Label" parent="VBoxContainer/LootScrollContainer/LootList/LootItemEntry1/ItemDetails"]
+layout_mode = 2
+text = "Crafted by: Player1"
+theme_override_font_sizes/font_size = 12 # Smaller for tags
+
+[node name="AddButton" type="Button" parent="VBoxContainer/LootScrollContainer/LootList/LootItemEntry1"]
+layout_mode = 2
+size_flags_vertical = 4 # Center button vertically if HBox allows
+text = "Add to Inventory"
+# This button's pressed signal would be connected in script when item is added
+
+
+[node name="CloseButton" type="Button" parent="VBoxContainer"]
+layout_mode = 2
+text = "Close / Take All"
+# This button might take all items and then close, or just close if items are added individually
+
+[connection signal="pressed" from="VBoxContainer/CloseButton" to="." method="_on_close_button_pressed"]

--- a/auto-battler/scenes/MainMenu.tscn
+++ b/auto-battler/scenes/MainMenu.tscn
@@ -1,0 +1,58 @@
+[gd_scene load_steps=2 format=3 uid="uid://bu2y7p7x0d5g1"]
+
+[ext_resource type="Script" path="res://scripts/ui/MainMenu.gd" id="1_2vj2a"]
+
+[node name="MainMenu" type="Control"]
+layout_mode = 3
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+script = ExtResource("1_2vj2a")
+
+[node name="VBoxContainer" type="VBoxContainer" parent="."]
+layout_mode = 1
+anchors_preset = 8
+anchor_left = 0.5
+anchor_top = 0.5
+anchor_right = 0.5
+anchor_bottom = 0.5
+offset_left = -100.0
+offset_top = -100.0
+offset_right = 100.0
+offset_bottom = 100.0
+grow_horizontal = 2
+grow_vertical = 2
+alignment = 1
+
+[node name="TitleLabel" type="Label" parent="VBoxContainer"]
+layout_mode = 2
+text = "Game Title"
+horizontal_alignment = 1
+
+[node name="StartButton" type="Button" parent="VBoxContainer"]
+layout_mode = 2
+text = "Start Game"
+
+[node name="ContinueButton" type="Button" parent="VBoxContainer"]
+layout_mode = 2
+text = "Continue"
+
+[node name="SettingsButton" type="Button" parent="VBoxContainer"]
+layout_mode = 2
+text = "Settings"
+
+[node name="CreditsButton" type="Button" parent="VBoxContainer"]
+layout_mode = 2
+text = "Credits"
+
+[node name="ExitButton" type="Button" parent="VBoxContainer"]
+layout_mode = 2
+text = "Exit"
+
+[connection signal="pressed" from="VBoxContainer/StartButton" to="." method="_on_start_button_pressed"]
+[connection signal="pressed" from="VBoxContainer/ContinueButton" to="." method="_on_continue_button_pressed"]
+[connection signal="pressed" from="VBoxContainer/SettingsButton" to="." method="_on_settings_button_pressed"]
+[connection signal="pressed" from="VBoxContainer/CreditsButton" to="." method="_on_credits_button_pressed"]
+[connection signal="pressed" from="VBoxContainer/ExitButton" to="." method="_on_exit_button_pressed"]

--- a/auto-battler/scenes/PartySetup.tscn
+++ b/auto-battler/scenes/PartySetup.tscn
@@ -1,0 +1,201 @@
+[gd_scene load_steps=2 format=3 uid="uid://c6vj0w0jqy7hx"]
+
+[ext_resource type="Script" path="res://scripts/ui/PartySetup.gd" id="1_abcde"]
+
+[node name="PartySetup" type="Control"]
+layout_mode = 3
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+script = ExtResource("1_abcde")
+
+[node name="HBoxContainer" type="HBoxContainer" parent="."]
+layout_mode = 1
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+alignment = 1
+
+[node name="PartyMemberSlot1" type="VBoxContainer" parent="HBoxContainer"]
+layout_mode = 2
+size_flags_horizontal = 3
+alignment = 1
+
+[node name="Portrait1" type="TextureRect" parent="HBoxContainer/PartyMemberSlot1"]
+layout_mode = 2
+size_flags_vertical = 3
+# Placeholder texture or color
+expand_mode = 1
+stretch_mode = 5
+
+[node name="NameLabel1" type="Label" parent="HBoxContainer/PartyMemberSlot1"]
+layout_mode = 2
+text = "Member 1 Name"
+horizontal_alignment = 1
+
+[node name="StatsLabel1" type="Label" parent="HBoxContainer/PartyMemberSlot1"]
+layout_mode = 2
+text = "HP: 100\nRole: Warrior\nClass: Fighter\nFood: 100\nWater: 100"
+horizontal_alignment = 1
+
+[node name="CardsLabel1" type="Label" parent="HBoxContainer/PartyMemberSlot1"]
+layout_mode = 2
+text = "Card 1, Card 2, Card 3, Card 4"
+horizontal_alignment = 1
+
+[node name="GearLabel1" type="Label" parent="HBoxContainer/PartyMemberSlot1"]
+layout_mode = 2
+text = "Equipped Gear"
+horizontal_alignment = 1
+
+# Repeat PartyMemberSlot for 5 members (PartyMemberSlot2 to PartyMemberSlot5)
+# ... (similar structure for members 2-5) ...
+
+[node name="PartyMemberSlot2" type="VBoxContainer" parent="HBoxContainer"]
+layout_mode = 2
+size_flags_horizontal = 3
+alignment = 1
+
+[node name="Portrait2" type="TextureRect" parent="HBoxContainer/PartyMemberSlot2"]
+layout_mode = 2
+size_flags_vertical = 3
+# Placeholder texture or color
+expand_mode = 1
+stretch_mode = 5
+
+[node name="NameLabel2" type="Label" parent="HBoxContainer/PartyMemberSlot2"]
+layout_mode = 2
+text = "Member 2 Name"
+horizontal_alignment = 1
+
+[node name="StatsLabel2" type="Label" parent="HBoxContainer/PartyMemberSlot2"]
+layout_mode = 2
+text = "HP: 100\nRole: Mage\nClass: Wizard\nFood: 100\nWater: 100"
+horizontal_alignment = 1
+
+[node name="CardsLabel2" type="Label" parent="HBoxContainer/PartyMemberSlot2"]
+layout_mode = 2
+text = "Card 1, Card 2, Card 3, Card 4"
+horizontal_alignment = 1
+
+[node name="GearLabel2" type="Label" parent="HBoxContainer/PartyMemberSlot2"]
+layout_mode = 2
+text = "Equipped Gear"
+horizontal_alignment = 1
+
+[node name="PartyMemberSlot3" type="VBoxContainer" parent="HBoxContainer"]
+layout_mode = 2
+size_flags_horizontal = 3
+alignment = 1
+
+[node name="Portrait3" type="TextureRect" parent="HBoxContainer/PartyMemberSlot3"]
+layout_mode = 2
+size_flags_vertical = 3
+# Placeholder texture or color
+expand_mode = 1
+stretch_mode = 5
+
+[node name="NameLabel3" type="Label" parent="HBoxContainer/PartyMemberSlot3"]
+layout_mode = 2
+text = "Member 3 Name"
+horizontal_alignment = 1
+
+[node name="StatsLabel3" type="Label" parent="HBoxContainer/PartyMemberSlot3"]
+layout_mode = 2
+text = "HP: 100\nRole: Rogue\nClass: Assassin\nFood: 100\nWater: 100"
+horizontal_alignment = 1
+
+[node name="CardsLabel3" type="Label" parent="HBoxContainer/PartyMemberSlot3"]
+layout_mode = 2
+text = "Card 1, Card 2, Card 3, Card 4"
+horizontal_alignment = 1
+
+[node name="GearLabel3" type="Label" parent="HBoxContainer/PartyMemberSlot3"]
+layout_mode = 2
+text = "Equipped Gear"
+horizontal_alignment = 1
+
+[node name="PartyMemberSlot4" type="VBoxContainer" parent="HBoxContainer"]
+layout_mode = 2
+size_flags_horizontal = 3
+alignment = 1
+
+[node name="Portrait4" type="TextureRect" parent="HBoxContainer/PartyMemberSlot4"]
+layout_mode = 2
+size_flags_vertical = 3
+# Placeholder texture or color
+expand_mode = 1
+stretch_mode = 5
+
+[node name="NameLabel4" type="Label" parent="HBoxContainer/PartyMemberSlot4"]
+layout_mode = 2
+text = "Member 4 Name"
+horizontal_alignment = 1
+
+[node name="StatsLabel4" type="Label" parent="HBoxContainer/PartyMemberSlot4"]
+layout_mode = 2
+text = "HP: 100\nRole: Cleric\nClass: Priest\nFood: 100\nWater: 100"
+horizontal_alignment = 1
+
+[node name="CardsLabel4" type="Label" parent="HBoxContainer/PartyMemberSlot4"]
+layout_mode = 2
+text = "Card 1, Card 2, Card 3, Card 4"
+horizontal_alignment = 1
+
+[node name="GearLabel4" type="Label" parent="HBoxContainer/PartyMemberSlot4"]
+layout_mode = 2
+text = "Equipped Gear"
+horizontal_alignment = 1
+
+[node name="PartyMemberSlot5" type="VBoxContainer" parent="HBoxContainer"]
+layout_mode = 2
+size_flags_horizontal = 3
+alignment = 1
+
+[node name="Portrait5" type="TextureRect" parent="HBoxContainer/PartyMemberSlot5"]
+layout_mode = 2
+size_flags_vertical = 3
+# Placeholder texture or color
+expand_mode = 1
+stretch_mode = 5
+
+[node name="NameLabel5" type="Label" parent="HBoxContainer/PartyMemberSlot5"]
+layout_mode = 2
+text = "Member 5 Name"
+horizontal_alignment = 1
+
+[node name="StatsLabel5" type="Label" parent="HBoxContainer/PartyMemberSlot5"]
+layout_mode = 2
+text = "HP: 100\nRole: Ranger\nClass: Archer\nFood: 100\nWater: 100"
+horizontal_alignment = 1
+
+[node name="CardsLabel5" type="Label" parent="HBoxContainer/PartyMemberSlot5"]
+layout_mode = 2
+text = "Card 1, Card 2, Card 3, Card 4"
+horizontal_alignment = 1
+
+[node name="GearLabel5" type="Label" parent="HBoxContainer/PartyMemberSlot5"]
+layout_mode = 2
+text = "Equipped Gear"
+horizontal_alignment = 1
+
+
+[node name="ReadyButton" type="Button" parent="."]
+layout_mode = 1
+anchors_preset = 7
+anchor_left = 0.5
+anchor_top = 1.0
+anchor_right = 0.5
+anchor_bottom = 1.0
+offset_left = -50.0
+offset_top = -40.0
+offset_right = 50.0
+grow_horizontal = 2
+grow_vertical = 0
+text = "Ready"
+
+[connection signal="pressed" from="ReadyButton" to="." method="_on_ready_button_pressed"]

--- a/auto-battler/scenes/RestScene.tscn
+++ b/auto-battler/scenes/RestScene.tscn
@@ -1,0 +1,98 @@
+[gd_scene load_steps=2 format=3 uid="uid://cyxrqx7w7x0x1"]
+
+[ext_resource type="Script" path="res://scripts/ui/RestScene.gd" id="1_tuvwx"]
+
+[node name="RestScene" type="Control"]
+layout_mode = 3
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+script = ExtResource("1_tuvwx")
+
+[node name="VBoxContainer" type="VBoxContainer" parent="."]
+layout_mode = 1
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+alignment = 1
+
+[node name="TitleLabel" type="Label" parent="VBoxContainer"]
+layout_mode = 2
+text = "Rest Area"
+horizontal_alignment = 1
+
+[node name="PartyStatusGrid" type="GridContainer" parent="VBoxContainer"]
+layout_mode = 2
+columns = 5 # One column per party member
+alignment = 1
+# Placeholder for PartyMemberStatus display in rest scene
+
+[node name="Member1Stats" type="VBoxContainer" parent="VBoxContainer/PartyStatusGrid"]
+layout_mode = 2
+size_flags_horizontal = 3
+[node name="Label" type="Label" parent="VBoxContainer/PartyStatusGrid/Member1Stats"]
+layout_mode = 2
+text = "Member 1\nHP: 80/100\nH: 50/100\nT: 60/100\nF: 30/100" # Hunger, Thirst, Fatigue
+horizontal_alignment = 1
+
+[node name="Member2Stats" type="VBoxContainer" parent="VBoxContainer/PartyStatusGrid"]
+layout_mode = 2
+size_flags_horizontal = 3
+[node name="Label" type="Label" parent="VBoxContainer/PartyStatusGrid/Member2Stats"]
+layout_mode = 2
+text = "Member 2\nHP: -/-\nH: -/-\nT: -/-\nF: -/-"
+horizontal_alignment = 1
+
+[node name="Member3Stats" type="VBoxContainer" parent="VBoxContainer/PartyStatusGrid"]
+layout_mode = 2
+size_flags_horizontal = 3
+[node name="Label" type="Label" parent="VBoxContainer/PartyStatusGrid/Member3Stats"]
+layout_mode = 2
+text = "Member 3\nHP: -/-\nH: -/-\nT: -/-\nF: -/-"
+horizontal_alignment = 1
+
+[node name="Member4Stats" type="VBoxContainer" parent="VBoxContainer/PartyStatusGrid"]
+layout_mode = 2
+size_flags_horizontal = 3
+[node name="Label" type="Label" parent="VBoxContainer/PartyStatusGrid/Member4Stats"]
+layout_mode = 2
+text = "Member 4\nHP: -/-\nH: -/-\nT: -/-\nF: -/-"
+horizontal_alignment = 1
+
+[node name="Member5Stats" type="VBoxContainer" parent="VBoxContainer/PartyStatusGrid"]
+layout_mode = 2
+size_flags_horizontal = 3
+[node name="Label" type="Label" parent="VBoxContainer/PartyStatusGrid/Member5Stats"]
+layout_mode = 2
+text = "Member 5\nHP: -/-\nH: -/-\nT: -/-\nF: -/-"
+horizontal_alignment = 1
+
+
+[node name="FoodDrinkPanel" type="HBoxContainer" parent="VBoxContainer"]
+layout_mode = 2
+alignment = 1
+
+[node name="FoodLabel" type="Label" parent="VBoxContainer/FoodDrinkPanel"]
+layout_mode = 2
+text = "Available Food/Drink:"
+
+[node name="FoodCard1Button" type="Button" parent="VBoxContainer/FoodDrinkPanel"]
+layout_mode = 2
+text = "Use Ration (H+20)" # Corrected to H for Hunger based on script
+# Add more food/drink card buttons or a list here
+
+[node name="RestProgressLabel" type="Label" parent="VBoxContainer"]
+layout_mode = 2
+text = "Resting... (Placeholder Animation)"
+horizontal_alignment = 1
+
+[node name="ContinueButton" type="Button" parent="VBoxContainer"]
+layout_mode = 2
+text = "Continue Journey"
+
+[connection signal="pressed" from="VBoxContainer/FoodDrinkPanel/FoodCard1Button" to="." method="_on_use_food_drink_pressed" binds= [{"name": "Ration", "type": "food", "value": 20, "target_stat": "hunger"}]]
+[connection signal="pressed" from="VBoxContainer/ContinueButton" to="." method="_on_continue_button_pressed"]

--- a/auto-battler/scripts/combat/CombatScene.gd
+++ b/auto-battler/scripts/combat/CombatScene.gd
@@ -1,0 +1,109 @@
+extends Control
+
+var is_paused = false
+var current_speed = 1.0
+const SPEED_LEVELS = [1.0, 1.5, 2.0]
+var current_speed_index = 0
+
+# References to UI elements that need updating (assign in _ready or via editor)
+@onready var party_panel: VBoxContainer = $"Main 전투 Layout/BattleArea/PartyPanel"
+@onready var enemy_panel: VBoxContainer = $"Main 전투 Layout/BattleArea/EnemyPanel"
+@onready var character_cards_area: HBoxContainer = $"Main 전투 Layout/CharacterCardsArea"
+@onready var combat_log_container: VBoxContainer = $"Main 전투 Layout/CombatLogPanel/CombatLogScroll/CombatLog"
+@onready var feedback_label: Label = $VisualFeedbackLabel
+@onready var speed_up_button: Button = $"Main 전투 Layout/TopBar/SpeedUpButton"
+@onready var pause_button: Button = $"Main 전투 Layout/TopBar/PauseButton"
+@onready var combat_log_scroll: ScrollContainer = $"Main 전투 Layout/CombatLogPanel/CombatLogScroll"
+
+# Placeholder data for party and enemies
+var party_members_data = []
+var enemies_data = []
+
+func _ready():
+	# Initialize combat: load party/enemy data, set up UI elements
+	# For now, using placeholder data and setup
+	add_combat_log_entry("Combat Scene Initialized. Player input disabled during auto-battle.")
+
+	# Example: Populate with placeholder party member panels
+	# for i in range(1, 3): # Assuming 2 party members for this example
+	#     var member_label = party_panel.get_node("PartyMember" + str(i) + "/Label")
+	#     if member_label:
+	#         member_label.text = "Party Member " + str(i) + "\nHP: 100/100\nFatigue: 0"
+
+	# Example: Populate with placeholder enemy panels
+	# for i in range(1, 2): # Assuming 1 enemy for this example
+	#     var enemy_label = enemy_panel.get_node("Enemy" + str(i) + "/Label")
+	#     if enemy_label:
+	#         enemy_label.text = "Enemy " + str(i) + "\nHP: 50/50"
+
+	# Disable player input areas (except pause/speed)
+	# This might involve disabling input on card nodes or other interactive elements
+	# For now, it's mostly a conceptual note as detailed interaction isn't built yet
+
+func _process(delta):
+	if is_paused:
+		return
+
+	var effective_delta = delta * current_speed
+	# Main combat loop logic would go here (AI turns, card resolution, etc.)
+	# For now, just a placeholder
+	# update_combat_state(effective_delta)
+	# update_ui()
+
+func _on_pause_button_pressed():
+	is_paused = !is_paused
+	if is_paused:
+		pause_button.text = "Resume"
+		add_combat_log_entry("Combat Paused.")
+		Engine.time_scale = 0 # More robust pausing if physics is involved
+	else:
+		pause_button.text = "Pause"
+		add_combat_log_entry("Combat Resumed.")
+		Engine.time_scale = 1.0 # Ensure time scale is reset
+	print("Pause button pressed. Paused: ", is_paused)
+
+func _on_speed_up_button_pressed():
+	current_speed_index = (current_speed_index + 1) % SPEED_LEVELS.size()
+	current_speed = SPEED_LEVELS[current_speed_index]
+	speed_up_button.text = "Speed Up x" + str(current_speed)
+	add_combat_log_entry("Combat speed set to x" + str(current_speed))
+	print("Speed up button pressed. Current speed: ", current_speed)
+
+func add_combat_log_entry(text_entry: String):
+	var new_log = Label.new()
+	new_log.text = text_entry
+	new_log.autowrap_mode = TextServer.AUTOWRAP_WORD
+	combat_log_container.add_child(new_log)
+	# Optional: Scroll to bottom if the log is in a ScrollContainer
+	await get_tree().process_frame # Wait for node to be added
+	# Alternative: call_deferred on scroll_bar.value = scroll_bar.max_value
+	var scroll_bar = combat_log_scroll.get_v_scroll_bar()
+	if scroll_bar:
+		scroll_bar.value = scroll_bar.max_value
+
+func show_visual_feedback(text: String, duration: float = 1.0):
+	feedback_label.text = text
+	feedback_label.visible = true
+	var timer = get_tree().create_timer(duration)
+	await timer.timeout # Use await with timeout signal
+	feedback_label.visible = false
+
+# Placeholder functions for updating UI based on game state
+func update_party_display(party_data):
+	# Iterate through party_data and update each PartyMemberPanel instance
+	pass
+
+func update_enemy_display(enemy_data):
+	# Iterate through enemy_data and update each EnemyPanel instance
+	pass
+
+func update_character_cards_display(character_cards):
+	# Display cards for the current acting character
+	# Highlight the card being played
+	pass
+
+# Example of how visual feedback might be triggered
+func _trigger_example_feedback():
+	# Simulate a damage event
+	show_visual_feedback("Direct Hit! -20 HP", 1.5)
+	add_combat_log_entry("Goblin attacks Player 1 for 20 damage.")

--- a/auto-battler/scripts/ui/CardViewer.gd
+++ b/auto-battler/scripts/ui/CardViewer.gd
@@ -1,0 +1,85 @@
+extends PanelContainer
+
+signal card_hovered(card_data: Dictionary)
+signal card_unhovered(card_data: Dictionary)
+signal card_selected(card_data: Dictionary) # For click/tap
+
+@onready var name_label: Label = $VBoxContainer/CardNameLabel
+@onready var art_texture: TextureRect = $VBoxContainer/CardArtTexture
+@onready var description_label: Label = $VBoxContainer/CardDescriptionLabel
+@onready var cost_label: Label = $VBoxContainer/CardCostLabel
+
+var card_data: Dictionary = {} : set = set_card_data # Store the card's data
+
+# Default texture for when card art is missing
+const DEFAULT_ART_TEXTURE = preload("res://assets/art/default_card_art.png") # Make sure this path is valid or null
+
+func _ready():
+	# Default appearance or based on initial card_data if set
+	if card_data:
+		update_display()
+	else:
+		# Set to some default placeholder state if no data yet
+		name_label.text = "No Card"
+		description_label.text = "This card has no data."
+		cost_label.text = "Cost: -"
+		art_texture.texture = DEFAULT_ART_TEXTURE if DEFAULT_ART_TEXTURE else null
+		if DEFAULT_ART_TEXTURE == null:
+			art_texture.color = Color.DARK_GRAY # Fallback color if default art also missing
+
+func set_card_data(new_card_data: Dictionary):
+	card_data = new_card_data
+	if is_inside_tree(): # Ensure nodes are ready
+		update_display()
+
+func update_display():
+	if not card_data: # Should not happen if setter is used properly, but good check
+		name_label.text = "Card Data Error"
+		description_label.text = "Invalid card data."
+		cost_label.text = "Cost: ERR"
+		art_texture.texture = DEFAULT_ART_TEXTURE if DEFAULT_ART_TEXTURE else null
+		if DEFAULT_ART_TEXTURE == null:
+			art_texture.color = Color.RED
+		return
+
+	name_label.text = card_data.get("name", "Unnamed Card")
+	description_label.text = card_data.get("description", "No description available.")
+	cost_label.text = "Cost: %s" % card_data.get("cost", "-")
+
+	var art_path = card_data.get("art_path", "")
+	if art_path and ResourceLoader.exists(art_path):
+		art_texture.texture = load(art_path)
+	else:
+		if art_path: # If path was provided but not found
+			print_debug("Card art not found at path: ", art_path)
+		art_texture.texture = DEFAULT_ART_TEXTURE if DEFAULT_ART_TEXTURE else null
+		if DEFAULT_ART_TEXTURE == null and art_texture.texture == null : # Check again in case DEFAULT_ART_TEXTURE was null
+			art_texture.color = Color.SLATE_GRAY # Fallback color if default art also missing and no texture set
+
+func _on_gui_input(event: InputEvent):
+	if event is InputEventMouseButton:
+		if event.button_index == MOUSE_BUTTON_LEFT and event.is_pressed(): # use is_pressed() for down click
+			emit_signal("card_selected", card_data)
+			# Optional: Add visual feedback for selection, e.g., a short animation or border change
+			# Example: create_tween().tween_property(self, "scale", Vector2(1.1, 1.1), 0.1).chain().tween_property(self, "scale", Vector2(1.0, 1.0), 0.1)
+			print("Card selected: ", card_data.get("name", "N/A"))
+
+func _on_mouse_entered():
+	emit_signal("card_hovered", card_data)
+	# Optional: Add visual feedback for hover, e.g., scale up, highlight border
+	# create_tween().tween_property(self, "modulate", Color(0.9, 0.9, 1.1), 0.1) # Slight tint
+	print("Card hovered: ", card_data.get("name", "N/A"))
+
+
+func _on_mouse_exited():
+	emit_signal("card_unhovered", card_data)
+	# Optional: Revert visual feedback for hover
+	# create_tween().tween_property(self, "modulate", Color(1,1,1), 0.1) # Reset tint
+	print("Card unhovered: ", card_data.get("name", "N/A"))
+
+# Public method to allow external highlighting (e.g., if it's the "current turn" card)
+func set_highlight(is_highlighted: bool):
+	if is_highlighted:
+		self_modulate = Color.GOLD # Example highlight color
+	else:
+		self_modulate = Color.WHITE # Default modulate (ensure no conflict with KO state etc. if used elsewhere)

--- a/auto-battler/scripts/ui/DungeonMap.gd
+++ b/auto-battler/scripts/ui/DungeonMap.gd
@@ -1,0 +1,85 @@
+extends Control
+
+var map_nodes = [] # Array to hold data about map nodes
+var current_party_status = {} # Dictionary to hold party status
+
+func _ready():
+	# Initialize map nodes (placeholder)
+	map_nodes = [
+		{"id": 0, "type": "room", "name": "Starting Room"},
+		{"id": 1, "type": "event", "name": "Mysterious Shrine"},
+		{"id": 2, "type": "room", "name": "Goblin Cave"}
+	]
+	# You would typically generate or load this data
+
+	# Initialize party status (placeholder)
+	current_party_status = {
+		"member1": {"hp": 100, "max_hp": 100, "food": 100, "water": 100, "energy":100},
+		"member2": {"hp": 100, "max_hp": 100, "food": 100, "water": 100, "energy":100},
+		"member3": {"hp": 100, "max_hp": 100, "food": 100, "water": 100, "energy":100},
+		"member4": {"hp": 100, "max_hp": 100, "food": 100, "water": 100, "energy":100},
+		"member5": {"hp": 100, "max_hp": 100, "food": 100, "water": 100, "energy":100}
+	}
+	update_party_status_display()
+	update_map_node_display()
+
+func update_map_node_display():
+	# This function would dynamically create/update buttons based on map_nodes
+	# For now, the buttons are static in the .tscn
+	var map_nodes_container = get_node_or_null("MapNodesContainer")
+	if !map_nodes_container:
+		print("Error: MapNodesContainer not found")
+		return
+
+	var node_buttons = map_nodes_container.get_children()
+	for i in range(min(node_buttons.size(), map_nodes.size())):
+		if node_buttons[i] is Button:
+			node_buttons[i].text = map_nodes[i].name
+			# Potentially disable buttons for already visited or unreachable nodes
+
+func _on_map_node_selected(node_index):
+	if node_index >= 0 and node_index < map_nodes.size():
+		var selected_node = map_nodes[node_index]
+		print("Map node selected: ", selected_node.name)
+		# Add logic to handle node selection, e.g.:
+		# if selected_node.type == "room":
+		#     get_tree().change_scene_to_file("res://scenes/CombatScene.tscn") # Or specific room scene
+		# elif selected_node.type == "event":
+		#     # Trigger event logic
+		#     pass
+	else:
+		print("Invalid node index: ", node_index)
+
+
+func update_party_status_display():
+	for i in range(1, 6):
+		var member_key = "member" + str(i)
+		var status_label_path = "PartyStatusOverlay/Member" + str(i) + "Status"
+		var status_label = get_node_or_null(status_label_path)
+
+		if status_label and current_party_status.has(member_key):
+			var stats = current_party_status[member_key]
+			status_label.text = "Member %d: HP %d/%d, F:%d, W:%d, E:%d" % [i, stats.hp, stats.max_hp, stats.food, stats.water, stats.energy]
+		elif !status_label:
+			print("Error: Status label not found for " + status_label_path)
+
+
+# Functions to be called by other game systems to update status
+func set_party_member_hp(member_index_from_1, hp):
+	var member_key = "member" + str(member_index_from_1)
+	if current_party_status.has(member_key):
+		current_party_status[member_key].hp = hp
+		update_party_status_display()
+	else:
+		print("Error: Member key not found for HP update: " + member_key)
+
+func set_party_member_survival_stat(member_index_from_1, stat_name, value):
+	var member_key = "member" + str(member_index_from_1)
+	if current_party_status.has(member_key):
+		if current_party_status[member_key].has(stat_name):
+			current_party_status[member_key][stat_name] = value
+			update_party_status_display()
+		else:
+			print("Error: Stat name not found for member: " + stat_name)
+	else:
+		print("Error: Member key not found for survival stat update: " + member_key)

--- a/auto-battler/scripts/ui/EnemyPanel.gd
+++ b/auto-battler/scripts/ui/EnemyPanel.gd
@@ -1,0 +1,130 @@
+extends PanelContainer
+
+signal enemy_selected(enemy_data: Dictionary) # E.g., for targeting intent or info display
+signal enemy_hovered(enemy_data: Dictionary)
+signal enemy_unhovered(enemy_data: Dictionary)
+
+@onready var name_label: Label = $VBoxContainer/NameLabel
+@onready var sprite_texture: TextureRect = $VBoxContainer/SpriteTexture
+@onready var hp_bar: ProgressBar = $VBoxContainer/HpBar
+@onready var hp_label: Label = $VBoxContainer/HpBar/HpLabel
+@onready var status_effects_box: HBoxContainer = $VBoxContainer/StatusEffectsBox
+
+var enemy_data: Dictionary = {} : set = set_enemy_data
+
+# Default texture for enemy sprites (optional, adjust path as needed)
+const DEFAULT_SPRITE_TEXTURE = preload("res://assets/sprites/default_enemy_sprite.png") # Ensure this path is valid or null
+
+
+func _ready():
+	if enemy_data:
+		update_display()
+	else:
+		name_label.text = "Unknown Enemy"
+		hp_bar.value = 0
+		hp_label.text = "0/0"
+		sprite_texture.texture = DEFAULT_SPRITE_TEXTURE if DEFAULT_SPRITE_TEXTURE else null
+		if DEFAULT_SPRITE_TEXTURE == null:
+			sprite_texture.color = Color.DARK_RED # Fallback color
+
+func set_enemy_data(new_data: Dictionary):
+	enemy_data = new_data.duplicate(true) # Store a deep copy
+	if is_inside_tree():
+		update_display()
+
+func update_display():
+	if not enemy_data:
+		name_label.text = "Data Error"
+		return
+
+	name_label.text = enemy_data.get("name", "N/A")
+
+	var current_hp = enemy_data.get("hp", 0)
+	var max_hp = enemy_data.get("max_hp", 100)
+	if max_hp > 0:
+		hp_bar.max_value = max_hp
+		hp_bar.value = current_hp
+		hp_label.text = "%d/%d" % [current_hp, max_hp]
+	else:
+		hp_bar.max_value = 1
+		hp_bar.value = 0
+		hp_label.text = "0/0"
+
+	var sprite_path = enemy_data.get("sprite_path", "")
+	if sprite_path and ResourceLoader.exists(sprite_path):
+		sprite_texture.texture = load(sprite_path)
+	else:
+		if sprite_path:
+			print_debug("Enemy sprite not found at path: ", sprite_path)
+		sprite_texture.texture = DEFAULT_SPRITE_TEXTURE if DEFAULT_SPRITE_TEXTURE else null
+		if DEFAULT_SPRITE_TEXTURE == null and sprite_texture.texture == null:
+			sprite_texture.color = Color.MAROON
+
+
+	clear_status_effects()
+	var status_effects_list = enemy_data.get("status_effects", [])
+	if status_effects_list is Array:
+		for effect_data_or_id in status_effects_list:
+			if effect_data_or_id is Dictionary:
+				add_status_effect_icon(effect_data_or_id)
+			# else if effect_data_or_id is String: # Extend with manager lookup if using IDs
+				# var full_effect_data = StatusEffectManager.get_effect_details(effect_data_or_id)
+				# if full_effect_data: add_status_effect_icon(full_effect_data)
+
+
+	if enemy_data.get("is_ko", false):
+		self_modulate = Color(0.5, 0.5, 0.5, 0.7) # Dim if KO'd
+		name_label.text += " (Defeated)" # Consider if name changes often
+	else:
+		self_modulate = Color.WHITE
+
+
+func _on_gui_input(event: InputEvent):
+	if event is InputEventMouseButton:
+		if event.button_index == MOUSE_BUTTON_LEFT and event.is_pressed():
+			if not enemy_data.get("is_ko", false):
+				emit_signal("enemy_selected", enemy_data)
+				print("Enemy selected: ", enemy_data.get("name", "N/A"))
+			else:
+				print("Enemy defeated, selection ignored: ", enemy_data.get("name", "N/A"))
+
+func _on_mouse_entered():
+	if not enemy_data.get("is_ko", false):
+		emit_signal("enemy_hovered", enemy_data)
+		# Visual feedback (e.g., outline or slight scale)
+		print("Enemy hovered: ", enemy_data.get("name", "N/A"))
+
+func _on_mouse_exited():
+	if not enemy_data.get("is_ko", false):
+		emit_signal("enemy_unhovered", enemy_data)
+		# Revert visual feedback
+		print("Enemy unhovered: ", enemy_data.get("name", "N/A"))
+
+func clear_status_effects():
+   for child in status_effects_box.get_children():
+       child.queue_free()
+
+func add_status_effect_icon(effect_data: Dictionary):
+	var icon = TextureRect.new()
+	icon.custom_minimum_size = Vector2(16,16) # Small icons
+	icon.expand_mode = TextureRect.EXPAND_IGNORE_SIZE
+	icon.stretch_mode = TextureRect.STRETCH_KEEP_ASPECT_CENTERED
+
+	var effect_icon_path = effect_data.get("icon_path", "res://assets/icons/default_status.png") # Default status icon
+	if ResourceLoader.exists(effect_icon_path):
+		icon.texture = load(effect_icon_path)
+	else:
+		icon.color = Color.PURPLE # Placeholder if icon missing
+		print_debug("Status effect icon not found for enemy: ", effect_icon_path)
+
+	icon.tooltip_text = effect_data.get("name", "Effect") + "\n" + effect_data.get("description", "No description.")
+	status_effects_box.add_child(icon)
+
+# Method to apply a temporary visual effect, e.g., when taking damage
+func flash_effect(color: Color = Color.RED, duration: float = 0.2):
+	var original_modulate = self_modulate
+	var tween = create_tween()
+	tween.set_parallel(true)
+	tween.tween_property(self, "modulate", color, duration / 2.0)
+	tween.tween_property(self, "modulate", original_modulate, duration / 2.0).set_delay(duration / 2.0)
+	tween.play()

--- a/auto-battler/scripts/ui/InventoryCrafting.gd
+++ b/auto-battler/scripts/ui/InventoryCrafting.gd
@@ -1,0 +1,189 @@
+extends Control
+
+# Signal for when an item is crafted
+signal item_crafted(item_data, ingredients_used)
+
+@onready var inventory_grid: GridContainer = $MainHBox/InventoryPanel/InventoryGrid
+@onready var crafting_slots_container: HBoxContainer = $MainHBox/CraftingPanel/CraftingSlots
+@onready var profession_label: Label = $MainHBox/CraftingPanel/ProfessionLabel
+@onready var known_recipes_label: Label = $MainHBox/CraftingPanel/KnownRecipesLabel
+@onready var crafting_preview_label: Label = $MainHBox/CraftingPanel/CraftingPreviewLabel
+@onready var crafting_log_label: Label = $MainHBox/CraftingPanel/CraftingLogLabel
+
+var inventory_items = [] # Array to hold actual inventory item data
+var crafting_slot_items = [null, null, null, null, null] # Items in crafting slots
+
+func _ready():
+	# Initialize inventory display (placeholder)
+	# For now, using static items in scene, but you'd populate this from InventorySystem
+	# Example: populate_inventory_display()
+
+	# Initialize crafting slots (e.g., set them as drop targets)
+	# For now, this is conceptual. Drag-and-drop setup is more involved.
+	update_crafting_slots_display()
+	update_profession_display()
+	update_known_recipes_display()
+	update_crafting_preview() # Initially empty or based on default selection
+
+func _on_craft_button_pressed():
+	print("Craft button pressed")
+	# 1. Check items in crafting_slot_items
+	# 2. Determine if a valid recipe matches
+	# 3. If yes, "craft" the item (e.g., remove ingredients, add result to inventory)
+	# 4. Emit item_crafted signal
+	# 5. Update inventory and crafting displays
+	# For now, a placeholder log:
+	var ingredients = []
+	var ingredient_names = [] # For logging
+	for item in crafting_slot_items:
+		if item != null: # Assuming item is some data structure or string
+			ingredients.append(item)
+			if item is Dictionary and item.has("name"):
+				ingredient_names.append(item.name)
+			else:
+				ingredient_names.append(str(item)) # Fallback to string representation
+
+	if ingredients.size() > 0:
+		# Simulate finding a recipe
+		var crafted_item_name = "Simulated Crafted Item" # Replace with actual recipe logic
+		# In a real system, you'd look up a recipe based on 'ingredients'
+		# var recipe = RecipeManager.find_recipe(ingredients)
+		# if recipe:
+		#    crafted_item_name = recipe.result_item_name
+		#    emit_signal("item_crafted", recipe.result_item_data, ingredients)
+		#    # Remove ingredients from inventory_items
+		#    # Add crafted_item_data to inventory_items
+		# else:
+		#    add_crafting_log("No recipe found for: " + str(ingredient_names))
+		#    return
+
+		add_crafting_log("Attempting to craft with: " + str(ingredient_names))
+		add_crafting_log("Success! Crafted: " + crafted_item_name)
+		# Example: emit_signal("item_crafted", {"name": crafted_item_name, "id": "sim_craft_01"}, ingredients)
+
+		# Clear crafting slots
+		for i in range(crafting_slot_items.size()):
+			crafting_slot_items[i] = null
+		update_crafting_slots_display()
+		update_crafting_preview() # Clear or update preview
+		# populate_inventory_display() # Refresh inventory display
+	else:
+		add_crafting_log("No items in crafting pouch.")
+
+func add_crafting_log(log_text: String):
+	crafting_log_label.text = log_text # Simple log, could be appended to a list or VBoxContainer of Labels
+	print("Crafting Log: ", log_text)
+
+# Placeholder functions for updating different parts of the UI
+func populate_inventory_display():
+	# Clear existing items
+	for child in inventory_grid.get_children():
+		child.queue_free()
+	# Add items from inventory_items (this requires item data and a scene for item display)
+	# For each item_data in inventory_items:
+	#   var item_ui_instance = load("res://scenes/ui_components/InventoryItemUI.tscn").instantiate() # Example path
+	#   item_ui_instance.set_item_data(item_data) # A function you'd define in InventoryItemUI.gd
+	#   inventory_grid.add_child(item_ui_instance)
+	#   # Connect drag signals for item_ui_instance here or in its own script
+	pass
+
+func update_crafting_slots_display():
+	var slots = crafting_slots_container.get_children()
+	for i in range(min(slots.size(), crafting_slot_items.size())):
+		var slot_node = slots[i]
+		var label = slot_node.get_node_or_null("Label")
+		if label:
+			if crafting_slot_items[i] != null:
+				var item = crafting_slot_items[i]
+				if item is Dictionary and item.has("name"):
+					label.text = item.name
+				else:
+					label.text = str(item) # Fallback
+			else:
+				label.text = "[Empty]"
+		# Setup _can_drop_data and _drop_data for each slot_node to receive items
+		# This would typically be done by assigning a script to each slot or handling it here
+		# For example, slot_node.set_script(load("res://scripts/ui_components/CraftingSlotDropTarget.gd"))
+		# Or connect signals: slot_node.gui_input.connect(Callable(self, "_on_slot_gui_input").bind(i))
+
+
+func update_profession_display(prof_name: String = "Herbalism", level: int = 1):
+	profession_label.text = "Profession: %s Lvl %d" % [prof_name, level]
+
+func update_known_recipes_display(recipes: Array = ["Healing Salve", "Stamina Draught"]):
+	var recipe_text = "Recipes: "
+	if recipes.size() > 0:
+		recipe_text += ", ".join(recipes)
+	else:
+		recipe_text += "None known"
+	known_recipes_label.text = recipe_text
+
+func update_crafting_preview():
+	# This would look at items in crafting_slot_items and check known recipes
+	var preview_text = "Output Preview: "
+	# var recipe_result = RecipeManager.check_recipe(crafting_slot_items) # Example
+	# if recipe_result:
+	#    preview_text += recipe_result.name # Assuming recipe_result has a name property
+	# else:
+	preview_text += "---"
+	crafting_preview_label.text = preview_text
+
+
+# --- Drag and Drop Handling (Conceptual) ---
+# Each inventory item needs to be draggable.
+# Each crafting slot needs to be a drop target.
+
+# This function would be connected to the 'gui_input' signal of each crafting slot.
+# You'd need to iterate through slots in _ready and connect them.
+func _on_slot_gui_input(event: InputEvent, slot_index: int):
+	if event is InputEventMouseButton and event.button_index == MOUSE_BUTTON_LEFT and event.pressed:
+		# Example: Clicking a slot could try to move an item back to inventory or clear it
+		# print("Clicked slot ", slot_index, " containing ", crafting_slot_items[slot_index])
+		# if crafting_slot_items[slot_index] != null:
+		#    # Add item back to inventory_items
+		#    # inventory_items.append(crafting_slot_items[slot_index])
+		#    crafting_slot_items[slot_index] = null
+		#    update_crafting_slots_display()
+		#    update_crafting_preview()
+		#    # populate_inventory_display() # Refresh inventory
+		pass
+
+# For actual drag and drop, each crafting slot (PanelContainer) should have a script
+# or this main script should handle their _can_drop_data and _drop_data methods.
+# If handled here, you would need to get the specific slot that is being targeted.
+# Godot's drag and drop system usually involves connecting signals on the controls themselves.
+
+# Example for a crafting slot (if it had its own script, or part of this main script):
+# func _can_drop_data(position, data): # position is local to the control
+#    # Assuming 'data' is a dictionary like: {"type": "inventory_item", "item_data": {...}}
+#    return data is Dictionary and data.has("type") and data.type == "inventory_item"
+
+# func _drop_data(position, data):
+#    var slot_index = get_index() # Or some other way to identify which slot this is
+#    crafting_slot_items[slot_index] = data.item_data
+#    # Remove from original source (e.g., inventory_grid or another crafting_slot)
+#    # This part is complex as you need to know where it came from.
+#    # Often, the drag data includes a reference to the source.
+#    update_crafting_slots_display()
+#    update_crafting_preview()
+
+
+# Example for an inventory item UI element (script on the item's scene):
+# func _get_drag_data(position):
+#   var preview_control = Label.new() # Or a more complex preview scene instance
+#   preview_control.text = self.item_data.name
+#   set_drag_preview(preview_control)
+#   return {"type": "inventory_item", "item_data": self.item_data, "source_inventory_index": self.inventory_slot_index}
+#
+# When an item is dropped onto a crafting slot, the slot's _drop_data would:
+# 1. Store item_data in its corresponding crafting_slot_items[slot_index].
+# 2. Potentially tell an InventoryManager to remove the item from source_inventory_index.
+#
+# If an item is dragged FROM a crafting slot, its _get_drag_data would be:
+# return {"type": "crafting_slot_item", "item_data": self.item_data, "source_crafting_slot_index": self.slot_index}
+# And if dropped on another crafting slot, that slot would clear crafting_slot_items[source_crafting_slot_index].
+# If dropped back onto the inventory grid, the grid's _drop_data would handle adding it back.
+#
+# This level of detail for drag and drop is typically handled by dedicated scripts on the draggable items
+# and drop target areas, or a more centralized drag-and-drop manager.
+# The functions here are mostly placeholders for that logic.

--- a/auto-battler/scripts/ui/LootPanel.gd
+++ b/auto-battler/scripts/ui/LootPanel.gd
@@ -1,0 +1,152 @@
+extends PanelContainer
+
+# Signal emitted when an item is chosen to be added to inventory
+signal add_item_to_inventory(item_data: Dictionary)
+# Signal emitted when the panel is closed
+signal loot_panel_closed
+
+@onready var loot_list_container: VBoxContainer = $VBoxContainer/LootScrollContainer/LootList
+@onready var close_button: Button = $VBoxContainer/CloseButton
+
+# Placeholder for loot items. In a real game, this would be passed to the panel.
+var current_loot_items: Array = []
+
+# Optional: Preload a scene for individual loot item entries if you make one
+# var LootItemEntryScene = preload("res://scenes/ui_components/LootItemEntry.tscn")
+
+func _ready():
+	# Populate with some example loot if nothing is passed AND this panel is visible on start (for testing)
+	# Typically, you'd call show_loot() from another script to display this panel.
+	if current_loot_items.is_empty() and self.visible:
+		# Rarity: 0=Common, 1=Uncommon, 2=Rare, 3=Epic
+		set_loot_items([
+			{"name": "Health Potion", "type": "consumable", "rarity": 0, "tags": ["Crafted by: Alchemist NPC"], "icon_path": "res://assets/icons/potion.png"}, # Example icon path
+			{"name": "Iron Sword", "type": "gear", "rarity": 1, "tags": ["Found in dungeon"], "icon_path": "res://assets/icons/sword.png"},
+			{"name": "Fireball Scroll", "type": "card", "rarity": 2, "tags": [], "icon_path": "res://assets/icons/scroll.png"}
+		])
+	elif !current_loot_items.is_empty():
+		populate_loot_display()
+	else:
+		# If no items and not visible for testing, ensure it's clear
+		clear_loot_display()
+
+
+func set_loot_items(items: Array):
+	current_loot_items = items.duplicate(true) # Store a deep copy
+	populate_loot_display()
+
+func clear_loot_display():
+	for child in loot_list_container.get_children():
+		child.queue_free()
+
+func populate_loot_display():
+	clear_loot_display() # Clear previous loot items
+
+	if current_loot_items.is_empty():
+		var empty_label = Label.new()
+		empty_label.text = "No loot this time!"
+		empty_label.horizontal_alignment = HORIZONTAL_ALIGNMENT_CENTER
+		loot_list_container.add_child(empty_label)
+		close_button.text = "Close" # No items to take
+		return
+	else:
+		close_button.text = "Close / Take All"
+
+
+	for item_data in current_loot_items:
+		# If using a LootItemEntryScene:
+		# var item_entry = LootItemEntryScene.instantiate()
+		# item_entry.set_item_data(item_data) # Assuming the scene script has this method
+		# loot_list_container.add_child(item_entry)
+		# var add_button_in_scene = item_entry.get_node_or_null("AddButton")
+		# if add_button_in_scene:
+		#    add_button_in_scene.pressed.connect(_on_add_item_button_pressed.bind(item_data, add_button_in_scene, item_entry))
+		# item_entry.set_meta("item_data", item_data) # Store data for "Take All"
+
+		# Create UI elements directly (similar to the .tscn example)
+		var item_entry_hbox = HBoxContainer.new()
+		item_entry_hbox.custom_minimum_size = Vector2(0, 50)
+		item_entry_hbox.set_meta("item_data", item_data) # Store data for "Take All"
+
+		var icon = TextureRect.new()
+		icon.custom_minimum_size = Vector2(40,40)
+		icon.expand_mode = TextureRect.EXPAND_IGNORE_SIZE
+		icon.stretch_mode = TextureRect.STRETCH_KEEP_ASPECT_CENTERED
+		var icon_path = item_data.get("icon_path", "res://assets/icons/default_item.png") # Default icon
+		var loaded_icon = load(icon_path) # In real game, handle load errors
+		if loaded_icon:
+			icon.texture = loaded_icon
+		else:
+			# Could set a placeholder color or default texture if load fails
+			icon.color = Color(0.6, 0.6, 0.6, 1) # Placeholder color if icon not found
+		item_entry_hbox.add_child(icon)
+
+		var details_vbox = VBoxContainer.new()
+		details_vbox.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+		item_entry_hbox.add_child(details_vbox)
+
+		var name_label = Label.new()
+		var rarity_str = get_rarity_string(item_data.get("rarity", 0))
+		name_label.text = "%s (%s)" % [item_data.get("name", "Unknown Item"), rarity_str]
+		details_vbox.add_child(name_label)
+
+		var tags_label = Label.new()
+		var tags_array = item_data.get("tags", [])
+		if tags_array is Array and not tags_array.is_empty():
+			tags_label.text = ", ".join(tags_array)
+		else:
+			tags_label.text = "" # Hide if no tags, or "No special tags"
+			tags_label.visible = false
+		tags_label.theme_override_font_sizes/font_size = 12
+		details_vbox.add_child(tags_label)
+
+		var add_button = Button.new()
+		add_button.text = "Add" # Shorter text
+		add_button.size_flags_vertical = Control.SIZE_SHRINK_CENTER
+		add_button.pressed.connect(_on_add_item_button_pressed.bind(item_data, add_button, item_entry_hbox))
+		item_entry_hbox.add_child(add_button)
+
+		loot_list_container.add_child(item_entry_hbox)
+
+func get_rarity_string(rarity_val: int) -> String:
+	match rarity_val:
+		0: return "Common"
+		1: return "Uncommon"
+		2: return "Rare"
+		3: return "Epic"
+		_: return "Unknown Rarity"
+
+func _on_add_item_button_pressed(item_data: Dictionary, button_node: Button, item_entry_node: HBoxContainer):
+	print("Add to inventory button pressed for: ", item_data.name)
+	emit_signal("add_item_to_inventory", item_data)
+
+	button_node.disabled = true
+	button_node.text = "Added"
+	# item_entry_node.modulate = Color(0.7, 0.7, 0.7, 0.5) # Dim it slightly and make transparent
+
+func _on_close_button_pressed():
+	print("Close button pressed on Loot Panel")
+	# "Take All" functionality: iterate through items not yet added and add them.
+	for child_node in loot_list_container.get_children():
+		if child_node is HBoxContainer: # Assuming HBoxContainer is an item entry
+			var add_button = child_node.find_child("Button", true, false) # Find the button more reliably
+			if add_button and add_button is Button and not add_button.disabled:
+				var item_data_from_node = child_node.get_meta("item_data", null)
+				if item_data_from_node:
+					emit_signal("add_item_to_inventory", item_data_from_node)
+					print("Auto-adding on close: ", item_data_from_node.name)
+					add_button.disabled = true # Visually mark as added
+					add_button.text = "Added"
+
+	emit_signal("loot_panel_closed")
+	# It's often better for the parent/manager of this panel to hide or queue_free it.
+	# This allows for pooling or re-showing. For now, queue_free.
+	queue_free()
+
+# Call this method to show the loot panel with specific items
+func show_loot(items_to_display: Array):
+	set_loot_items(items_to_display)
+	self.visible = true
+	# Optional: Bring to front if it's part of a complex UI
+	# move_to_front()
+```

--- a/auto-battler/scripts/ui/MainMenu.gd
+++ b/auto-battler/scripts/ui/MainMenu.gd
@@ -1,0 +1,30 @@
+extends Control
+
+# Called when the node enters the scene tree for the first time.
+func _ready():
+	pass # Replace with function body.
+
+
+# Called every frame. 'delta' is the elapsed time since the previous frame.
+func _process(delta):
+	pass
+
+func _on_start_button_pressed():
+	print("Start Game button pressed")
+	# Replace with game start logic, e.g., get_tree().change_scene_to_file("res://scenes/PartySetup.tscn")
+
+func _on_continue_button_pressed():
+	print("Continue button pressed")
+	# Replace with continue game logic, e.g., load game state
+
+func _on_settings_button_pressed():
+	print("Settings button pressed")
+	# Replace with settings screen logic
+
+func _on_credits_button_pressed():
+	print("Credits button pressed")
+	# Replace with credits screen logic
+
+func _on_exit_button_pressed():
+	print("Exit button pressed")
+	get_tree().quit()

--- a/auto-battler/scripts/ui/PartyMemberPanel.gd
+++ b/auto-battler/scripts/ui/PartyMemberPanel.gd
@@ -1,0 +1,153 @@
+extends PanelContainer
+
+signal member_selected(member_data: Dictionary)
+signal member_hovered(member_data: Dictionary)
+signal member_unhovered(member_data: Dictionary)
+
+@onready var name_label: Label = $VBoxContainer/NameLabel
+@onready var portrait_texture: TextureRect = $VBoxContainer/PortraitTexture
+@onready var hp_bar: ProgressBar = $VBoxContainer/HpBar
+@onready var hp_label: Label = $VBoxContainer/HpBar/HpLabel # Path to the label inside progress bar
+@onready var role_class_label: Label = $VBoxContainer/RoleClassLabel
+@onready var status_effects_box: HBoxContainer = $VBoxContainer/StatusEffectsBox
+@onready var fatigue_label: Label = $VBoxContainer/FatigueMeterLabel # Example
+
+var member_data: Dictionary = {} : set = set_member_data
+
+# Default texture for portraits (optional, adjust path as needed)
+const DEFAULT_PORTRAIT_TEXTURE = preload("res://assets/portraits/default_portrait.png") # Ensure this path is valid or null
+
+func _ready():
+	if member_data:
+		update_display()
+	else:
+		# Default placeholder state
+		name_label.text = "Unknown Member"
+		hp_bar.value = 0
+		hp_label.text = "0/0"
+		role_class_label.text = "N/A"
+		fatigue_label.text = "Fatigue: -"
+		portrait_texture.texture = DEFAULT_PORTRAIT_TEXTURE if DEFAULT_PORTRAIT_TEXTURE else null
+		if DEFAULT_PORTRAIT_TEXTURE == null:
+			portrait_texture.color = Color.DARK_GRAY
+
+func set_member_data(new_data: Dictionary):
+	member_data = new_data.duplicate(true) # Store a deep copy to avoid external modifications
+	if is_inside_tree():
+		update_display()
+
+func update_display():
+	if not member_data:
+		name_label.text = "Data Error"
+		return
+
+	name_label.text = member_data.get("name", "N/A")
+
+	var current_hp = member_data.get("hp", 0)
+	var max_hp = member_data.get("max_hp", 100)
+	if max_hp > 0:
+		hp_bar.max_value = max_hp
+		hp_bar.value = current_hp # ProgressBar clamps value automatically
+		hp_label.text = "%d/%d" % [current_hp, max_hp]
+	else: # Avoid division by zero or negative max_hp issues
+		hp_bar.max_value = 1 # Still have a basis for the bar
+		hp_bar.value = 0
+		hp_label.text = "0/0"
+
+	var role = member_data.get("role", "Role")
+	var char_class = member_data.get("class", "Class")
+	role_class_label.text = "%s / %s" % [role, char_class]
+
+	var fatigue_val = member_data.get("fatigue", 0)
+	var max_fatigue = member_data.get("max_fatigue", 100)
+	if max_fatigue > 0: # Similar check for fatigue
+		fatigue_label.text = "Fatigue: %d/%d" % [fatigue_val, max_fatigue]
+	else:
+		fatigue_label.text = "Fatigue: %d/-" % fatigue_val
+
+
+	var portrait_path = member_data.get("portrait_path", "")
+	if portrait_path and ResourceLoader.exists(portrait_path):
+		portrait_texture.texture = load(portrait_path)
+	else:
+		if portrait_path:
+			print_debug("Portrait not found at path: ", portrait_path)
+		portrait_texture.texture = DEFAULT_PORTRAIT_TEXTURE if DEFAULT_PORTRAIT_TEXTURE else null
+		if DEFAULT_PORTRAIT_TEXTURE == null and portrait_texture.texture == null:
+			portrait_texture.color = Color.SLATE_GRAY
+
+
+	clear_status_effects() # Clear old effects first
+	var status_effects_list = member_data.get("status_effects", [])
+	if status_effects_list is Array:
+		for effect_data_or_id in status_effects_list:
+			# Assuming effect_data_or_id could be a string ID or a Dictionary
+			# You'd need a system to get full effect data (icon, tooltip) from an ID
+			if effect_data_or_id is Dictionary:
+				add_status_effect_icon(effect_data_or_id)
+			# else if effect_data_or_id is String:
+				# var full_effect_data = StatusEffectManager.get_effect_details(effect_data_or_id)
+				# if full_effect_data: add_status_effect_icon(full_effect_data)
+
+	# Handle KO status display
+	if member_data.get("is_ko", false):
+		self_modulate = Color(0.5, 0.5, 0.5, 0.8) # Dim if KO'd
+		name_label.text += " (KO)" # Append KO, consider if name changes often
+	else:
+		self_modulate = Color.WHITE # Reset modulation
+
+
+func _on_gui_input(event: InputEvent):
+	if event is InputEventMouseButton:
+		if event.button_index == MOUSE_BUTTON_LEFT and event.is_pressed():
+			if not member_data.get("is_ko", false): # Optionally prevent selection if KO'd
+				emit_signal("member_selected", member_data)
+				print("Party member selected: ", member_data.get("name", "N/A"))
+			else:
+				print("Party member KO'd, selection ignored: ", member_data.get("name", "N/A"))
+
+
+func _on_mouse_entered():
+	if not member_data.get("is_ko", false): # Don't signal hover for KO'd members if not desired
+		emit_signal("member_hovered", member_data)
+		# Visual feedback, e.g., highlight
+		# self.get_parent().get_node("HighlightRect").visible = true # Example if using a separate highlight node
+		print("Party member hovered: ", member_data.get("name", "N/A"))
+
+
+func _on_mouse_exited():
+	if not member_data.get("is_ko", false):
+		emit_signal("member_unhovered", member_data)
+		# Revert visual feedback
+		# if not member_data.get("is_ko", false): # Already checked above
+		#    self.modulate = Color.WHITE # Be careful if other modulations are active (KO)
+		print("Party member unhovered: ", member_data.get("name", "N/A"))
+
+func clear_status_effects():
+   for child in status_effects_box.get_children():
+       child.queue_free()
+
+func add_status_effect_icon(effect_data: Dictionary):
+	var icon = TextureRect.new()
+	icon.custom_minimum_size = Vector2(16,16) # Small icons
+	icon.expand_mode = TextureRect.EXPAND_IGNORE_SIZE
+	icon.stretch_mode = TextureRect.STRETCH_KEEP_ASPECT_CENTERED
+
+	var effect_icon_path = effect_data.get("icon_path", "res://assets/icons/default_status.png") # Default status icon
+	if ResourceLoader.exists(effect_icon_path):
+		icon.texture = load(effect_icon_path)
+	else:
+		icon.color = Color.PURPLE # Placeholder if icon missing
+		print_debug("Status effect icon not found: ", effect_icon_path)
+
+	icon.tooltip_text = effect_data.get("name", "Effect") + "\n" + effect_data.get("description", "No description.")
+	status_effects_box.add_child(icon)
+
+# Method to apply a temporary visual effect, e.g., when taking damage
+func flash_effect(color: Color = Color.RED, duration: float = 0.2):
+	var original_modulate = self_modulate # Store current modulate (e.g., if KO'd)
+	var tween = create_tween()
+	tween.set_parallel(true)
+	tween.tween_property(self, "modulate", color, duration / 2.0)
+	tween.tween_property(self, "modulate", original_modulate, duration / 2.0).set_delay(duration / 2.0)
+	tween.play()

--- a/auto-battler/scripts/ui/PartySetup.gd
+++ b/auto-battler/scripts/ui/PartySetup.gd
@@ -1,0 +1,46 @@
+extends Control
+
+# Signals for card assignment (placeholders)
+signal card_assigned(member_index, card_slot, card_data)
+signal gear_equipped(member_index, gear_slot, gear_data)
+
+func _ready():
+	# Initialize party member slots (e.g., load character data)
+	# For now, we'll use placeholders
+	for i in range(1, 6):
+		var name_label = get_node_or_null("HBoxContainer/PartyMemberSlot" + str(i) + "/NameLabel" + str(i))
+		if name_label:
+			name_label.text = "Member " + str(i)
+
+		# Initialize other labels and placeholders as needed
+		var stats_label = get_node_or_null("HBoxContainer/PartyMemberSlot" + str(i) + "/StatsLabel" + str(i))
+		if stats_label:
+			# You can set default stats here if needed, or leave them as is from the scene file
+			pass
+
+		var cards_label = get_node_or_null("HBoxContainer/PartyMemberSlot" + str(i) + "/CardsLabel" + str(i))
+		if cards_label:
+			# You can set default cards info here
+			pass
+
+		var gear_label = get_node_or_null("HBoxContainer/PartyMemberSlot" + str(i) + "/GearLabel" + str(i))
+		if gear_label:
+			# You can set default gear info here
+			pass
+
+
+func _on_ready_button_pressed():
+	print("Ready button pressed")
+	# Transition to the dungeon map scene
+	# get_tree().change_scene_to_file("res://scenes/DungeonMap.tscn")
+
+# Placeholder functions for drag-and-drop card assignment
+# In a real implementation, these would handle drag data
+func _can_drop_data(position, data, member_index, card_slot_index):
+	# Check if data is a card and can be dropped here
+	return true # Placeholder
+
+func _drop_data(position, data, member_index, card_slot_index):
+	# Handle card drop, assign card to member
+	# emit_signal("card_assigned", member_index, card_slot_index, data)
+	print("Card dropped on member %d, slot %d" % [member_index, card_slot_index])

--- a/auto-battler/scripts/ui/RestScene.gd
+++ b/auto-battler/scripts/ui/RestScene.gd
@@ -1,0 +1,122 @@
+extends Control
+
+# Signal for when resting is complete and player continues
+signal rest_completed
+
+# References to UI elements
+@onready var party_status_grid: GridContainer = $VBoxContainer/PartyStatusGrid
+@onready var rest_progress_label: Label = $VBoxContainer/RestProgressLabel
+# Add @onready vars for food/drink buttons if they are dynamic
+
+# Placeholder for party data. In a real game, this would come from GameManager or PartyManager
+var party_members_data = {
+	"member1": {"name": "Alice", "hp": 80, "max_hp": 100, "hunger": 50, "max_hunger": 100, "thirst": 60, "max_thirst": 100, "fatigue": 30, "max_fatigue": 100},
+	"member2": {"name": "Bob", "hp": 90, "max_hp": 100, "hunger": 70, "max_hunger": 100, "thirst": 40, "max_thirst": 100, "fatigue": 20, "max_fatigue": 100},
+	"member3": {"name": "Charlie", "hp": 70, "max_hp": 100, "hunger": 60, "max_hunger": 100, "thirst": 50, "max_thirst": 100, "fatigue": 40, "max_fatigue": 100},
+	# Add up to 5 members
+}
+
+func _ready():
+	update_party_status_display()
+	# Hide progress label initially or manage its visibility during a "resting" state
+	rest_progress_label.visible = false
+
+func update_party_status_display():
+	var member_nodes = party_status_grid.get_children() # These are VBoxContainers
+	var member_keys = party_members_data.keys()
+	member_keys.sort() # Ensure consistent order if dictionary order changes
+
+	for i in range(member_nodes.size()):
+		var member_node_container = member_nodes[i]
+		var stat_label = member_node_container.get_node_or_null("Label") # Path to the Label inside VBoxContainer
+
+		if stat_label:
+			if i < member_keys.size():
+				var member_key = member_keys[i]
+				var data = party_members_data[member_key]
+				stat_label.text = "%s\nHP: %d/%d\nH: %d/%d\nT: %d/%d\nF: %d/%d" % [
+					data.name, data.hp, data.max_hp,
+					data.hunger, data.max_hunger,
+					data.thirst, data.max_thirst,
+					data.fatigue, data.max_fatigue
+				]
+				member_node_container.visible = true
+			else: # If no data for this slot, hide it
+				member_node_container.visible = false
+		else:
+			print("Error: Label node not found in PartyStatusGrid child: ", member_node_container.name)
+
+
+func _on_use_food_drink_pressed(item_effect_data: Dictionary):
+	# This is a simplified example.
+	# A real system would target a specific party member (e.g., via another UI element or game logic).
+	# For now, let's assume it applies to the first member or a selected member.
+	print("Use Food/Drink button pressed: ", item_effect_data)
+
+	# Example: Apply to the first member (if they exist)
+	if party_members_data.is_empty():
+		print("No party members to apply item to.")
+		return
+
+	var first_member_key = party_members_data.keys()[0] # This is not ideal, better to have a selected_member_key
+	# In a real game, you'd get the target member from UI selection or game context
+	var target_member_key = first_member_key
+
+	var stat_to_change = item_effect_data.get("target_stat", "hunger")
+	var value_change = item_effect_data.get("value", 0)
+	var max_stat_key = "max_" + stat_to_change
+
+	if party_members_data[target_member_key].has(stat_to_change) and party_members_data[target_member_key].has(max_stat_key):
+		party_members_data[target_member_key][stat_to_change] = min(
+			party_members_data[target_member_key][stat_to_change] + value_change,
+			party_members_data[target_member_key][max_stat_key]
+		)
+		update_party_status_display()
+		# You might want to consume the item from inventory here
+		# InventoryManager.consume_item(item_effect_data.name) # Assuming item_effect_data has a unique name/id
+		add_rest_log_entry("Applied %s to %s. New %s: %d" % [item_effect_data.get("name", "Item"), party_members_data[target_member_key].name, stat_to_change, party_members_data[target_member_key][stat_to_change]])
+	else:
+		add_rest_log_entry("Error: Stat '%s' or '%s' not found for %s." % [stat_to_change, max_stat_key, party_members_data[target_member_key].name])
+
+
+func add_rest_log_entry(log_text: String):
+	# Simulate showing a log entry, perhaps by making the progress label show it briefly
+	print("Rest Log: ", log_text)
+	rest_progress_label.text = log_text
+	rest_progress_label.visible = true
+	var timer = get_tree().create_timer(2.0) # Show log for 2 seconds
+	await timer.timeout
+	rest_progress_label.visible = false
+
+
+func _on_continue_button_pressed():
+	print("Continue button pressed from Rest Scene")
+	# Perform any final rest calculations (e.g., small passive recovery for all members)
+	# Example: Small fatigue recovery for everyone
+	for member_key in party_members_data:
+		if party_members_data[member_key].has("fatigue") and party_members_data[member_key].has("max_fatigue"):
+			party_members_data[member_key].fatigue = max(0, party_members_data[member_key].fatigue - 10) # Recover 10 fatigue
+
+	update_party_status_display() # Update display after final changes
+	add_rest_log_entry("Journey continues. Party is somewhat rested.")
+
+	await get_tree().create_timer(1.0).timeout # Brief pause to show final log
+
+	emit_signal("rest_completed")
+	# Transition to the next scene (e.g., DungeonMap or a post-rest summary)
+	# Example: get_tree().change_scene_to_file("res://scenes/DungeonMap.tscn")
+
+
+# Call this function if party data changes from an external source
+func set_party_data(new_party_data: Dictionary):
+	party_members_data = new_party_data.duplicate(true) # Make a deep copy
+	update_party_status_display()
+
+# Example of how to add a third member for testing
+func _add_test_member_data():
+	if !party_members_data.has("member3"):
+		party_members_data["member3"] = {"name": "Charlie", "hp": 70, "max_hp": 100, "hunger": 60, "max_hunger": 100, "thirst": 50, "max_thirst": 100, "fatigue": 40, "max_fatigue": 100}
+	# You might need to manually ensure PartyStatusGrid has enough VBoxContainer children
+	# or dynamically create them if party size can change.
+	# For this example, the .tscn file should already have 5 MemberXStats VBoxContainers.
+	update_party_status_display()

--- a/auto-battler/ui/CardViewer.tscn
+++ b/auto-battler/ui/CardViewer.tscn
@@ -1,0 +1,43 @@
+[gd_scene load_steps=2 format=3 uid="uid://cv1x0x7w7x0x3"]
+
+[ext_resource type="Script" path="res://scripts/ui/CardViewer.gd" id="1_abc12"]
+
+[node name="CardViewer" type="PanelContainer"]
+custom_minimum_size = Vector2(100, 150) # Example size
+script = ExtResource("1_abc12")
+focus_mode = Control.FOCUS_ALL # Allow focus for GUI input if needed by some interactions
+mouse_filter = Control.MOUSE_FILTER_STOP # Stop mouse events from passing through if it covers other elements
+
+[node name="VBoxContainer" type="VBoxContainer" parent="."]
+layout_mode = 2
+
+[node name="CardNameLabel" type="Label" parent="VBoxContainer"]
+layout_mode = 2
+text = "Card Name"
+horizontal_alignment = 1
+theme_override_font_sizes/font_size = 14 # Slightly larger for name
+
+[node name="CardArtTexture" type="TextureRect" parent="VBoxContainer"]
+layout_mode = 2
+size_flags_vertical = 3 # Art takes up available space
+expand_mode = 1
+stretch_mode = 5 # Keep aspect, fit
+# Add a placeholder color or texture if desired
+color = Color(0.8, 0.8, 0.8, 1) # Placeholder color for art area
+
+[node name="CardDescriptionLabel" type="Label" parent="VBoxContainer"]
+layout_mode = 2
+custom_minimum_size = Vector2(0, 30) # Ensure some space for description
+text = "Card effect description here."
+autowrap_mode = 3
+theme_override_font_sizes/font_size = 10 # Smaller for description
+
+[node name="CardCostLabel" type="Label" parent="VBoxContainer"]
+layout_mode = 2
+text = "Cost: 3"
+horizontal_alignment = 2 # Right align
+theme_override_font_sizes/font_size = 12
+
+[connection signal="gui_input" from="." to="." method="_on_gui_input"]
+[connection signal="mouse_entered" from="." to="." method="_on_mouse_entered"]
+[connection signal="mouse_exited" from="." to="." method="_on_mouse_exited"]

--- a/auto-battler/ui/EnemyPanel.tscn
+++ b/auto-battler/ui/EnemyPanel.tscn
@@ -1,0 +1,60 @@
+[gd_scene load_steps=2 format=3 uid="uid://em1x0x7w7x0x5"]
+
+[ext_resource type="Script" path="res://scripts/ui/EnemyPanel.gd" id="1_fghij"]
+
+[node name="EnemyPanel" type="PanelContainer"]
+custom_minimum_size = Vector2(100, 180)
+script = ExtResource("1_fghij")
+focus_mode = Control.FOCUS_ALL
+mouse_filter = Control.MOUSE_FILTER_STOP
+
+[node name="VBoxContainer" type="VBoxContainer" parent="."]
+layout_mode = 2
+
+[node name="NameLabel" type="Label" parent="VBoxContainer"]
+layout_mode = 2
+text = "Enemy Name"
+horizontal_alignment = 1
+theme_override_font_sizes/font_size = 14
+
+[node name="SpriteTexture" type="TextureRect" parent="VBoxContainer"] # Or Sprite2D if used in a 2D scene context
+layout_mode = 2
+custom_minimum_size = Vector2(0, 70) # Min height for sprite
+size_flags_vertical = 3
+expand_mode = 1
+stretch_mode = 5 # Keep aspect, fit
+color = Color(0.7, 0.7, 0.7, 1) # Placeholder color
+
+[node name="HpBar" type="ProgressBar" parent="VBoxContainer"]
+layout_mode = 2
+value = 50.0
+show_percentage = false
+theme_override_styles/fill = SubResource("StyleBoxFlat_enemyhpfill") # Placeholder for custom style
+
+
+[node name="HpLabel" type="Label" parent="VBoxContainer/HpBar"]
+layout_mode = 1
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+text = "50/50"
+horizontal_alignment = 1
+vertical_alignment = 1
+theme_override_colors/font_color = Color(1, 1, 1, 1) # White text
+theme_override_font_sizes/font_size = 10
+
+
+[node name="StatusEffectsBox" type="HBoxContainer" parent="VBoxContainer"]
+layout_mode = 2
+custom_minimum_size = Vector2(0, 20) # Min height for status icons
+alignment = 1
+# Add TextureRects here for buffs/debuffs
+
+[connection signal="gui_input" from="." to="." method="_on_gui_input"]
+[connection signal="mouse_entered" from="." to="." method="_on_mouse_entered"]
+[connection signal="mouse_exited" from="." to="." method="_on_mouse_exited"]
+
+[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_enemyhpfill"]
+bg_color = Color(0.6, 0.1, 0.1, 1) # Darker Red for enemy HP bar fill

--- a/auto-battler/ui/PartyMemberPanel.tscn
+++ b/auto-battler/ui/PartyMemberPanel.tscn
@@ -1,0 +1,70 @@
+[gd_scene load_steps=2 format=3 uid="uid://pm1x0x7w7x0x4"]
+
+[ext_resource type="Script" path="res://scripts/ui/PartyMemberPanel.gd" id="1_abcde"]
+
+[node name="PartyMemberPanel" type="PanelContainer"]
+custom_minimum_size = Vector2(120, 200)
+script = ExtResource("1_abcde")
+focus_mode = Control.FOCUS_ALL
+mouse_filter = Control.MOUSE_FILTER_STOP
+
+[node name="VBoxContainer" type="VBoxContainer" parent="."]
+layout_mode = 2
+
+[node name="NameLabel" type="Label" parent="VBoxContainer"]
+layout_mode = 2
+text = "Character Name"
+horizontal_alignment = 1
+theme_override_font_sizes/font_size = 14
+
+[node name="PortraitTexture" type="TextureRect" parent="VBoxContainer"]
+layout_mode = 2
+custom_minimum_size = Vector2(0, 80) # Min height for portrait
+size_flags_vertical = 3
+expand_mode = 1
+stretch_mode = 5 # Keep aspect, fit
+color = Color(0.7, 0.7, 0.7, 1) # Placeholder color
+
+[node name="HpBar" type="ProgressBar" parent="VBoxContainer"]
+layout_mode = 2
+value = 75.0 # Example value
+show_percentage = false
+theme_override_styles/fill = SubResource("StyleBoxFlat_hpbarfill") # Placeholder for custom style
+
+[node name="HpLabel" type="Label" parent="VBoxContainer/HpBar"] # Child of ProgressBar for overlay
+layout_mode = 1
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+text = "75/100"
+horizontal_alignment = 1
+vertical_alignment = 1
+theme_override_colors/font_color = Color(1, 1, 1, 1) # White text
+theme_override_font_sizes/font_size = 10
+
+[node name="RoleClassLabel" type="Label" parent="VBoxContainer"]
+layout_mode = 2
+text = "Warrior / Fighter"
+horizontal_alignment = 1
+theme_override_font_sizes/font_size = 11
+
+[node name="StatusEffectsBox" type="HBoxContainer" parent="VBoxContainer"]
+layout_mode = 2
+custom_minimum_size = Vector2(0, 20) # Min height for status icons
+alignment = 1 # Center status icons
+# Add TextureRects here for buffs/debuffs
+
+[node name="FatigueMeterLabel" type="Label" parent="VBoxContainer"] # Example for a survival meter
+layout_mode = 2
+text = "Fatigue: 20/100"
+horizontal_alignment = 1
+theme_override_font_sizes/font_size = 10
+
+[connection signal="gui_input" from="." to="." method="_on_gui_input"]
+[connection signal="mouse_entered" from="." to="." method="_on_mouse_entered"]
+[connection signal="mouse_exited" from="." to="." method="_on_mouse_exited"]
+
+[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_hpbarfill"]
+bg_color = Color(0.8, 0.2, 0.2, 1) # Red color for HP bar fill


### PR DESCRIPTION
This commit introduces the foundational UI structure for various game screens and components as outlined in the issue:

- MainMenu: Basic menu with title and navigation buttons.
- PartySetup: Layout for 5 party member slots with placeholder data display.
- DungeonMap: Scene for map node display and selection, plus a party status overlay.
- CombatScene: Layout for party, enemies, cards, combat log, and control buttons.
- InventoryCrafting: Panels for inventory grid, crafting slots, recipe info, and crafting log.
- RestScene: UI for party status display and using consumables during rest.
- LootPanel: Panel to display and collect loot items after encounters.
- Modular Components:
    - CardViewer: Reusable scene to display card details.
    - PartyMemberPanel: Reusable scene for party member information.
    - EnemyPanel: Reusable scene for enemy information.

All scenes are accompanied by GDScript files with stub functions and placeholder logic for future implementation. Signals for interactions are defined. The project's main scene has been updated to `MainMenu.tscn`.