### PR TITLE
Refactor PartySetup scene to use theme and containers

### DIFF
--- a/auto-battler/scenes/PartySetup.tscn
+++ b/auto-battler/scenes/PartySetup.tscn
@@ -1,205 +1,143 @@
-[gd_scene load_steps=2 format=3 uid="uid://c6vj0w0jqy7hx"]
+[gd_scene load_steps=3 format=3 uid="uid://c6vj0w0jqy7hx"]
 
 [ext_resource type="Script" uid="uid://dp5sxi2lnxtoh" path="res://scripts/ui/PartySetup.gd" id="1_abcde"]
+[ext_resource type="Theme" path="res://ui/GameTheme.tres" id="2_theme"]
 
 [node name="PartySetup" type="Control"]
-layout_mode = 3
-anchors_preset = 15
 anchor_right = 1.0
 anchor_bottom = 1.0
-grow_horizontal = 2
-grow_vertical = 2
+theme = ExtResource("2_theme")
 script = ExtResource("1_abcde")
 
-[node name="MainColumn" type="VBoxContainer" parent="."]
-layout_mode = 1
-anchors_preset = 15
-anchor_right = 0.75
+[node name="BG" type="TextureRect" parent="."]
+anchor_right = 1.0
 anchor_bottom = 1.0
-grow_horizontal = 2
-grow_vertical = 2
+expand = true
+stretch_mode = 7
+
+[node name="ContentContainer" type="MarginContainer" parent="."]
+anchor_right = 1.0
+anchor_bottom = 1.0
+margin_left = 20.0
+margin_top = 20.0
+margin_right = -20.0
+margin_bottom = -20.0
+
+[node name="MainVBox" type="VBoxContainer" parent="ContentContainer"]
+anchor_right = 1.0
+anchor_bottom = 1.0
 alignment = 1
+separation = 20
 
-[node name="HBoxContainer" type="HBoxContainer" parent="MainColumn"]
-layout_mode = 2
-size_flags_vertical = 3
-alignment = 1
-
-[node name="PartyMemberSlot1" type="VBoxContainer" parent="MainColumn/HBoxContainer"]
-layout_mode = 2
-size_flags_horizontal = 3
-alignment = 1
-
-[node name="Portrait1" type="TextureRect" parent="MainColumn/HBoxContainer/PartyMemberSlot1"]
-layout_mode = 2
-size_flags_vertical = 3
-stretch_mode = 5
-
-[node name="NameLabel1" type="Label" parent="MainColumn/HBoxContainer/PartyMemberSlot1"]
-layout_mode = 2
-text = "Member 1 Name"
+[node name="TitleLabel" type="Label" parent="ContentContainer/MainVBox"]
+text = "Party Setup"
 horizontal_alignment = 1
 
-[node name="StatsLabel1" type="Label" parent="MainColumn/HBoxContainer/PartyMemberSlot1"]
-layout_mode = 2
-text = "HP: 100\nRole: Warrior\nClass: Fighter\nFood: 100\nWater: 100"
-horizontal_alignment = 1
+[node name="MembersGrid" type="GridContainer" parent="ContentContainer/MainVBox"]
+anchor_right = 1.0
+anchor_bottom = 1.0
+columns = 5
+h_separation = 10
+v_separation = 10
 
