### PR TITLE
Fix party setup UI layout

### DIFF
--- a/auto-battler/scenes/PartySetup.tscn
+++ b/auto-battler/scenes/PartySetup.tscn
@@ -11,203 +11,195 @@ grow_horizontal = 2
 grow_vertical = 2
 script = ExtResource("1_abcde")
 
-[node name="HBoxContainer" type="HBoxContainer" parent="."]
+[node name="MainColumn" type="VBoxContainer" parent="."]
+layout_mode = 1
+anchors_preset = 15
+anchor_right = 0.75
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+alignment = 1
+
+[node name="HBoxContainer" type="HBoxContainer" parent="MainColumn"]
+layout_mode = 2
+size_flags_vertical = 3
+alignment = 1
+
+[node name="PartyMemberSlot1" type="VBoxContainer" parent="MainColumn/HBoxContainer"]
+layout_mode = 2
+size_flags_horizontal = 3
+alignment = 1
+
+[node name="Portrait1" type="TextureRect" parent="MainColumn/HBoxContainer/PartyMemberSlot1"]
+layout_mode = 2
+size_flags_vertical = 3
+stretch_mode = 5
+
+[node name="NameLabel1" type="Label" parent="MainColumn/HBoxContainer/PartyMemberSlot1"]
+layout_mode = 2
+text = "Member 1 Name"
+horizontal_alignment = 1
+
+[node name="StatsLabel1" type="Label" parent="MainColumn/HBoxContainer/PartyMemberSlot1"]
+layout_mode = 2
+text = "HP: 100\nRole: Warrior\nClass: Fighter\nFood: 100\nWater: 100"
+horizontal_alignment = 1
+
+[node name="CardsLabel1" type="Label" parent="MainColumn/HBoxContainer/PartyMemberSlot1"]
+layout_mode = 2
+text = "Card 1, Card 2, Card 3, Card 4"
+horizontal_alignment = 1
+
+[node name="GearLabel1" type="Label" parent="MainColumn/HBoxContainer/PartyMemberSlot1"]
+layout_mode = 2
+text = "Equipped Gear"
+horizontal_alignment = 1
+
+[node name="PartyMemberSlot2" type="VBoxContainer" parent="MainColumn/HBoxContainer"]
+layout_mode = 2
+size_flags_horizontal = 3
+alignment = 1
+
+[node name="Portrait2" type="TextureRect" parent="MainColumn/HBoxContainer/PartyMemberSlot2"]
+layout_mode = 2
+size_flags_vertical = 3
+stretch_mode = 5
+
+[node name="NameLabel2" type="Label" parent="MainColumn/HBoxContainer/PartyMemberSlot2"]
+layout_mode = 2
+text = "Member 2 Name"
+horizontal_alignment = 1
+
+[node name="StatsLabel2" type="Label" parent="MainColumn/HBoxContainer/PartyMemberSlot2"]
+layout_mode = 2
+text = "HP: 100\nRole: Mage\nClass: Wizard\nFood: 100\nWater: 100"
+horizontal_alignment = 1
+
+[node name="CardsLabel2" type="Label" parent="MainColumn/HBoxContainer/PartyMemberSlot2"]
+layout_mode = 2
+text = "Card 1, Card 2, Card 3, Card 4"
+horizontal_alignment = 1
+
+[node name="GearLabel2" type="Label" parent="MainColumn/HBoxContainer/PartyMemberSlot2"]
+layout_mode = 2
+text = "Equipped Gear"
+horizontal_alignment = 1
+
+[node name="PartyMemberSlot3" type="VBoxContainer" parent="MainColumn/HBoxContainer"]
+layout_mode = 2
+size_flags_horizontal = 3
+alignment = 1
+
+[node name="Portrait3" type="TextureRect" parent="MainColumn/HBoxContainer/PartyMemberSlot3"]
+layout_mode = 2
+size_flags_vertical = 3
+stretch_mode = 5
+
+[node name="NameLabel3" type="Label" parent="MainColumn/HBoxContainer/PartyMemberSlot3"]
+layout_mode = 2
+text = "Member 3 Name"
+horizontal_alignment = 1
+
+[node name="StatsLabel3" type="Label" parent="MainColumn/HBoxContainer/PartyMemberSlot3"]
+layout_mode = 2
+text = "HP: 100\nRole: Rogue\nClass: Assassin\nFood: 100\nWater: 100"
+horizontal_alignment = 1
+
+[node name="CardsLabel3" type="Label" parent="MainColumn/HBoxContainer/PartyMemberSlot3"]
+layout_mode = 2
+text = "Card 1, Card 2, Card 3, Card 4"
+horizontal_alignment = 1
+
+[node name="GearLabel3" type="Label" parent="MainColumn/HBoxContainer/PartyMemberSlot3"]
+layout_mode = 2
+text = "Equipped Gear"
+horizontal_alignment = 1
+
+[node name="PartyMemberSlot4" type="VBoxContainer" parent="MainColumn/HBoxContainer"]
+layout_mode = 2
+size_flags_horizontal = 3
+alignment = 1
+
+[node name="Portrait4" type="TextureRect" parent="MainColumn/HBoxContainer/PartyMemberSlot4"]
+layout_mode = 2
+size_flags_vertical = 3
+stretch_mode = 5
+
+[node name="NameLabel4" type="Label" parent="MainColumn/HBoxContainer/PartyMemberSlot4"]
+layout_mode = 2
+text = "Member 4 Name"
+horizontal_alignment = 1
+
+[node name="StatsLabel4" type="Label" parent="MainColumn/HBoxContainer/PartyMemberSlot4"]
+layout_mode = 2
+text = "HP: 100\nRole: Cleric\nClass: Priest\nFood: 100\nWater: 100"
+horizontal_alignment = 1
+
+[node name="CardsLabel4" type="Label" parent="MainColumn/HBoxContainer/PartyMemberSlot4"]
+layout_mode = 2
+text = "Card 1, Card 2, Card 3, Card 4"
+horizontal_alignment = 1
+
+[node name="GearLabel4" type="Label" parent="MainColumn/HBoxContainer/PartyMemberSlot4"]
+layout_mode = 2
+text = "Equipped Gear"
+horizontal_alignment = 1
+
+[node name="PartyMemberSlot5" type="VBoxContainer" parent="MainColumn/HBoxContainer"]
+layout_mode = 2
+size_flags_horizontal = 3
+alignment = 1
+
+[node name="Portrait5" type="TextureRect" parent="MainColumn/HBoxContainer/PartyMemberSlot5"]
+layout_mode = 2
+size_flags_vertical = 3
+stretch_mode = 5
+
+[node name="NameLabel5" type="Label" parent="MainColumn/HBoxContainer/PartyMemberSlot5"]
+layout_mode = 2
+text = "Member 5 Name"
+horizontal_alignment = 1
+
+[node name="StatsLabel5" type="Label" parent="MainColumn/HBoxContainer/PartyMemberSlot5"]
+layout_mode = 2
+text = "HP: 100\nRole: Ranger\nClass: Archer\nFood: 100\nWater: 100"
+horizontal_alignment = 1
+
+[node name="CardsLabel5" type="Label" parent="MainColumn/HBoxContainer/PartyMemberSlot5"]
+layout_mode = 2
+text = "Card 1, Card 2, Card 3, Card 4"
+horizontal_alignment = 1
+
+[node name="GearLabel5" type="Label" parent="MainColumn/HBoxContainer/PartyMemberSlot5"]
+layout_mode = 2
+text = "Equipped Gear"
+horizontal_alignment = 1
+
+[node name="ReadyMargin" type="MarginContainer" parent="MainColumn"]
+layout_mode = 2
+size_flags_vertical = 1
+
+[node name="ReadyButton" type="Button" parent="MainColumn/ReadyMargin"]
+layout_mode = 2
+text = "Ready"
+
+[node name="SelectedDetails" type="VBoxContainer" parent="."]
+layout_mode = 1
+anchors_preset = 15
+anchor_left = 0.75
+anchor_right = 1.0
+anchor_top = 0.0
+anchor_bottom = 0.5
+grow_horizontal = 2
+grow_vertical = 2
+
+[node name="SelectedLabel" type="Label" parent="SelectedDetails"]
 layout_mode = 1
 anchors_preset = 15
 anchor_right = 1.0
 anchor_bottom = 1.0
 grow_horizontal = 2
 grow_vertical = 2
