### PR TITLE
Add basic UI scenes and scripts

### DIFF
--- a/auto-battler/scenes/CombatScene.tscn
+++ b/auto-battler/scenes/CombatScene.tscn
@@ -1,137 +1,50 @@
-[gd_scene load_steps=2 format=3 uid="uid://cqx705wscy5vt"]
+[gd_scene load_steps=2 format=3]
 
-[ext_resource type="Script" uid="uid://c5qpnq7d2jtrt" path="res://scripts/combat/CombatScene.gd" id="1_klmno"]
+[ext_resource type="Script" path="res://scripts/combat/CombatScene.gd" id="1"]
 
 [node name="CombatScene" type="Control"]
-layout_mode = 3
-anchors_preset = 15
 anchor_right = 1.0
 anchor_bottom = 1.0
-grow_horizontal = 2
-grow_vertical = 2
-script = ExtResource("1_klmno")
+script = ExtResource("1")
 
-[node name="Main 전투 Layout" type="VBoxContainer" parent="."]
-layout_mode = 1
-anchors_preset = 15
+[node name="TopBar" type="HBoxContainer" parent="."]
 anchor_right = 1.0
-anchor_bottom = 1.0
-grow_horizontal = 2
-grow_vertical = 2
 
-[node name="TopBar" type="HBoxContainer" parent="Main 전투 Layout"]
-layout_mode = 2
-alignment = 2
-"#Aligntotherightforpause/speedbuttons[nodename" = "PauseButton"
-type = "Button"
-parent = "Main 전투 Layout/TopBar"
-"]layout_mode" = 2
+[node name="PauseButton" type="Button" parent="TopBar"]
 text = "Pause"
 
-[node name="SpeedUpButton" type="Button" parent="Main 전투 Layout/TopBar"]
-layout_mode = 2
-text = "Speed Up x1"
+[node name="SpeedUpButton" type="Button" parent="TopBar"]
+text = "Speed x1"
 
-[node name="BattleArea" type="HBoxContainer" parent="Main 전투 Layout"]
-layout_mode = 2
-size_flags_vertical = 3
-#Makethisareatakemostoftheverticalspacealignment = 1
-"#Centerchildren[nodename" = "PartyPanel"
-type = "VBoxContainer"
-parent = "Main 전투 Layout/BattleArea"
-"]layout_mode" = 2
-size_flags_horizontal = 3
-#Partytakesupsomespacealignment = 1
-"#PlaceholderforPartyMemberPanelinstances[nodename" = "PartyMember1"
-type = "PanelContainer"
-parent = "Main 전투 Layout/BattleArea/PartyPanel"
-"]layout_mode" = 2
-"#childwillbePartyMemberPanel.tscninstance[nodename" = "Label"
-type = "Label"
-parent = "Main 전투 Layout/BattleArea/PartyPanel/PartyMember1"
-"]layout_mode" = 2
-text = "Party Member 1
-HP: 100/100
-Fatigue: 0"
-horizontal_alignment = 1
-vertical_alignment = 1
+[node name="PartyPanel" type="VBoxContainer" parent="."]
+margin_top = 40
+custom_minimum_size = Vector2(0,150)
 
-[node name="EnemyPanel" type="VBoxContainer" parent="Main 전투 Layout/BattleArea"]
-layout_mode = 2
-size_flags_horizontal = 3
-#Enemiestakeupsomespacealignment = 1
-"#PlaceholderforEnemyPanel.tscninstances[nodename" = "Enemy1"
-type = "PanelContainer"
-parent = "Main 전투 Layout/BattleArea/EnemyPanel"
-"]layout_mode" = 2
-"#childwillbeEnemyPanel.tscninstance[nodename" = "Label"
-type = "Label"
-parent = "Main 전투 Layout/BattleArea/EnemyPanel/Enemy1"
-"]layout_mode" = 2
-text = "Enemy 1
-HP: 50/50"
-horizontal_alignment = 1
-vertical_alignment = 1
+[node name="EnemyPanel" type="VBoxContainer" parent="."]
+margin_top = 200
+custom_minimum_size = Vector2(0,150)
 
-[node name="CharacterCardsArea" type="HBoxContainer" parent="Main 전투 Layout"]
-layout_mode = 2
-custom_minimum_size = Vector2(0, 100)
-#Minheightforcarddisplayareaalignment = 1
-"#Placeholderforactivecharacter'scards(CardViewer.tscninstances)[nodename" = "Card1"
-type = "PanelContainer"
-parent = "Main 전투 Layout/CharacterCardsArea"
-"]layout_mode" = 2
-"#childwillbeCardViewer.tscninstance[nodename" = "Label"
-type = "Label"
-parent = "Main 전투 Layout/CharacterCardsArea/Card1"
-"]layout_mode" = 2
-text = "Card 1 Name"
-horizontal_alignment = 1
-vertical_alignment = 1
+[node name="CharacterCardsArea" type="HBoxContainer" parent="."]
+margin_top = 360
+custom_minimum_size = Vector2(0,100)
 
