### PR TITLE
Add gdformat CI workflow

### DIFF
--- a/.github/workflows/gdformat.yml
+++ b/.github/workflows/gdformat.yml
@@ -1,0 +1,27 @@
+name: GDScript Formatting Check
+
+on:
+  push:
+    paths:
+      - '**.gd'
+  pull_request:
+    paths:
+      - '**.gd'
+
+jobs:
+  gdformat-check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+
+      - name: Install gdtoolkit
+        run: pip install gdtoolkit
+
+      - name: Run gdformat (check mode)
+        run: |
+          gdformat --check .

--- a/README.md
+++ b/README.md
@@ -45,3 +45,8 @@ When generating documentation, docstrings, or comments, base them on the termino
 Additional developer notes are available in [docs/TECHNICAL_OVERVIEW.md](docs/TECHNICAL_OVERVIEW.md). The full game design outline is in [GAME_DESIGN.md](GAME_DESIGN.md).
 
 This repository is a prototype for demonstration purposes. Many scenes and scripts are incomplete and subject to change.
+
+## Formatting
+
+All GDScript files must be formatted using [gdformat](https://github.com/Scony/godot-gdscript-toolkit). A GitHub Actions workflow automatically checks formatting on pushes and pull requests. Run `gdformat .` before committing changes to avoid CI failures.
+


### PR DESCRIPTION
## Summary
- add gdformat CI workflow to automatically check formatting
- document gdformat usage in README

## Testing
- `pip install gdtoolkit` *(fails: Tunnel connection failed)*

------
https://chatgpt.com/codex/tasks/task_e_6840d03862208327a3ae0cb12f48f278