### PR TITLE
Fix GameManager call in PreparationScene

### DIFF
--- a/auto-battler/scripts/ui/PreparationScene.gd
+++ b/auto-battler/scripts/ui/PreparationScene.gd
@@ -8,7 +8,7 @@ func _ready() -> void:
 func _on_ReadyButton_pressed() -> void:
     var party_selection := gather_selected_party()
     print("Party ready:", party_selection)
-    GameManager.on_preparation_done(party_selection)
+    get_node("/root/GameManager").on_preparation_done(party_selection)
 
 func gather_selected_party() -> Array:
     var result: Array = []


### PR DESCRIPTION
## Summary
- replace static GameManager call with scene node lookup

## Testing
- `godot --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68406f05a350832788c3a6f8eb6e635d