### PR TITLE
Fix GDScript parsing errors in UI and combat scripts

### DIFF
--- a/auto-battler/scripts/combat/CombatScene.gd
+++ b/auto-battler/scripts/combat/CombatScene.gd
@@ -42,7 +42,7 @@ func _ready():
                         combat_manager.combat_victory.connect(_on_combat_victory)
                 if not combat_manager.combat_defeat.is_connected(_on_combat_defeat):
                         combat_manager.combat_defeat.connect(_on_combat_defeat)
-                var gm_callable := GameManager.callable("on_combat_end")
+                var gm_callable: Callable = GameManager.callable("on_combat_end")
                 if not combat_manager.combat_ended.is_connected(gm_callable):
                         combat_manager.combat_ended.connect(gm_callable)
                 combat_manager.run_auto_battle_loop()

--- a/auto-battler/scripts/ui/LootPanel.gd
+++ b/auto-battler/scripts/ui/LootPanel.gd
@@ -20,9 +20,9 @@ var current_loot_items: Array = []
 # var LootItemEntryScene = preload("res://scenes/ui_components/LootItemEntry.tscn")
 
 func _ready():
-        if collect_button:
-                collect_button.pressed.connect(_on_CollectButton_pressed)
-        # Populate with some example loot if nothing is passed AND this panel is visible on start (for testing)
+	if collect_button:
+		collect_button.pressed.connect(_on_CollectButton_pressed)
+	# Populate with some example loot if nothing is passed AND this panel is visible on start (for testing)
 	# Typically, you'd call show_loot() from another script to display this panel.
 	if current_loot_items.is_empty() and self.visible:
 		# Rarity: 0=Common, 1=Uncommon, 2=Rare, 3=Epic
@@ -162,4 +162,3 @@ func _on_CollectButton_pressed():
                 var gm = Engine.get_singleton("GameManager")
                 if gm.has_method("change_to_dungeon_map"):
                         gm.change_to_dungeon_map()
-

--- a/auto-battler/scripts/ui/PostBattleSummary.gd
+++ b/auto-battler/scripts/ui/PostBattleSummary.gd
@@ -11,7 +11,7 @@ signal continue_pressed
 @onready var continue_button: Button = get_node(continue_button_path)
 
 func _ready() -> void:
-    continue_button.connect("pressed", self, "_on_ContinueButton_pressed")
+    continue_button.pressed.connect(_on_continue_button_pressed)
 
 func show_summary(rewards: Dictionary) -> void:
     var xp: int = rewards.get("xp_gained", 0)
@@ -28,7 +28,5 @@ func show_summary(rewards: Dictionary) -> void:
     summary_label.text = "XP Gained: %d\nLoot: %s" % [xp, loot_text]
 
 func _on_continue_button_pressed() -> void:
-    emit_signal("continue_pressed")
-
-func _on_ContinueButton_pressed() -> void:
     GameManager.on_post_battle_continue()
+    emit_signal("continue_pressed")

--- a/auto-battler/scripts/ui/PreparationScene.gd
+++ b/auto-battler/scripts/ui/PreparationScene.gd
@@ -1,13 +1,11 @@
 extends Control
 
 # Emitted when the "Enter Dungeon" button is pressed.
-signal enter_dungeon_pressed
 signal enter_dungeon
 
 @export var party_panel_path: NodePath = NodePath("PartyPanel")
 @export var card_panel_path: NodePath = NodePath("CardSelectPanel")
 @export var gear_panel_path: NodePath = NodePath("GearSelectPanel")
-@export var ready_button_path: NodePath = NodePath("ReadyButton")
 @export var enter_dungeon_button_path: NodePath = NodePath("EnterDungeonButton")
 
 ## Stores the party composition chosen in the preparation screen.
@@ -17,16 +15,14 @@ signal enter_dungeon
 @onready var party_panel: Node = get_node(party_panel_path)
 @onready var card_panel: Node = get_node(card_panel_path)
 @onready var gear_panel: Node = get_node(gear_panel_path)
-@onready var ready_button: Button = get_node(ready_button_path)
 @onready var enter_dungeon_button: Button = get_node(enter_dungeon_button_path)
 
 func _ready() -> void:
     # Connect the "Enter Dungeon" button to its handler when the scene is ready.
     if is_instance_valid(enter_dungeon_button):
-        enter_dungeon_button.connect("pressed", self, "_on_EnterDungeonButton_pressed")
+        enter_dungeon_button.pressed.connect(_on_enter_dungeon_button_pressed)
 
-func _on_ready_button_pressed() -> void:
-    emit_signal("enter_dungeon_pressed")
+func _on_enter_dungeon_button_pressed() -> void:
     emit_signal("enter_dungeon")
 
 func gather_selected_party() -> Array:


### PR DESCRIPTION
Corrects several GDScript parsing errors identified from engine logs:

- CombatScene.gd: Fixed type inference for `gm_callable` by explicitly declaring its type as `Callable`.
- PreparationScene.gd: Updated signal connection for `enter_dungeon_button` to Godot 4.x syntax. Consolidated `enter_dungeon_pressed` and `enter_dungeon` signals and handlers, removing unused `ready_button` references.
- LootPanel.gd: Corrected indentation errors within the `_ready` function's conditional loot population logic.
- PostBattleSummary.gd: Updated signal connection for `continue_button` to Godot 4.x syntax. Consolidated duplicate `_on_ContinueButton_pressed` methods into a single handler that calls GameManager and emits the signal.

These changes resolve the reported parse errors and ensure compatibility with Godot 4.x signal handling.