### PR TITLE
Add PartyBuilder UI with sample data

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -1,34 +1,12 @@
-import { useState } from 'react'
-import reactLogo from './assets/react.svg'
-import viteLogo from '/vite.svg'
 import './App.css'
+import PartyBuilder from './components/PartyBuilder.jsx'
 
 function App() {
-  const [count, setCount] = useState(0)
-
   return (
-    <>
-      <div>
-        <a href="https://vite.dev" target="_blank">
-          <img src={viteLogo} className="logo" alt="Vite logo" />
-        </a>
-        <a href="https://react.dev" target="_blank">
-          <img src={reactLogo} className="logo react" alt="React logo" />
-        </a>
-      </div>
-      <h1>Vite + React</h1>
-      <div className="card">
-        <button onClick={() => setCount((count) => count + 1)}>
-          count is {count}
-        </button>
-        <p>
-          Edit <code>src/App.jsx</code> and save to test HMR
-        </p>
-      </div>
-      <p className="read-the-docs">
-        Click on the Vite and React logos to learn more
-      </p>
-    </>
+    <div className="app-container">
+      <h1>Party Builder</h1>
+      <PartyBuilder />
+    </div>
   )
 }
 

--- a/client/src/components/PartyBuilder.jsx
+++ b/client/src/components/PartyBuilder.jsx
@@ -1,0 +1,109 @@
+import { useState } from 'react'
+import { sampleCharacters } from 'shared/models/characters.js'
+import { sampleCards } from 'shared/models/cards.js'
+
+function PartyBuilder() {
+  const [party, setParty] = useState([])
+  const [selectedCards, setSelectedCards] = useState({})
+
+  const availableCharacters = sampleCharacters.filter(
+    (c) => !party.some((p) => p.id === c.id),
+  )
+
+  function addCharacter(char) {
+    if (party.length >= 5) return
+    setParty([...party, { ...char, cards: [] }])
+  }
+
+  function removeCharacter(id) {
+    setParty(party.filter((c) => c.id !== id))
+  }
+
+  function addCard(index) {
+    const cardId = selectedCards[index]
+    if (!cardId) return
+    setParty((prev) =>
+      prev.map((c, i) => {
+        if (i !== index || c.cards.length >= 4 || c.cards.includes(cardId))
+          return c
+        return { ...c, cards: [...c.cards, cardId] }
+      }),
+    )
+  }
+
+  function removeCard(index, cardId) {
+    setParty((prev) =>
+      prev.map((c, i) => {
+        if (i !== index) return c
+        return { ...c, cards: c.cards.filter((id) => id !== cardId) }
+      }),
+    )
+  }
+
+  return (
+    <div className="party-builder">
+      <div className="selection">
+        <h2>Add Characters</h2>
+        <ul>
+          {availableCharacters.map((c) => (
+            <li key={c.id}>
+              {c.name}{' '}
+              <button
+                disabled={party.length >= 5}
+                onClick={() => addCharacter(c)}
+              >
+                Add
+              </button>
+            </li>
+          ))}
+        </ul>
+      </div>
+      <div className="preview">
+        <h2>Party Preview</h2>
+        {party.length === 0 && <p>No characters added.</p>}
+        <ul>
+          {party.map((char, idx) => (
+            <li key={char.id}>
+              <strong>{char.name}</strong>{' '}
+              <button onClick={() => removeCharacter(char.id)}>Remove</button>
+              <ul>
+                {char.cards.map((cid) => {
+                  const card = sampleCards.find((c) => c.id === cid)
+                  return (
+                    <li key={cid}>
+                      {card ? card.name : cid}{' '}
+                      <button onClick={() => removeCard(idx, cid)}>X</button>
+                    </li>
+                  )
+                })}
+              </ul>
+              {char.cards.length < 4 && (
+                <div>
+                  <select
+                    value={selectedCards[idx] || ''}
+                    onChange={(e) =>
+                      setSelectedCards({
+                        ...selectedCards,
+                        [idx]: e.target.value,
+                      })
+                    }
+                  >
+                    <option value="">Select card</option>
+                    {sampleCards.map((c) => (
+                      <option key={c.id} value={c.id}>
+                        {c.name}
+                      </option>
+                    ))}
+                  </select>
+                  <button onClick={() => addCard(idx)}>Add Card</button>
+                </div>
+              )}
+            </li>
+          ))}
+        </ul>
+      </div>
+    </div>
+  )
+}
+
+export default PartyBuilder

--- a/shared/models/cards.js
+++ b/shared/models/cards.js
@@ -1,0 +1,8 @@
+export const sampleCards = [
+  { id: 'strike', name: 'Strike' },
+  { id: 'heal', name: 'Heal' },
+  { id: 'fireball', name: 'Fireball' },
+  { id: 'guard', name: 'Guard' },
+  { id: 'poison', name: 'Poison' },
+  { id: 'arrow', name: 'Arrow Shot' },
+]

--- a/shared/models/characters.js
+++ b/shared/models/characters.js
@@ -1,0 +1,8 @@
+export const sampleCharacters = [
+  { id: 'warrior', name: 'Warrior' },
+  { id: 'cleric', name: 'Cleric' },
+  { id: 'rogue', name: 'Rogue' },
+  { id: 'mage', name: 'Mage' },
+  { id: 'ranger', name: 'Ranger' },
+  { id: 'paladin', name: 'Paladin' },
+]


### PR DESCRIPTION
## Summary
- add sample characters and cards to shared models
- implement a PartyBuilder component for assigning cards to characters
- display the PartyBuilder in the React app

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6841d79e05a08327b9befff6ae08a8ed