### PR TITLE
Fix PartySetup slot2 node header

### DIFF
--- a/auto-battler/scenes/PartySetup.tscn
+++ b/auto-battler/scenes/PartySetup.tscn
@@ -54,10 +54,8 @@ horizontal_alignment = 1
 layout_mode = 2
 text = "Equipped Gear"
 horizontal_alignment = 1
-"#RepeatPartyMemberSlotfor5members(PartyMemberSlot2toPartyMemberSlot5)#...(similarstructureformembers2-5)...[nodename" = "PartyMemberSlot2"
-type = "VBoxContainer"
-parent = "HBoxContainer"
-"]layout_mode" = 2
+[node name="PartyMemberSlot2" type="VBoxContainer" parent="HBoxContainer"]
+layout_mode = 2
 size_flags_horizontal = 3
 alignment = 1
 


### PR DESCRIPTION
## Summary
- correct the node header for PartyMemberSlot2 so it is a proper VBoxContainer

## Testing
- `godot --headless --path auto-battler -s res://dummy.gd` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_683fa34cba0c8327b086d972ba242b07