### PR TITLE
Enable localStorage sharing for battle scene

### DIFF
--- a/client/src/components/PartyBuilder.jsx
+++ b/client/src/components/PartyBuilder.jsx
@@ -59,10 +59,14 @@ function PartyBuilder() {
       survival: { hunger: 0, thirst: 0, fatigue: 0 },
     }))
 
-    localStorage.setItem('partyData', JSON.stringify(fullParty))
-    // Navigate to the Phaser game. In a production app this could be a route
-    // change or modal. For simplicity we load the bundled game directly.
-    window.location.href = '/game'
+    try {
+      localStorage.setItem('partyData', JSON.stringify(fullParty))
+      // Navigate to the Phaser game. In a production app this could be a route
+      // change or modal. For simplicity we load the bundled game directly.
+      window.location.href = '/game'
+    } catch (error) {
+      console.error('Error storing party data:', error)
+    }
   }
 
   return (

--- a/game/src/scenes/BattleScene.js
+++ b/game/src/scenes/BattleScene.js
@@ -1,16 +1,6 @@
 import Phaser from 'phaser'
 import { enemies } from 'shared/models'
 
-function loadParty() {
-  const data = localStorage.getItem('partyData')
-  if (!data) return null
-  try {
-    return JSON.parse(data)
-  } catch {
-    return null
-  }
-}
-
 export default class BattleScene extends Phaser.Scene {
   constructor() {
     super('battle')
@@ -21,7 +11,18 @@ export default class BattleScene extends Phaser.Scene {
   }
 
   create() {
-    this.party = loadParty() || []
+    const partyDataJSON = localStorage.getItem('partyData')
+    if (partyDataJSON) {
+      try {
+        this.party = JSON.parse(partyDataJSON)
+      } catch (error) {
+        console.error('Error parsing party data:', error)
+        this.party = []
+      }
+    } else {
+      console.warn('No party data found in localStorage.')
+      this.party = []
+    }
     this.createPartyDisplay()
     this.createEnemyDisplay()
 


### PR DESCRIPTION
## Summary
- persist generated party data in PartyBuilder
- load persisted party data in BattleScene

## Testing
- `npm --workspace=client run lint`


------
https://chatgpt.com/codex/tasks/task_e_6841e8f463fc83279e0b40f261fe635c