-[node name="CardsLabel1" type="Label" parent="MainColumn/HBoxContainer/PartyMemberSlot1"]
-layout_mode = 2
-text = "Card 1, Card 2, Card 3, Card 4"
-horizontal_alignment = 1
+[node name="MemberPanel1" type="PanelContainer" parent="ContentContainer/MainVBox/MembersGrid"]
+[node name="MemberVBox" type="VBoxContainer" parent="ContentContainer/MainVBox/MembersGrid/MemberPanel1"]
+[node name="NameLabel" type="Label" parent="ContentContainer/MainVBox/MembersGrid/MemberPanel1/MemberVBox"]
+text = "Member 1"
+[node name="HPLabel" type="Label" parent="ContentContainer/MainVBox/MembersGrid/MemberPanel1/MemberVBox"]
+text = "HP: 100"
+[node name="RoleLabel" type="Label" parent="ContentContainer/MainVBox/MembersGrid/MemberPanel1/MemberVBox"]
+text = "Role: –"
+[node name="ClassLabel" type="Label" parent="ContentContainer/MainVBox/MembersGrid/MemberPanel1/MemberVBox"]
+text = "Class: –"
+[node name="FoodLabel" type="Label" parent="ContentContainer/MainVBox/MembersGrid/MemberPanel1/MemberVBox"]
+text = "Food: 100"
+[node name="WaterLabel" type="Label" parent="ContentContainer/MainVBox/MembersGrid/MemberPanel1/MemberVBox"]
+text = "Water: 100"
+[node name="CardsLabel" type="Label" parent="ContentContainer/MainVBox/MembersGrid/MemberPanel1/MemberVBox"]
+text = "Cards: –"
+[node name="GearLabel" type="Label" parent="ContentContainer/MainVBox/MembersGrid/MemberPanel1/MemberVBox"]
+text = "Equipped Gear: –"
 
-[node name="GearLabel1" type="Label" parent="MainColumn/HBoxContainer/PartyMemberSlot1"]
-layout_mode = 2
-text = "Equipped Gear"
-horizontal_alignment = 1
+[node name="MemberPanel2" type="PanelContainer" parent="ContentContainer/MainVBox/MembersGrid"]
+[node name="MemberVBox" type="VBoxContainer" parent="ContentContainer/MainVBox/MembersGrid/MemberPanel2"]
+[node name="NameLabel" type="Label" parent="ContentContainer/MainVBox/MembersGrid/MemberPanel2/MemberVBox"]
+text = "Member 2"
+[node name="HPLabel" type="Label" parent="ContentContainer/MainVBox/MembersGrid/MemberPanel2/MemberVBox"]
+text = "HP: 100"
+[node name="RoleLabel" type="Label" parent="ContentContainer/MainVBox/MembersGrid/MemberPanel2/MemberVBox"]
+text = "Role: –"
+[node name="ClassLabel" type="Label" parent="ContentContainer/MainVBox/MembersGrid/MemberPanel2/MemberVBox"]
+text = "Class: –"
+[node name="FoodLabel" type="Label" parent="ContentContainer/MainVBox/MembersGrid/MemberPanel2/MemberVBox"]
+text = "Food: 100"
+[node name="WaterLabel" type="Label" parent="ContentContainer/MainVBox/MembersGrid/MemberPanel2/MemberVBox"]
+text = "Water: 100"
+[node name="CardsLabel" type="Label" parent="ContentContainer/MainVBox/MembersGrid/MemberPanel2/MemberVBox"]
+text = "Cards: –"
+[node name="GearLabel" type="Label" parent="ContentContainer/MainVBox/MembersGrid/MemberPanel2/MemberVBox"]
+text = "Equipped Gear: –"
 
-[node name="PartyMemberSlot2" type="VBoxContainer" parent="HBoxContainer"]
-layout_mode = 2
-size_flags_horizontal = 3
-alignment = 1
+[node name="MemberPanel3" type="PanelContainer" parent="ContentContainer/MainVBox/MembersGrid"]
+[node name="MemberVBox" type="VBoxContainer" parent="ContentContainer/MainVBox/MembersGrid/MemberPanel3"]
+[node name="NameLabel" type="Label" parent="ContentContainer/MainVBox/MembersGrid/MemberPanel3/MemberVBox"]
+text = "Member 3"
+[node name="HPLabel" type="Label" parent="ContentContainer/MainVBox/MembersGrid/MemberPanel3/MemberVBox"]
+text = "HP: 100"
+[node name="RoleLabel" type="Label" parent="ContentContainer/MainVBox/MembersGrid/MemberPanel3/MemberVBox"]
+text = "Role: –"
+[node name="ClassLabel" type="Label" parent="ContentContainer/MainVBox/MembersGrid/MemberPanel3/MemberVBox"]
+text = "Class: –"
+[node name="FoodLabel" type="Label" parent="ContentContainer/MainVBox/MembersGrid/MemberPanel3/MemberVBox"]
+text = "Food: 100"
+[node name="WaterLabel" type="Label" parent="ContentContainer/MainVBox/MembersGrid/MemberPanel3/MemberVBox"]
+text = "Water: 100"
+[node name="CardsLabel" type="Label" parent="ContentContainer/MainVBox/MembersGrid/MemberPanel3/MemberVBox"]
+text = "Cards: –"
+[node name="GearLabel" type="Label" parent="ContentContainer/MainVBox/MembersGrid/MemberPanel3/MemberVBox"]
+text = "Equipped Gear: –"
 
