### PR TITLE
Fix Godot4 signal syntax

### DIFF
--- a/auto-battler/scripts/combat/CombatScene.gd
+++ b/auto-battler/scripts/combat/CombatScene.gd
@@ -42,8 +42,8 @@ func _ready():
                         combat_manager.combat_victory.connect(_on_combat_victory)
                 if not combat_manager.combat_defeat.is_connected(_on_combat_defeat):
                         combat_manager.combat_defeat.connect(_on_combat_defeat)
-                if not combat_manager.combat_ended.is_connected(GameManager, "on_combat_ended"):
-                        combat_manager.connect("combat_ended", GameManager, "on_combat_ended")
+                if not combat_manager.combat_ended.is_connected(GameManager.on_combat_end):
+                        combat_manager.combat_ended.connect(GameManager.on_combat_end)
                 combat_manager.run_auto_battle_loop()
 
     # Example: Populate with placeholder party member panels

--- a/auto-battler/scripts/preparation/PreparationManager.gd
+++ b/auto-battler/scripts/preparation/PreparationManager.gd
@@ -29,8 +29,8 @@ func _ready() -> void:
     # Connect to the PreparationScene's signal if present
     var scene := get_tree().current_scene
     if scene and scene.has_signal("enter_dungeon_pressed"):
-        if not scene.is_connected("enter_dungeon_pressed", self, "_on_enter_dungeon_pressed"):
-            scene.connect("enter_dungeon_pressed", self, "_on_enter_dungeon_pressed")
+        if not scene.enter_dungeon_pressed.is_connected(_on_enter_dungeon_pressed):
+            scene.enter_dungeon_pressed.connect(_on_enter_dungeon_pressed)
 
 func load_party_data() -> void:
     # This function should load all necessary information:

--- a/auto-battler/scripts/ui/PostBattleSummary.gd
+++ b/auto-battler/scripts/ui/PostBattleSummary.gd
@@ -11,7 +11,8 @@ signal continue_pressed
 @onready var continue_button: Button = get_node(continue_button_path)
 
 func _ready() -> void:
-    continue_button.connect("pressed", self, "_on_ContinueButton_pressed")
+    if not continue_button.pressed.is_connected(_on_ContinueButton_pressed):
+        continue_button.pressed.connect(_on_ContinueButton_pressed)
 
 func show_summary(rewards: Dictionary) -> void:
     var xp: int = rewards.get("xp_gained", 0)

--- a/auto-battler/scripts/ui/PreparationScene.gd
+++ b/auto-battler/scripts/ui/PreparationScene.gd
@@ -8,7 +8,7 @@ signal enter_dungeon
 @export var card_panel_path: NodePath = NodePath("CardSelectPanel")
 @export var gear_panel_path: NodePath = NodePath("GearSelectPanel")
 @export var ready_button_path: NodePath = NodePath("ReadyButton")
-@export var enter_dungeon_button_path: NodePath = NodePath("EnterDungeonButton")
+@export var enter_dungeon_button_path: NodePath = NodePath("ReadyButton")
 
 ## Stores the party composition chosen in the preparation screen.
 ## Each entry should contain the member data along with assigned cards.
@@ -21,9 +21,10 @@ signal enter_dungeon
 @onready var enter_dungeon_button: Button = get_node(enter_dungeon_button_path)
 
 func _ready() -> void:
-    # Connect the "Enter Dungeon" button to its handler when the scene is ready.
+    # Connect the "Enter Dungeon" button (same as ReadyButton) when the scene is ready.
     if is_instance_valid(enter_dungeon_button):
-        enter_dungeon_button.connect("pressed", self, "_on_EnterDungeonButton_pressed")
+        if not enter_dungeon_button.pressed.is_connected(_on_ready_button_pressed):
+            enter_dungeon_button.pressed.connect(_on_ready_button_pressed)
 
 func _on_ready_button_pressed() -> void:
     emit_signal("enter_dungeon_pressed")

--- a/auto-battler/scripts/ui/RestScene.gd
+++ b/auto-battler/scripts/ui/RestScene.gd
@@ -33,8 +33,9 @@ var party_members_data = {
 func _ready():
         update_party_status_display()
         # Hide progress label initially or manage its visibility during a "resting" state
-        rest_progress_label.visible = false
-        _continue_button.connect("pressed", self, "_on_ContinueButton_pressed")
+    rest_progress_label.visible = false
+    if not _continue_button.pressed.is_connected(_on_ContinueButton_pressed):
+        _continue_button.pressed.connect(_on_ContinueButton_pressed)
 
 func update_party_status_display():
 	var member_nodes = party_status_grid.get_children() # These are VBoxContainers


### PR DESCRIPTION
## Summary
- update signal connection syntax to Godot 4 style
- adjust PreparationScene button path

## Testing
- `godot --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f8e26bf3883278ec583a3fead31b1