### PR TITLE
Fix GameManager autoload references

### DIFF
--- a/auto-battler/scripts/main/GameManager.gd
+++ b/auto-battler/scripts/main/GameManager.gd
@@ -1,4 +1,3 @@
-class_name GameManager
 extends Node
 
 var party_data

--- a/auto-battler/scripts/ui/RestScene.gd
+++ b/auto-battler/scripts/ui/RestScene.gd
@@ -136,7 +136,7 @@ func _on_continue_button_pressed():
         emit_signal("rest_completed")
         if _rest_manager and _rest_manager.has_method("on_rest_continue"):
                 _rest_manager.on_rest_continue()
-        GameManager.on_rest_continue() # Check if GameManager is globally accessible or needs get_node
+        GameManager.on_rest_continue()
         # Transition to the next scene (e.g., DungeonMap or a post-rest summary)
         # Example: get_tree().change_scene_to_file("res://scenes/DungeonMap.tscn")
 


### PR DESCRIPTION
## Summary
- remove `class_name` from GameManager.gd so the autoload instance is used
- clean up RestScene to call the GameManager singleton directly

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68406ee8426c83279ebbeaf876609d34