-[node name="CombatLogPanel" type="PanelContainer" parent="Main 전투 Layout"]
-layout_mode = 2
-custom_minimum_size = Vector2(0, 150)
-"#Minheightforcombatlog[nodename" = "CombatLogScroll"
-type = "ScrollContainer"
-parent = "Main 전투 Layout/CombatLogPanel"
-"]layout_mode" = 2
-horizontal_scroll_mode = 0
-"#Disablehorizontalscroll[nodename" = "CombatLog"
-type = "VBoxContainer"
-parent = "Main 전투 Layout/CombatLogPanel/CombatLogScroll"
-"]layout_mode" = 2
-size_flags_horizontal = 3
-"#Expandtofillscrollcontainerwidth[nodename" = "LogEntry1"
-type = "Label"
-parent = "Main 전투 Layout/CombatLogPanel/CombatLogScroll/CombatLog"
-"]layout_mode" = 2
-text = "Combat Started!"
-autowrap_mode = 3
-"#Wordwrap[nodename" = "VisualFeedbackLabel"
-type = "Label"
-parent = "."
-Heal!#Positionitinthecenterofthescreenorovercharacterslayout_mode = 1
-anchors_preset = 8
+[node name="CombatLogPanel" type="PanelContainer" parent="."]
+margin_top = 470
+custom_minimum_size = Vector2(0,150)
+
+[node name="CombatLogScroll" type="ScrollContainer" parent="CombatLogPanel"]
+[node name="CombatLog" type="VBoxContainer" parent="CombatLogScroll"]
+
+[node name="FeedbackLabel" type="Label" parent="."]
 anchor_left = 0.5
-anchor_top = 0.5
 anchor_right = 0.5
+anchor_top = 0.5
 anchor_bottom = 0.5
-offset_left = -50.0
-offset_top = -15.0
-offset_right = 50.0
-offset_bottom = 15.0
-grow_horizontal = 2
-grow_vertical = 2
-text = "Feedback!"
-horizontal_alignment = 1
-vertical_alignment = 1
+offset_left = -60
+offset_right = 60
+offset_top = -20
+offset_bottom = 20
 visible = false
-"#Initiallyhidden[connectionsignal" = "pressed"
-from = "Main 전투 Layout/TopBar/PauseButton"
-to = "."
-method = "_on_pause_button_pressed"
-"][connectionsignal" = "pressed"
-from = "Main 전투 Layout/TopBar/SpeedUpButton"
-to = "."
-method = "_on_speed_up_button_pressed"
+
+[connection signal="pressed" from="TopBar/PauseButton" to="." method="_on_pause_button_pressed"]
+[connection signal="pressed" from="TopBar/SpeedUpButton" to="." method="_on_speed_up_button_pressed"]

--- a/auto-battler/scenes/DungeonMap.tscn
+++ b/auto-battler/scenes/DungeonMap.tscn
@@ -1,47 +1,41 @@
-[gd_scene load_steps=2 format=3 uid="uid://b201p5jvvtfib"]
+[gd_scene load_steps=2 format=3]
 
-[ext_resource type="Script" uid="uid://io8v7vjm8uk7" path="res://scripts/main/DungeonMapManager.gd" id="1"]
+[ext_resource type="Script" path="res://scripts/ui/DungeonMap.gd" id="1"]
 
 [node name="DungeonMap" type="Control"]
-script = ExtResource("1")
-layout_mode = 3
-anchors_preset = 15
 anchor_right = 1.0
 anchor_bottom = 1.0
-grow_horizontal = 2
-grow_vertical = 2
+script = ExtResource("1")
 
 [node name="MapNodesContainer" type="HBoxContainer" parent="."]
-layout_mode = 1
-anchors_preset = 8
 anchor_left = 0.5
 anchor_top = 0.5
 anchor_right = 0.5
 anchor_bottom = 0.5
 offset_left = -200
-offset_top = -50
 offset_right = 200
+offset_top = -50
 offset_bottom = 50
-grow_horizontal = 2
-grow_vertical = 2
 alignment = 1
 
 [node name="PartyStatusOverlay" type="VBoxContainer" parent="."]
-layout_mode = 0
-offset_right = 150
-offset_bottom = 200
+anchor_left = 0.0
+anchor_top = 0.0
+anchor_right = 0.0
+anchor_bottom = 0.0
+custom_minimum_size = Vector2(150, 0)
 
 [node name="Member1Status" type="Label" parent="PartyStatusOverlay"]
-text = "Member 1: HP 100/100, F:100, W:100, E:100"
+text = "Member 1"
 
 [node name="Member2Status" type="Label" parent="PartyStatusOverlay"]
-text = "Member 2: HP 100/100, F:100, W:100, E:100"
+text = "Member 2"
 
 [node name="Member3Status" type="Label" parent="PartyStatusOverlay"]
-text = "Member 3: HP 100/100, F:100, W:100, E:100"
+text = "Member 3"
 
 [node name="Member4Status" type="Label" parent="PartyStatusOverlay"]
-text = "Member 4: HP 100/100, F:100, W:100, E:100"
+text = "Member 4"
 
 [node name="Member5Status" type="Label" parent="PartyStatusOverlay"]
