### PR TITLE
Fix GDScript parse errors

### DIFF
--- a/auto-battler/scripts/combat/CombatManager.gd
+++ b/auto-battler/scripts/combat/CombatManager.gd
@@ -35,7 +35,7 @@ class Combatant:
         source_data = data_resource
         is_player_side = is_player
         # Ensure assigned_cards is always an array, even if empty
-        var card_key = is_player ? "assigned_cards" : "abilities"
+        var card_key = "assigned_cards" if is_player else "abilities"
         assigned_cards = data_resource.get(card_key) ?? []
         current_hp = data_resource.get("base_hp") ?? 10 # Default to 10 HP if not specified
         # Note: Initial fatigue, hunger, thirst from source_data are not directly used by Combatant during combat itself.

--- a/auto-battler/scripts/combat/CombatScene.gd
+++ b/auto-battler/scripts/combat/CombatScene.gd
@@ -43,50 +43,50 @@ func _ready():
                 if not combat_manager.combat_defeat.is_connected(_on_combat_defeat):
                         combat_manager.combat_defeat.connect(_on_combat_defeat)
 
-	# Example: Populate with placeholder party member panels
-	# for i in range(1, 3): # Assuming 2 party members for this example
-	#     var member_label = party_panel.get_node("PartyMember" + str(i) + "/Label")
-	#     if member_label:
-	#         member_label.text = "Party Member " + str(i) + "\nHP: 100/100\nFatigue: 0"
+    # Example: Populate with placeholder party member panels
+    # for i in range(1, 3): # Assuming 2 party members for this example
+    #     var member_label = party_panel.get_node("PartyMember" + str(i) + "/Label")
+    #     if member_label:
+    #         member_label.text = "Party Member " + str(i) + "\nHP: 100/100\nFatigue: 0"
 
-	# Example: Populate with placeholder enemy panels
-	# for i in range(1, 2): # Assuming 1 enemy for this example
-	#     var enemy_label = enemy_panel.get_node("Enemy" + str(i) + "/Label")
-	#     if enemy_label:
-	#         enemy_label.text = "Enemy " + str(i) + "\nHP: 50/50"
+    # Example: Populate with placeholder enemy panels
+    # for i in range(1, 2): # Assuming 1 enemy for this example
+    #     var enemy_label = enemy_panel.get_node("Enemy" + str(i) + "/Label")
+    #     if enemy_label:
+    #         enemy_label.text = "Enemy " + str(i) + "\nHP: 50/50"
 
-	# Disable player input areas (except pause/speed)
-	# This might involve disabling input on card nodes or other interactive elements
-	# For now, it's mostly a conceptual note as detailed interaction isn't built yet
+    # Disable player input areas (except pause/speed)
+    # This might involve disabling input on card nodes or other interactive elements
+    # For now, it's mostly a conceptual note as detailed interaction isn't built yet
 
 func _process(delta):
-	if is_paused:
-		return
+    if is_paused:
+        return
 
-	var effective_delta = delta * current_speed
-	# Main combat loop logic would go here (AI turns, card resolution, etc.)
-	# For now, just a placeholder
-	# update_combat_state(effective_delta)
-	# update_ui()
+    var effective_delta = delta * current_speed
+    # Main combat loop logic would go here (AI turns, card resolution, etc.)
+    # For now, just a placeholder
+    # update_combat_state(effective_delta)
+    # update_ui()
 
 func _on_pause_button_pressed():
-	is_paused = !is_paused
-	if is_paused:
-		pause_button.text = "Resume"
-		add_combat_log_entry("Combat Paused.")
-		Engine.time_scale = 0 # More robust pausing if physics is involved
-	else:
-		pause_button.text = "Pause"
-		add_combat_log_entry("Combat Resumed.")
-		Engine.time_scale = 1.0 # Ensure time scale is reset
-	print("Pause button pressed. Paused: ", is_paused)
+    is_paused = !is_paused
+    if is_paused:
+        pause_button.text = "Resume"
+        add_combat_log_entry("Combat Paused.")
+        Engine.time_scale = 0 # More robust pausing if physics is involved
+    else:
+        pause_button.text = "Pause"
+        add_combat_log_entry("Combat Resumed.")
+        Engine.time_scale = 1.0 # Ensure time scale is reset
+    print("Pause button pressed. Paused: ", is_paused)
 
 func _on_speed_up_button_pressed():
-	current_speed_index = (current_speed_index + 1) % SPEED_LEVELS.size()
-	current_speed = SPEED_LEVELS[current_speed_index]
-	speed_up_button.text = "Speed Up x" + str(current_speed)
-	add_combat_log_entry("Combat speed set to x" + str(current_speed))
-	print("Speed up button pressed. Current speed: ", current_speed)
+    current_speed_index = (current_speed_index + 1) % SPEED_LEVELS.size()
+    current_speed = SPEED_LEVELS[current_speed_index]
+    speed_up_button.text = "Speed Up x" + str(current_speed)
+    add_combat_log_entry("Combat speed set to x" + str(current_speed))
+    print("Speed up button pressed. Current speed: ", current_speed)
 
 func end_combat() -> void:
     emit_signal("combat_finished")
