### PR TITLE
Add crafting profession and recipe resources

### DIFF
--- a/auto-battler/data/cards/HealingElixir.tres
+++ b/auto-battler/data/cards/HealingElixir.tres
@@ -1,0 +1,19 @@
+[gd_resource type="Resource" script_class="CardData" load_steps=2 format=3 uid="uid://healing_elixir_card"]
+
+[ext_resource type="Script" uid="uid://d28ph5bgy4xlp" path="res://scripts/data/CardData.gd" id="1_he"]
+
+[resource]
+script = ExtResource("1_he")
+card_name = "Healing Elixir"
+description = "Restores a small amount of health."
+card_type = 9
+role_restriction = "Any"
+class_restriction = "Any"
+effect_description = "Drink to heal minor wounds."
+rarity = 0
+icon_path = ""
+synergy_tags = Array[String]([])
+energy_cost = 0
+is_combo_starter = false
+is_combo_finisher = false
+metadata/_custom_type_script = "uid://d28ph5bgy4xlp"

--- a/auto-battler/data/cards/MushroomSoup.tres
+++ b/auto-battler/data/cards/MushroomSoup.tres
@@ -1,0 +1,19 @@
+[gd_resource type="Resource" script_class="CardData" load_steps=2 format=3 uid="uid://mushroom_soup_card"]
+
+[ext_resource type="Script" uid="uid://d28ph5bgy4xlp" path="res://scripts/data/CardData.gd" id="1_ms"]
+
+[resource]
+script = ExtResource("1_ms")
+card_name = "Mushroom Soup"
+description = "Warm soup made from mushrooms."
+card_type = 8
+role_restriction = "Any"
+class_restriction = "Any"
+effect_description = "Restores a small amount of health."
+rarity = 0
+icon_path = ""
+synergy_tags = Array[String]([])
+energy_cost = 0
+is_combo_starter = false
+is_combo_finisher = false
+metadata/_custom_type_script = "uid://d28ph5bgy4xlp"

--- a/auto-battler/data/cards/ReinforcedSword.tres
+++ b/auto-battler/data/cards/ReinforcedSword.tres
@@ -1,0 +1,19 @@
+[gd_resource type="Resource" script_class="CardData" load_steps=2 format=3 uid="uid://reinforced_sword_card"]
+
+[ext_resource type="Script" uid="uid://d28ph5bgy4xlp" path="res://scripts/data/CardData.gd" id="1_rs"]
+
+[resource]
+script = ExtResource("1_rs")
+card_name = "Reinforced Sword"
+description = "Sturdier than a basic blade."
+card_type = 6
+role_restriction = "Any"
+class_restriction = "Any"
+effect_description = "Deals increased melee damage."
+rarity = 0
+icon_path = ""
+synergy_tags = Array[String]([])
+energy_cost = 0
+is_combo_starter = false
+is_combo_finisher = false
+metadata/_custom_type_script = "uid://d28ph5bgy4xlp"

--- a/auto-battler/data/professions/Alchemy.tres
+++ b/auto-battler/data/professions/Alchemy.tres
@@ -1,0 +1,16 @@
+[gd_resource type="Resource" script_class="ProfessionData" load_steps=2 format=3 uid="uid://profession_alchemy"]
+
+[ext_resource type="Script" uid="uid://dsqh2gx7jt5cq" path="res://scripts/data/ProfessionData.gd" id="1_alch"]
+[ext_resource type="Resource" path="res://data/recipes/HealingElixir.tres" id="2_he_recipe"]
+
+[resource]
+script = ExtResource("1_alch")
+profession_name = "Alchemy"
+description = "Brews elixirs and utility items"
+max_level = 10
+current_level = 1
+known_recipes = [ExtResource("2_he_recipe")]
+crafting_bonus = 0.0
+exclusive_cards = []
+crafted_by_tag = "Alchemist"
+metadata/_custom_type_script = "uid://dsqh2gx7jt5cq"

--- a/auto-battler/data/professions/Cooking.tres
+++ b/auto-battler/data/professions/Cooking.tres
@@ -1,0 +1,16 @@
+[gd_resource type="Resource" script_class="ProfessionData" load_steps=2 format=3 uid="uid://profession_cooking"]
+
+[ext_resource type="Script" uid="uid://dsqh2gx7jt5cq" path="res://scripts/data/ProfessionData.gd" id="1_cook"]
+[ext_resource type="Resource" path="res://data/recipes/MushroomSoup.tres" id="2_msh"]
+
+[resource]
+script = ExtResource("1_cook")
+profession_name = "Cooking"
+description = "Creates food and drink cards"
+max_level = 10
+current_level = 1
+known_recipes = [ExtResource("2_msh")]
+crafting_bonus = 0.0
+exclusive_cards = []
+crafted_by_tag = "Chef"
+metadata/_custom_type_script = "uid://dsqh2gx7jt5cq"