-text = "Member 5: HP 100/100, F:100, W:100, E:100"
+text = "Member 5"

--- a/auto-battler/scenes/LootPanel.tscn
+++ b/auto-battler/scenes/LootPanel.tscn
@@ -1,80 +1,26 @@
-[gd_scene load_steps=2 format=3 uid="uid://dxylqx7w7x0x2"]
+[gd_scene load_steps=2 format=3]
 
-[ext_resource type="Script" uid="uid://d222suaqeiq8l" path="res://scripts/ui/LootPanel.gd" id="1_yzabc"]
+[ext_resource type="Script" path="res://scripts/ui/LootPanel.gd" id="1"]
 
 [node name="LootPanel" type="PanelContainer"]
-#ChangedroottoPanelContainerforbettertheming/backgroundlayout_mode = 3
-anchors_preset = 15
-anchor_left = 0.25
-#Example:Centeritabitmoreanchor_top = 0.25
 anchor_right = 0.75
+anchor_left = 0.25
+anchor_top = 0.25
 anchor_bottom = 0.75
-grow_horizontal = 2
-grow_vertical = 2
-script = ExtResource("1_yzabc")
+script = ExtResource("1")
 
-[node name="VBoxContainer" type="VBoxContainer" parent="."]
-layout_mode = 2
+[node name="VBox" type="VBoxContainer" parent="."]
 alignment = 1
 
-[node name="TitleLabel" type="Label" parent="VBoxContainer"]
-layout_mode = 2
-text = "Loot & Rewards"
+[node name="TitleLabel" type="Label" parent="VBox"]
+text = "Loot"
 horizontal_alignment = 1
-theme_override_font_sizes/font_size = 24
-"#Maketitlebigger[nodename" = "LootScrollContainer"
-type = "ScrollContainer"
-parent = "VBoxContainer"
-"]layout_mode" = 2
-size_flags_vertical = 3
-#Makescrollcontainertakeavailableverticalspacehorizontal_scroll_mode = 0
-#Disablehorizontalscrollifitemsarestackedverticallycustom_minimum_size = Vector2(0, 150)
-"#Ensureithassomeminheight[nodename" = "LootList"
-type = "VBoxContainer"
-parent = "VBoxContainer/LootScrollContainer"
-"]layout_mode" = 2
-size_flags_horizontal = 3
-"#Lootitemswillfillwidth#ExampleLootItemEntry(Thiswouldideallybeareusablesceneinstance)#Thescriptwillpopulatethisareadynamically.#Keepingoneexampleforstructurereference,thoughscriptwillclearit.[nodename" = "LootItemEntry1"
-type = "HBoxContainer"
-parent = "VBoxContainer/LootScrollContainer/LootList"
-"]layout_mode" = 2
-custom_minimum_size = Vector2(0, 50)
-#Minheightforanitementryvisible = false
-"#Initiallyinvisible,scriptwillhandlepopulation[nodename" = "ItemIcon"
-type = "TextureRect"
-parent = "VBoxContainer/LootScrollContainer/LootList/LootItemEntry1"
-"]#Placeholderforitemiconcustom_minimum_size" = Vector2(40, 40)
-layout_mode = 2
-expand_mode = 1
-#Orkeepaspectratioifneededstretch_mode = 5
-#Scaletofitcolor = Color(0.5, 0.5, 0.5, 1)
-"#Placeholdercolor[nodename" = "ItemDetails"
-type = "VBoxContainer"
-parent = "VBoxContainer/LootScrollContainer/LootList/LootItemEntry1"
-"]layout_mode" = 2
-size_flags_horizontal = 3
-"#Detailstakeremainingspace[nodename" = "ItemNameLabel"
-type = "Label"
-parent = "VBoxContainer/LootScrollContainer/LootList/LootItemEntry1/ItemDetails"
-"]layout_mode" = 2
-text = "Magic Sword (Rare)"
 
-[node name="ItemTagsLabel" type="Label" parent="VBoxContainer/LootScrollContainer/LootList/LootItemEntry1/ItemDetails"]
-layout_mode = 2
-text = "Crafted by: Player1"
-theme_override_font_sizes/font_size = 12
-"#Smallerfortags[nodename" = "AddButton"
-type = "Button"
-parent = "VBoxContainer/LootScrollContainer/LootList/LootItemEntry1"
-"]layout_mode" = 2
-size_flags_vertical = 4
-#CenterbuttonverticallyifHBoxallowstext = "Add to Inventory"
-"#Thisbutton'spressedsignalwouldbeconnectedinscriptwhenitemisadded[nodename" = "CloseButton"
-type = "Button"
-parent = "VBoxContainer"
-"]layout_mode" = 2
-text = "Close / Take All"
-"#Thisbuttonmighttakeallitemsandthenclose,orjustcloseifitemsareaddedindividually[connectionsignal" = "pressed"
-from = "VBoxContainer/CloseButton"
-to = "."
-method = "_on_close_button_pressed"
+[node name="LootScroll" type="ScrollContainer" parent="VBox"]
+size_flags_vertical = 3
+[node name="LootList" type="VBoxContainer" parent="LootScroll"]
+
+[node name="CloseButton" type="Button" parent="VBox"]
+text = "Take All"
+
+[connection signal="pressed" from="CloseButton" to="." method="_on_close_button_pressed"]

