### PR TITLE
Fix logical operator in GameManager

### DIFF
--- a/auto-battler/scripts/main/GameManager.gd
+++ b/auto-battler/scripts/main/GameManager.gd
@@ -100,7 +100,7 @@ func _ready() -> void:
 
     # Initialize game, potentially load initial data or set up for main menu.
     # For a new game, this might mean transitioning to a main menu scene.
-    if get_tree().current_scene == null && !Engine.is_editor_hint():
+    if get_tree().current_scene == null and !Engine.is_editor_hint():
          _change_game_phase_and_scene("main_menu", "res://auto-battler/scenes/MainMenu.tscn") # Example path
 
     print("GameManager: Initialization complete. Current phase: %s" % current_game_phase)


### PR DESCRIPTION
## Summary
- fix wrong logical operator in GameManager `_ready`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683fa0d312388327817ab3d5d4180822