-[node name="Portrait2" type="TextureRect" parent="MainColumn/HBoxContainer/PartyMemberSlot2"]
-layout_mode = 2
-size_flags_vertical = 3
-stretch_mode = 5
+[node name="MemberPanel4" type="PanelContainer" parent="ContentContainer/MainVBox/MembersGrid"]
+[node name="MemberVBox" type="VBoxContainer" parent="ContentContainer/MainVBox/MembersGrid/MemberPanel4"]
+[node name="NameLabel" type="Label" parent="ContentContainer/MainVBox/MembersGrid/MemberPanel4/MemberVBox"]
+text = "Member 4"
+[node name="HPLabel" type="Label" parent="ContentContainer/MainVBox/MembersGrid/MemberPanel4/MemberVBox"]
+text = "HP: 100"
+[node name="RoleLabel" type="Label" parent="ContentContainer/MainVBox/MembersGrid/MemberPanel4/MemberVBox"]
+text = "Role: –"
+[node name="ClassLabel" type="Label" parent="ContentContainer/MainVBox/MembersGrid/MemberPanel4/MemberVBox"]
+text = "Class: –"
+[node name="FoodLabel" type="Label" parent="ContentContainer/MainVBox/MembersGrid/MemberPanel4/MemberVBox"]
+text = "Food: 100"
+[node name="WaterLabel" type="Label" parent="ContentContainer/MainVBox/MembersGrid/MemberPanel4/MemberVBox"]
+text = "Water: 100"
+[node name="CardsLabel" type="Label" parent="ContentContainer/MainVBox/MembersGrid/MemberPanel4/MemberVBox"]
+text = "Cards: –"
+[node name="GearLabel" type="Label" parent="ContentContainer/MainVBox/MembersGrid/MemberPanel4/MemberVBox"]
+text = "Equipped Gear: –"
 
-[node name="NameLabel2" type="Label" parent="MainColumn/HBoxContainer/PartyMemberSlot2"]
-layout_mode = 2
-text = "Member 2 Name"
-horizontal_alignment = 1
+[node name="MemberPanel5" type="PanelContainer" parent="ContentContainer/MainVBox/MembersGrid"]
+[node name="MemberVBox" type="VBoxContainer" parent="ContentContainer/MainVBox/MembersGrid/MemberPanel5"]
+[node name="NameLabel" type="Label" parent="ContentContainer/MainVBox/MembersGrid/MemberPanel5/MemberVBox"]
+text = "Member 5"
+[node name="HPLabel" type="Label" parent="ContentContainer/MainVBox/MembersGrid/MemberPanel5/MemberVBox"]
+text = "HP: 100"
+[node name="RoleLabel" type="Label" parent="ContentContainer/MainVBox/MembersGrid/MemberPanel5/MemberVBox"]
+text = "Role: –"
+[node name="ClassLabel" type="Label" parent="ContentContainer/MainVBox/MembersGrid/MemberPanel5/MemberVBox"]
+text = "Class: –"
+[node name="FoodLabel" type="Label" parent="ContentContainer/MainVBox/MembersGrid/MemberPanel5/MemberVBox"]
+text = "Food: 100"
+[node name="WaterLabel" type="Label" parent="ContentContainer/MainVBox/MembersGrid/MemberPanel5/MemberVBox"]
+text = "Water: 100"
+[node name="CardsLabel" type="Label" parent="ContentContainer/MainVBox/MembersGrid/MemberPanel5/MemberVBox"]
+text = "Cards: –"
+[node name="GearLabel" type="Label" parent="ContentContainer/MainVBox/MembersGrid/MemberPanel5/MemberVBox"]
+text = "Equipped Gear: –"
 