-alignment = 1
+text = "Select a member to see details."
 
-[node name="PartyMemberSlot1" type="VBoxContainer" parent="HBoxContainer"]
-layout_mode = 2
-size_flags_horizontal = 3
-alignment = 1
-
-[node name="Portrait1" type="TextureRect" parent="HBoxContainer/PartyMemberSlot1"]
-layout_mode = 2
-size_flags_vertical = 3
-#Placeholdertextureorcolorexpand_mode = 1
-stretch_mode = 5
-
-[node name="NameLabel1" type="Label" parent="HBoxContainer/PartyMemberSlot1"]
-layout_mode = 2
-text = "Member 1 Name"
-horizontal_alignment = 1
-
-[node name="StatsLabel1" type="Label" parent="HBoxContainer/PartyMemberSlot1"]
-layout_mode = 2
-text = "HP: 100
-Role: Warrior
-Class: Fighter
-Food: 100
-Water: 100"
-horizontal_alignment = 1
-
-[node name="CardsLabel1" type="Label" parent="HBoxContainer/PartyMemberSlot1"]
-layout_mode = 2
-text = "Card 1, Card 2, Card 3, Card 4"
-horizontal_alignment = 1
-
-[node name="GearLabel1" type="Label" parent="HBoxContainer/PartyMemberSlot1"]
-layout_mode = 2
-text = "Equipped Gear"
-horizontal_alignment = 1
-"#RepeatPartyMemberSlotfor5members(PartyMemberSlot2toPartyMemberSlot5)#...(similarstructureformembers2-5)...[nodename" = "PartyMemberSlot2"
-type = "VBoxContainer"
-parent = "HBoxContainer"
-"]layout_mode" = 2
-size_flags_horizontal = 3
-alignment = 1
-
-[node name="Portrait2" type="TextureRect" parent="HBoxContainer/PartyMemberSlot2"]
-layout_mode = 2
-size_flags_vertical = 3
-#Placeholdertextureorcolorexpand_mode = 1
-stretch_mode = 5
-
-[node name="NameLabel2" type="Label" parent="HBoxContainer/PartyMemberSlot2"]
-layout_mode = 2
-text = "Member 2 Name"
-horizontal_alignment = 1
-
-[node name="StatsLabel2" type="Label" parent="HBoxContainer/PartyMemberSlot2"]
-layout_mode = 2
-text = "HP: 100
-Role: Mage
-Class: Wizard
-Food: 100
-Water: 100"
-horizontal_alignment = 1
-
-[node name="CardsLabel2" type="Label" parent="HBoxContainer/PartyMemberSlot2"]
-layout_mode = 2
-text = "Card 1, Card 2, Card 3, Card 4"
-horizontal_alignment = 1
-
-[node name="GearLabel2" type="Label" parent="HBoxContainer/PartyMemberSlot2"]
-layout_mode = 2
-text = "Equipped Gear"
-horizontal_alignment = 1
-
-[node name="PartyMemberSlot3" type="VBoxContainer" parent="HBoxContainer"]
-layout_mode = 2
-size_flags_horizontal = 3
-alignment = 1
-
-[node name="Portrait3" type="TextureRect" parent="HBoxContainer/PartyMemberSlot3"]
-layout_mode = 2
-size_flags_vertical = 3
-#Placeholdertextureorcolorexpand_mode = 1
-stretch_mode = 5
-
-[node name="NameLabel3" type="Label" parent="HBoxContainer/PartyMemberSlot3"]
-layout_mode = 2
-text = "Member 3 Name"
-horizontal_alignment = 1
-
-[node name="StatsLabel3" type="Label" parent="HBoxContainer/PartyMemberSlot3"]
-layout_mode = 2
-text = "HP: 100
-Role: Rogue
-Class: Assassin
-Food: 100
-Water: 100"
-horizontal_alignment = 1
-
-[node name="CardsLabel3" type="Label" parent="HBoxContainer/PartyMemberSlot3"]
-layout_mode = 2
-text = "Card 1, Card 2, Card 3, Card 4"
-horizontal_alignment = 1
-
-[node name="GearLabel3" type="Label" parent="HBoxContainer/PartyMemberSlot3"]
-layout_mode = 2
-text = "Equipped Gear"
-horizontal_alignment = 1
-
-[node name="PartyMemberSlot4" type="VBoxContainer" parent="HBoxContainer"]
-layout_mode = 2
-size_flags_horizontal = 3
-alignment = 1
-
-[node name="Portrait4" type="TextureRect" parent="HBoxContainer/PartyMemberSlot4"]
-layout_mode = 2
-size_flags_vertical = 3
-#Placeholdertextureorcolorexpand_mode = 1
-stretch_mode = 5
-
-[node name="NameLabel4" type="Label" parent="HBoxContainer/PartyMemberSlot4"]
-layout_mode = 2
-text = "Member 4 Name"
-horizontal_alignment = 1
-
-[node name="StatsLabel4" type="Label" parent="HBoxContainer/PartyMemberSlot4"]
-layout_mode = 2
-text = "HP: 100
-Role: Cleric
-Class: Priest
-Food: 100
-Water: 100"
-horizontal_alignment = 1
-
-[node name="CardsLabel4" type="Label" parent="HBoxContainer/PartyMemberSlot4"]
-layout_mode = 2
-text = "Card 1, Card 2, Card 3, Card 4"
-horizontal_alignment = 1
-
-[node name="GearLabel4" type="Label" parent="HBoxContainer/PartyMemberSlot4"]
-layout_mode = 2
-text = "Equipped Gear"
-horizontal_alignment = 1
-
-[node name="PartyMemberSlot5" type="VBoxContainer" parent="HBoxContainer"]
-layout_mode = 2
-size_flags_horizontal = 3
-alignment = 1
-
-[node name="Portrait5" type="TextureRect" parent="HBoxContainer/PartyMemberSlot5"]
-layout_mode = 2
-size_flags_vertical = 3
-#Placeholdertextureorcolorexpand_mode = 1
-stretch_mode = 5
-
-[node name="NameLabel5" type="Label" parent="HBoxContainer/PartyMemberSlot5"]
-layout_mode = 2
-text = "Member 5 Name"
-horizontal_alignment = 1
-
-[node name="StatsLabel5" type="Label" parent="HBoxContainer/PartyMemberSlot5"]
-layout_mode = 2
-text = "HP: 100
-Role: Ranger
-Class: Archer
-Food: 100
-Water: 100"
-horizontal_alignment = 1
-
-[node name="CardsLabel5" type="Label" parent="HBoxContainer/PartyMemberSlot5"]
-layout_mode = 2
-text = "Card 1, Card 2, Card 3, Card 4"
-horizontal_alignment = 1
-
-[node name="GearLabel5" type="Label" parent="HBoxContainer/PartyMemberSlot5"]
-layout_mode = 2
-text = "Equipped Gear"
-horizontal_alignment = 1
-
-[node name="ReadyButton" type="Button" parent="."]
-layout_mode = 1
-anchors_preset = 7
-anchor_left = 0.5
-anchor_top = 1.0
-anchor_right = 0.5
-anchor_bottom = 1.0
-offset_left = -50.0
-offset_top = -40.0
-offset_right = 50.0
-grow_horizontal = 2
-grow_vertical = 0
-text = "Ready"
-
-[connection signal="pressed" from="ReadyButton" to="." method="_on_ready_button_pressed"]
+[connection signal="pressed" from="MainColumn/ReadyMargin/ReadyButton" to="." method="_on_ready_button_pressed"]