@@ -110,40 +110,40 @@ func _on_combat_defeat(results: Dictionary) -> void:
         end_combat()
 
 func add_combat_log_entry(text_entry: String):
-	var new_log = Label.new()
-	new_log.text = text_entry
-	new_log.autowrap_mode = TextServer.AUTOWRAP_WORD
-	combat_log_container.add_child(new_log)
-	# Optional: Scroll to bottom if the log is in a ScrollContainer
-	await get_tree().process_frame # Wait for node to be added
-	# Alternative: call_deferred on scroll_bar.value = scroll_bar.max_value
-	var scroll_bar = combat_log_scroll.get_v_scroll_bar()
-	if scroll_bar:
-		scroll_bar.value = scroll_bar.max_value
+    var new_log = Label.new()
+    new_log.text = text_entry
+    new_log.autowrap_mode = TextServer.AUTOWRAP_WORD
+    combat_log_container.add_child(new_log)
+    # Optional: Scroll to bottom if the log is in a ScrollContainer
+    await get_tree().process_frame # Wait for node to be added
+    # Alternative: call_deferred on scroll_bar.value = scroll_bar.max_value
+    var scroll_bar = combat_log_scroll.get_v_scroll_bar()
+    if scroll_bar:
+        scroll_bar.value = scroll_bar.max_value
 
 func show_visual_feedback(text: String, duration: float = 1.0):
-	feedback_label.text = text
-	feedback_label.visible = true
-	var timer = get_tree().create_timer(duration)
-	await timer.timeout # Use await with timeout signal
-	feedback_label.visible = false
+    feedback_label.text = text
+    feedback_label.visible = true
+    var timer = get_tree().create_timer(duration)
+    await timer.timeout # Use await with timeout signal
+    feedback_label.visible = false
 
 # Placeholder functions for updating UI based on game state
 func update_party_display(party_data):
-	# Iterate through party_data and update each PartyMemberPanel instance
-	pass
+    # Iterate through party_data and update each PartyMemberPanel instance
+    pass
 
 func update_enemy_display(enemy_data):
-	# Iterate through enemy_data and update each EnemyPanel instance
-	pass
+    # Iterate through enemy_data and update each EnemyPanel instance
+    pass
 
 func update_character_cards_display(character_cards):
-	# Display cards for the current acting character
-	# Highlight the card being played
-	pass
+    # Display cards for the current acting character
+    # Highlight the card being played
+    pass
 
 # Example of how visual feedback might be triggered
 func _trigger_example_feedback():
-	# Simulate a damage event
-	show_visual_feedback("Direct Hit! -20 HP", 1.5)
-	add_combat_log_entry("Goblin attacks Player 1 for 20 damage.")
+    # Simulate a damage event
+    show_visual_feedback("Direct Hit! -20 HP", 1.5)
+    add_combat_log_entry("Goblin attacks Player 1 for 20 damage.")

--- a/auto-battler/scripts/main/GameManager.gd
+++ b/auto-battler/scripts/main/GameManager.gd
@@ -1,4 +1,4 @@
-class_name GameManager
+class_name GameManagerRoot
 extends Node
 
 ## Manages global game state, persistent data, and scene/phase transitions for the auto-battler.

--- a/auto-battler/scripts/main/PostBattleManager.gd
+++ b/auto-battler/scripts/main/PostBattleManager.gd
@@ -5,7 +5,7 @@
 extends Node
 class_name PostBattleManager
 
-const SUMMARY_SCENE := preload("res://auto-battler/scenes/PostBattleSummary.tscn")
+const SUMMARY_SCENE: PackedScene = preload("res://scenes/PostBattleSummary.tscn")
 
 var _summary_ui: Control
 

--- a/auto-battler/scripts/ui/LootPanel.gd
+++ b/auto-battler/scripts/ui/LootPanel.gd
@@ -93,15 +93,15 @@ func populate_loot_display():
 		name_label.text = "%s (%s)" % [item_data.get("name", "Unknown Item"), rarity_str]
 		details_vbox.add_child(name_label)
 
-                var tags_label = Label.new()
-                var tags_array = item_data.get("tags", [])
-                if tags_array is Array and not tags_array.is_empty():
-                        tags_label.text = ", ".join(tags_array)
-                else:
-                        tags_label.text = "" # Hide if no tags, or "No special tags"
-                        tags_label.visible = false
-                tags_label.add_theme_font_size_override("font_size", 12)
-                details_vbox.add_child(tags_label)
+		var tags_label = Label.new()
+		var tags_array = item_data.get("tags", [])
+		if tags_array is Array and not tags_array.is_empty():
+			tags_label.text = ", ".join(tags_array)
+		else:
+			tags_label.text = "" # Hide if no tags, or "No special tags"
+			tags_label.visible = false
+		tags_label.add_theme_font_size_override("font_size", 12)
+		details_vbox.add_child(tags_label)
 
                 var add_button = Button.new()
 		add_button.text = "Add" # Shorter text