-[node name="StatsLabel2" type="Label" parent="MainColumn/HBoxContainer/PartyMemberSlot2"]
-layout_mode = 2
-text = "HP: 100\nRole: Mage\nClass: Wizard\nFood: 100\nWater: 100"
-horizontal_alignment = 1
-
-[node name="CardsLabel2" type="Label" parent="MainColumn/HBoxContainer/PartyMemberSlot2"]
-layout_mode = 2
-text = "Card 1, Card 2, Card 3, Card 4"
-horizontal_alignment = 1
-
-[node name="GearLabel2" type="Label" parent="MainColumn/HBoxContainer/PartyMemberSlot2"]
-layout_mode = 2
-text = "Equipped Gear"
-horizontal_alignment = 1
-
-[node name="PartyMemberSlot3" type="VBoxContainer" parent="MainColumn/HBoxContainer"]
-layout_mode = 2
-size_flags_horizontal = 3
-alignment = 1
-
-[node name="Portrait3" type="TextureRect" parent="MainColumn/HBoxContainer/PartyMemberSlot3"]
-layout_mode = 2
-size_flags_vertical = 3
-stretch_mode = 5
-
-[node name="NameLabel3" type="Label" parent="MainColumn/HBoxContainer/PartyMemberSlot3"]
-layout_mode = 2
-text = "Member 3 Name"
-horizontal_alignment = 1
-
-[node name="StatsLabel3" type="Label" parent="MainColumn/HBoxContainer/PartyMemberSlot3"]
-layout_mode = 2
-text = "HP: 100\nRole: Rogue\nClass: Assassin\nFood: 100\nWater: 100"
-horizontal_alignment = 1
-
-[node name="CardsLabel3" type="Label" parent="MainColumn/HBoxContainer/PartyMemberSlot3"]
-layout_mode = 2
-text = "Card 1, Card 2, Card 3, Card 4"
-horizontal_alignment = 1
-
-[node name="GearLabel3" type="Label" parent="MainColumn/HBoxContainer/PartyMemberSlot3"]
-layout_mode = 2
-text = "Equipped Gear"
-horizontal_alignment = 1
-
-[node name="PartyMemberSlot4" type="VBoxContainer" parent="MainColumn/HBoxContainer"]
-layout_mode = 2
-size_flags_horizontal = 3
-alignment = 1
-
-[node name="Portrait4" type="TextureRect" parent="MainColumn/HBoxContainer/PartyMemberSlot4"]
-layout_mode = 2
-size_flags_vertical = 3
-stretch_mode = 5
-
-[node name="NameLabel4" type="Label" parent="MainColumn/HBoxContainer/PartyMemberSlot4"]
-layout_mode = 2
-text = "Member 4 Name"
-horizontal_alignment = 1
-
-[node name="StatsLabel4" type="Label" parent="MainColumn/HBoxContainer/PartyMemberSlot4"]
-layout_mode = 2
-text = "HP: 100\nRole: Cleric\nClass: Priest\nFood: 100\nWater: 100"
-horizontal_alignment = 1
-
-[node name="CardsLabel4" type="Label" parent="MainColumn/HBoxContainer/PartyMemberSlot4"]
-layout_mode = 2
-text = "Card 1, Card 2, Card 3, Card 4"
-horizontal_alignment = 1
-
-[node name="GearLabel4" type="Label" parent="MainColumn/HBoxContainer/PartyMemberSlot4"]
-layout_mode = 2
-text = "Equipped Gear"
-horizontal_alignment = 1
-
-[node name="PartyMemberSlot5" type="VBoxContainer" parent="MainColumn/HBoxContainer"]
-layout_mode = 2
-size_flags_horizontal = 3
-alignment = 1
-
-[node name="Portrait5" type="TextureRect" parent="MainColumn/HBoxContainer/PartyMemberSlot5"]
-layout_mode = 2
-size_flags_vertical = 3
-stretch_mode = 5
-
-[node name="NameLabel5" type="Label" parent="MainColumn/HBoxContainer/PartyMemberSlot5"]
-layout_mode = 2
-text = "Member 5 Name"
-horizontal_alignment = 1
-
-[node name="StatsLabel5" type="Label" parent="MainColumn/HBoxContainer/PartyMemberSlot5"]
-layout_mode = 2
-text = "HP: 100\nRole: Ranger\nClass: Archer\nFood: 100\nWater: 100"
-horizontal_alignment = 1
-
-[node name="CardsLabel5" type="Label" parent="MainColumn/HBoxContainer/PartyMemberSlot5"]
-layout_mode = 2
-text = "Card 1, Card 2, Card 3, Card 4"
-horizontal_alignment = 1
-
-[node name="GearLabel5" type="Label" parent="MainColumn/HBoxContainer/PartyMemberSlot5"]
-layout_mode = 2
-text = "Equipped Gear"
-horizontal_alignment = 1
-
-[node name="ReadyMargin" type="MarginContainer" parent="MainColumn"]
-layout_mode = 2
-size_flags_vertical = 1
-
-[node name="ReadyButton" type="Button" parent="MainColumn/ReadyMargin"]
-layout_mode = 2
+[node name="ReadyButton" type="Button" parent="ContentContainer/MainVBox"]
 text = "Ready"
