### PR TITLE
Fix combat ended connection

### DIFF
--- a/auto-battler/scripts/combat/CombatScene.gd
+++ b/auto-battler/scripts/combat/CombatScene.gd
@@ -35,7 +35,7 @@ func _ready():
     add_combat_log_entry("Combat Scene Initialized. Player input disabled during auto-battle.")
 
     var combat_mgr: AutoCombatManager = get_node("CombatManager")
-    combat_mgr.combat_ended.connect(get_node("/root/GameManager").on_combat_ended)
+    combat_mgr.connect("combat_ended", Callable(get_node("/root/GameManager"), "on_combat_ended"))
     if not combat_mgr.combat_victory.is_connected(_on_combat_victory):
         combat_mgr.combat_victory.connect(_on_combat_victory)
     if not combat_mgr.combat_defeat.is_connected(_on_combat_defeat):


### PR DESCRIPTION
## Summary
- connect CombatScene's `combat_ended` signal using a Callable

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68409fcd63748327b2631d3976a616eb