### PR TITLE
Fix Godot 4 connect syntax

### DIFF
--- a/auto-battler/scripts/ui/PreparationScene.gd
+++ b/auto-battler/scripts/ui/PreparationScene.gd
@@ -1,9 +1,11 @@
+# res://scripts/ui/PreparationScene.gd
 extends Control
 
 @onready var ready_button = $PreparationManager/ReadyButton
 
 func _ready():
-    ready_button.connect("pressed", self, "_on_ReadyButton_pressed")
+    # Godot 4 requires a Callable instead of "self, method_name"
+    ready_button.connect("pressed", Callable(self, "_on_ReadyButton_pressed"))
 
 func _on_ReadyButton_pressed():
     var party_selection = gather_selected_party()


### PR DESCRIPTION
## Summary
- update `PreparationScene.gd` to use Callable for `connect`

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6840a9b85a6c8327890815aa3b081bbb