### PR TITLE
Connect combat_ended signal

### DIFF
--- a/auto-battler/scripts/combat/CombatManager.gd
+++ b/auto-battler/scripts/combat/CombatManager.gd
@@ -103,7 +103,8 @@ func run_auto_battle_loop() -> void:
     if party_members.is_empty() or enemies.is_empty():
         _log("Cannot start battle: one or both sides are empty.")
         # Determine if this is an immediate win/loss or an error
-        _finalize_combat() # Will determine outcome based on empty sides
+        var immediate_result = _finalize_combat() # Will determine outcome based on empty sides
+        emit_signal("combat_ended", immediate_result)
         return
 
     _build_turn_order() # Initial turn order
@@ -124,7 +125,8 @@ func run_auto_battle_loop() -> void:
         if not (_is_side_defeated(party_members) or _is_side_defeated(enemies)):
             _build_turn_order() # Rebuild turn order for the next round if combat continues
 
-    _finalize_combat()
+    var victory = _finalize_combat()
+    emit_signal("combat_ended", victory)
 
 
 ## Builds or rebuilds the turn order based on combatant speed and status.
@@ -242,7 +244,7 @@ func _is_side_defeated(side_combatants: Array[Combatant]) -> bool:
 
 
 ## Finalizes combat, determines outcome, and emits appropriate signal.
-func _finalize_combat() -> void:
+func _finalize_combat() -> bool:
     var party_defeated = _is_side_defeated(party_members)
     var enemies_defeated = _is_side_defeated(enemies)
     var final_party_state = _get_final_party_state()
@@ -256,7 +258,7 @@ func _finalize_combat() -> void:
         emit_signal("combat_defeat", results)
         if gm and gm.has_method("on_combat_end"):
             gm.on_combat_end(false, results)
-        emit_signal("combat_ended", false)
+        return false
     elif enemies_defeated:
         _log("Party is victorious!")
         _distribute_loot_and_xp() # Calculate loot and XP
@@ -268,7 +270,7 @@ func _finalize_combat() -> void:
         emit_signal("combat_victory", results)
         if gm and gm.has_method("on_combat_end"):
             gm.on_combat_end(true, results)
-        emit_signal("combat_ended", true)
+        return true
     else:
         # This case (neither side defeated, e.g. from round limit) might be a draw or special scenario
         _log("Combat ended inconclusively (e.g., round limit reached).")
@@ -278,7 +280,7 @@ func _finalize_combat() -> void:
         emit_signal("combat_defeat", results) # Or a specific "combat_draw" signal
         if gm and gm.has_method("on_combat_end"):
             gm.on_combat_end(false, results)
-        emit_signal("combat_ended", false)
+        return false
 
 
 ## Gathers the final state of party members (HP, statuses, etc.).

--- a/auto-battler/scripts/combat/CombatScene.gd
+++ b/auto-battler/scripts/combat/CombatScene.gd
@@ -42,7 +42,7 @@ func _ready():
                         combat_manager.combat_victory.connect(_on_combat_victory)
                 if not combat_manager.combat_defeat.is_connected(_on_combat_defeat):
                         combat_manager.combat_defeat.connect(_on_combat_defeat)
-                var gm_callable: Callable = GameManager.callable("on_combat_end")
+                var gm_callable: Callable = GameManager.callable("on_combat_ended")
                 if not combat_manager.combat_ended.is_connected(gm_callable):
                         combat_manager.combat_ended.connect(gm_callable)
                 combat_manager.run_auto_battle_loop()

--- a/auto-battler/scripts/main/GameManager.gd
+++ b/auto-battler/scripts/main/GameManager.gd
@@ -360,6 +360,10 @@ func on_combat_end(victory: bool, results: Dictionary) -> void:
     else:
         on_combat_defeat(results)
 
+## Called when CombatManager emits combat_ended.
+func on_combat_ended(victory: bool) -> void:
+    print("GameManager: combat_ended received. Victory: %s" % victory)
+
 
 ## Called by PostBattleManager when all its processing is complete.
 func on_post_battle_processing_complete(final_party_state_after_effects: Array, rewards_summary: Dictionary) -> void:


### PR DESCRIPTION
## Summary
- emit `combat_ended` after the battle loop concludes
- connect `CombatManager.combat_ended` to `GameManager.on_combat_ended`
- add `GameManager.on_combat_ended` handler

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_683f953ab5e8832792e4e5342785dcee