### PR TITLE
Refactor DungeonMap UI layout

### DIFF
--- a/auto-battler/scenes/DungeonMap.tscn
+++ b/auto-battler/scenes/DungeonMap.tscn
@@ -1,45 +1,111 @@
-
 [gd_scene load_steps=2 format=3]
 
 [ext_resource type="Script" path="res://scripts/main/DungeonMapManager.gd" id="1"]
 
-
 [node name="DungeonMap" type="Control"]
 anchor_right = 1.0
 anchor_bottom = 1.0
+theme = preload("res://ui/GameTheme.tres")
+
+[node name="BG" type="TextureRect" parent="."]
+anchor_right = 1.0
+anchor_bottom = 1.0
+expand = true
+stretch_mode = 6
 
 [node name="DungeonMapManager" type="Node" parent="."]
 script = ExtResource("1")
 
-[node name="MapContainer" type="HBoxContainer" parent="DungeonMapManager"]
-anchor_left = 0.5
-anchor_top = 0.5
-anchor_right = 0.5
-anchor_bottom = 0.5
-offset_left = -200
-offset_right = 200
-offset_top = -50
-offset_bottom = 50
+[node name="ContentMargin" type="MarginContainer" parent="."]
+anchor_right = 1.0
+anchor_bottom = 1.0
+offset_left = 20
+offset_top = 20
+offset_right = -20
+offset_bottom = -20
+
+[node name="MainVBox" type="VBoxContainer" parent="ContentMargin"]
+anchor_right = 1.0
+anchor_bottom = 1.0
 alignment = 1
+separation = 20
 
-[node name="PartyStatusOverlay" type="VBoxContainer" parent="DungeonMapManager"]
-anchor_left = 0.0
-anchor_top = 0.0
-anchor_right = 0.0
-anchor_bottom = 0.0
-custom_minimum_size = Vector2(150, 0)
+[node name="MapTitle" type="Label" parent="ContentMargin/MainVBox"]
+text = "Dungeon Map"
 
-[node name="Member1Status" type="Label" parent="PartyStatusOverlay"]
-text = "Member 1"
+[node name="MapGrid" type="GridContainer" parent="ContentMargin/MainVBox"]
+anchor_right = 1.0
+anchor_bottom = 1.0
+columns = 3
+custom_constants/separation = Vector2(10, 10)
 
-[node name="Member2Status" type="Label" parent="PartyStatusOverlay"]
-text = "Member 2"
+[node name="CombatNode1" type="Button" parent="ContentMargin/MainVBox/MapGrid"]
+text = "C"
 
-[node name="Member3Status" type="Label" parent="PartyStatusOverlay"]
-text = "Member 3"
+[node name="RestNode2" type="Button" parent="ContentMargin/MainVBox/MapGrid"]
+text = "R"
 
-[node name="Member4Status" type="Label" parent="PartyStatusOverlay"]
-text = "Member 4"
+[node name="LootNode3" type="Button" parent="ContentMargin/MainVBox/MapGrid"]
+text = "L"
 
-[node name="Member5Status" type="Label" parent="PartyStatusOverlay"]
-text = "Member 5"
+[node name="CombatNode4" type="Button" parent="ContentMargin/MainVBox/MapGrid"]
+text = "C"
+
+[node name="RestNode5" type="Button" parent="ContentMargin/MainVBox/MapGrid"]
+text = "R"
+
+[node name="LootNode6" type="Button" parent="ContentMargin/MainVBox/MapGrid"]
+text = "L"
+
+[node name="CombatNode7" type="Button" parent="ContentMargin/MainVBox/MapGrid"]
+text = "C"
+
+[node name="RestNode8" type="Button" parent="ContentMargin/MainVBox/MapGrid"]
+text = "R"
+
+[node name="LootNode9" type="Button" parent="ContentMargin/MainVBox/MapGrid"]
+text = "L"
+
+[node name="PartyStatusBar" type="HBoxContainer" parent="ContentMargin/MainVBox"]
+size_flags_horizontal = 3
+separation = 10
+
+[node name="Portrait1" type="TextureRect" parent="ContentMargin/MainVBox/PartyStatusBar"]
+custom_minimum_size = Vector2(64, 64)
+
+[node name="HPBar1" type="ProgressBar" parent="ContentMargin/MainVBox/PartyStatusBar"]
+size_flags_horizontal = 3
+max_value = 100
+value = 100
+
+[node name="Portrait2" type="TextureRect" parent="ContentMargin/MainVBox/PartyStatusBar"]
+custom_minimum_size = Vector2(64, 64)
+
+[node name="HPBar2" type="ProgressBar" parent="ContentMargin/MainVBox/PartyStatusBar"]
+size_flags_horizontal = 3
+max_value = 100
+value = 100
+
+[node name="Portrait3" type="TextureRect" parent="ContentMargin/MainVBox/PartyStatusBar"]
+custom_minimum_size = Vector2(64, 64)
+
+[node name="HPBar3" type="ProgressBar" parent="ContentMargin/MainVBox/PartyStatusBar"]
+size_flags_horizontal = 3
+max_value = 100
+value = 100
+
+[node name="Portrait4" type="TextureRect" parent="ContentMargin/MainVBox/PartyStatusBar"]
+custom_minimum_size = Vector2(64, 64)
+
+[node name="HPBar4" type="ProgressBar" parent="ContentMargin/MainVBox/PartyStatusBar"]
+size_flags_horizontal = 3
+max_value = 100
+value = 100
+
+[node name="Portrait5" type="TextureRect" parent="ContentMargin/MainVBox/PartyStatusBar"]
+custom_minimum_size = Vector2(64, 64)
+
+[node name="HPBar5" type="ProgressBar" parent="ContentMargin/MainVBox/PartyStatusBar"]
+size_flags_horizontal = 3
+max_value = 100
+value = 100


### PR DESCRIPTION
## Summary
- rebuild DungeonMap.tscn using containers
- apply shared theme and add basic background node
- add map grid buttons and party status bar controls

## Testing
- `true`

------
https://chatgpt.com/codex/tasks/task_e_684066bff7a08327986aec34aae2f9eb