### PR TITLE
Fix duplicate function causing parse error

### DIFF
--- a/auto-battler/scripts/main/GameManager.gd
+++ b/auto-battler/scripts/main/GameManager.gd
@@ -354,10 +354,6 @@ func on_loot_collected():
     # placeholder
     pass
 
-func on_game_over_requested():
-    # placeholder
-    pass
-
 func on_rest_continue_exploration(_updated_party_data = []):
     # placeholder
     pass


### PR DESCRIPTION
## Summary
- remove duplicate placeholder `on_game_over_requested` implementation

## Testing
- `godot --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68408392d7f08327827d198871ee254f