### PR TITLE
Wire start button to preparation scene

### DIFF
--- a/auto-battler/scenes/MainMenu.tscn
+++ b/auto-battler/scenes/MainMenu.tscn
@@ -34,7 +34,6 @@ text = "Settings"
 [node name="ExitButton" type="Button" parent="VBox"]
 text = "Exit"
 
-[connection signal="pressed" from="VBox/StartButton" to="." method="_on_start_button_pressed"]
 [connection signal="pressed" from="VBox/ContinueButton" to="." method="_on_continue_button_pressed"]
 [connection signal="pressed" from="VBox/SettingsButton" to="." method="_on_settings_button_pressed"]
 [connection signal="pressed" from="VBox/ExitButton" to="." method="_on_exit_button_pressed"]

--- a/auto-battler/scripts/ui/MainMenu.gd
+++ b/auto-battler/scripts/ui/MainMenu.gd
@@ -13,19 +13,17 @@ signal exit_game
 @export var settings_button_path: NodePath = NodePath("VBox/SettingsButton")
 @export var exit_button_path: NodePath = NodePath("VBox/ExitButton")
 
-@onready var _start_button: Button = get_node(start_button_path)
+@onready var start_button: Button = get_node(start_button_path)
 @onready var _continue_button: Button = get_node(continue_button_path)
 @onready var _settings_button: Button = get_node(settings_button_path)
 @onready var _exit_button: Button = get_node(exit_button_path)
 
 func _ready() -> void:
-    # Placeholder for any setup logic. Buttons are connected in the scene file.
-    pass
+    if is_instance_valid(start_button):
+        start_button.pressed.connect(_on_StartButton_pressed)
 
-func _on_start_button_pressed() -> void:
-    print("Start Game button pressed")
-    emit_signal("start_game")
-    # GameManager or another controller should handle the actual scene change.
+func _on_StartButton_pressed() -> void:
+    get_tree().change_scene_to_file("res://scenes/PreparationScene.tscn")
 
 func _on_continue_button_pressed() -> void:
     print("Continue button pressed")


### PR DESCRIPTION
## Summary
- attach start button variable in MainMenu script
- connect the start button in `_ready` and switch to `PreparationScene` on press
- remove automatic signal connection from scene file

## Testing
- `gdformat --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_683fa364d27c8327bce1ef5006867ab0