### PR TITLE
Implement preparation done transition

### DIFF
--- a/auto-battler/scripts/main/GameManager.gd
+++ b/auto-battler/scripts/main/GameManager.gd
@@ -1,5 +1,14 @@
 extends Node
+var current_party_selection: Array = []
 
 func start_run():
 	print("GameManager.start_run()")
 	get_tree().change_scene_to_file("res://scenes/MainMenu.tscn")
+
+func on_preparation_done(party_data: Array) -> void:
+	current_party_selection = party_data
+	print("GameManager: Received party data:", party_data)
+	change_to_dungeon_map()
+
+func change_to_dungeon_map() -> void:
+	get_tree().change_scene_to_file("res://scenes/DungeonMap.tscn")


### PR DESCRIPTION
## Summary
- track party selection in `GameManager.gd`
- add `on_preparation_done` to handle party ready signal
- implement `change_to_dungeon_map` for scene swap

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6840bc1123f08327a00ced62f98c1e62