--- a/auto-battler/scripts/ui/PostBattleSummary.gd
+++ b/auto-battler/scripts/ui/PostBattleSummary.gd
@@ -11,8 +11,8 @@ signal continue_pressed
 @onready var continue_button: Button = get_node(continue_button_path)
 
 func show_summary(rewards: Dictionary) -> void:
-    var xp := rewards.get("xp_gained", 0)
-    var loot := rewards.get("loot_received", [])
+    var xp: int = rewards.get("xp_gained", 0)
+    var loot: Array = rewards.get("loot_received", [])
     var loot_names: Array = []
     for item in loot:
         if typeof(item) == TYPE_STRING:

--- a/auto-battler/scripts/ui/RestScene.gd
+++ b/auto-battler/scripts/ui/RestScene.gd
@@ -89,24 +89,24 @@ func _on_use_food_drink_pressed(item_effect_data: Dictionary):
 		# You might want to consume the item from inventory here
 		# InventoryManager.consume_item(item_effect_data.name) # Assuming item_effect_data has a unique name/id
 		add_rest_log_entry("Applied %s to %s. New %s: %d" % [item_effect_data.get("name", "Item"), party_members_data[target_member_key].name, stat_to_change, party_members_data[target_member_key][stat_to_change]])
-        else:
-                add_rest_log_entry("Error: Stat '%s' or '%s' not found for %s." % [stat_to_change, max_stat_key, party_members_data[target_member_key].name])
+	else:
+		add_rest_log_entry("Error: Stat '%s' or '%s' not found for %s." % [stat_to_change, max_stat_key, party_members_data[target_member_key].name])
 
 
 func _on_use_food_button_pressed() -> void:
-        var food_effect := {"name": "Ration", "target_stat": "hunger", "value": 20}
-        _on_use_food_drink_pressed(food_effect)
+	var food_effect := {"name": "Ration", "target_stat": "hunger", "value": 20}
+	_on_use_food_drink_pressed(food_effect)
 
 
 func _on_use_drink_button_pressed() -> void:
-        var drink_effect := {"name": "Water", "target_stat": "thirst", "value": 20}
-        _on_use_food_drink_pressed(drink_effect)
+	var drink_effect := {"name": "Water", "target_stat": "thirst", "value": 20}
+	_on_use_food_drink_pressed(drink_effect)
 
 
 func _on_craft_button_pressed() -> void:
-        print("Crafting button pressed")
-        if _rest_manager and _rest_manager.has_method("_on_crafting_invoked"):
-                _rest_manager._on_crafting_invoked()
+	print("Crafting button pressed")
+	if _rest_manager and _rest_manager.has_method("_on_crafting_invoked"):
+		_rest_manager._on_crafting_invoked()
 
 
 func add_rest_log_entry(log_text: String):
@@ -120,8 +120,8 @@ func add_rest_log_entry(log_text: String):
 
 
 func _on_continue_button_pressed():
-        print("Continue button pressed from Rest Scene")
-        # Perform any final rest calculations (e.g., small passive recovery for all members)
+	print("Continue button pressed from Rest Scene")
+	# Perform any final rest calculations (e.g., small passive recovery for all members)
 	# Example: Small fatigue recovery for everyone
 	for member_key in party_members_data:
 		if party_members_data[member_key].has("fatigue") and party_members_data[member_key].has("max_fatigue"):
@@ -130,13 +130,13 @@ func _on_continue_button_pressed():
 	update_party_status_display() # Update display after final changes
 	add_rest_log_entry("Journey continues. Party is somewhat rested.")
 
-        await get_tree().create_timer(1.0).timeout # Brief pause to show final log
+	await get_tree().create_timer(1.0).timeout # Brief pause to show final log
 
-        emit_signal("rest_completed")
-        if _rest_manager and _rest_manager.has_method("on_rest_continue"):
-                _rest_manager.on_rest_continue()
-        # Transition to the next scene (e.g., DungeonMap or a post-rest summary)
-        # Example: get_tree().change_scene_to_file("res://scenes/DungeonMap.tscn")
+	emit_signal("rest_completed")
+	if _rest_manager and _rest_manager.has_method("on_rest_continue"):
+		_rest_manager.on_rest_continue()
+	# Transition to the next scene (e.g., DungeonMap or a post-rest summary)
+	# Example: get_tree().change_scene_to_file("res://scenes/DungeonMap.tscn")
 
 
 # Call this function if party data changes from an external source


### PR DESCRIPTION
## Summary
- resolve autoload naming conflict in GameManager
- fix warnings treated as errors in PostBattleSummary
- standardize indentation in RestScene and LootPanel
- switch to new ternary operator syntax
- adjust PostBattleSummary path and type
- convert tabs to spaces in CombatScene

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_683f8358e3b88327a1e19fe0272eda74