+size_flags_horizontal = 3
+custom_minimum_size = Vector2(0, 40)
 
-[node name="SelectedDetails" type="VBoxContainer" parent="."]
-layout_mode = 1
-anchors_preset = 15
-anchor_left = 0.75
-anchor_right = 1.0
-anchor_top = 0.0
-anchor_bottom = 0.5
-grow_horizontal = 2
-grow_vertical = 2
-
-[node name="SelectedLabel" type="Label" parent="SelectedDetails"]
-layout_mode = 1
-anchors_preset = 15
-anchor_right = 1.0
-anchor_bottom = 1.0
-grow_horizontal = 2
-grow_vertical = 2
-text = "Select a member to see details."
-
-[connection signal="pressed" from="MainColumn/ReadyMargin/ReadyButton" to="." method="_on_ready_button_pressed"]
+[connection signal="pressed" from="ContentContainer/MainVBox/ReadyButton" to="." method="_on_ready_button_pressed"]

--- a/auto-battler/scripts/ui/PartySetup.gd
+++ b/auto-battler/scripts/ui/PartySetup.gd
@@ -8,26 +8,12 @@ func _ready():
     # Initialize party member slots (e.g., load character data)
     # For now, we'll use placeholders
     for i in range(1, 6):
-        var base_path = "MainColumn/HBoxContainer/PartyMemberSlot" + str(i)
-        var name_label = get_node_or_null(base_path + "/NameLabel" + str(i))
+        var base_path = "ContentContainer/MainVBox/MembersGrid/MemberPanel" + str(i) + "/MemberVBox"
+        var name_label = get_node_or_null(base_path + "/NameLabel")
         if name_label:
             name_label.text = "Member " + str(i)
 
-        # Initialize other labels and placeholders as needed
-        var stats_label = get_node_or_null(base_path + "/StatsLabel" + str(i))
-        if stats_label:
-            # You can set default stats here if needed, or leave them as is from the scene file
-            pass
-
-        var cards_label = get_node_or_null(base_path + "/CardsLabel" + str(i))
-        if cards_label:
-            # You can set default cards info here
-            pass
-
-        var gear_label = get_node_or_null(base_path + "/GearLabel" + str(i))
-        if gear_label:
-            # You can set default gear info here
-            pass
+        # Additional labels can be initialized here if needed
 
 func _on_ready_button_pressed():
     print("Ready button pressed")

--- a/auto-battler/ui/GameTheme.tres
+++ b/auto-battler/ui/GameTheme.tres
@@ -1,0 +1,3 @@
+[gd_resource type="Theme" format=3]
+
+[resource]


### PR DESCRIPTION
## Summary
- add placeholder `GameTheme.tres`
- rebuild `PartySetup.tscn` with container-based layout and theme reference
- update `PartySetup.gd` node paths

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684066b198d48327b0e653a2ce8770a7