### PR TITLE
Fix enums and variable usage in scripts

### DIFF
--- a/auto-battler/data/recipes/SampleRecipes.gd
+++ b/auto-battler/data/recipes/SampleRecipes.gd
@@ -1,12 +1,12 @@
-extends Node
 class_name SampleRecipes
+extends Node
 
 
 static func _create_card(name: String, desc: String) -> CardData:
 	var c := CardData.new()
 	c.card_name = name
 	c.description = desc
-	c.card_type = CardData.CardType.Utility
+	c.card_type = CardData.CardType.UTILITY
 	return c
 
 

--- a/auto-battler/scripts/data/CardData.gd
+++ b/auto-battler/scripts/data/CardData.gd
@@ -4,18 +4,27 @@ extends Resource
 # Resource describing a card used throughout the Survival Dungeon CCG.
 
 enum CardType {
-	ABILITY, ATTACK, BUFF, HEAL, DEBUFF, UTILITY, EQUIPMENT, INGREDIENT, FOODDRINK, ELIXIR
+	ABILITY,
+	ATTACK,
+	BUFF,
+	HEAL,
+	DEBUFF,
+	UTILITY,
+	EQUIPMENT,
+	INGREDIENT,
+	FOOD_DRINK,
+	ELIXIR,
 }
 
 enum Rarity { COMMON, UNCOMMON, RARE, LEGENDARY }
 
 @export var card_name: String = ""
 @export_multiline var description: String = ""  # Multiline for better editor UX
-@export var card_type: CardType = CardType.Ability
+@export var card_type: CardType = CardType.ABILITY
 @export var role_restriction: String = ""
 @export var class_restriction: String = ""
 @export_multiline var effect_description: String = ""
-@export var rarity: Rarity = Rarity.Common
+@export var rarity: Rarity = Rarity.COMMON
 @export_file("*.png", "*.jpg", "*.jpeg", "*.webp") var icon_path: String = ""
 @export var synergy_tags: Array[String] = []
 @export var energy_cost: int = 0

