### PR TITLE
Wire dungeon map node signal

### DIFF
--- a/auto-battler/scenes/DungeonMap.tscn
+++ b/auto-battler/scenes/DungeonMap.tscn
@@ -1,13 +1,17 @@
+
 [gd_scene load_steps=2 format=3]
 
 [ext_resource type="Script" path="res://scripts/main/DungeonMapManager.gd" id="1"]
 
-[node name="DungeonMapManager" type="Control"]
+
+[node name="DungeonMap" type="Control"]
 anchor_right = 1.0
 anchor_bottom = 1.0
+
+[node name="DungeonMapManager" type="Node" parent="."]
 script = ExtResource("1")
 
-[node name="MapNodesContainer" type="HBoxContainer" parent="."]
+[node name="MapContainer" type="HBoxContainer" parent="DungeonMapManager"]
 anchor_left = 0.5
 anchor_top = 0.5
 anchor_right = 0.5
@@ -18,7 +22,7 @@ offset_top = -50
 offset_bottom = 50
 alignment = 1
 
-[node name="PartyStatusOverlay" type="VBoxContainer" parent="."]
+[node name="PartyStatusOverlay" type="VBoxContainer" parent="DungeonMapManager"]
 anchor_left = 0.0
 anchor_top = 0.0
 anchor_right = 0.0

--- a/auto-battler/scripts/main/GameManager.gd
+++ b/auto-battler/scripts/main/GameManager.gd
@@ -306,6 +306,15 @@ func _notify_dungeon_map_manager_to_initialize():
     else:
         printerr("GameManager: Failed to notify DungeonMapManager or method not found.")
 
+func change_to_dungeon_map():
+    get_tree().change_scene_to_file("res://scenes/DungeonMap.tscn")
+    yield(get_tree(), "idle_frame")
+    var map_mgr = get_tree().current_scene.get_node("DungeonMapManager")
+    map_mgr.connect("node_selected", self, "on_node_selected")
+
+func on_node_selected(node_type: String) -> void:
+    on_map_node_selected(node_type)
+
 func on_map_node_selected(node_type: String) -> void:
     match node_type:
         "combat":


### PR DESCRIPTION
## Summary
- convert `DungeonMap.tscn` to use `DungeonMapManager` under a root `Control`
- simplify `DungeonMapManager.gd` for node button callbacks and signal emission
- add `change_to_dungeon_map` and `on_node_selected` helpers in `GameManager`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6840624ac98c8327aa834f7ae4192ed6