### PR TITLE
Refactor PostBattleSummary layout

### DIFF
--- a/auto-battler/scenes/PostBattleSummary.tscn
+++ b/auto-battler/scenes/PostBattleSummary.tscn
@@ -1,31 +1,89 @@
-
-[gd_scene load_steps=1 format=3]
+[gd_scene load_steps=2 format=3]
 
 [ext_resource type="Script" path="res://scripts/main/PostBattleManager.gd" id="1"]
+[ext_resource type="Theme" path="res://ui/GameTheme.tres" id="2"]
 
 [node name="PostBattleSummary" type="Control"]
 anchor_right = 1.0
 anchor_bottom = 1.0
+theme = ExtResource("2")
+
+[node name="BG" type="TextureRect" parent="."]
+anchor_right = 1.0
+anchor_bottom = 1.0
+expand = true
+stretch_mode = 6
+
+[node name="MainVBox" type="VBoxContainer" parent="."]
+anchor_right = 1.0
+anchor_bottom = 1.0
+offset_left = 20.0
+offset_top = 20.0
+offset_right = -20.0
+offset_bottom = -20.0
+alignment = 1
+separation = 20
+
+[node name="TitleLabel" type="Label" parent="MainVBox"]
+text = "Post-Battle Summary"
+horizontal_alignment = 1
+
+[node name="StatsVBox" type="VBoxContainer" parent="MainVBox"]
+separation = 10
+
+[node name="FatigueLabel" type="Label" parent="MainVBox/StatsVBox"]
+text = "Fatigue +1"
+
+[node name="HungerLabel" type="Label" parent="MainVBox/StatsVBox"]
+text = "Hunger +1"
+
+[node name="ThirstLabel" type="Label" parent="MainVBox/StatsVBox"]
+text = "Thirst +1"
+
+[node name="LootGrid" type="GridContainer" parent="MainVBox"]
+columns = 5
+custom_constants/hseparation = 10
+custom_constants/vseparation = 10
+
+[node name="LootItem1" type="VBoxContainer" parent="MainVBox/LootGrid"]
+[node name="LootPlaceholder" type="TextureRect" parent="MainVBox/LootGrid/LootItem1"]
+custom_minimum_size = Vector2(64, 64)
+
+[node name="ItemLabel" type="Label" parent="MainVBox/LootGrid/LootItem1"]
+text = "ItemName"
+
+[node name="LootItem2" type="VBoxContainer" parent="MainVBox/LootGrid"]
+[node name="LootPlaceholder" type="TextureRect" parent="MainVBox/LootGrid/LootItem2"]
+custom_minimum_size = Vector2(64, 64)
+
+[node name="ItemLabel" type="Label" parent="MainVBox/LootGrid/LootItem2"]
+text = "ItemName"
+
+[node name="LootItem3" type="VBoxContainer" parent="MainVBox/LootGrid"]
+[node name="LootPlaceholder" type="TextureRect" parent="MainVBox/LootGrid/LootItem3"]
+custom_minimum_size = Vector2(64, 64)
+
+[node name="ItemLabel" type="Label" parent="MainVBox/LootGrid/LootItem3"]
+text = "ItemName"
+
+[node name="LootItem4" type="VBoxContainer" parent="MainVBox/LootGrid"]
+[node name="LootPlaceholder" type="TextureRect" parent="MainVBox/LootGrid/LootItem4"]
+custom_minimum_size = Vector2(64, 64)
+
+[node name="ItemLabel" type="Label" parent="MainVBox/LootGrid/LootItem4"]
+text = "ItemName"
+
+[node name="LootItem5" type="VBoxContainer" parent="MainVBox/LootGrid"]
+[node name="LootPlaceholder" type="TextureRect" parent="MainVBox/LootGrid/LootItem5"]
+custom_minimum_size = Vector2(64, 64)
+
+[node name="ItemLabel" type="Label" parent="MainVBox/LootGrid/LootItem5"]
+text = "ItemName"
+
+[node name="ContinueButton" type="Button" parent="MainVBox"]
+text = "Continue"
+rect_min_size = Vector2(0, 40)
 
 [node name="PostBattleManager" type="Node" parent="."]
 script = ExtResource("1")
-
-[node name="VBox" type="VBoxContainer" parent="PostBattleManager"]
-anchor_left = 0.25
-anchor_top = 0.25
-anchor_right = 0.75
-anchor_bottom = 0.75
-alignment = 1
-
-[node name="TitleLabel" type="Label" parent="VBox"]
-text = "Battle Results"
-horizontal_alignment = 1
-
-[node name="SummaryLabel" type="Label" parent="VBox"]
-autowrap_mode = 1
-horizontal_alignment = 1
-text = ""
-
-[node name="ContinueButton" type="Button" parent="VBox"]
-text = "Continue"
 

--- a/auto-battler/scripts/main/PostBattleManager.gd
+++ b/auto-battler/scripts/main/PostBattleManager.gd
@@ -3,7 +3,7 @@ extends Node
 signal post_battle_complete
 
 func _ready():
-    $VBox/ContinueButton.connect("pressed", self, "_on_Continue_pressed")
+    $MainVBox/ContinueButton.connect("pressed", self, "_on_Continue_pressed")
 
 func _on_Continue_pressed():
     emit_signal("post_battle_complete")


### PR DESCRIPTION
## Summary
- convert PostBattleSummary layout to container-based structure
- apply shared GameTheme and new UI hierarchy
- update PostBattleManager path for Continue button

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684066cef9188327b4f65933f16392a3