### PR TITLE
Hook map node clicks to GameManager

### DIFF
--- a/auto-battler/project.godot
+++ b/auto-battler/project.godot
@@ -14,3 +14,5 @@ config/name="Auto Battler"
 run/main_scene="res://scenes/MainMenu.tscn"
 config/features=PackedStringArray("4.4", "GL Compatibility")
 config/icon="res://icon.svg"
+[autoload]
+GameManager="*res://scripts/main/GameManager.gd"

--- a/auto-battler/scenes/DungeonMap.tscn
+++ b/auto-battler/scenes/DungeonMap.tscn
@@ -1,8 +1,8 @@
 [gd_scene load_steps=2 format=3]
 
-[ext_resource type="Script" path="res://scripts/ui/DungeonMap.gd" id="1"]
+[ext_resource type="Script" path="res://scripts/main/DungeonMapManager.gd" id="1"]
 
-[node name="DungeonMap" type="Control"]
+[node name="DungeonMapManager" type="Control"]
 anchor_right = 1.0
 anchor_bottom = 1.0
 script = ExtResource("1")

--- a/auto-battler/scripts/main/DungeonMapManager.gd
+++ b/auto-battler/scripts/main/DungeonMapManager.gd
@@ -8,6 +8,7 @@ signal node_interaction_selected(node_data: Dictionary)
 signal transition_to_combat(combat_setup_data: Dictionary)
 signal transition_to_loot_event(loot_event_data: Dictionary) # For both loot and generic events
 signal transition_to_rest(rest_setup_data: Dictionary)
+signal node_selected(node_type: String)
 
 @onready var nodes_container: HBoxContainer = $MapNodesContainer # UI container for map node buttons
 # Optional: Preload scenes for popups if they remain part of this manager
@@ -154,6 +155,11 @@ func on_node_button_pressed(node_id: int) -> void:
 
         if current_node_data and node_id in current_node_data.connections and not node_id in visited_node_ids:
             emit_signal("node_interaction_selected", selected_node_data)
+            emit_signal("node_selected", selected_node_data.type)
+            if Engine.has_singleton("GameManager"):
+                var gm = Engine.get_singleton("GameManager")
+                if gm.has_method("on_map_node_selected"):
+                    gm.on_map_node_selected(selected_node_data.type)
         else:
             print("Invalid node selection or already visited: ", node_id)
     else:

--- a/auto-battler/scripts/main/GameManager.gd
+++ b/auto-battler/scripts/main/GameManager.gd
@@ -268,6 +268,17 @@ func _notify_dungeon_map_manager_to_initialize():
     else:
         printerr("GameManager: Failed to notify DungeonMapManager or method not found.")
 
+func on_map_node_selected(node_type: String) -> void:
+    match node_type:
+        "combat":
+            _change_game_phase_and_scene("combat", "res://auto-battler/scenes/CombatScene.tscn")
+        "rest":
+            _change_game_phase_and_scene("rest", "res://auto-battler/scenes/RestScene.tscn")
+        "loot":
+            _change_game_phase_and_scene("loot", "res://auto-battler/scenes/LootPanel.tscn")
+        _:
+            print("GameManager: Unknown node type '%s' selected." % node_type)
+
 
 ## Called when DungeonMapManager requests a transition to combat.
 func on_transition_to_combat_requested(combat_setup_data: Dictionary) -> void:


### PR DESCRIPTION
## Summary
- autoload `GameManager` so it can be called globally
- swap map scene root to use `DungeonMapManager` logic
- emit `node_selected` when clicking on a node and forward to `GameManager`
- add `on_map_node_selected` in `GameManager` to load scenes based on node type

## Testing
- `true`

------
https://chatgpt.com/codex/tasks/task_e_683f7e8eb60083278c38262f6a35dad2