### PR TITLE
Fix mixed indentation in LootPanel.gd

### DIFF
--- a/auto-battler/scripts/ui/LootPanel.gd
+++ b/auto-battler/scripts/ui/LootPanel.gd
@@ -152,13 +152,13 @@ func _on_close_button_pressed():
 
 # Call this method to show the loot panel with specific items
 func show_loot(items_to_display: Array):
-        set_loot_items(items_to_display)
-        self.visible = true
-        # Optional: Bring to front if it's part of a complex UI
-        # move_to_front()
+	set_loot_items(items_to_display)
+	self.visible = true
+	# Optional: Bring to front if it's part of a complex UI
+	# move_to_front()
 
 func _on_CollectButton_pressed():
-        if Engine.has_singleton("GameManager"):
-                var gm = Engine.get_singleton("GameManager")
-                if gm.has_method("change_to_dungeon_map"):
-                        gm.change_to_dungeon_map()
+	if Engine.has_singleton("GameManager"):
+		var gm = Engine.get_singleton("GameManager")
+		if gm.has_method("change_to_dungeon_map"):
+			gm.change_to_dungeon_map()


### PR DESCRIPTION
Corrects a mixed indentation issue (spaces instead of tabs) in auto-battler/scripts/ui/LootPanel.gd.

The methods `show_loot` and `_on_CollectButton_pressed` were using space-based indentation while the rest of the file used tabs. This change ensures consistent tab-based indentation throughout the script.