--- a/auto-battler/scenes/MainMenu.tscn
+++ b/auto-battler/scenes/MainMenu.tscn
@@ -1,58 +1,40 @@
-[gd_scene load_steps=2 format=3 uid="uid://bu2y7p7x0d5g1"]
+[gd_scene load_steps=2 format=3]
 
-[ext_resource type="Script" uid="uid://b22edasq1nnfq" path="res://scripts/ui/MainMenu.gd" id="1_2vj2a"]
+[ext_resource type="Script" path="res://scripts/ui/MainMenu.gd" id="1"]
 
 [node name="MainMenu" type="Control"]
-layout_mode = 3
-anchors_preset = 15
 anchor_right = 1.0
 anchor_bottom = 1.0
-grow_horizontal = 2
-grow_vertical = 2
-script = ExtResource("1_2vj2a")
+script = ExtResource("1")
 
-[node name="VBoxContainer" type="VBoxContainer" parent="."]
-layout_mode = 1
-anchors_preset = 8
+[node name="VBox" type="VBoxContainer" parent="."]
 anchor_left = 0.5
 anchor_top = 0.5
 anchor_right = 0.5
 anchor_bottom = 0.5
-offset_left = -100.0
-offset_top = -100.0
-offset_right = 100.0
-offset_bottom = 100.0
-grow_horizontal = 2
-grow_vertical = 2
+offset_left = -150
+offset_top = -200
+offset_right = 150
+offset_bottom = 200
 alignment = 1
 
-[node name="TitleLabel" type="Label" parent="VBoxContainer"]
-layout_mode = 2
+[node name="TitleLabel" type="Label" parent="VBox"]
 text = "Game Title"
 horizontal_alignment = 1
 
-[node name="StartButton" type="Button" parent="VBoxContainer"]
-layout_mode = 2
+[node name="StartButton" type="Button" parent="VBox"]
 text = "Start Game"
 
-[node name="ContinueButton" type="Button" parent="VBoxContainer"]
-layout_mode = 2
+[node name="ContinueButton" type="Button" parent="VBox"]
 text = "Continue"
 
-[node name="SettingsButton" type="Button" parent="VBoxContainer"]
-layout_mode = 2
+[node name="SettingsButton" type="Button" parent="VBox"]
 text = "Settings"
 
-[node name="CreditsButton" type="Button" parent="VBoxContainer"]
-layout_mode = 2
-text = "Credits"
-
-[node name="ExitButton" type="Button" parent="VBoxContainer"]
-layout_mode = 2
+[node name="ExitButton" type="Button" parent="VBox"]
 text = "Exit"
 
-[connection signal="pressed" from="VBoxContainer/StartButton" to="." method="_on_start_button_pressed"]
-[connection signal="pressed" from="VBoxContainer/ContinueButton" to="." method="_on_continue_button_pressed"]
-[connection signal="pressed" from="VBoxContainer/SettingsButton" to="." method="_on_settings_button_pressed"]
-[connection signal="pressed" from="VBoxContainer/CreditsButton" to="." method="_on_credits_button_pressed"]
-[connection signal="pressed" from="VBoxContainer/ExitButton" to="." method="_on_exit_button_pressed"]
+[connection signal="pressed" from="VBox/StartButton" to="." method="_on_start_button_pressed"]
+[connection signal="pressed" from="VBox/ContinueButton" to="." method="_on_continue_button_pressed"]
+[connection signal="pressed" from="VBox/SettingsButton" to="." method="_on_settings_button_pressed"]
+[connection signal="pressed" from="VBox/ExitButton" to="." method="_on_exit_button_pressed"]

--- a/auto-battler/scenes/PreparationScene.tscn
+++ b/auto-battler/scenes/PreparationScene.tscn
@@ -1,11 +1,25 @@
-[gd_scene load_steps=2 format=3 uid="uid://tduowt4vqxrh"]
+[gd_scene load_steps=2 format=3]
 
-[ext_resource type="Script" uid="uid://1m17alwsg3ty" path="res://scripts/preparation/PreparationManager.gd" id="1"]
+[ext_resource type="Script" path="res://scripts/ui/PreparationScene.gd" id="1"]
 
-[node name="Preparation" type="Control"]
+[node name="PreparationScene" type="Control"]
+anchor_right = 1.0
+anchor_bottom = 1.0
 script = ExtResource("1")
 
-[node name="EnterDungeonButton" type="Button" parent="."]
-text = "Enter Dungeon"
+[node name="PartyPanel" type="GridContainer" parent="."]
+columns = 5
 
