### PR TITLE
Add Bootstrap startup call

### DIFF
--- a/auto-battler/scripts/main/Bootstrap.gd
+++ b/auto-battler/scripts/main/Bootstrap.gd
@@ -1,5 +1,5 @@
 extends Node
 
 func _ready() -> void:
-    # Let the GameManager autoload handle initial scene setup.
-    pass
+    print("Bootstrap loaded")
+    GameManager.start_run()

--- a/auto-battler/scripts/main/GameManager.gd
+++ b/auto-battler/scripts/main/GameManager.gd
@@ -49,6 +49,13 @@ func _ready() -> void:
     print("GameManager: Initialization complete. Current phase: %s" % current_game_phase)
 
 
+## Entry point invoked by Bootstrap scene to kick off the game flow.
+func start_run() -> void:
+    print("GameManager: start_run called")
+    if get_tree().current_scene == null:
+        _change_game_phase_and_scene("main_menu", "res://auto-battler/scenes/MainMenu.tscn")
+
+
 ## Starts a new dungeon run with selected party and gear.
 func start_new_run(selected_party_composition: Array, initial_gear: Array = []) -> void:
     print("GameManager: Starting new run.")


### PR DESCRIPTION
## Summary
- add start_run hook in Bootstrap.gd
- implement GameManager.start_run helper

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_683f94ea20208327ad60d50b97536d60