### PR TITLE
Fix AutoCombatManager parse error

### DIFF
--- a/auto-battler/scripts/combat/CombatManager.gd
+++ b/auto-battler/scripts/combat/CombatManager.gd
@@ -50,7 +50,7 @@ class Combatant:
         return card
 
     func get_name() -> String:
-        var name_key = is_player_side ? "character_name" : "enemy_name"
+        var name_key = "character_name" if is_player_side else "enemy_name"
         var n = source_data.get(name_key)
         return n if n != null else "Unknown Combatant"
 


### PR DESCRIPTION
## Summary
- fix ternary syntax in `CombatManager.gd`

## Testing
- `godot --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f874feb908327a9861b36e2319f2d