### PR TITLE
Add dungeon navigation demo

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -6,6 +6,7 @@ import NewGame from './components/NewGame.jsx'
 import LoadGame from './components/LoadGame.jsx'
 import Settings from './components/Settings.jsx'
 import PartySetupScreen from './components/PartySetupScreen.tsx'; // Import the new screen
+import DungeonPage from './components/DungeonPage.tsx';
 
 function App() {
   const location = useLocation()
@@ -24,6 +25,7 @@ function App() {
           <Route path="/party-setup" element={<PartySetupScreen />} /> {/* Add this route */}
           <Route path="/load-game" element={<LoadGame />} />
           <Route path="/settings" element={<Settings />} />
+          <Route path="/dungeon" element={<DungeonPage />} />
         </Routes>
       </CSSTransition>
     </SwitchTransition>

--- a/client/src/components/DungeonPage.tsx
+++ b/client/src/components/DungeonPage.tsx
@@ -1,0 +1,109 @@
+import React, { useEffect, useRef, useState } from 'react'
+import Phaser from 'phaser'
+import DungeonScene from '../phaser/DungeonScene'
+import MiniMap from './MiniMap'
+import type { DungeonMap } from 'shared/models'
+
+const STORAGE_KEY = 'dungeonState'
+
+type StoredState = {
+  dungeon: DungeonMap
+  current: string
+  explored: string[]
+}
+
+function generateDungeon(size = 5): DungeonMap {
+  const rooms: Record<string, any> = {}
+  for (let x = 0; x < size; x++) {
+    for (let y = 0; y < size; y++) {
+      const id = `${x}-${y}`
+      const typeOptions = ['empty', 'enemy', 'treasure', 'trap'] as const
+      const type = typeOptions[Math.floor(Math.random() * typeOptions.length)]
+      const connections: string[] = []
+      if (x > 0) connections.push(`${x - 1}-${y}`)
+      if (x < size - 1) connections.push(`${x + 1}-${y}`)
+      if (y > 0) connections.push(`${x}-${y - 1}`)
+      if (y < size - 1) connections.push(`${x}-${y + 1}`)
+      rooms[id] = { id, x, y, type, connections }
+    }
+  }
+  return { rooms, startRoomId: '0-0' }
+}
+
+export default function DungeonPage() {
+  const containerRef = useRef<HTMLDivElement | null>(null)
+  const [dungeon, setDungeon] = useState<DungeonMap>(() => {
+    const raw = localStorage.getItem(STORAGE_KEY)
+    if (raw) {
+      try {
+        const parsed: StoredState = JSON.parse(raw)
+        return parsed.dungeon
+      } catch {
+        /* ignore */
+      }
+    }
+    return generateDungeon()
+  })
+  const [current, setCurrent] = useState<string>(() => {
+    const raw = localStorage.getItem(STORAGE_KEY)
+    if (raw) {
+      try {
+        const parsed: StoredState = JSON.parse(raw)
+        return parsed.current
+      } catch {
+        /* ignore */
+      }
+    }
+    return dungeon.startRoomId
+  })
+  const [explored, setExplored] = useState<Set<string>>(() => {
+    const raw = localStorage.getItem(STORAGE_KEY)
+    if (raw) {
+      try {
+        const parsed: StoredState = JSON.parse(raw)
+        return new Set(parsed.explored)
+      } catch {
+        /* ignore */
+      }
+    }
+    return new Set([dungeon.startRoomId])
+  })
+
+  useEffect(() => {
+    const stored: StoredState = {
+      dungeon,
+      current,
+      explored: Array.from(explored),
+    }
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(stored))
+  }, [dungeon, current, explored])
+
+  useEffect(() => {
+    if (!containerRef.current) return
+    const game = new Phaser.Game({
+      type: Phaser.AUTO,
+      width: 400,
+      height: 400,
+      parent: containerRef.current,
+      scene: DungeonScene,
+    })
+    game.scene.start('dungeon', { dungeon, currentRoom: current })
+
+    const handler = (e: any) => {
+      setCurrent(e.detail)
+      setExplored((prev) => new Set(prev).add(e.detail))
+    }
+    window.addEventListener('roomEnter', handler)
+    return () => {
+      window.removeEventListener('roomEnter', handler)
+      game.destroy(true)
+    }
+  }, [dungeon])
+
+  return (
+    <div style={{ display: 'flex', gap: 20 }}>
+      <div ref={containerRef} />
+      <MiniMap dungeon={dungeon} explored={explored} current={current} />
+    </div>
+  )
+}

--- a/client/src/components/MiniMap.tsx
+++ b/client/src/components/MiniMap.tsx
@@ -1,0 +1,45 @@
+import React from 'react'
+import type { DungeonMap } from 'shared/models'
+
+interface MiniMapProps {
+  dungeon: DungeonMap
+  explored: Set<string>
+  current: string
+}
+
+const colors: Record<string, string> = {
+  enemy: '#ff0000',
+  treasure: '#ffff00',
+  trap: '#ff00ff',
+  empty: '#666666',
+}
+
+export default function MiniMap({ dungeon, explored, current }: MiniMapProps) {
+  const size = Math.max(...Object.values(dungeon.rooms).map((r) => r.x)) + 1
+  const rows = []
+  for (let y = 0; y < size; y++) {
+    const cells = []
+    for (let x = 0; x < size; x++) {
+      const id = `${x}-${y}`
+      const room = dungeon.rooms[id]
+      const isExplored = explored.has(id)
+      const style: React.CSSProperties = {
+        width: 20,
+        height: 20,
+        border: '1px solid #444',
+        background: isExplored ? colors[room.type] : '#000',
+        opacity: isExplored ? 1 : 0.2,
+      }
+      if (id === current) {
+        style.outline = '2px solid white'
+      }
+      cells.push(<div key={id} style={style} />)
+    }
+    rows.push(
+      <div key={y} style={{ display: 'flex' }}>
+        {cells}
+      </div>,
+    )
+  }
+  return <div>{rows}</div>
+}

--- a/client/src/components/PartySetupScreen.tsx
+++ b/client/src/components/PartySetupScreen.tsx
@@ -96,9 +96,7 @@ const PartySetupScreen: React.FC = () => {
 
     try {
       localStorage.setItem('partyData', JSON.stringify(partyData));
-      // Navigate directly to the Phaser game. React Router does not have a /game
-      // route so we perform a full page change.
-      window.location.href = '/game';
+      navigate('/dungeon');
     } catch (error) {
       console.error('Error storing party data:', error);
       // Handle error, e.g., show a notification to the user

--- a/client/src/phaser/DungeonScene.ts
+++ b/client/src/phaser/DungeonScene.ts
@@ -1,0 +1,82 @@
+import Phaser from 'phaser'
+import type { DungeonMap } from 'shared/models'
+
+interface SceneData {
+  dungeon: DungeonMap
+  currentRoom: string
+}
+
+export default class DungeonScene extends Phaser.Scene {
+  private dungeon!: DungeonMap
+  private currentRoom!: string
+  private cursors!: Phaser.Types.Input.Keyboard.CursorKeys
+  private roomRect?: Phaser.GameObjects.Rectangle
+
+  constructor() {
+    super('dungeon')
+  }
+
+  init(data: SceneData) {
+    this.dungeon = data.dungeon
+    this.currentRoom = data.currentRoom
+  }
+
+  create() {
+    this.cursors = this.input.keyboard.createCursorKeys()
+    this.drawRoom()
+  }
+
+  private drawRoom() {
+    if (this.roomRect) this.roomRect.destroy()
+    const room = this.dungeon.rooms[this.currentRoom]
+    const colors: Record<string, number> = {
+      enemy: 0xff0000,
+      treasure: 0xffff00,
+      trap: 0xff00ff,
+      empty: 0x666666,
+    }
+    this.roomRect = this.add.rectangle(200, 200, 300, 300, colors[room.type] || 0x666666)
+    this.add.text(16, 16, `Room: ${room.id}`, { color: '#ffffff' })
+  }
+
+  update() {
+    if (Phaser.Input.Keyboard.JustDown(this.cursors.left!)) {
+      this.attemptMove(-1, 0)
+    } else if (Phaser.Input.Keyboard.JustDown(this.cursors.right!)) {
+      this.attemptMove(1, 0)
+    } else if (Phaser.Input.Keyboard.JustDown(this.cursors.up!)) {
+      this.attemptMove(0, -1)
+    } else if (Phaser.Input.Keyboard.JustDown(this.cursors.down!)) {
+      this.attemptMove(0, 1)
+    }
+  }
+
+  private attemptMove(dx: number, dy: number) {
+    const current = this.dungeon.rooms[this.currentRoom]
+    const target = Object.values(this.dungeon.rooms).find(
+      (r) => r.x === current.x + dx && r.y === current.y + dy,
+    )
+    if (target && current.connections.includes(target.id)) {
+      this.currentRoom = target.id
+      this.drawRoom()
+      window.dispatchEvent(new CustomEvent('roomEnter', { detail: target.id }))
+      this.triggerEvent(target.type)
+    }
+  }
+
+  private triggerEvent(type: string) {
+    switch (type) {
+      case 'enemy':
+        console.log('Enemy encountered!')
+        break
+      case 'treasure':
+        console.log('Treasure found!')
+        break
+      case 'trap':
+        console.log('A trap is sprung!')
+        break
+      default:
+        break
+    }
+  }
+}

--- a/shared/models/DungeonMap.ts
+++ b/shared/models/DungeonMap.ts
@@ -1,0 +1,8 @@
+import type { Room } from './Room'
+
+export interface DungeonMap {
+  /** Rooms indexed by id */
+  rooms: Record<string, Room>
+  /** Starting room id */
+  startRoomId: string
+}

--- a/shared/models/Room.ts
+++ b/shared/models/Room.ts
@@ -1,0 +1,14 @@
+export type RoomType = 'empty' | 'enemy' | 'treasure' | 'trap'
+
+export interface Room {
+  /** Unique room identifier */
+  id: string
+  /** X coordinate used for map layout */
+  x: number
+  /** Y coordinate used for map layout */
+  y: number
+  /** Type of the room */
+  type: RoomType
+  /** Adjacent room ids */
+  connections: string[]
+}

--- a/shared/models/index.d.ts
+++ b/shared/models/index.d.ts
@@ -5,4 +5,6 @@ export * from './Character'
 export * from './Enemy'
 export * from './Party'; // Added
 export * from './Resource'
+export * from './Room'
+export * from './DungeonMap'
 export const enemies: Enemy[]

--- a/shared/models/index.js
+++ b/shared/models/index.js
@@ -6,5 +6,7 @@ export * from './Character';
 export * from './Enemy';
 export * from './Party';
 export * from './Resource';
+export * from './Room';
+export * from './DungeonMap';
 // Sample enemies used by the game during early development
 export { enemies } from './enemies.js';


### PR DESCRIPTION
## Summary
- expose new `Room` and `DungeonMap` models
- implement `DungeonScene` Phaser scene to handle room movement
- create React `DungeonPage` with minimap and Phaser canvas
- add `/dungeon` route and start game there after party setup

## Testing
- `npm run lint` in `client`

------
https://chatgpt.com/codex/tasks/task_e_6842226d7ef483279e2c3b888ad1a3f8