### PR TITLE
Add GDScript linting and headless syntax check

### DIFF
--- a/.github/workflows/gdscript-quality.yml
+++ b/.github/workflows/gdscript-quality.yml
@@ -1,0 +1,34 @@
+name: GDScript Code Quality
+
+on:
+  push:
+    paths: ['**.gd']
+  pull_request:
+    paths: ['**.gd']
+
+jobs:
+  gdscript-quality:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+
+      - name: Install gdtoolkit
+        run: pip install gdtoolkit
+
+      - name: Lint GDScript with gdlint
+        run: gdlint .
+
+      - name: Download Godot Headless
+        run: |
+          wget https://downloads.tuxfamily.org/godotengine/4.4.1/mono/Godot_v4.4.1-stable_linux_headless.64.zip
+          unzip Godot_v4.4.1-stable_linux_headless.64.zip
+          mv Godot_v4.4.1-stable_linux_headless.64 godot
+          chmod +x godot
+
+      - name: Syntax check with Godot headless
+        run: ./godot --headless --check-only


### PR DESCRIPTION
## Summary
- add workflow to lint GDScript with gdlint
- download Godot headless and run syntax checks

## Testing
- `pip install gdtoolkit` *(fails: Tunnel connection failed)*
- `gdformat --help` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840d3bdcef08327ae483a8abfe3e405