### PR TITLE
Implement party data serialization

### DIFF
--- a/client/src/components/PartySetupScreen.tsx
+++ b/client/src/components/PartySetupScreen.tsx
@@ -82,8 +82,6 @@ const PartySetupScreen: React.FC = () => {
 
   const handleStartGame = () => {
     const partyData: Party = {
-      // Transform selectedCharacters to match the structure expected by the game
-      // This might involve mapping `assignedCards` to the `deck` property or similar
       characters: selectedCharacters.map(pc => ({
         id: pc.id,
         name: pc.name,
@@ -91,14 +89,16 @@ const PartySetupScreen: React.FC = () => {
         portrait: pc.portrait,
         description: pc.description,
         stats: pc.stats,
-        deck: pc.assignedCards, // Assuming assignedCards directly translates to deck
+        deck: pc.assignedCards,
         survival: pc.survival,
       })),
     };
 
     try {
       localStorage.setItem('partyData', JSON.stringify(partyData));
-      navigate('/game');
+      // Navigate directly to the Phaser game. React Router does not have a /game
+      // route so we perform a full page change.
+      window.location.href = '/game';
     } catch (error) {
       console.error('Error storing party data:', error);
       // Handle error, e.g., show a notification to the user

--- a/game/src/scenes/BattleScene.js
+++ b/game/src/scenes/BattleScene.js
@@ -14,7 +14,10 @@ export default class BattleScene extends Phaser.Scene {
     const partyDataJSON = localStorage.getItem('partyData')
     if (partyDataJSON) {
       try {
-        this.party = JSON.parse(partyDataJSON)
+        const parsed = JSON.parse(partyDataJSON)
+        // Support both the legacy array format and the Party interface which
+        // stores characters under a `characters` field.
+        this.party = Array.isArray(parsed) ? parsed : parsed.characters || []
       } catch (error) {
         console.error('Error parsing party data:', error)
         this.party = []


### PR DESCRIPTION
## Summary
- fix start game navigation and localStorage serialization
- make Phaser battle scene parse either Party object or legacy array

## Testing
- `npm run lint` in `client`
- `npm run build` in `client`
- `npm run build` in `game` *(fails: "enemies" is not exported)*

------
https://chatgpt.com/codex/tasks/task_e_6841f6030d60832789b4eeab72408d59