### PR TITLE
Add SceneLoader and sequential scene transitions

### DIFF
--- a/auto-battler/project.godot
+++ b/auto-battler/project.godot
@@ -18,3 +18,4 @@ config/icon="res://icon.svg"
 [autoload]
 
 GameManager="*res://scripts/main/GameManager.gd"
+SceneLoader="*res://scripts/main/SceneLoader.gd"

--- a/auto-battler/scripts/combat/CombatScene.gd
+++ b/auto-battler/scripts/combat/CombatScene.gd
@@ -97,7 +97,8 @@ func _on_combat_victory(results: Dictionary) -> void:
 						gm.on_combat_end(true, results)
 				elif gm.has_method("on_combat_victory"):
 						gm.on_combat_victory(results)
-		end_combat()
+                end_combat()
+                SceneLoader.goto_scene("PostBattleSummary")
 
 func _on_combat_defeat(results: Dictionary) -> void:
 		var gm = get_node_or_null("/root/GameManager")
@@ -106,7 +107,8 @@ func _on_combat_defeat(results: Dictionary) -> void:
 						gm.on_combat_end(false, results)
 				elif gm.has_method("on_combat_ended"):
 						gm.on_combat_ended(false)
-		end_combat()
+                end_combat()
+                SceneLoader.goto_scene("PostBattleSummary")
 
 func add_combat_log_entry(text_entry: String):
 	var new_log = Label.new()

--- a/auto-battler/scripts/main/GameManager.gd
+++ b/auto-battler/scripts/main/GameManager.gd
@@ -2,8 +2,8 @@ extends Node
 var current_party_selection: Array = []
 
 func start_run():
-	print("GameManager.start_run()")
-	get_tree().change_scene_to_file("res://scenes/MainMenu.tscn")
+        print("GameManager.start_run()")
+        SceneLoader.goto_scene("MainMenu")
 
 func on_preparation_done(party_data: Array) -> void:
 	current_party_selection = party_data
@@ -11,4 +11,4 @@ func on_preparation_done(party_data: Array) -> void:
 	change_to_dungeon_map()
 
 func change_to_dungeon_map() -> void:
-	get_tree().change_scene_to_file("res://scenes/DungeonMap.tscn")
+        SceneLoader.goto_scene("DungeonMap")

--- a/auto-battler/scripts/main/SceneLoader.gd
+++ b/auto-battler/scripts/main/SceneLoader.gd
@@ -1,0 +1,26 @@
+extends Node
+class_name SceneLoader
+
+static var SCENES := {
+    "MainMenu": "res://scenes/MainMenu.tscn",
+    "PartySetup": "res://scenes/PartySetup.tscn",
+    "PreparationScene": "res://scenes/PreparationScene.tscn",
+    "DungeonMap": "res://scenes/DungeonMap.tscn",
+    "CombatScene": "res://scenes/CombatScene.tscn",
+    "PostBattleSummary": "res://scenes/PostBattleSummary.tscn",
+    "RestScene": "res://scenes/RestScene.tscn",
+    "SettingsScene": "res://scenes/SettingsScene.tscn",
+    "CraftingScene": "res://scenes/CraftingScene.tscn",
+    "LootPanel": "res://scenes/LootPanel.tscn",
+    "EventPanel": "res://scenes/EventPanel.tscn",
+    "InventoryCrafting": "res://scenes/InventoryCrafting.tscn",
+    "Bootstrap": "res://scenes/Bootstrap.tscn"
+}
+
+static func goto_scene(key: String) -> void:
+    if !SCENES.has(key):
+        push_error("SceneLoader: Unknown scene key %s" % key)
+        return
+    get_tree().change_scene_to_file(SCENES[key])
+
+

--- a/auto-battler/scripts/ui/LootPanel.gd
+++ b/auto-battler/scripts/ui/LootPanel.gd
@@ -155,4 +155,4 @@ func show_loot(items_to_display: Array):
 	# move_to_front()
 
 func _on_Collect_pressed():
-	get_node("/root/GameManager").change_to_dungeon_map()
+        SceneLoader.goto_scene("DungeonMap")

