### PR TITLE
Add combat ended signal

### DIFF
--- a/auto-battler/scripts/combat/CombatManager.gd
+++ b/auto-battler/scripts/combat/CombatManager.gd
@@ -9,6 +9,8 @@ class_name AutoCombatManager
 signal combat_victory(results: Dictionary)
 # Signal emitted when combat ends in defeat
 signal combat_defeat(results: Dictionary)
+# Signal emitted when combat resolution is complete
+signal combat_ended(victory: bool)
 
 var party_members: Array[Combatant] = []  # Array of Combatant objects for the player's party
 var enemies: Array[Combatant] = []        # Array of Combatant objects for the enemy side
@@ -254,6 +256,7 @@ func _finalize_combat() -> void:
         emit_signal("combat_defeat", results)
         if gm and gm.has_method("on_combat_end"):
             gm.on_combat_end(false, results)
+        emit_signal("combat_ended", false)
     elif enemies_defeated:
         _log("Party is victorious!")
         _distribute_loot_and_xp() # Calculate loot and XP
@@ -265,6 +268,7 @@ func _finalize_combat() -> void:
         emit_signal("combat_victory", results)
         if gm and gm.has_method("on_combat_end"):
             gm.on_combat_end(true, results)
+        emit_signal("combat_ended", true)
     else:
         # This case (neither side defeated, e.g. from round limit) might be a draw or special scenario
         _log("Combat ended inconclusively (e.g., round limit reached).")
@@ -274,6 +278,7 @@ func _finalize_combat() -> void:
         emit_signal("combat_defeat", results) # Or a specific "combat_draw" signal
         if gm and gm.has_method("on_combat_end"):
             gm.on_combat_end(false, results)
+        emit_signal("combat_ended", false)
 
 
 ## Gathers the final state of party members (HP, statuses, etc.).

--- a/auto-battler/scripts/combat/CombatScene.gd
+++ b/auto-battler/scripts/combat/CombatScene.gd
@@ -42,6 +42,9 @@ func _ready():
                         combat_manager.combat_victory.connect(_on_combat_victory)
                 if not combat_manager.combat_defeat.is_connected(_on_combat_defeat):
                         combat_manager.combat_defeat.connect(_on_combat_defeat)
+                if not combat_manager.combat_ended.is_connected(GameManager, "on_combat_ended"):
+                        combat_manager.connect("combat_ended", GameManager, "on_combat_ended")
+                combat_manager.run_auto_battle_loop()
 
     # Example: Populate with placeholder party member panels
     # for i in range(1, 3): # Assuming 2 party members for this example


### PR DESCRIPTION
## Summary
- add new `combat_ended` signal in `CombatManager`
- emit `combat_ended` when a battle finishes
- connect `CombatScene` to `GameManager.on_combat_ended`
- auto-run the battle loop in `CombatScene`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683f8b88bc608327ab1509708eabbacb