### PR TITLE
Add SettingsScene stub

### DIFF
--- a/auto-battler/scenes/SettingsScene.tscn
+++ b/auto-battler/scenes/SettingsScene.tscn
@@ -1,0 +1,18 @@
+[gd_scene load_steps=2 format=3]
+
+[ext_resource type="Script" path="res://scripts/ui/SettingsScene.gd" id="1"]
+[ext_resource type="Theme" path="res://ui/GameTheme.tres" id="2"]
+
+[node name="SettingsScene" type="Control"]
+anchor_right = 1.0
+anchor_bottom = 1.0
+theme = ExtResource("2")
+script = ExtResource("1")
+
+[node name="SettingsLabel" type="Label" parent="."]
+text = "Settings"
+# If the font resource exists, assign it and set font size
+
+[node name="BackButton" type="Button" parent="."]
+text = "Back"
+

--- a/auto-battler/scripts/ui/SettingsScene.gd
+++ b/auto-battler/scripts/ui/SettingsScene.gd
@@ -1,0 +1,7 @@
+extends Control
+
+func _ready():
+    $BackButton.connect("pressed", Callable(self, "_on_BackButton_pressed"))
+
+func _on_BackButton_pressed():
+    get_tree().change_scene_to_file("res://scenes/MainMenu.tscn")


### PR DESCRIPTION
## Summary
- add a basic SettingsScene for future configuration
- implement SettingsScene script to return to MainMenu

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6840adc715a483278da621129f85124b