### PR TITLE
Fix indentation and ternary usage

### DIFF
--- a/auto-battler/scripts/preparation/PreparationManager.gd
+++ b/auto-battler/scripts/preparation/PreparationManager.gd
@@ -189,9 +189,7 @@ func _on_enter_dungeon_pressed() -> void:
     var party_data := party_members_data.duplicate(true)
 
     # Attempt to pass this data to the GameManager singleton
-    var gm := Engine.has_singleton("GameManager") \
-            ? Engine.get_singleton("GameManager") \
-            : get_node_or_null("/root/GameManager")
+    var gm := Engine.get_singleton("GameManager") if Engine.has_singleton("GameManager") else get_node_or_null("/root/GameManager")
 
     if gm:
         if gm.has_method("start_dungeon_run"):

--- a/auto-battler/scripts/ui/PartySetup.gd
+++ b/auto-battler/scripts/ui/PartySetup.gd
@@ -37,9 +37,9 @@ func _on_ready_button_pressed():
 # Placeholder functions for drag-and-drop card assignment
 # In a real implementation, these would handle drag data
 func _can_drop_data(position: Vector2, data) -> bool:
-        # Check if data is a card and can be dropped here
-        return true # Placeholder
+	# Check if data is a card and can be dropped here
+	return true # Placeholder
 
 func _drop_data(position: Vector2, data) -> void:
-        # Handle card drop, assign card to member
-        print("Card dropped: %s" % [str(data)])
+	# Handle card drop, assign card to member
+	print("Card dropped: %s" % [str(data)])


### PR DESCRIPTION
## Summary
- fix PreparationManager's ternary expression
- correct tabs in PartySetup

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_683f9f8cabe88327b24509fd2ffe27fb