### PR TITLE
Implement simple scene flow

### DIFF
--- a/auto-battler/scenes/PartySetup.tscn
+++ b/auto-battler/scenes/PartySetup.tscn
@@ -228,10 +228,10 @@ text = "Cards: –"
 layout_mode = 2
 text = "Equipped Gear: –"
 
-[node name="ReadyButton" type="Button" parent="ContentContainer/MainVBox"]
+[node name="ConfirmPartyButton" type="Button" parent="ContentContainer/MainVBox"]
 custom_minimum_size = Vector2(0, 40)
 layout_mode = 2
 size_flags_horizontal = 3
 text = "Ready"
 
-[connection signal="pressed" from="ContentContainer/MainVBox/ReadyButton" to="." method="_on_ready_button_pressed"]
+[connection signal="pressed" from="ContentContainer/MainVBox/ConfirmPartyButton" to="." method="_on_confirm_party"]

--- a/auto-battler/scenes/PreparationScene.tscn
+++ b/auto-battler/scenes/PreparationScene.tscn
@@ -14,7 +14,7 @@ script = ExtResource("1_script")
 [node name="PreparationManager" type="Control" parent="."]
 anchors_preset = 0
 
-[node name="ReadyButton" type="Button" parent="PreparationManager"]
+[node name="ContinueButton" type="Button" parent="PreparationManager"]
 layout_mode = 0
 text = "Enter Dungeon"
 

--- a/auto-battler/scripts/ui/PartySetup.gd
+++ b/auto-battler/scripts/ui/PartySetup.gd
@@ -5,19 +5,19 @@ signal card_assigned(member_index, card_slot, card_data)
 signal gear_equipped(member_index, gear_slot, gear_data)
 
 func _ready():
-	# Initialize party member slots (e.g., load character data)
-	# For now, we'll use placeholders
-	for i in range(1, 6):
-		var base_path = "ContentContainer/MainVBox/MembersGrid/MemberPanel" + str(i) + "/MemberVBox"
-		var name_label = get_node_or_null(base_path + "/NameLabel")
-		if name_label:
-			name_label.text = "Member " + str(i)
+    $ConfirmPartyButton.pressed.connect(_on_confirm_party)
+    # Initialize party member slots (e.g., load character data)
+    # For now, we'll use placeholders
+    for i in range(1, 6):
+        var base_path = "ContentContainer/MainVBox/MembersGrid/MemberPanel" + str(i) + "/MemberVBox"
+        var name_label = get_node_or_null(base_path + "/NameLabel")
+        if name_label:
+            name_label.text = "Member " + str(i)
 
-		# Additional labels can be initialized here if needed
+        # Additional labels can be initialized here if needed
 
-func _on_ready_button_pressed():
-        print("Ready button pressed")
-        SceneLoader.goto_scene("PreparationScene")
+func _on_confirm_party():
+    SceneLoader.goto_scene("PreparationScene")
 
 # Placeholder functions for drag-and-drop card assignment
 # In a real implementation, these would handle drag data

--- a/auto-battler/scripts/ui/PreparationScene.gd
+++ b/auto-battler/scripts/ui/PreparationScene.gd
@@ -1,19 +1,7 @@
 extends Control
 
-@onready var ready_button = $PreparationManager/ReadyButton
-
 func _ready():
-    ready_button.connect("pressed", Callable(self, "_on_ReadyButton_pressed"))
+    $ContinueButton.pressed.connect(_on_continue)
 
-func _on_ReadyButton_pressed():
-    var party_selection = gather_selected_party()
-    print("Party ready:", party_selection)
+func _on_continue():
     SceneLoader.goto_scene("DungeonMap")
-
-func gather_selected_party() -> Array:
-    var result: Array = []
-    for panel in $PreparationManager/PartyMembersContainer.get_children():
-        var char_data = panel.character_data
-        var assigned = panel.get_assigned_cards()
-        result.append({ "character": char_data, "cards": assigned })
-    return result


### PR DESCRIPTION
## Summary
- update party setup script to use ConfirmPartyButton
- simplify preparation scene script to use ContinueButton
- rename button nodes in corresponding scenes

## Testing
- `godot --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840c2591b648327b9c38b280d4c4225