### PR TITLE
Update all documentation

### DIFF
--- a/GAME_DESIGN.md
+++ b/GAME_DESIGN.md
@@ -138,10 +138,11 @@ Each class has access to:
 
 1. **Card Assignment Phase** – Player equips cards to each character
 2. **Enter Dungeon** – Procedural biome floors generated
-3. **Combat Phase** – Auto-battle executes based on speed and card AI logic
-4. **Post-Battle** – Gain loot, fatigue, hunger, thirst
-5. **Rest** – Use Food/Drink to recover, apply buffs
-6. **Continue or Exit** – Players may advance deeper or retreat to reset
+3. **Navigate Map** – Nodes may present combat, loot, random events, rest spots or traps
+4. **Combat Phase** – Auto-battle executes based on speed and card AI logic
+5. **Post-Battle** – Gain loot, fatigue, hunger, thirst
+6. **Rest** – Use Food/Drink to recover, apply buffs
+7. **Continue or Exit** – Players may advance deeper or retreat to reset
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@
 A tactical survival dungeon crawler with collectible card game (CCG) mechanics and auto-battler combat, built in Godot.  
 Players guide a party of adventurers through procedural dungeon biomes, surviving by managing hunger, thirst, fatigue, and tactical card resources.
 
+Navigation now runs through a simple dungeon map. Nodes may lead to combat, loot, random events, rest points, or traps. The `DungeonMapManager` script handles node generation and scene transitions.
+
 ---
 
 ## 🚀 Getting Started
@@ -39,3 +41,5 @@ When generating documentation, docstrings, or comments, base them on the termino
 ### Documentation
 
 Additional developer notes are available in [docs/TECHNICAL_OVERVIEW.md](docs/TECHNICAL_OVERVIEW.md). The full game design outline is in [GAME_DESIGN.md](GAME_DESIGN.md).
+
+This repository is a prototype for demonstration purposes. Many scenes and scripts are incomplete and subject to change.

--- a/auto-battler/README.md
+++ b/auto-battler/README.md
@@ -1,0 +1,4 @@
+# Auto-Battler Game Files
+
+This directory contains the Godot project resources for the Survival Dungeon CCG Auto-Battler prototype.
+Refer to the [root README](../README.md) for setup and usage instructions.

--- a/docs/TECHNICAL_OVERVIEW.md
+++ b/docs/TECHNICAL_OVERVIEW.md
@@ -11,7 +11,7 @@ auto-battler/
 ├─ scripts/     # GDScript sources
 │  ├─ combat/   # Combat manager and AI stubs
 │  ├─ data/     # Resource classes (CardData, EnemyData, etc.)
-│  ├─ main/        # Game and encounter managers
+│  ├─ main/        # Game, encounter and map managers
 │  ├─ preparation/ # Pre-combat party setup logic
 │  ├─ systems/     # Crafting, inventory and economy systems
 │  ├─ ui/       # UI controllers
@@ -48,6 +48,9 @@ Represents a specific crafting recipe, mapping input cards to an output card and
 
 ### PreparationManager
 `scripts/preparation/PreparationManager.gd` powers the pre-combat setup screen, letting players assign cards, equip gear and pick consumables before entering the dungeon.
+
+### DungeonMapManager
+`scripts/main/DungeonMapManager.gd` builds a chain of dungeon nodes. Each node can trigger combat, loot, a random event, a rest opportunity or a trap. The manager handles navigation and displays the appropriate panels.
 
 ### CraftingSystem
 `scripts/systems/CraftingSystem.gd` is a stub demonstrating how magical pouch crafting might work.  It selects a recipe based on up to five ingredient cards and emits a `crafted` signal with the result.


### PR DESCRIPTION
## Summary
- expand project overview to mention dungeon map
- note prototype status in README
- list `DungeonMapManager` and map nodes in technical overview
- describe map navigation in game design
- add readme to game files directory

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_683f5ad683a883279e91bcd6eb9e1d66