### PR TITLE
Fix GameManager signal connection

### DIFF
--- a/auto-battler/scripts/combat/CombatScene.gd
+++ b/auto-battler/scripts/combat/CombatScene.gd
@@ -42,8 +42,9 @@ func _ready():
                         combat_manager.combat_victory.connect(_on_combat_victory)
                 if not combat_manager.combat_defeat.is_connected(_on_combat_defeat):
                         combat_manager.combat_defeat.connect(_on_combat_defeat)
-                if not combat_manager.combat_ended.is_connected(GameManager, "on_combat_ended"):
-                        combat_manager.connect("combat_ended", GameManager, "on_combat_ended")
+                var gm_callable := GameManager.callable("on_combat_end")
+                if not combat_manager.combat_ended.is_connected(gm_callable):
+                        combat_manager.combat_ended.connect(gm_callable)
                 combat_manager.run_auto_battle_loop()
 
     # Example: Populate with placeholder party member panels


### PR DESCRIPTION
## Summary
- fix improper GameManager signal connection in CombatScene

## Testing
- `true`


------
https://chatgpt.com/codex/tasks/task_e_683f8e12f2a88327a4b0ba8d1973c480