--- a/auto-battler/scripts/ui/PartySetup.gd
+++ b/auto-battler/scripts/ui/PartySetup.gd
@@ -7,23 +7,24 @@ signal gear_equipped(member_index, gear_slot, gear_data)
 func _ready():
 	# Initialize party member slots (e.g., load character data)
 	# For now, we'll use placeholders
-	for i in range(1, 6):
-		var name_label = get_node_or_null("HBoxContainer/PartyMemberSlot" + str(i) + "/NameLabel" + str(i))
-		if name_label:
-			name_label.text = "Member " + str(i)
+        for i in range(1, 6):
+                var base_path = "MainColumn/HBoxContainer/PartyMemberSlot" + str(i)
+                var name_label = get_node_or_null(base_path + "/NameLabel" + str(i))
+                if name_label:
+                        name_label.text = "Member " + str(i)
 
 		# Initialize other labels and placeholders as needed
-		var stats_label = get_node_or_null("HBoxContainer/PartyMemberSlot" + str(i) + "/StatsLabel" + str(i))
+                var stats_label = get_node_or_null(base_path + "/StatsLabel" + str(i))
 		if stats_label:
 			# You can set default stats here if needed, or leave them as is from the scene file
 			pass
 
-		var cards_label = get_node_or_null("HBoxContainer/PartyMemberSlot" + str(i) + "/CardsLabel" + str(i))
+                var cards_label = get_node_or_null(base_path + "/CardsLabel" + str(i))
 		if cards_label:
 			# You can set default cards info here
 			pass
 
-		var gear_label = get_node_or_null("HBoxContainer/PartyMemberSlot" + str(i) + "/GearLabel" + str(i))
+                var gear_label = get_node_or_null(base_path + "/GearLabel" + str(i))
 		if gear_label:
 			# You can set default gear info here
 			pass


### PR DESCRIPTION
## Summary
- refactor PartySetup.tscn to use containers for member slots, selected member details, and Ready button
- update PartySetup.gd node paths for new layout

## Testing
- `echo "No tests present"`

------
https://chatgpt.com/codex/tasks/task_e_683fa2b3aae483279f7abf3b85248419