### PR TITLE
Add event and trap system

### DIFF
--- a/auto-battler/scenes/EventPanel.tscn
+++ b/auto-battler/scenes/EventPanel.tscn
@@ -1,0 +1,33 @@
+[gd_scene load_steps=2 format=3]
+
+[ext_resource type="Script" path="res://scripts/ui/EventPanel.gd" id="1"]
+
+[node name="EventPanel" type="PanelContainer"]
+layout_mode = 3
+anchors_preset = 15
+anchor_left = 0.3
+anchor_top = 0.3
+anchor_right = 0.7
+anchor_bottom = 0.7
+grow_horizontal = 2
+grow_vertical = 2
+script = ExtResource("1")
+
+[node name="VBoxContainer" type="VBoxContainer" parent="."]
+layout_mode = 2
+alignment = 1
+
+[node name="DescriptionLabel" type="Label" parent="VBoxContainer"]
+layout_mode = 2
+text = "Event description"
+
+[node name="ResultLabel" type="Label" parent="VBoxContainer"]
+layout_mode = 2
+text = ""
+
+[node name="ConfirmButton" type="Button" parent="VBoxContainer"]
+layout_mode = 2
+text = "Continue"
+
+[connection signal="pressed" from="VBoxContainer/ConfirmButton" to="." method="_on_confirm_button_pressed"]
+

--- a/auto-battler/scripts/ui/EventPanel.gd
+++ b/auto-battler/scripts/ui/EventPanel.gd
@@ -1,0 +1,37 @@
+extends PanelContainer
+
+## Simple panel to display random events or traps.
+signal event_resolved
+
+@onready var description_label: Label = $VBoxContainer/DescriptionLabel
+@onready var result_label: Label = $VBoxContainer/ResultLabel
+@onready var confirm_button: Button = $VBoxContainer/ConfirmButton
+
+var event_data: Dictionary = {}
+var resolved: bool = false
+
+func show_event(data: Dictionary) -> void:
+    """Display an event description and optional skill check."""
+    event_data = data
+    description_label.text = data.get("description", "An event occurs.")
+    result_label.text = ""
+    confirm_button.text = data.get("skill_check", false) ? "Attempt" : "Continue"
+
+func _on_confirm_button_pressed() -> void:
+    if not resolved and event_data.get("skill_check", false):
+        _run_skill_check()
+    else:
+        emit_signal("event_resolved")
+        queue_free()
+
+func _run_skill_check() -> void:
+    var dc := int(event_data.get("dc", 10))
+    var roll := randi() % 20 + 1
+    if roll >= dc:
+        result_label.text = event_data.get("success_text", "Success!")
+    else:
+        result_label.text = event_data.get("fail_text", "Failure.")
+    resolved = true
+    confirm_button.text = "Continue"
+
+


### PR DESCRIPTION
## Summary
- introduce `EventPanel` scene and script for random events and skill checks
- update `DungeonMapManager` to generate `event` and `trap` nodes
- handle events with damage and simple skill checks

## Testing
- `godot --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f58677e6483278290adf69d0e06ed