### PR TITLE
Connect PreparationScene ready button

### DIFF
--- a/auto-battler/scenes/PreparationScene.tscn
+++ b/auto-battler/scenes/PreparationScene.tscn
@@ -1,25 +1,28 @@
+
 [gd_scene load_steps=2 format=3]
 
 [ext_resource type="Script" path="res://scripts/ui/PreparationScene.gd" id="1"]
 
+
 [node name="PreparationScene" type="Control"]
 anchor_right = 1.0
 anchor_bottom = 1.0
+
+[node name="PreparationManager" type="Control" parent="."]
 script = ExtResource("1")
 
-[node name="PartyPanel" type="GridContainer" parent="."]
+[node name="PartyMembersContainer" type="GridContainer" parent="PreparationManager"]
 columns = 5
 
-[node name="CardSelectPanel" type="VBoxContainer" parent="."]
+[node name="CardSelectPanel" type="VBoxContainer" parent="PreparationManager"]
 margin_top = 220
 custom_minimum_size = Vector2(0, 150)
 
-[node name="GearSelectPanel" type="VBoxContainer" parent="."]
+[node name="GearSelectPanel" type="VBoxContainer" parent="PreparationManager"]
 margin_top = 380
 custom_minimum_size = Vector2(0, 150)
 
-[node name="ReadyButton" type="Button" parent="."]
+[node name="ReadyButton" type="Button" parent="PreparationManager"]
 text = "Enter Dungeon"
 margin_top = 560
 
-[connection signal="pressed" from="ReadyButton" to="." method="_on_ready_button_pressed"]

--- a/auto-battler/scripts/main/GameManager.gd
+++ b/auto-battler/scripts/main/GameManager.gd
@@ -176,6 +176,10 @@ func start_dungeon_run(party_data: Array) -> void:
     _change_game_phase_and_scene("dungeon_map", "res://scenes/DungeonMap.tscn")
     call_deferred("_notify_dungeon_map_manager_to_initialize")
 
+## Called by PreparationScene when the player is ready.
+func on_preparation_done(party_data: Array) -> void:
+    start_dungeon_run(party_data)
+
 
 ## Saves the current game state to a specified slot.
 func save_game_state(slot_name: String) -> void:

--- a/auto-battler/scripts/ui/PreparationScene.gd
+++ b/auto-battler/scripts/ui/PreparationScene.gd
@@ -1,36 +1,19 @@
 extends Control
 
-# Emitted when the "Enter Dungeon" button is pressed.
-signal enter_dungeon
-
-@export var party_panel_path: NodePath = NodePath("PartyPanel")
-@export var card_panel_path: NodePath = NodePath("CardSelectPanel")
-@export var gear_panel_path: NodePath = NodePath("GearSelectPanel")
-@export var enter_dungeon_button_path: NodePath = NodePath("EnterDungeonButton")
-
-## Stores the party composition chosen in the preparation screen.
-## Each entry should contain the member data along with assigned cards.
-@export var party_selection: Array = []
-
-@onready var party_panel: Node = get_node(party_panel_path)
-@onready var card_panel: Node = get_node(card_panel_path)
-@onready var gear_panel: Node = get_node(gear_panel_path)
-@onready var enter_dungeon_button: Button = get_node(enter_dungeon_button_path)
+@onready var ready_button: Button = $PreparationManager/ReadyButton
 
 func _ready() -> void:
-    # Connect the "Enter Dungeon" button to its handler when the scene is ready.
-    if is_instance_valid(enter_dungeon_button):
-        enter_dungeon_button.pressed.connect(_on_enter_dungeon_button_pressed)
+    ready_button.connect("pressed", self, "_on_ReadyButton_pressed")
 
-func _on_enter_dungeon_button_pressed() -> void:
-    emit_signal("enter_dungeon")
+func _on_ReadyButton_pressed() -> void:
+    var party_selection := gather_selected_party()
+    print("Party ready:", party_selection)
+    GameManager.on_preparation_done(party_selection)
 
 func gather_selected_party() -> Array:
-    var party: Array = []
-    for panel in party_panel.get_children():
-        var char_data: CharacterData = panel.character_data
-        var assigned_cards: Array = []
-        if panel.has_method("get_assigned_cards"):
-            assigned_cards = panel.get_assigned_cards()
-        party.append({"character": char_data, "cards": assigned_cards})
-    return party
+    var result: Array = []
+    for panel in $PreparationManager/PartyMembersContainer.get_children():
+        var char_data = panel.character_data
+        var assigned = panel.get_assigned_cards()
+        result.append({ "character": char_data, "cards": assigned })
+    return result


### PR DESCRIPTION
## Summary
- restructure PreparationScene.tscn to include a `PreparationManager` node
- update `PreparationScene.gd` to send party data to GameManager
- add `GameManager.on_preparation_done` helper

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68406231ac108327b2b4f46a911e6c62