--- a/auto-battler/scripts/data/CardLibrary.gd
+++ b/auto-battler/scripts/data/CardLibrary.gd
@@ -22,7 +22,7 @@ static func _create_card(
 	c.role_restriction = role_restriction
 	c.class_restriction = class_restriction
 	c.effect_description = effect_description
-	c.rarity = CardData.Rarity.Common
+	c.rarity = CardData.Rarity.COMMON
 	c.icon_path = "res://assets/cards/%s.png" % icon_name
 	c.synergy_tags = synergy_tags
 	c.energy_cost = energy_cost
@@ -38,7 +38,7 @@ static func get_all_cards() -> Array[CardData]:
 		_create_card(
 			"Shield Bash",
 			"Slam enemy with shield, may stun.",
-			CardData.CardType.Attack,
+			CardData.CardType.ATTACK,
 			"Tank",
 			"Guardian, Warrior",
 			"1–3 dmg, 25% stun chance.",
@@ -50,7 +50,7 @@ static func get_all_cards() -> Array[CardData]:
 		_create_card(
 			"Fortify",
 			"Harden defenses for a short period.",
-			CardData.CardType.Buff,
+			CardData.CardType.BUFF,
 			"Tank",
 			"Warrior",
 			"+1 Armor (2 turns).",
@@ -63,7 +63,7 @@ static func get_all_cards() -> Array[CardData]:
 		_create_card(
 			"Taunt",
 			"Draw enemy attacks to self.",
-			CardData.CardType.Utility,
+			CardData.CardType.UTILITY,
 			"Tank",
 			"Guardian",
 			"Enemies focus attacks on user for 1 round.",
@@ -75,7 +75,7 @@ static func get_all_cards() -> Array[CardData]:
 		_create_card(
 			"Iron Will",
 			"Resist debuffs and control effects.",
-			CardData.CardType.Buff,
+			CardData.CardType.BUFF,
 			"Tank",
 			"Any",
 			"Immune to debuffs this round.",
@@ -87,7 +87,7 @@ static func get_all_cards() -> Array[CardData]:
 		_create_card(
 			"Bodyguard",
 			"Protect a weak ally.",
-			CardData.CardType.Utility,
+			CardData.CardType.UTILITY,
 			"Tank",
 			"Guardian",
 			"Redirect next attack targeting an ally to self.",
@@ -99,7 +99,7 @@ static func get_all_cards() -> Array[CardData]:
 		_create_card(
 			"Mending Touch",
 			"Restore moderate HP to an ally.",
-			CardData.CardType.Heal,
+			CardData.CardType.HEAL,
 			"Healer",
 			"Cleric",
 			"Heal 2–4 HP.",
@@ -111,7 +111,7 @@ static func get_all_cards() -> Array[CardData]:
 		_create_card(
 			"Purify",
 			"Remove all debuffs from a party member.",
-			CardData.CardType.Utility,
+			CardData.CardType.UTILITY,
 			"Healer",
 			"Cleric",
 			"Cleanse all debuffs on target.",
@@ -123,7 +123,7 @@ static func get_all_cards() -> Array[CardData]:
 		_create_card(
 			"Revitalize",
 			"Small heal + fatigue reduction.",
-			CardData.CardType.Heal,
+			CardData.CardType.HEAL,
 			"Healer",
 			"Any",
 			"Heal 1–2 HP, -1 Fatigue.",
@@ -135,7 +135,7 @@ static func get_all_cards() -> Array[CardData]:
 		_create_card(
 			"Sanctuary",
 			"Shield party from next damage.",
-			CardData.CardType.Buff,
+			CardData.CardType.BUFF,
 			"Healer",
 			"Cleric",
 			"Next damage instance to party reduced by 2.",
@@ -147,7 +147,7 @@ static func get_all_cards() -> Array[CardData]:
 		_create_card(
 			"Bless",
 			"Enhance an ally’s next action.",
-			CardData.CardType.Buff,
+			CardData.CardType.BUFF,
 			"Healer",
 			"Any",
 			"Next ability used by target gets +1 effect.",
@@ -159,7 +159,7 @@ static func get_all_cards() -> Array[CardData]:
 		_create_card(
 			"Rally Cry",
 			"Inspire allies, boosting attack.",
-			CardData.CardType.Buff,
+			CardData.CardType.BUFF,
 			"Support",
 			"Bard",
 			"All allies +1 damage for next attack.",
@@ -171,7 +171,7 @@ static func get_all_cards() -> Array[CardData]:
 		_create_card(
 			"Mood Maker",
 			"Bestows a random buff to an ally.",
-			CardData.CardType.Buff,
+			CardData.CardType.BUFF,
 			"Support",
 			"Bard",
 			"Random: +1 ATK, +1 DEF, or +1 Energy Regen.",
@@ -183,7 +183,7 @@ static func get_all_cards() -> Array[CardData]:
 		_create_card(
 			"Quick Tune",
 			"Let an ally act sooner.",
-			CardData.CardType.Buff,
+			CardData.CardType.BUFF,
 			"Support",
 			"Bard",
 			"Next turn: target ally acts at top of order.",
@@ -195,7 +195,7 @@ static func get_all_cards() -> Array[CardData]:
 		_create_card(
 			"Disarm",
 			"Reduce enemy’s attack.",
-			CardData.CardType.Debuff,
+			CardData.CardType.DEBUFF,
 			"Support",
 			"Any",
 			"Target enemy deals -1 damage on next attack.",
@@ -207,7 +207,7 @@ static func get_all_cards() -> Array[CardData]:
 		_create_card(
 			"Encore",
 			"Grant extra action to ally.",
-			CardData.CardType.Utility,
+			CardData.CardType.UTILITY,
 			"Support",
 			"Bard",
 			"Ally may repeat last used card.",
@@ -219,7 +219,7 @@ static func get_all_cards() -> Array[CardData]:
 		_create_card(
 			"Quick Slash",
 			"Fast melee attack.",
-			CardData.CardType.Attack,
+			CardData.CardType.ATTACK,
 			"DPS",
 			"Blademaster",
 			"2–4 damage, physical.",
@@ -231,7 +231,7 @@ static func get_all_cards() -> Array[CardData]:
 		_create_card(
 			"Arcane Spark",
 			"Burst of magical energy.",
-			CardData.CardType.Attack,
+			CardData.CardType.ATTACK,
 			"DPS",
 			"Wizard",
 			"2–4 magic damage.",
@@ -243,7 +243,7 @@ static func get_all_cards() -> Array[CardData]:
 		_create_card(
 			"Flurry",
 			"Multiple low-damage hits.",
-			CardData.CardType.Attack,
+			CardData.CardType.ATTACK,
 			"DPS",
 			"Blademaster",
 			"1–2 damage, hit 2 times.",
@@ -255,7 +255,7 @@ static func get_all_cards() -> Array[CardData]:
 		_create_card(
 			"Venom Strike",
 			"Apply poison effect.",
-			CardData.CardType.Debuff,
+			CardData.CardType.DEBUFF,
 			"DPS",
 			"Any",
 			"1–2 damage, +1 DoT (2 turns).",
@@ -267,7 +267,7 @@ static func get_all_cards() -> Array[CardData]:
 		_create_card(
 			"Finisher",
 			"Extra damage if enemy was hit this round.",
-			CardData.CardType.Attack,
+			CardData.CardType.ATTACK,
 			"DPS",
 			"Blademaster",
 			"3–5 damage if enemy already damaged this round.",

--- a/auto-battler/scripts/data/CharacterData.gd
+++ b/auto-battler/scripts/data/CharacterData.gd
@@ -1,10 +1,10 @@
-extends Resource
 class_name CharacterData
+extends Resource
 
 enum Role { TANK, HEALER, SUPPORT, DPS }
 
 @export var character_name: String = ""
-@export var role: Role = Role.Tank
+@export var role: Role = Role.TANK
 @export var character_class: String = ""
 @export var base_hp: int = 10
 @export var base_attack: int = 2

--- a/auto-battler/scripts/data/EnemyData.gd
+++ b/auto-battler/scripts/data/EnemyData.gd
@@ -1,5 +1,5 @@
-extends Resource
 class_name EnemyData
+extends Resource
 
 # Resource data for enemy definitions used in encounters.
 # Allows creation of .tres files within the Godot editor.
@@ -9,7 +9,7 @@ enum EnemyType { CREATURE, DEMIHUMAN, UNDEAD, BOSS }
 
 @export var enemy_name: String = ""
 @export var description: String = ""
-@export var enemy_type: EnemyType = EnemyType.Creature
+@export var enemy_type: EnemyType = EnemyType.CREATURE
 # List of abilities this enemy can use.
 # Entries may be ability names or CardData resources.
 @export var abilities: Array = []  # Array[String] or CardData

--- a/auto-battler/scripts/main/DungeonMapManager.gd
+++ b/auto-battler/scripts/main/DungeonMapManager.gd
@@ -10,10 +10,10 @@ signal transition_to_loot_event(loot_event_data: Dictionary)  # For both loot an
 signal transition_to_rest(rest_setup_data: Dictionary)
 signal node_selected(node_type: String)
 
+const LOOT_PANEL_SCENE := preload("res://scenes/LootPanel.tscn")
+const EVENT_PANEL_SCENE := preload("res://scenes/EventPanel.tscn")
+
 @onready var nodes_container: HBoxContainer = $MapContainer  # UI container for map node buttons
-# Optional: Preload scenes for popups if they remain part of this manager
-const LOOT_PANEL_SCENE := preload("res://scenes/LootPanel.tscn")  # Example if used as popup
-const EVENT_PANEL_SCENE := preload("res://scenes/EventPanel.tscn")  # Example if used as popup
 
 var map_nodes: Array[Dictionary] = []  # Array of dictionaries, each describing a node on the map
 var current_node_id: int = 0  # ID of the node the party is currently on

--- a/auto-battler/scripts/systems/CraftingSystem.gd
+++ b/auto-battler/scripts/systems/CraftingSystem.gd
@@ -1,5 +1,5 @@
-extends Node
 class_name CraftingSystem
+extends Node
 
 ## Handles magical pouch crafting. Accepts up to 5 ingredient cards and outputs
 ## a new card if a recipe is matched. Otherwise creates scrap.
@@ -44,7 +44,7 @@ func _generate_failure_item() -> CardData:
 	var scrap := CardData.new()
 	scrap.card_name = "Scrap"
 	scrap.description = "Leftover debris from failed crafting."
-	scrap.card_type = CardData.CardType.Utility
+	scrap.card_type = CardData.CardType.UTILITY
 	return scrap
 
 
@@ -60,8 +60,8 @@ func _has_synergy(inputs: Array) -> bool:
 
 func _upgrade_output(card: CardData) -> void:
 	## Improve output rarity when synergy is detected.
-	if card.rarity < CardData.Rarity.Legendary:
-		card.rarity += 1
+	if card.rarity < CardData.Rarity.LEGENDARY:
+	card.rarity += 1
 
 
 func _apply_crafted_by_tag(card: CardData, profession: ProfessionData) -> void:


### PR DESCRIPTION
## Summary
- ensure class declarations come before `extends`
- standardize enum names and defaults to ALL_CAPS
- fix crafting and library scripts to use new enum names
- add constants and indent fixes in `DungeonMapManager`

## Testing
- `gdformat auto-battler/scripts/data/CardData.gd auto-battler/scripts/data/EnemyData.gd auto-battler/scripts/data/CharacterData.gd auto-battler/scripts/data/CardLibrary.gd auto-battler/scripts/systems/CraftingSystem.gd auto-battler/data/recipes/SampleRecipes.gd auto-battler/scripts/main/DungeonMapManager.gd`
- `gdlint auto-battler/scripts/data/CardData.gd auto-battler/scripts/data/EnemyData.gd auto-battler/scripts/data/CharacterData.gd auto-battler/scripts/data/CardLibrary.gd auto-battler/scripts/systems/CraftingSystem.gd auto-battler/data/recipes/SampleRecipes.gd auto-battler/scripts/main/DungeonMapManager.gd` *(fails: max-line-length, class-definitions-order)*

------
https://chatgpt.com/codex/tasks/task_e_6840da834188832792abc21129c7eb46