### PR TITLE
Fix connect() calls for Godot 4

### DIFF
--- a/auto-battler/scripts/combat/CombatScene.gd
+++ b/auto-battler/scripts/combat/CombatScene.gd
@@ -42,8 +42,8 @@ func _ready():
                         combat_manager.combat_victory.connect(_on_combat_victory)
                 if not combat_manager.combat_defeat.is_connected(_on_combat_defeat):
                         combat_manager.combat_defeat.connect(_on_combat_defeat)
-                if not combat_manager.combat_ended.is_connected(GameManager, "on_combat_ended"):
-                        combat_manager.connect("combat_ended", GameManager, "on_combat_ended")
+                if not combat_manager.combat_ended.is_connected(GameManager.on_combat_ended):
+                        combat_manager.combat_ended.connect(GameManager.on_combat_ended)
                 combat_manager.run_auto_battle_loop()
 
     # Example: Populate with placeholder party member panels

--- a/auto-battler/scripts/preparation/PreparationManager.gd
+++ b/auto-battler/scripts/preparation/PreparationManager.gd
@@ -29,8 +29,8 @@ func _ready() -> void:
     # Connect to the PreparationScene's signal if present
     var scene := get_tree().current_scene
     if scene and scene.has_signal("enter_dungeon_pressed"):
-        if not scene.is_connected("enter_dungeon_pressed", self, "_on_enter_dungeon_pressed"):
-            scene.connect("enter_dungeon_pressed", self, "_on_enter_dungeon_pressed")
+        if not scene.enter_dungeon_pressed.is_connected(_on_enter_dungeon_pressed):
+            scene.enter_dungeon_pressed.connect(_on_enter_dungeon_pressed)
 
 func load_party_data() -> void:
     # This function should load all necessary information:

--- a/auto-battler/scripts/ui/PostBattleSummary.gd
+++ b/auto-battler/scripts/ui/PostBattleSummary.gd
@@ -11,7 +11,8 @@ signal continue_pressed
 @onready var continue_button: Button = get_node(continue_button_path)
 
 func _ready() -> void:
-    continue_button.connect("pressed", self, "_on_ContinueButton_pressed")
+    # Connect button using Godot 4 callable style
+    continue_button.pressed.connect(_on_continue_button_pressed)
 
 func show_summary(rewards: Dictionary) -> void:
     var xp: int = rewards.get("xp_gained", 0)

--- a/auto-battler/scripts/ui/PreparationScene.gd
+++ b/auto-battler/scripts/ui/PreparationScene.gd
@@ -23,7 +23,8 @@ signal enter_dungeon
 func _ready() -> void:
     # Connect the "Enter Dungeon" button to its handler when the scene is ready.
     if is_instance_valid(enter_dungeon_button):
-        enter_dungeon_button.connect("pressed", self, "_on_EnterDungeonButton_pressed")
+        # Use Godot 4 callable connection style
+        enter_dungeon_button.pressed.connect(_on_EnterDungeonButton_pressed)
 
 func _on_ready_button_pressed() -> void:
     emit_signal("enter_dungeon_pressed")

--- a/auto-battler/scripts/ui/RestScene.gd
+++ b/auto-battler/scripts/ui/RestScene.gd
@@ -34,7 +34,8 @@ func _ready():
         update_party_status_display()
         # Hide progress label initially or manage its visibility during a "resting" state
         rest_progress_label.visible = false
-        _continue_button.connect("pressed", self, "_on_ContinueButton_pressed")
+        # Connect continue button using Callable syntax
+        _continue_button.pressed.connect(_on_ContinueButton_pressed)
 
 func update_party_status_display():
 	var member_nodes = party_status_grid.get_children() # These are VBoxContainers


### PR DESCRIPTION
## Summary
- update old `connect()` usage to Godot 4 callable syntax
- clean up PreparationManager connection check

## Testing
- `godot` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f8e3c1b648327a37aa23aeced4cea