### PR TITLE
Fix Godot script indentation and connections

### DIFF
--- a/auto-battler/scripts/combat/CombatScene.gd
+++ b/auto-battler/scripts/combat/CombatScene.gd
@@ -97,8 +97,8 @@ func _on_combat_victory(results: Dictionary) -> void:
 						gm.on_combat_end(true, results)
 				elif gm.has_method("on_combat_victory"):
 						gm.on_combat_victory(results)
-                end_combat()
-                SceneLoader.goto_scene("PostBattleSummary")
+		end_combat()
+		SceneLoader.goto_scene("PostBattleSummary")
 
 func _on_combat_defeat(results: Dictionary) -> void:
 		var gm = get_node_or_null("/root/GameManager")
@@ -107,8 +107,8 @@ func _on_combat_defeat(results: Dictionary) -> void:
 						gm.on_combat_end(false, results)
 				elif gm.has_method("on_combat_ended"):
 						gm.on_combat_ended(false)
-                end_combat()
-                SceneLoader.goto_scene("PostBattleSummary")
+		end_combat()
+		SceneLoader.goto_scene("PostBattleSummary")
 
 func add_combat_log_entry(text_entry: String):
 	var new_log = Label.new()

--- a/auto-battler/scripts/main/GameManager.gd
+++ b/auto-battler/scripts/main/GameManager.gd
@@ -2,13 +2,13 @@ extends Node
 var current_party_selection: Array = []
 
 func start_run():
-        print("GameManager.start_run()")
-        SceneLoader.goto_scene("MainMenu")
+    print("GameManager.start_run()")
+    SceneLoader.goto_scene("MainMenu")
 
 func on_preparation_done(party_data: Array) -> void:
-	current_party_selection = party_data
-	print("GameManager: Received party data:", party_data)
-	change_to_dungeon_map()
+    current_party_selection = party_data
+    print("GameManager: Received party data:", party_data)
+    change_to_dungeon_map()
 
 func change_to_dungeon_map() -> void:
-        SceneLoader.goto_scene("DungeonMap")
+    SceneLoader.goto_scene("DungeonMap")

--- a/auto-battler/scripts/main/SceneLoader.gd
+++ b/auto-battler/scripts/main/SceneLoader.gd
@@ -1,7 +1,6 @@
 extends Node
-class_name SceneLoader
 
-static var SCENES := {
+const SCENES := {
     "MainMenu": "res://scenes/MainMenu.tscn",
     "PartySetup": "res://scenes/PartySetup.tscn",
     "PreparationScene": "res://scenes/PreparationScene.tscn",
@@ -17,7 +16,7 @@ static var SCENES := {
     "Bootstrap": "res://scenes/Bootstrap.tscn"
 }
 
-static func goto_scene(key: String) -> void:
+func goto_scene(key: String) -> void:
     if !SCENES.has(key):
         push_error("SceneLoader: Unknown scene key %s" % key)
         return

--- a/auto-battler/scripts/ui/LootPanel.gd
+++ b/auto-battler/scripts/ui/LootPanel.gd
@@ -155,4 +155,4 @@ func show_loot(items_to_display: Array):
 	# move_to_front()
 
 func _on_Collect_pressed():
-        SceneLoader.goto_scene("DungeonMap")
+	SceneLoader.goto_scene("DungeonMap")

--- a/auto-battler/scripts/ui/MainMenu.gd
+++ b/auto-battler/scripts/ui/MainMenu.gd
@@ -10,10 +10,10 @@ const SETTINGS_SCENE := "res://scenes/SettingsScene.tscn"
 @onready var exit_button     = $ContentMargin/MainVBox/ButtonsVBox/ExitButton
 
 func _ready():
-	start_button.connect("pressed", Callable(self, "_on_StartButton_pressed"))
-	continue_button.connect("pressed", Callable(self, "_on_ContinueButton_pressed"))
-	settings_button.connect("pressed", Callable(self, "_on_SettingsButton_pressed"))
-	exit_button.connect("pressed", Callable(self, "_on_ExitButton_pressed"))
+    start_button.connect("pressed", Callable(self, "_on_StartButton_pressed"))
+    continue_button.connect("pressed", Callable(self, "_on_ContinueButton_pressed"))
+    settings_button.connect("pressed", Callable(self, "_on_SettingsButton_pressed"))
+    exit_button.connect("pressed", Callable(self, "_on_ExitButton_pressed"))
 
 func _on_StartButton_pressed():
         get_tree().change_scene_to_file(PARTY_SETUP_SCENE)
@@ -25,4 +25,4 @@ func _on_SettingsButton_pressed():
         get_tree().change_scene_to_file(SETTINGS_SCENE)
 
 func _on_ExitButton_pressed():
-	get_tree().quit()
+    get_tree().quit()

--- a/auto-battler/scripts/ui/PartySetup.gd
+++ b/auto-battler/scripts/ui/PartySetup.gd
@@ -25,9 +25,9 @@ func _on_ready_button_pressed():
 # Placeholder functions for drag-and-drop card assignment
 # In a real implementation, these would handle drag data
 func _can_drop_data(position: Vector2, data) -> bool:
-	# Check if data is a card and can be dropped here
-	return true # Placeholder
+    # Check if data is a card and can be dropped here
+    return true # Placeholder
 
 func _drop_data(position: Vector2, data) -> void:
-	# Handle card drop, assign card to member
-	print("Card dropped: %s" % [str(data)])
+    # Handle card drop, assign card to member
+    print("Card dropped: %s" % [str(data)])

--- a/auto-battler/scripts/ui/PreparationScene.gd
+++ b/auto-battler/scripts/ui/PreparationScene.gd
@@ -3,14 +3,14 @@ extends Control
 
 const DUNGEON_MAP_SCENE := "res://scenes/DungeonMap.tscn"
 
-@onready var ready_button = $PreparationManager/ReadyButton
+@onready var continue_button = $PreparationManager/ContinueButton
 
 
 func _ready():
-    $ContinueButton.pressed.connect(_on_continue)
+    continue_button.pressed.connect(_on_continue_button_pressed)
 
 
-func _on_ReadyButton_pressed():
+func _on_continue_button_pressed():
     var party_selection = gather_selected_party()
     print("Party ready:", party_selection)
     get_tree().change_scene_to_file(DUNGEON_MAP_SCENE)

--- a/auto-battler/scripts/ui/RestScene.gd
+++ b/auto-battler/scripts/ui/RestScene.gd
@@ -34,7 +34,7 @@ func _ready():
     update_party_status_display()
     # Hide progress label initially or manage its visibility during a "resting" state
     rest_progress_label.visible = false
-    _continue_button.connect("pressed", self, "_on_continue_button_pressed")
+    _continue_button.pressed.connect(_on_continue_button_pressed)
 
 func update_party_status_display():
     var member_nodes = party_status_grid.get_children() # These are VBoxContainers


### PR DESCRIPTION
## Summary
- fix mixed indentation in several GDScript files
- remove static declaration from SceneLoader and update scene switching
- replace outdated signal connection syntax
- correct PreparationScene logic

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6840ce71948883279d4becb126c7a8f3