### PR TITLE
I've fixed the GDScript parsing errors.

### DIFF
--- a/auto-battler/scripts/combat/CombatScene.gd
+++ b/auto-battler/scripts/combat/CombatScene.gd
@@ -35,7 +35,7 @@ func _ready():
     add_combat_log_entry("Combat Scene Initialized. Player input disabled during auto-battle.")
 
     var combat_mgr: AutoCombatManager = get_node("CombatManager")
-    combat_mgr.connect("combat_ended", GameManager, "on_combat_ended")
+    combat_mgr.combat_ended.connect(GameManager.on_combat_ended)
     if not combat_mgr.combat_victory.is_connected(_on_combat_victory):
         combat_mgr.combat_victory.connect(_on_combat_victory)
     if not combat_mgr.combat_defeat.is_connected(_on_combat_defeat):

--- a/auto-battler/scripts/main/DungeonMapManager.gd
+++ b/auto-battler/scripts/main/DungeonMapManager.gd
@@ -30,7 +30,7 @@ var current_party_status := {
 
 func _ready() -> void:
     for btn in $MapContainer.get_children():
-        btn.connect("pressed", self, "_on_Node_pressed", [btn.name])
+        btn.pressed.connect(_on_Node_pressed.bind(btn.name))
 
 
 ## Generates the procedural map data.

--- a/auto-battler/scripts/main/GameManager.gd
+++ b/auto-battler/scripts/main/GameManager.gd
@@ -11,10 +11,6 @@ func change_to_preparation():
     print("GameManager.change_to_preparation()")
     get_tree().change_scene_to_file("res://scenes/PreparationScene.tscn")
 
-func on_preparation_done(party_data):
-    self.party_data = party_data
-    change_to_dungeon_map()
-
 func change_to_dungeon_map():
     print("GameManager.change_to_dungeon_map()")
     get_tree().change_scene_to_file("res://scenes/DungeonMap.tscn")
@@ -268,7 +264,7 @@ func change_to_rest():
     get_tree().change_scene_to_file("res://scenes/RestScene.tscn")
     yield(get_tree(), "idle_frame")
     var rest_mgr = get_tree().current_scene.get_node("RestManager")
-    rest_mgr.connect("rest_complete", self, "on_rest_continue")
+    rest_mgr.rest_complete.connect(on_rest_continue)
 
 
 # --- Handler Functions for Signals from Other Managers ---
@@ -291,12 +287,6 @@ func _notify_dungeon_map_manager_to_initialize():
         map_manager.display_map()
     else:
         printerr("GameManager: Failed to notify DungeonMapManager or method not found.")
-
-func change_to_dungeon_map():
-    get_tree().change_scene_to_file("res://scenes/DungeonMap.tscn")
-    yield(get_tree(), "idle_frame")
-    var map_mgr = get_tree().current_scene.get_node("DungeonMapManager")
-    map_mgr.connect("node_selected", self, "on_node_selected")
 
 func on_node_selected(node_type: String) -> void:
     on_map_node_selected(node_type)
@@ -394,28 +384,14 @@ func on_combat_ended(victory):
     else:
         get_tree().change_scene_to_file("res://scenes/GameOver.tscn")
 
-func change_to_post_battle():
-    print("GameManager.change_to_post_battle()")
-    get_tree().change_scene_to_file("res://scenes/PostBattleSummary.tscn")
-
 func on_post_battle_continue():
     change_to_rest()
-
-func change_to_rest():
-    print("GameManager.change_to_rest()")
-    get_tree().change_scene_to_file("res://scenes/RestScene.tscn")
-
-func on_rest_continue():
-    change_to_dungeon_map()
 
 func change_to_post_battle() -> void:
     get_tree().change_scene_to_file("res://scenes/PostBattleSummary.tscn")
     yield(get_tree(), "idle_frame")
     var post_mgr = get_tree().current_scene.get_node("PostBattleManager")
-    post_mgr.connect("post_battle_complete", self, "on_post_battle_continue")
-
-func on_post_battle_continue() -> void:
-    print("GameManager: Post-battle continue pressed.")
+    post_mgr.post_battle_complete.connect(on_post_battle_continue)
 
 func on_rest_continue() -> void:
     _change_game_phase_and_scene("dungeon_map", "res://scenes/DungeonMap.tscn")
@@ -426,8 +402,4 @@ func on_rest_continue() -> void:
 
 func change_to_loot() -> void:
     get_tree().change_scene_to_file("res://scenes/LootPanel.tscn")
-    yield(get_tree(), "idle_frame")
-
-func change_to_dungeon_map() -> void:
-    get_tree().change_scene_to_file("res://scenes/DungeonMap.tscn")
     yield(get_tree(), "idle_frame")

--- a/auto-battler/scripts/main/PostBattleManager.gd
+++ b/auto-battler/scripts/main/PostBattleManager.gd
@@ -3,7 +3,7 @@ extends Node
 signal post_battle_complete
 
 func _ready():
-    $VBox/ContinueButton.connect("pressed", self, "_on_Continue_pressed")
+    $VBox/ContinueButton.pressed.connect(_on_Continue_pressed)
 
 func _on_Continue_pressed():
     emit_signal("post_battle_complete")

--- a/auto-battler/scripts/main/RestManager.gd
+++ b/auto-battler/scripts/main/RestManager.gd
@@ -27,7 +27,7 @@ var current_party_data: Array = [] # To store/display party member details
 var available_consumables: Array = [] # Consumables the player has access to
 
 func _ready() -> void:
-    $ContinueButton.connect("pressed", self, "_on_Continue_pressed")
+    $ContinueButton.pressed.connect(_on_Continue_pressed)
 
 func _on_Continue_pressed() -> void:
     emit_signal("rest_complete")

--- a/auto-battler/scripts/ui/LootPanel.gd
+++ b/auto-battler/scripts/ui/LootPanel.gd
@@ -18,7 +18,7 @@ var current_loot_items: Array = []
 # var LootItemEntryScene = preload("res://scenes/ui_components/LootItemEntry.tscn")
 
 func _ready():
-        $CollectButton.connect("pressed", self, "_on_Collect_pressed")
+	$CollectButton.pressed.connect(_on_Collect_pressed)
 	# Populate with some example loot if nothing is passed AND this panel is visible on start (for testing)
 	# Typically, you'd call show_loot() from another script to display this panel.
 	if current_loot_items.is_empty() and self.visible:

--- a/auto-battler/scripts/ui/PreparationScene.gd
+++ b/auto-battler/scripts/ui/PreparationScene.gd
@@ -3,7 +3,7 @@ extends Control
 @onready var ready_button: Button = $PreparationManager/ReadyButton
 
 func _ready() -> void:
-    ready_button.connect("pressed", self, "_on_ReadyButton_pressed")
+    ready_button.pressed.connect(_on_ReadyButton_pressed)
 
 func _on_ReadyButton_pressed() -> void:
     var party_selection := gather_selected_party()


### PR DESCRIPTION
This resolves multiple parsing errors reported in your Godot project:

- Corrected duplicate function definitions in `GameManager.gd`.
- Fixed an indentation error in `LootPanel.gd`.
- Updated Godot 3.x `connect` call syntax to Godot 4.x style across multiple files:
    - GameManager.gd
    - LootPanel.gd
    - DungeonMapManager.gd
    - RestManager.gd
    - PreparationScene.gd
    - CombatScene.gd
    - PostBattleManager.gd

These changes should allow the scripts to compile correctly, addressing the primary errors from the issue log. Scene warnings related to missing parent paths may require separate attention in the Godot editor if they persist.