-[connection signal="pressed" from="EnterDungeonButton" to="." method="_on_EnterDungeonButton_pressed"]
+[node name="CardSelectPanel" type="VBoxContainer" parent="."]
+margin_top = 220
+custom_minimum_size = Vector2(0, 150)
+
+[node name="GearSelectPanel" type="VBoxContainer" parent="."]
+margin_top = 380
+custom_minimum_size = Vector2(0, 150)
+
+[node name="ReadyButton" type="Button" parent="."]
+text = "Enter Dungeon"
+margin_top = 560
+
+[connection signal="pressed" from="ReadyButton" to="." method="_on_ready_button_pressed"]

--- a/auto-battler/scenes/RestScene.tscn
+++ b/auto-battler/scenes/RestScene.tscn
@@ -1,127 +1,30 @@
-[gd_scene load_steps=2 format=3 uid="uid://cyxrqx7w7x0x1"]
+[gd_scene load_steps=2 format=3]
 
-[ext_resource type="Script" uid="uid://6aj40qujtdu2" path="res://scripts/ui/RestScene.gd" id="1_tuvwx"]
+[ext_resource type="Script" path="res://scripts/ui/RestScene.gd" id="1"]
 
 [node name="RestScene" type="Control"]
-layout_mode = 3
-anchors_preset = 15
 anchor_right = 1.0
 anchor_bottom = 1.0
-grow_horizontal = 2
-grow_vertical = 2
-script = ExtResource("1_tuvwx")
+script = ExtResource("1")
 
-[node name="VBoxContainer" type="VBoxContainer" parent="."]
-layout_mode = 1
-anchors_preset = 15
+[node name="VBox" type="VBoxContainer" parent="."]
 anchor_right = 1.0
 anchor_bottom = 1.0
-grow_horizontal = 2
-grow_vertical = 2
 alignment = 1
 
-[node name="TitleLabel" type="Label" parent="VBoxContainer"]
-layout_mode = 2
-text = "Rest Area"
+[node name="TitleLabel" type="Label" parent="VBox"]
+text = "Rest"
 horizontal_alignment = 1
 
-[node name="PartyStatusGrid" type="GridContainer" parent="VBoxContainer"]
-layout_mode = 2
+[node name="PartyStatusGrid" type="GridContainer" parent="VBox"]
 columns = 5
-#Onecolumnperpartymemberalignment = 1
-"#PlaceholderforPartyMemberStatusdisplayinrestscene[nodename" = "Member1Stats"
-type = "VBoxContainer"
-parent = "VBoxContainer/PartyStatusGrid"
-"]layout_mode" = 2
-size_flags_horizontal = 3
+custom_minimum_size = Vector2(0,150)
 
-[node name="Label" type="Label" parent="VBoxContainer/PartyStatusGrid/Member1Stats"]
-layout_mode = 2
-text = "Member 1
-HP: 80/100
-H: 50/100
-T: 60/100
-F: 30/100"
-#Hunger,Thirst,Fatiguehorizontal_alignment = 1
+[node name="RestProgressLabel" type="Label" parent="VBox"]
+text = "Resting..."
+visible = false
 
-[node name="Member2Stats" type="VBoxContainer" parent="VBoxContainer/PartyStatusGrid"]
-layout_mode = 2
-size_flags_horizontal = 3
+[node name="ContinueButton" type="Button" parent="VBox"]
+text = "Continue"
 
-[node name="Label" type="Label" parent="VBoxContainer/PartyStatusGrid/Member2Stats"]
-layout_mode = 2
-text = "Member 2
-HP: -/-
-H: -/-
-T: -/-
-F: -/-"
-horizontal_alignment = 1
-
-[node name="Member3Stats" type="VBoxContainer" parent="VBoxContainer/PartyStatusGrid"]
-layout_mode = 2
-size_flags_horizontal = 3
-
-[node name="Label" type="Label" parent="VBoxContainer/PartyStatusGrid/Member3Stats"]
-layout_mode = 2
-text = "Member 3
-HP: -/-
-H: -/-
-T: -/-
-F: -/-"
-horizontal_alignment = 1
-
-[node name="Member4Stats" type="VBoxContainer" parent="VBoxContainer/PartyStatusGrid"]
-layout_mode = 2
-size_flags_horizontal = 3
-
-[node name="Label" type="Label" parent="VBoxContainer/PartyStatusGrid/Member4Stats"]
-layout_mode = 2
-text = "Member 4
-HP: -/-
-H: -/-
-T: -/-
-F: -/-"
-horizontal_alignment = 1
-
-[node name="Member5Stats" type="VBoxContainer" parent="VBoxContainer/PartyStatusGrid"]
-layout_mode = 2
-size_flags_horizontal = 3
-
-[node name="Label" type="Label" parent="VBoxContainer/PartyStatusGrid/Member5Stats"]
-layout_mode = 2
-text = "Member 5
-HP: -/-
-H: -/-
-T: -/-
-F: -/-"
-horizontal_alignment = 1
-
-[node name="FoodDrinkPanel" type="HBoxContainer" parent="VBoxContainer"]
-layout_mode = 2
-alignment = 1
-
-[node name="FoodLabel" type="Label" parent="VBoxContainer/FoodDrinkPanel"]
-layout_mode = 2
-text = "Available Food/Drink:"
-
-[node name="FoodCard1Button" type="Button" parent="VBoxContainer/FoodDrinkPanel"]
-layout_mode = 2
-text = "Use Ration (H+20)"
-"#CorrectedtoHforHungerbasedonscript#Addmorefood/drinkcardbuttonsoralisthere[nodename" = "RestProgressLabel"
-type = "Label"
-parent = "VBoxContainer"
-"]layout_mode" = 2
-text = "Resting... (Placeholder Animation)"
-horizontal_alignment = 1
-
-[node name="ContinueButton" type="Button" parent="VBoxContainer"]
-layout_mode = 2
-text = "Continue Journey"
-
-[connection signal="pressed" from="VBoxContainer/FoodDrinkPanel/FoodCard1Button" to="." method="_on_use_food_drink_pressed" binds= [{
-"name": "Ration",
-"target_stat": "hunger",
-"type": "food",
-"value": 20
-}]]
-[connection signal="pressed" from="VBoxContainer/ContinueButton" to="." method="_on_continue_button_pressed"]
+[connection signal="pressed" from="ContinueButton" to="." method="_on_continue_button_pressed"]