--- a/auto-battler/scripts/ui/MainMenu.gd
+++ b/auto-battler/scripts/ui/MainMenu.gd
@@ -12,13 +12,13 @@ func _ready():
 	exit_button.connect("pressed", Callable(self, "_on_ExitButton_pressed"))
 
 func _on_StartButton_pressed():
-	get_tree().change_scene_to_file("res://scenes/PreparationScene.tscn")
+        SceneLoader.goto_scene("PartySetup")
 
 func _on_ContinueButton_pressed():
-	get_tree().change_scene_to_file("res://scenes/DungeonMap.tscn")
+        SceneLoader.goto_scene("DungeonMap")
 
 func _on_SettingsButton_pressed():
-	get_tree().change_scene_to_file("res://scenes/SettingsScene.tscn")
+        SceneLoader.goto_scene("SettingsScene")
 
 func _on_ExitButton_pressed():
 	get_tree().quit()

--- a/auto-battler/scripts/ui/PartySetup.gd
+++ b/auto-battler/scripts/ui/PartySetup.gd
@@ -16,9 +16,8 @@ func _ready():
 		# Additional labels can be initialized here if needed
 
 func _on_ready_button_pressed():
-	print("Ready button pressed")
-	# Transition to the dungeon map scene
-	# get_tree().change_scene_to_file("res://scenes/DungeonMap.tscn")
+        print("Ready button pressed")
+        SceneLoader.goto_scene("PreparationScene")
 
 # Placeholder functions for drag-and-drop card assignment
 # In a real implementation, these would handle drag data

--- a/auto-battler/scripts/ui/PostBattleSummary.gd
+++ b/auto-battler/scripts/ui/PostBattleSummary.gd
@@ -28,5 +28,5 @@ func show_summary(rewards: Dictionary) -> void:
     summary_label.text = "XP Gained: %d\nLoot: %s" % [xp, loot_text]
 
 func _on_continue_button_pressed() -> void:
-    GameManager.on_post_battle_continue()
+    SceneLoader.goto_scene("RestScene")
     emit_signal("continue_pressed")

--- a/auto-battler/scripts/ui/PreparationScene.gd
+++ b/auto-battler/scripts/ui/PreparationScene.gd
@@ -8,7 +8,7 @@ func _ready():
 func _on_ReadyButton_pressed():
     var party_selection = gather_selected_party()
     print("Party ready:", party_selection)
-    get_node("/root/GameManager").on_preparation_done(party_selection)
+    SceneLoader.goto_scene("DungeonMap")
 
 func gather_selected_party() -> Array:
     var result: Array = []

--- a/auto-battler/scripts/ui/RestScene.gd
+++ b/auto-battler/scripts/ui/RestScene.gd
@@ -137,8 +137,7 @@ func _on_continue_button_pressed():
     if _rest_manager and _rest_manager.has_method("on_rest_continue"):
         _rest_manager.on_rest_continue()
     get_node("/root/GameManager").on_rest_continue()
-    # Transition to the next scene (e.g., DungeonMap or a post-rest summary)
-    # Example: get_tree().change_scene_to_file("res://scenes/DungeonMap.tscn")
+    SceneLoader.goto_scene("DungeonMap")
 
 
 # Call this function if party data changes from an external source

--- a/auto-battler/scripts/ui/SettingsScene.gd
+++ b/auto-battler/scripts/ui/SettingsScene.gd
@@ -4,4 +4,4 @@ func _ready():
     $BackButton.connect("pressed", Callable(self, "_on_BackButton_pressed"))
 
 func _on_BackButton_pressed():
-    get_tree().change_scene_to_file("res://scenes/MainMenu.tscn")
+    SceneLoader.goto_scene("MainMenu")


### PR DESCRIPTION
## Summary
- implement `SceneLoader` singleton to load scenes by key
- hook MainMenu, SettingsScene, PartySetup, PreparationScene and other scenes to call `SceneLoader.goto_scene()`
- update GameManager and project settings to reference the new autoload
- after combat, move to `PostBattleSummary` then `RestScene`, and return to the map after resting

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6840c0a61134832780836de0870a11ae