### PR TITLE
Fix Continue button connection in RestScene

### DIFF
--- a/auto-battler/scenes/RestScene.tscn
+++ b/auto-battler/scenes/RestScene.tscn
@@ -38,7 +38,7 @@ visible = false
 [node name="ContinueButton" type="Button" parent="VBox"]
 text = "Continue"
 
-[connection signal="pressed" from="ContinueButton" to="." method="_on_continue_button_pressed"]
+[connection signal="pressed" from="ContinueButton" to="." method="_on_Continue_pressed"]
 [connection signal="pressed" from="ItemButtons/UseFoodButton" to="." method="_on_use_food_button_pressed"]
 [connection signal="pressed" from="ItemButtons/UseDrinkButton" to="." method="_on_use_drink_button_pressed"]
 [connection signal="pressed" from="ItemButtons/CraftButton" to="." method="_on_craft_button_pressed"]

--- a/auto-battler/scripts/ui/RestScene.gd
+++ b/auto-battler/scripts/ui/RestScene.gd
@@ -34,7 +34,7 @@ func _ready():
         update_party_status_display()
         # Hide progress label initially or manage its visibility during a "resting" state
         rest_progress_label.visible = false
-        _continue_button.connect("pressed", self, "_on_ContinueButton_pressed")
+        _continue_button.connect("pressed", self, "_on_Continue_pressed")
 
 func update_party_status_display():
 	var member_nodes = party_status_grid.get_children() # These are VBoxContainers
@@ -139,7 +139,7 @@ func _on_continue_button_pressed():
         # Transition to the next scene (e.g., DungeonMap or a post-rest summary)
         # Example: get_tree().change_scene_to_file("res://scenes/DungeonMap.tscn")
 
-func _on_ContinueButton_pressed() -> void:
+func _on_Continue_pressed() -> void:
         GameManager.on_rest_continue()
 
 


### PR DESCRIPTION
## Summary
- hook up the Continue button in RestScene via script
- call `GameManager.on_rest_continue` when pressed
- update RestScene.tscn connection to new handler

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_683f954c4e588327a45e42a39af54a9b