### PR TITLE
Fix RestScene continue handler

### DIFF
--- a/auto-battler/scripts/ui/RestScene.gd
+++ b/auto-battler/scripts/ui/RestScene.gd
@@ -34,7 +34,7 @@ func _ready():
     update_party_status_display()
     # Hide progress label initially or manage its visibility during a "resting" state
     rest_progress_label.visible = false
-    _continue_button.pressed.connect(_on_continue_button_pressed)
+    _continue_button.connect("pressed", self, "_on_continue_button_pressed")
 
 func update_party_status_display():
     var member_nodes = party_status_grid.get_children() # These are VBoxContainers
@@ -136,7 +136,7 @@ func _on_continue_button_pressed():
     emit_signal("rest_completed")
     if _rest_manager and _rest_manager.has_method("on_rest_continue"):
         _rest_manager.on_rest_continue()
-    GameManager.on_rest_continue()
+    get_node("/root/GameManager").on_rest_continue()
     # Transition to the next scene (e.g., DungeonMap or a post-rest summary)
     # Example: get_tree().change_scene_to_file("res://scenes/DungeonMap.tscn")
 


### PR DESCRIPTION
## Summary
- connect RestScene continue button with signal-style `connect`
- call the GameManager singleton via its root path when continuing

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68409fd95acc8327bff971895a25f6e1