### PR TITLE
Connect RestScene continue to GameManager

### DIFF
--- a/auto-battler/scenes/RestScene.tscn
+++ b/auto-battler/scenes/RestScene.tscn
@@ -1,11 +1,15 @@
-[gd_scene load_steps=2 format=3]
+[gd_scene load_steps=3 format=3]
 
 [ext_resource type="Script" path="res://scripts/ui/RestScene.gd" id="1"]
+[ext_resource type="Script" path="res://scripts/main/RestManager.gd" id="2"]
 
 [node name="RestScene" type="Control"]
 anchor_right = 1.0
 anchor_bottom = 1.0
 script = ExtResource("1")
+
+[node name="RestManager" type="Node" parent="."]
+script = ExtResource("2")
 
 [node name="VBox" type="VBoxContainer" parent="."]
 anchor_right = 1.0
@@ -38,7 +42,6 @@ visible = false
 [node name="ContinueButton" type="Button" parent="VBox"]
 text = "Continue"
 
-[connection signal="pressed" from="ContinueButton" to="." method="_on_continue_button_pressed"]
 [connection signal="pressed" from="ItemButtons/UseFoodButton" to="." method="_on_use_food_button_pressed"]
 [connection signal="pressed" from="ItemButtons/UseDrinkButton" to="." method="_on_use_drink_button_pressed"]
 [connection signal="pressed" from="ItemButtons/CraftButton" to="." method="_on_craft_button_pressed"]

--- a/auto-battler/scripts/main/GameManager.gd
+++ b/auto-battler/scripts/main/GameManager.gd
@@ -284,6 +284,12 @@ func _change_game_phase_and_scene(new_phase: String, scene_path: String) -> void
 
     emit_signal("game_phase_changed", new_phase) # For UI or other global listeners
 
+func change_to_rest():
+    get_tree().change_scene_to_file("res://scenes/RestScene.tscn")
+    yield(get_tree(), "idle_frame")
+    var rest_mgr = get_tree().current_scene.get_node("RestManager")
+    rest_mgr.connect("rest_complete", self, "on_rest_continue")
+
 
 # --- Handler Functions for Signals from Other Managers ---
 ## Called when PreparationManager signals party is ready for the dungeon.
@@ -491,6 +497,10 @@ func on_rest_exit_dungeon(updated_party_data: Array) -> void:
     current_party_members = updated_party_data.duplicate(true)
     # Save progress and return to main menu or a summary screen
     end_current_run("autosave", true)
+
+func on_rest_continue() -> void:
+    _change_game_phase_and_scene("dungeon_map", "res://scenes/DungeonMap.tscn")
+    call_deferred("_notify_dungeon_map_manager_to_initialize")
 
 # Remove old scene transition logic if fully replaced.
 # The old on_combat_finished, on_loot_complete, on_rest_complete are now handled by the new signal system.

--- a/auto-battler/scripts/main/RestManager.gd
+++ b/auto-battler/scripts/main/RestManager.gd
@@ -13,6 +13,9 @@ signal rest_continue_exploration(updated_party_data: Array)
 # Emitted when the player decides to exit the dungeon from the rest phase.
 signal rest_exit_dungeon(updated_party_data: Array)
 
+# Simple signal when rest is finished via Continue button
+signal rest_complete
+
 # Exported variables for UI node paths (examples)
 @export var party_stats_display_node: Control  # Assign in editor: Node to display party stats
 @export var consumables_panel_node: Control # Assign in editor: Node for consumable usage
@@ -24,13 +27,10 @@ var current_party_data: Array = [] # To store/display party member details
 var available_consumables: Array = [] # Consumables the player has access to
 
 func _ready() -> void:
-    # Initialization logic for the rest screen
-    # Example: Connect UI element signals to functions in this script
-    # if crafting_button_node:
-    #     crafting_button_node.pressed.connect(_on_crafting_invoked)
-    # if repair_button_node:
-    #     repair_button_node.pressed.connect(_on_repair_invoked)
-    pass
+    $ContinueButton.connect("pressed", self, "_on_Continue_pressed")
+
+func _on_Continue_pressed() -> void:
+    emit_signal("rest_complete")
 
 # Called by GameManager to initialize the rest phase with current data.
 func initialize_rest_phase(party_data: Array, inventory_consumables: Array) -> void:


### PR DESCRIPTION
## Summary
- add RestManager node to RestScene and drop inline connection
- signal RestManager when continuing rest
- add `change_to_rest()` and `on_rest_continue()` in GameManager

## Testing
- `godot --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840626882088327a347d28b21716ac2