### PR TITLE
Add Phaser BattleScene and shared models

### DIFF
--- a/game/index.html
+++ b/game/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Battle Scene</title>
+  </head>
+  <body>
+    <div id="game-container"></div>
+    <script type="module" src="/src/index.js"></script>
+  </body>
+</html>

--- a/game/src/index.js
+++ b/game/src/index.js
@@ -1,1 +1,12 @@
-// Phaser game entry
+import Phaser from 'phaser'
+import BattleScene from './scenes/BattleScene'
+
+const config = {
+  type: Phaser.AUTO,
+  width: 800,
+  height: 600,
+  parent: 'game-container',
+  scene: [BattleScene],
+}
+
+new Phaser.Game(config)

--- a/game/src/scenes/BattleScene.js
+++ b/game/src/scenes/BattleScene.js
@@ -1,0 +1,75 @@
+import Phaser from 'phaser'
+import { party, enemies } from 'shared/models'
+
+export default class BattleScene extends Phaser.Scene {
+  constructor() {
+    super('battle')
+  }
+
+  preload() {
+    // Placeholder preload - no external assets yet
+  }
+
+  create() {
+    this.createPartyDisplay()
+    this.createEnemyDisplay()
+
+    // Prepare turn sequence placeholders
+    this.turnIndex = 0
+    this.turnOrder = [...party, ...enemies]
+  }
+
+  createPartyDisplay() {
+    const startX = 50
+    const startY = 100
+    const offsetY = 120
+
+    party.forEach((member, index) => {
+      const y = startY + index * offsetY
+
+      // Placeholder rectangle for character
+      this.add.rectangle(startX, y, 80, 80, 0x6699ff).setOrigin(0)
+
+      this.add.text(startX + 90, y, member.name, { fontSize: '16px' })
+      this.add.text(startX + 90, y + 20, `HP: ${member.hp}`)
+      this.add.text(startX + 90, y + 40, `Energy: ${member.energy}`)
+
+      member.cards.forEach((card, cIndex) => {
+        const cardX = startX + cIndex * 60
+        const cardY = y + 90
+        // Placeholder rectangle for card
+        this.add.rectangle(cardX, cardY, 50, 70, 0xcccccc).setOrigin(0)
+        this.add.text(cardX + 5, cardY + 5, card.name, { fontSize: '12px' })
+      })
+    })
+  }
+
+  createEnemyDisplay() {
+    const startX = 500
+    const startY = 100
+    const offsetY = 120
+
+    enemies.forEach((enemy, index) => {
+      const y = startY + index * offsetY
+
+      // Placeholder rectangle for character
+      this.add.rectangle(startX, y, 80, 80, 0xff6666).setOrigin(0)
+
+      this.add.text(startX + 90, y, enemy.name, { fontSize: '16px' })
+      this.add.text(startX + 90, y + 20, `HP: ${enemy.hp}`)
+      this.add.text(startX + 90, y + 40, `Energy: ${enemy.energy}`)
+
+      enemy.cards.forEach((card, cIndex) => {
+        const cardX = startX + cIndex * 60
+        const cardY = y + 90
+        // Placeholder rectangle for card
+        this.add.rectangle(cardX, cardY, 50, 70, 0xcccccc).setOrigin(0)
+        this.add.text(cardX + 5, cardY + 5, card.name, { fontSize: '12px' })
+      })
+    })
+  }
+
+  update() {
+    // Future turn sequencing logic will go here
+  }
+}

--- a/shared/index.js
+++ b/shared/index.js
@@ -1,1 +1,2 @@
-// shared utilities
+// shared utilities and data
+export * from './models/index.js'

--- a/shared/models/index.js
+++ b/shared/models/index.js
@@ -1,0 +1,43 @@
+export const party = [
+  {
+    id: 'hero',
+    name: 'Hero',
+    hp: 100,
+    energy: 3,
+    cards: [
+      { id: 'slash', name: 'Slash', power: 10 },
+      { id: 'defend', name: 'Defend', power: 0 },
+    ],
+  },
+  {
+    id: 'mage',
+    name: 'Mage',
+    hp: 80,
+    energy: 4,
+    cards: [
+      { id: 'fireball', name: 'Fireball', power: 12 },
+      { id: 'barrier', name: 'Barrier', power: 0 },
+    ],
+  },
+]
+
+export const enemies = [
+  {
+    id: 'goblin',
+    name: 'Goblin',
+    hp: 50,
+    energy: 2,
+    cards: [
+      { id: 'stab', name: 'Stab', power: 5 },
+    ],
+  },
+  {
+    id: 'orc',
+    name: 'Orc',
+    hp: 70,
+    energy: 2,
+    cards: [
+      { id: 'smash', name: 'Smash', power: 8 },
+    ],
+  },
+]


### PR DESCRIPTION
## Summary
- create shared data models for party and enemies
- export models from shared package
- build Phaser BattleScene to display parties using placeholder graphics
- wire scene into game entry point and add HTML page for the Phaser game

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6841d7a416008327abee3d1061bc1d7c