### PR TITLE
Fix missing enemies export

### DIFF
--- a/game/src/scenes/BattleScene.js
+++ b/game/src/scenes/BattleScene.js
@@ -83,9 +83,23 @@ export default class BattleScene extends Phaser.Scene {
       // Placeholder rectangle for character
       this.add.rectangle(startX, y, 80, 80, 0xff6666).setOrigin(0)
 
-      this.add.text(startX + 90, y, enemy.name, { fontSize: '16px' })
-      this.add.text(startX + 90, y + 20, `HP: ${enemy.hp}`)
-      this.add.text(startX + 90, y + 40, `Energy: ${enemy.energy}`)
+      const name = enemy.name || enemy.archetype || enemy.id
+      const hp =
+        enemy.hp !== undefined
+          ? enemy.hp
+          : enemy.stats && enemy.stats.hp !== undefined
+            ? enemy.stats.hp
+            : 0
+      const energy =
+        enemy.energy !== undefined
+          ? enemy.energy
+          : enemy.stats && enemy.stats.energy !== undefined
+            ? enemy.stats.energy
+            : 0
+
+      this.add.text(startX + 90, y, name, { fontSize: '16px' })
+      this.add.text(startX + 90, y + 20, `HP: ${hp}`)
+      this.add.text(startX + 90, y + 40, `Energy: ${energy}`)
 
       const cards = enemy.cards || enemy.deck || []
       cards.forEach((card, cIndex) => {

--- a/shared/models/enemies.js
+++ b/shared/models/enemies.js
@@ -1,0 +1,18 @@
+import { sampleCards } from './cards.js'
+
+export const enemies = [
+  {
+    id: 'goblin',
+    name: 'Goblin',
+    hp: 20,
+    energy: 2,
+    cards: [sampleCards[0], sampleCards[3]],
+  },
+  {
+    id: 'skeleton',
+    name: 'Skeleton',
+    hp: 25,
+    energy: 1,
+    cards: [sampleCards[0], sampleCards[4]],
+  },
+]

--- a/shared/models/index.js
+++ b/shared/models/index.js
@@ -6,3 +6,5 @@ export * from './Character';
 export * from './Enemy';
 export * from './Party';
 export * from './Resource';
+// Sample enemies used by the game during early development
+export { enemies } from './enemies.js';


### PR DESCRIPTION
## Summary
- add a sample enemy list in `shared/models`
- re-export enemies from the models index file
- display enemy stats correctly in `BattleScene`

## Testing
- `npm -w game run build`
- `npm -w client run build`


------
https://chatgpt.com/codex/tasks/task_e_6841fc01a51c8327b76626e94ff61a80