### PR TITLE
Fix readme spacing for Phaser

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This monorepo hosts a small web based game split into three workspaces:
 
 - **client** – a React UI powered by Vite for menus and interface elements.
   See [client/README.md](client/README.md) for available scripts.
-- **game** – Phaser&nbsp;3 scenes for the dungeon and battle logic.
+- **game** – Phaser 3 scenes for the dungeon and battle logic.
   See [game/README.md](game/README.md) for available scripts.
 - **shared** – common models and utilities used by both stacks.
   See [shared/README.md](shared/README.md).


### PR DESCRIPTION
## Summary
- fix `Phaser` version spacing in README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6841fbc9f8a08327a086104b644f2637