--- a/auto-battler/scripts/combat/CombatScene.gd
+++ b/auto-battler/scripts/combat/CombatScene.gd
@@ -1,19 +1,30 @@
 extends Control
 
+signal combat_finished
+
 var is_paused = false
 var current_speed = 1.0
 const SPEED_LEVELS = [1.0, 1.5, 2.0]
 var current_speed_index = 0
 
-# References to UI elements that need updating (assign in _ready or via editor)
-@onready var party_panel: VBoxContainer = $"Main 전투 Layout/BattleArea/PartyPanel"
-@onready var enemy_panel: VBoxContainer = $"Main 전투 Layout/BattleArea/EnemyPanel"
-@onready var character_cards_area: HBoxContainer = $"Main 전투 Layout/CharacterCardsArea"
-@onready var combat_log_container: VBoxContainer = $"Main 전투 Layout/CombatLogPanel/CombatLogScroll/CombatLog"
-@onready var feedback_label: Label = $VisualFeedbackLabel
-@onready var speed_up_button: Button = $"Main 전투 Layout/TopBar/SpeedUpButton"
-@onready var pause_button: Button = $"Main 전투 Layout/TopBar/PauseButton"
-@onready var combat_log_scroll: ScrollContainer = $"Main 전투 Layout/CombatLogPanel/CombatLogScroll"
+# Exported node paths for important panels
+@export var party_panel_path: NodePath = NodePath("PartyPanel")
+@export var enemy_panel_path: NodePath = NodePath("EnemyPanel")
+@export var cards_area_path: NodePath = NodePath("CharacterCardsArea")
+@export var combat_log_container_path: NodePath = NodePath("CombatLogPanel/CombatLogScroll/CombatLog")
+@export var combat_log_scroll_path: NodePath = NodePath("CombatLogPanel/CombatLogScroll")
+@export var speed_button_path: NodePath = NodePath("TopBar/SpeedUpButton")
+@export var pause_button_path: NodePath = NodePath("TopBar/PauseButton")
+@export var feedback_label_path: NodePath = NodePath("FeedbackLabel")
+
+@onready var party_panel: VBoxContainer = get_node(party_panel_path)
+@onready var enemy_panel: VBoxContainer = get_node(enemy_panel_path)
+@onready var character_cards_area: HBoxContainer = get_node(cards_area_path)
+@onready var combat_log_container: VBoxContainer = get_node(combat_log_container_path)
+@onready var combat_log_scroll: ScrollContainer = get_node(combat_log_scroll_path)
+@onready var speed_up_button: Button = get_node(speed_button_path)
+@onready var pause_button: Button = get_node(pause_button_path)
+@onready var feedback_label: Label = get_node(feedback_label_path)
 
 # Placeholder data for party and enemies
 var party_members_data = []
@@ -67,7 +78,10 @@ func _on_speed_up_button_pressed():
 	current_speed = SPEED_LEVELS[current_speed_index]
 	speed_up_button.text = "Speed Up x" + str(current_speed)
 	add_combat_log_entry("Combat speed set to x" + str(current_speed))
-	print("Speed up button pressed. Current speed: ", current_speed)
+        print("Speed up button pressed. Current speed: ", current_speed)
+
+func end_combat() -> void:
+    emit_signal("combat_finished")
 
 func add_combat_log_entry(text_entry: String):
 	var new_log = Label.new()

--- a/auto-battler/scripts/ui/DungeonMap.gd
+++ b/auto-battler/scripts/ui/DungeonMap.gd
@@ -1,25 +1,33 @@
 extends Control
 
-var map_nodes = [] # Array to hold data about map nodes
-var current_party_status = {} # Dictionary to hold party status
+signal map_node_selected(node_id)
+
+# Exported paths to important UI containers
+@export var map_nodes_container_path: NodePath = NodePath("MapNodesContainer")
+@export var party_status_overlay_path: NodePath = NodePath("PartyStatusOverlay")
+
+var map_nodes: Array = [] # Array describing generated map nodes
+var current_party_status: Dictionary = {} # Tracks party status values
+
+@onready var _map_nodes_container: HBoxContainer = get_node(map_nodes_container_path)
+@onready var _party_status_overlay: VBoxContainer = get_node(party_status_overlay_path)
 
 func _ready():
