### PR TITLE
Add direct scene transitions with constants

### DIFF
--- a/auto-battler/scripts/ui/MainMenu.gd
+++ b/auto-battler/scripts/ui/MainMenu.gd
@@ -1,5 +1,9 @@
 extends Control
 
+const PARTY_SETUP_SCENE := "res://scenes/PartySetup.tscn"
+const DUNGEON_MAP_SCENE := "res://scenes/DungeonMap.tscn"
+const SETTINGS_SCENE := "res://scenes/SettingsScene.tscn"
+
 @onready var start_button    = $ContentMargin/MainVBox/ButtonsVBox/StartButton
 @onready var continue_button = $ContentMargin/MainVBox/ButtonsVBox/ContinueButton
 @onready var settings_button = $ContentMargin/MainVBox/ButtonsVBox/SettingsButton
@@ -12,13 +16,13 @@ func _ready():
 	exit_button.connect("pressed", Callable(self, "_on_ExitButton_pressed"))
 
 func _on_StartButton_pressed():
-        SceneLoader.goto_scene("PartySetup")
+        get_tree().change_scene_to_file(PARTY_SETUP_SCENE)
 
 func _on_ContinueButton_pressed():
-        SceneLoader.goto_scene("DungeonMap")
+        get_tree().change_scene_to_file(DUNGEON_MAP_SCENE)
 
 func _on_SettingsButton_pressed():
-        SceneLoader.goto_scene("SettingsScene")
+        get_tree().change_scene_to_file(SETTINGS_SCENE)
 
 func _on_ExitButton_pressed():
 	get_tree().quit()

--- a/auto-battler/scripts/ui/PartySetup.gd
+++ b/auto-battler/scripts/ui/PartySetup.gd
@@ -1,5 +1,7 @@
 extends Control
 
+const PREPARATION_SCENE := "res://scenes/PreparationScene.tscn"
+
 # Signals for card assignment (placeholders)
 signal card_assigned(member_index, card_slot, card_data)
 signal gear_equipped(member_index, gear_slot, gear_data)
@@ -17,7 +19,7 @@ func _ready():
 
 func _on_ready_button_pressed():
         print("Ready button pressed")
-        SceneLoader.goto_scene("PreparationScene")
+        get_tree().change_scene_to_file(PREPARATION_SCENE)
 
 # Placeholder functions for drag-and-drop card assignment
 # In a real implementation, these would handle drag data

--- a/auto-battler/scripts/ui/PreparationScene.gd
+++ b/auto-battler/scripts/ui/PreparationScene.gd
@@ -1,5 +1,7 @@
 extends Control
 
+const DUNGEON_MAP_SCENE := "res://scenes/DungeonMap.tscn"
+
 @onready var ready_button = $PreparationManager/ReadyButton
 
 func _ready():
@@ -8,7 +10,7 @@ func _ready():
 func _on_ReadyButton_pressed():
     var party_selection = gather_selected_party()
     print("Party ready:", party_selection)
-    SceneLoader.goto_scene("DungeonMap")
+    get_tree().change_scene_to_file(DUNGEON_MAP_SCENE)
 
 func gather_selected_party() -> Array:
     var result: Array = []


### PR DESCRIPTION
## Summary
- reference target scenes directly via constants
- transition MainMenu -> PartySetup, PartySetup -> Preparation, and Preparation -> DungeonMap using `change_scene_to_file`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6840c28f7d7083279bcbdee43c785377