### PR TITLE
Add data sharing between React and Phaser

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,3 +9,10 @@ This monorepo hosts a small web based game split into three workspaces:
 Each package contains minimal build and start scripts. Run `npm install` in the
 root and then `npm start` inside either the `client` or `game` folder to launch
 their development servers.
+
+## Data Flow Between React and Phaser
+
+When a party has been finalized in the React UI, clicking **Start Game** will
+serialize the party using the shared TypeScript interfaces and store it under the
+`partyData` key in `localStorage`. The Phaser game reads this value on load and
+displays the chosen characters and their decks inside the battle scene.

--- a/client/src/components/PartyBuilder.jsx
+++ b/client/src/components/PartyBuilder.jsx
@@ -40,6 +40,31 @@ function PartyBuilder() {
     )
   }
 
+  function startGame() {
+    const fullParty = party.map((char) => ({
+      id: char.id,
+      name: char.name,
+      class: '',
+      stats: { hp: 100, energy: 3 },
+      deck: char.cards.map((cid) => {
+        const card = sampleCards.find((c) => c.id === cid)
+        return {
+          id: cid,
+          name: card ? card.name : cid,
+          type: 'basic',
+          cost: 0,
+          effects: [],
+        }
+      }),
+      survival: { hunger: 0, thirst: 0, fatigue: 0 },
+    }))
+
+    localStorage.setItem('partyData', JSON.stringify(fullParty))
+    // Navigate to the Phaser game. In a production app this could be a route
+    // change or modal. For simplicity we load the bundled game directly.
+    window.location.href = '/game'
+  }
+
   return (
     <div className="party-builder">
       <div className="selection">
@@ -101,6 +126,11 @@ function PartyBuilder() {
             </li>
           ))}
         </ul>
+      </div>
+      <div className="start-game">
+        <button disabled={party.length === 0} onClick={startGame}>
+          Start Game
+        </button>
       </div>
     </div>
   )

--- a/game/src/scenes/BattleScene.js
+++ b/game/src/scenes/BattleScene.js
@@ -1,5 +1,15 @@
 import Phaser from 'phaser'
-import { party, enemies } from 'shared/models'
+import { enemies } from 'shared/models'
+
+function loadParty() {
+  const data = localStorage.getItem('partyData')
+  if (!data) return null
+  try {
+    return JSON.parse(data)
+  } catch {
+    return null
+  }
+}
 
 export default class BattleScene extends Phaser.Scene {
   constructor() {
@@ -11,12 +21,13 @@ export default class BattleScene extends Phaser.Scene {
   }
 
   create() {
+    this.party = loadParty() || []
     this.createPartyDisplay()
     this.createEnemyDisplay()
 
     // Prepare turn sequence placeholders
     this.turnIndex = 0
-    this.turnOrder = [...party, ...enemies]
+    this.turnOrder = [...this.party, ...enemies]
   }
 
   createPartyDisplay() {
@@ -24,7 +35,7 @@ export default class BattleScene extends Phaser.Scene {
     const startY = 100
     const offsetY = 120
 
-    party.forEach((member, index) => {
+    this.party.forEach((member, index) => {
       const y = startY + index * offsetY
 
       // Placeholder rectangle for character
@@ -34,7 +45,8 @@ export default class BattleScene extends Phaser.Scene {
       this.add.text(startX + 90, y + 20, `HP: ${member.hp}`)
       this.add.text(startX + 90, y + 40, `Energy: ${member.energy}`)
 
-      member.cards.forEach((card, cIndex) => {
+      const cards = member.deck || member.cards || []
+      cards.forEach((card, cIndex) => {
         const cardX = startX + cIndex * 60
         const cardY = y + 90
         // Placeholder rectangle for card
@@ -59,7 +71,8 @@ export default class BattleScene extends Phaser.Scene {
       this.add.text(startX + 90, y + 20, `HP: ${enemy.hp}`)
       this.add.text(startX + 90, y + 40, `Energy: ${enemy.energy}`)
 
-      enemy.cards.forEach((card, cIndex) => {
+      const cards = enemy.cards || enemy.deck || []
+      cards.forEach((card, cIndex) => {
         const cardX = startX + cIndex * 60
         const cardY = y + 90
         // Placeholder rectangle for card


### PR DESCRIPTION
## Summary
- store finalized party in localStorage when clicking **Start Game** in the React PartyBuilder
- load the stored party in Phaser's `BattleScene`
- document the new data flow

## Testing
- `npm --workspace client run lint`
- `npm --workspace game run build`
- `npm --workspace client run build`


------
https://chatgpt.com/codex/tasks/task_e_6841dc264a7c832797b458d1afbbe2f5