### PR TITLE
Fix manager script headers

### DIFF
--- a/auto-battler/scripts/combat/CombatManager.gd
+++ b/auto-battler/scripts/combat/CombatManager.gd
@@ -1,5 +1,5 @@
 extends Node
-class_name AutoCombatManager
+class_name CombatManager
 
 ## Manages turn-based combat for the Survival Dungeon CCG Auto-Battler.
 ## Handles party and enemy combatants, turn order, and card usage.

--- a/auto-battler/scripts/combat/CombatScene.gd
+++ b/auto-battler/scripts/combat/CombatScene.gd
@@ -26,7 +26,7 @@ var current_speed_index = 0
 @onready var speed_up_button: Button = get_node(speed_button_path)
 @onready var pause_button: Button = get_node(pause_button_path)
 @onready var feedback_label: Label = get_node(feedback_label_path)
-@onready var combat_manager: AutoCombatManager = get_node(combat_manager_path)
+@onready var combat_manager: CombatManager = get_node(combat_manager_path)
 
 # Placeholder data for party and enemies
 var party_members_data = []

--- a/auto-battler/scripts/main/DungeonMapManager.gd
+++ b/auto-battler/scripts/main/DungeonMapManager.gd
@@ -1,5 +1,5 @@
+extends Node
 class_name DungeonMapManager
-extends Control
 
 ## Manages the procedural dungeon map, node interactions, and transitions to other game states.
 

--- a/auto-battler/scripts/main/PostBattleManager.gd
+++ b/auto-battler/scripts/main/PostBattleManager.gd
@@ -1,9 +1,8 @@
-# PostBattleManager.gd
-# Handles the phase immediately after combat, applying effects,
-# distributing rewards, and determining the next game state transition.
-
 extends Node
 class_name PostBattleManager
+
+# Handles the phase immediately after combat, applying effects,
+# distributing rewards, and determining the next game state transition.
 
 const SUMMARY_SCENE: PackedScene = preload("res://scenes/PostBattleSummary.tscn")
 

--- a/auto-battler/scripts/preparation/PreparationManager.gd
+++ b/auto-battler/scripts/preparation/PreparationManager.gd
@@ -1,5 +1,5 @@
-class_name PreparationManager
 extends Node
+class_name PreparationManager
 
 # Signal emitted when the party is ready to enter the dungeon
 signal party_ready_for_dungeon

--- a/auto-battler/scripts/ui/RestScene.gd
+++ b/auto-battler/scripts/ui/RestScene.gd
@@ -1,5 +1,7 @@
+extends Node
+class_name RestScene
+
 # Scene controlling the rest phase UI
-extends Control
 
 # Signal emitted when the player chooses to continue
 signal rest_completed


### PR DESCRIPTION
## Summary
- ensure manager scripts extend Node before declaring class_name
- rename CombatManager class and update CombatScene

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_683f955e15c88327bcb00b379b59d350