-	# Initialize map nodes (placeholder)
-	map_nodes = [
-		{"id": 0, "type": "room", "name": "Starting Room"},
-		{"id": 1, "type": "event", "name": "Mysterious Shrine"},
-		{"id": 2, "type": "room", "name": "Goblin Cave"}
-	]
-	# You would typically generate or load this data
+        # Placeholder map generation. Real data should come from a manager.
+        map_nodes = [
+                {"id": 0, "type": "room", "name": "Starting Room"},
+                {"id": 1, "type": "event", "name": "Mysterious Shrine"},
+                {"id": 2, "type": "room", "name": "Goblin Cave"}
+        ]
 
 	# Initialize party status (placeholder)
-	current_party_status = {
-		"member1": {"hp": 100, "max_hp": 100, "food": 100, "water": 100, "energy":100},
-		"member2": {"hp": 100, "max_hp": 100, "food": 100, "water": 100, "energy":100},
-		"member3": {"hp": 100, "max_hp": 100, "food": 100, "water": 100, "energy":100},
-		"member4": {"hp": 100, "max_hp": 100, "food": 100, "water": 100, "energy":100},
-		"member5": {"hp": 100, "max_hp": 100, "food": 100, "water": 100, "energy":100}
-	}
+        current_party_status = {
+                "member1": {"hp": 100, "max_hp": 100, "food": 100, "water": 100, "energy":100},
+                "member2": {"hp": 100, "max_hp": 100, "food": 100, "water": 100, "energy":100},
+                "member3": {"hp": 100, "max_hp": 100, "food": 100, "water": 100, "energy":100},
+                "member4": {"hp": 100, "max_hp": 100, "food": 100, "water": 100, "energy":100},
+                "member5": {"hp": 100, "max_hp": 100, "food": 100, "water": 100, "energy":100}
+        }
 	update_party_status_display()
 	update_map_node_display()
 
@@ -38,17 +46,12 @@ func update_map_node_display():
 			# Potentially disable buttons for already visited or unreachable nodes
 
 func _on_map_node_selected(node_index):
-	if node_index >= 0 and node_index < map_nodes.size():
-		var selected_node = map_nodes[node_index]
-		print("Map node selected: ", selected_node.name)
-		# Add logic to handle node selection, e.g.:
-		# if selected_node.type == "room":
-		#     get_tree().change_scene_to_file("res://scenes/CombatScene.tscn") # Or specific room scene
-		# elif selected_node.type == "event":
-		#     # Trigger event logic
-		#     pass
-	else:
-		print("Invalid node index: ", node_index)
+        if node_index >= 0 and node_index < map_nodes.size():
+                var selected_node = map_nodes[node_index]
+                emit_signal("map_node_selected", selected_node.id)
+                print("Map node selected: ", selected_node.name)
+        else:
+                print("Invalid node index: ", node_index)
 
 
 func update_party_status_display():

--- a/auto-battler/scripts/ui/LootPanel.gd
+++ b/auto-battler/scripts/ui/LootPanel.gd
@@ -5,8 +5,11 @@ signal add_item_to_inventory(item_data: Dictionary)
 # Signal emitted when the panel is closed
 signal loot_panel_closed
 
-@onready var loot_list_container: VBoxContainer = $VBoxContainer/LootScrollContainer/LootList
-@onready var close_button: Button = $VBoxContainer/CloseButton
+@export var loot_list_container_path: NodePath = NodePath("VBox/LootScroll/LootList")
+@export var close_button_path: NodePath = NodePath("VBox/CloseButton")
+
+@onready var loot_list_container: VBoxContainer = get_node(loot_list_container_path)
+@onready var close_button: Button = get_node(close_button_path)
 
 # Placeholder for loot items. In a real game, this would be passed to the panel.
 var current_loot_items: Array = []

--- a/auto-battler/scripts/ui/MainMenu.gd
+++ b/auto-battler/scripts/ui/MainMenu.gd
@@ -1,30 +1,46 @@
 extends Control
 
-# Called when the node enters the scene tree for the first time.
-func _ready():
-	pass # Replace with function body.
+# Signals emitted for other systems to react to menu actions
+signal start_game
+signal continue_game
+signal settings_requested
+signal exit_game
 
+# Exported paths for key UI elements so they can be reassigned in the editor if
+# the layout changes.
+@export var start_button_path: NodePath = NodePath("VBox/StartButton")
+@export var continue_button_path: NodePath = NodePath("VBox/ContinueButton")
+@export var settings_button_path: NodePath = NodePath("VBox/SettingsButton")
+@export var exit_button_path: NodePath = NodePath("VBox/ExitButton")
 
-# Called every frame. 'delta' is the elapsed time since the previous frame.
-func _process(delta):
-	pass
+@onready var _start_button: Button = get_node(start_button_path)
+@onready var _continue_button: Button = get_node(continue_button_path)
+@onready var _settings_button: Button = get_node(settings_button_path)
+@onready var _exit_button: Button = get_node(exit_button_path)
 
