### PR TITLE
Link CombatManager with GameManager

### DIFF
--- a/auto-battler/scenes/CombatScene.tscn
+++ b/auto-battler/scenes/CombatScene.tscn
@@ -1,11 +1,15 @@
-[gd_scene load_steps=2 format=3]
+[gd_scene load_steps=3 format=3]
 
 [ext_resource type="Script" path="res://scripts/combat/CombatScene.gd" id="1"]
+[ext_resource type="Script" path="res://scripts/combat/CombatManager.gd" id="2"]
 
 [node name="CombatScene" type="Control"]
 anchor_right = 1.0
 anchor_bottom = 1.0
 script = ExtResource("1")
+
+[node name="CombatManager" type="Node" parent="."]
+script = ExtResource("2")
 
 [node name="TopBar" type="HBoxContainer" parent="."]
 anchor_right = 1.0

--- a/auto-battler/scripts/combat/CombatManager.gd
+++ b/auto-battler/scripts/combat/CombatManager.gd
@@ -235,10 +235,14 @@ func _finalize_combat() -> void:
     var final_party_state = _get_final_party_state()
     _apply_survival_penalties()
 
+    var gm = get_node_or_null("/root/GameManager")
+
     if party_defeated:
         _log("Party was defeated.")
         var results = {"final_party_state": final_party_state}
         emit_signal("combat_defeat", results)
+        if gm and gm.has_method("on_combat_end"):
+            gm.on_combat_end(false, results)
     elif enemies_defeated:
         _log("Party is victorious!")
         _distribute_loot_and_xp() # Calculate loot and XP
@@ -248,6 +252,8 @@ func _finalize_combat() -> void:
             "final_party_state": final_party_state
         }
         emit_signal("combat_victory", results)
+        if gm and gm.has_method("on_combat_end"):
+            gm.on_combat_end(true, results)
     else:
         # This case (neither side defeated, e.g. from round limit) might be a draw or special scenario
         _log("Combat ended inconclusively (e.g., round limit reached).")
@@ -255,6 +261,8 @@ func _finalize_combat() -> void:
         # For now, treating as a defeat if party isn't victorious.
         var results = {"final_party_state": final_party_state}
         emit_signal("combat_defeat", results) # Or a specific "combat_draw" signal
+        if gm and gm.has_method("on_combat_end"):
+            gm.on_combat_end(false, results)
 
 
 ## Gathers the final state of party members (HP, statuses, etc.).

--- a/auto-battler/scripts/main/GameManager.gd
+++ b/auto-battler/scripts/main/GameManager.gd
@@ -280,6 +280,10 @@ func on_transition_to_combat_requested(combat_setup_data: Dictionary) -> void:
 func _notify_combat_manager_to_initialize(combat_setup_data: Dictionary):
     var combat_manager = get_node_or_null(COMBAT_MANAGER_PATH)
     if combat_manager and combat_manager.has_method("initialize_combat"):
+        if not combat_manager.combat_victory.is_connected(on_combat_victory):
+            combat_manager.combat_victory.connect(on_combat_victory)
+        if not combat_manager.combat_defeat.is_connected(on_combat_defeat):
+            combat_manager.combat_defeat.connect(on_combat_defeat)
         var enemy_data_list = combat_setup_data.get("enemies", [])
         combat_manager.initialize_combat(current_party_members, enemy_data_list)
         combat_manager.run_auto_battle_loop() # Start the battle
@@ -356,6 +360,13 @@ func on_combat_defeat(results: Dictionary) -> void:
         # Fallback if PostBattleManager is missing: go to game over directly
         # current_party_members = results.get("final_party_state", current_party_members)
         # on_game_over_requested()
+
+## Wrapper called by CombatManager when combat ends.
+func on_combat_end(victory: bool, results: Dictionary) -> void:
+    if victory:
+        on_combat_victory(results)
+    else:
+        on_combat_defeat(results)
 
 
 ## Called by PostBattleManager when all its processing is complete.


### PR DESCRIPTION
## Summary
- add a CombatManager node to CombatScene
- call GameManager when combat ends via a new `on_combat_end()` wrapper
- wire GameManager to the manager after changing scenes
- forward victory/defeat from CombatScene to GameManager

## Testing
- `git commit -m "Integrate combat manager with game manager"`

------
https://chatgpt.com/codex/tasks/task_e_683f7e95700c8327bc1da94fa0094356