### PR TITLE
Add shared model interfaces

### DIFF
--- a/shared/models/Card.ts
+++ b/shared/models/Card.ts
@@ -1,0 +1,29 @@
+export interface Effect {
+  /**
+   * The effect type identifier (e.g. "damage", "heal").
+   */
+  type: string
+  /**
+   * Numerical value associated with the effect.
+   */
+  value?: number
+  /**
+   * Optional target description for the effect.
+   */
+  target?: string
+}
+
+export interface Card {
+  /** Unique card id */
+  id: string
+  /** Display name */
+  name: string
+  /** Category of card (attack, defense, item, etc.) */
+  type: string
+  /** Resource cost to play the card */
+  cost: number
+  /** Effects triggered when the card is used */
+  effects: Effect[]
+  /** Optional description shown in the UI */
+  description?: string
+}

--- a/shared/models/Character.ts
+++ b/shared/models/Character.ts
@@ -1,0 +1,38 @@
+import type { Card } from './Card'
+
+export interface Stats {
+  /** Health points */
+  hp: number
+  /** Energy or mana available each turn */
+  energy: number
+  /** Optional attack attribute */
+  attack?: number
+  /** Optional defense attribute */
+  defense?: number
+  /** Optional speed attribute */
+  speed?: number
+}
+
+export interface SurvivalStats {
+  /** Hunger level */
+  hunger: number
+  /** Thirst level */
+  thirst: number
+  /** Fatigue or tiredness */
+  fatigue: number
+}
+
+export interface Character {
+  /** Unique character id */
+  id: string
+  /** Character name */
+  name: string
+  /** Character class or role */
+  class: string
+  /** Primary combat stats */
+  stats: Stats
+  /** Deck of cards assigned to this character */
+  deck: Card[]
+  /** Survival stats tracked outside combat */
+  survival: SurvivalStats
+}

--- a/shared/models/Enemy.ts
+++ b/shared/models/Enemy.ts
@@ -1,0 +1,22 @@
+import type { Card } from './Card'
+import type { Stats } from './Character'
+
+export interface AIProfile {
+  /** Short descriptor of behavior (e.g. "aggressive", "defensive") */
+  behavior: string
+  /** Value from 0-1 representing how likely the enemy is to attack */
+  aggressiveness: number
+}
+
+export interface Enemy {
+  /** Unique enemy id */
+  id: string
+  /** The archetype or species of the enemy */
+  archetype: string
+  /** Combat stats */
+  stats: Stats
+  /** Cards used by this enemy */
+  deck: Card[]
+  /** AI behavior profile */
+  aiProfile: AIProfile
+}

--- a/shared/models/Resource.ts
+++ b/shared/models/Resource.ts
@@ -1,0 +1,12 @@
+import type { Effect } from './Card'
+
+export interface Resource {
+  /** Unique resource id */
+  id: string
+  /** Name shown to players */
+  name: string
+  /** Effect granted when consumed or used */
+  effect: Effect
+  /** Quantity carried or available */
+  quantity: number
+}

--- a/shared/models/index.d.ts
+++ b/shared/models/index.d.ts
@@ -1,0 +1,9 @@
+import type { Character } from './Character'
+import type { Enemy } from './Enemy'
+export * from './Card'
+export * from './Character'
+export * from './Enemy'
+export * from './Resource'
+
+export const party: Character[]
+export const enemies: Enemy[]


### PR DESCRIPTION
## Summary
- define new interfaces for Card, Character, Enemy and Resource
- add a declaration file to export these interfaces along with party/enemy arrays

## Testing
- `npm run lint -w client`

------
https://chatgpt.com/codex/tasks/task_e_6841dafb3a988327839a6893c175ceeb