-func _on_start_button_pressed():
-	print("Start Game button pressed")
-	# Replace with game start logic, e.g., get_tree().change_scene_to_file("res://scenes/PartySetup.tscn")
+func _ready() -> void:
+    # Placeholder for any setup logic. Buttons are connected in the scene file.
+    pass
 
-func _on_continue_button_pressed():
-	print("Continue button pressed")
-	# Replace with continue game logic, e.g., load game state
+func _on_start_button_pressed() -> void:
+    print("Start Game button pressed")
+    emit_signal("start_game")
+    # GameManager or another controller should handle the actual scene change.
 
-func _on_settings_button_pressed():
-	print("Settings button pressed")
-	# Replace with settings screen logic
+func _on_continue_button_pressed() -> void:
+    print("Continue button pressed")
+    emit_signal("continue_game")
 
-func _on_credits_button_pressed():
-	print("Credits button pressed")
-	# Replace with credits screen logic
+func _on_settings_button_pressed() -> void:
+    print("Settings button pressed")
+    emit_signal("settings_requested")
 
-func _on_exit_button_pressed():
-	print("Exit button pressed")
-	get_tree().quit()
+func _on_credits_button_pressed() -> void:
+    print("Credits button pressed")
+    # Could emit a signal if a dedicated credits scene is used
+
+func _on_exit_button_pressed() -> void:
+    print("Exit button pressed")
+    emit_signal("exit_game")
+    # Default behaviour quits the application
+    get_tree().quit()

--- a/auto-battler/scripts/ui/PreparationScene.gd
+++ b/auto-battler/scripts/ui/PreparationScene.gd
@@ -1,0 +1,19 @@
+extends Control
+
+signal enter_dungeon
+
+@export var party_panel_path: NodePath = NodePath("PartyPanel")
+@export var card_panel_path: NodePath = NodePath("CardSelectPanel")
+@export var gear_panel_path: NodePath = NodePath("GearSelectPanel")
+@export var ready_button_path: NodePath = NodePath("ReadyButton")
+
+@onready var party_panel: Node = get_node(party_panel_path)
+@onready var card_panel: Node = get_node(card_panel_path)
+@onready var gear_panel: Node = get_node(gear_panel_path)
+@onready var ready_button: Button = get_node(ready_button_path)
+
+func _ready() -> void:
+    pass # Placeholder for future initialization
+
+func _on_ready_button_pressed() -> void:
+    emit_signal("enter_dungeon")

--- a/auto-battler/scripts/ui/RestScene.gd
+++ b/auto-battler/scripts/ui/RestScene.gd
@@ -1,11 +1,17 @@
+# Scene controlling the rest phase UI
 extends Control
 
-# Signal for when resting is complete and player continues
+# Signal emitted when the player chooses to continue
 signal rest_completed
 
-# References to UI elements
-@onready var party_status_grid: GridContainer = $VBoxContainer/PartyStatusGrid
-@onready var rest_progress_label: Label = $VBoxContainer/RestProgressLabel
+# Exported paths to key UI nodes
+@export var party_status_grid_path: NodePath = NodePath("VBox/PartyStatusGrid")
+@export var rest_progress_label_path: NodePath = NodePath("VBox/RestProgressLabel")
+@export var continue_button_path: NodePath = NodePath("VBox/ContinueButton")
+
+@onready var party_status_grid: GridContainer = get_node(party_status_grid_path)
+@onready var rest_progress_label: Label = get_node(rest_progress_label_path)
+@onready var _continue_button: Button = get_node(continue_button_path)
 # Add @onready vars for food/drink buttons if they are dynamic
 
 # Placeholder for party data. In a real game, this would come from GameManager or PartyManager
@@ -90,8 +96,8 @@ func add_rest_log_entry(log_text: String):
 
 
 func _on_continue_button_pressed():
-	print("Continue button pressed from Rest Scene")
-	# Perform any final rest calculations (e.g., small passive recovery for all members)
+        print("Continue button pressed from Rest Scene")
+        # Perform any final rest calculations (e.g., small passive recovery for all members)
 	# Example: Small fatigue recovery for everyone
 	for member_key in party_members_data:
 		if party_members_data[member_key].has("fatigue") and party_members_data[member_key].has("max_fatigue"):
@@ -102,7 +108,7 @@ func _on_continue_button_pressed():
 
 	await get_tree().create_timer(1.0).timeout # Brief pause to show final log
 
-	emit_signal("rest_completed")
+        emit_signal("rest_completed")
 	# Transition to the next scene (e.g., DungeonMap or a post-rest summary)
 	# Example: get_tree().change_scene_to_file("res://scenes/DungeonMap.tscn")
 


### PR DESCRIPTION
## Summary
- create clean placeholder scenes for the main gameplay phases
- implement UI scripts with exported node paths and signals for transitions
- wire buttons to stub methods for future integration

## Testing
- `godot --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f732207308327929490919ef1cbaf