--- a/auto-battler/data/professions/Smithing.tres
+++ b/auto-battler/data/professions/Smithing.tres
@@ -1,0 +1,16 @@
+[gd_resource type="Resource" script_class="ProfessionData" load_steps=2 format=3 uid="uid://profession_smithing"]
+
+[ext_resource type="Script" uid="uid://dsqh2gx7jt5cq" path="res://scripts/data/ProfessionData.gd" id="1_smith"]
+[ext_resource type="Resource" path="res://data/recipes/ReinforcedSword.tres" id="2_rs_recipe"]
+
+[resource]
+script = ExtResource("1_smith")
+profession_name = "Smithing"
+description = "Creates and upgrades equipment"
+max_level = 10
+current_level = 1
+known_recipes = [ExtResource("2_rs_recipe")]
+crafting_bonus = 0.0
+exclusive_cards = []
+crafted_by_tag = "Blacksmith"
+metadata/_custom_type_script = "uid://dsqh2gx7jt5cq"

--- a/auto-battler/data/recipes/HealingElixir.tres
+++ b/auto-battler/data/recipes/HealingElixir.tres
@@ -1,0 +1,15 @@
+[gd_resource type="Resource" script_class="RecipeData" load_steps=2 format=3 uid="uid://healing_elixir_recipe"]
+
+[ext_resource type="Script" uid="uid://bu61k6ltodatl" path="res://scripts/data/RecipeData.gd" id="1_herecipe"]
+[ext_resource type="Resource" path="res://data/cards/HealingElixir.tres" id="2_he_card"]
+
+[resource]
+script = ExtResource("1_herecipe")
+recipe_name = "Healing Elixir"
+input_cards = ["Herb", "Water"]
+output_card = ExtResource("2_he_card")
+profession_required = "Alchemy"
+level_required = 1
+synergy_tags = Array[String]([])
+discovered = true
+metadata/_custom_type_script = "uid://bu61k6ltodatl"

--- a/auto-battler/data/recipes/MushroomSoup.tres
+++ b/auto-battler/data/recipes/MushroomSoup.tres
@@ -1,0 +1,15 @@
+[gd_resource type="Resource" script_class="RecipeData" load_steps=2 format=3 uid="uid://mushroom_soup_recipe"]
+
+[ext_resource type="Script" uid="uid://bu61k6ltodatl" path="res://scripts/data/RecipeData.gd" id="1_msrecipe"]
+[ext_resource type="Resource" path="res://data/cards/MushroomSoup.tres" id="2_ms_card"]
+
+[resource]
+script = ExtResource("1_msrecipe")
+recipe_name = "Mushroom Soup"
+input_cards = ["Mushroom", "Water"]
+output_card = ExtResource("2_ms_card")
+profession_required = "Cooking"
+level_required = 1
+synergy_tags = Array[String]([])
+discovered = true
+metadata/_custom_type_script = "uid://bu61k6ltodatl"

--- a/auto-battler/data/recipes/ReinforcedSword.tres
+++ b/auto-battler/data/recipes/ReinforcedSword.tres
@@ -1,0 +1,15 @@
+[gd_resource type="Resource" script_class="RecipeData" load_steps=2 format=3 uid="uid://reinforced_sword_recipe"]
+
+[ext_resource type="Script" uid="uid://bu61k6ltodatl" path="res://scripts/data/RecipeData.gd" id="1_rsrecipe"]
+[ext_resource type="Resource" path="res://data/cards/ReinforcedSword.tres" id="2_rs_card"]
+
+[resource]
+script = ExtResource("1_rsrecipe")
+recipe_name = "Reinforced Sword"
+input_cards = ["Iron Ore", "Wood"]
+output_card = ExtResource("2_rs_card")
+profession_required = "Smithing"
+level_required = 1
+synergy_tags = Array[String]([])
+discovered = true
+metadata/_custom_type_script = "uid://bu61k6ltodatl"


### PR DESCRIPTION
## Summary
- generate sample `CardData` .tres assets for Mushroom Soup, Reinforced Sword and Healing Elixir
- generate `RecipeData` .tres resources using the cards above
- create `ProfessionData` .tres files for Cooking, Smithing and Alchemy

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_683f720bcbe88327940377c80fac642e