### PR TITLE
Add dungeon map with phaser and react

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -6,6 +6,7 @@ import NewGame from './components/NewGame.jsx'
 import LoadGame from './components/LoadGame.jsx'
 import Settings from './components/Settings.jsx'
 import PartySetupScreen from './components/PartySetupScreen.tsx'; // Import the new screen
+import DungeonPage from './components/DungeonPage.tsx';
 
 function App() {
   const location = useLocation()
@@ -21,7 +22,8 @@ function App() {
         <Routes location={location}>
           <Route path="/" element={<MainMenu />} />
           <Route path="/new-game" element={<NewGame />} />
-          <Route path="/party-setup" element={<PartySetupScreen />} /> {/* Add this route */}
+          <Route path="/party-setup" element={<PartySetupScreen />} />
+          <Route path="/dungeon" element={<DungeonPage />} />
           <Route path="/load-game" element={<LoadGame />} />
           <Route path="/settings" element={<Settings />} />
         </Routes>

--- a/client/src/components/DungeonMap.tsx
+++ b/client/src/components/DungeonMap.tsx
@@ -1,0 +1,32 @@
+import React, { useEffect, useRef } from 'react';
+import Phaser from 'phaser';
+import DungeonScene from '../phaser/DungeonScene';
+import { generateDungeon } from '../phaser/generateDungeon';
+
+interface DungeonMapProps {
+  onPlayerMove?: (pos: { x: number; y: number }) => void;
+}
+
+const DungeonMap: React.FC<DungeonMapProps> = ({ onPlayerMove }) => {
+  const containerRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    const dungeon = generateDungeon();
+    const scene = new DungeonScene({ dungeon, onPlayerMove });
+    const game = new Phaser.Game({
+      type: Phaser.AUTO,
+      width: dungeon.width * 32,
+      height: dungeon.height * 32,
+      parent: containerRef.current!,
+      scene,
+    });
+
+    return () => {
+      game.destroy(true);
+    };
+  }, [onPlayerMove]);
+
+  return <div ref={containerRef} aria-label="Dungeon map" />;
+};
+
+export default DungeonMap;

--- a/client/src/components/DungeonPage.module.css
+++ b/client/src/components/DungeonPage.module.css
@@ -1,0 +1,16 @@
+.container {
+  display: flex;
+  height: 100vh;
+}
+
+.mapArea {
+  flex: 1;
+  background: #000;
+}
+
+.sidebar {
+  width: 250px;
+  background: #222;
+  color: #fff;
+  overflow-y: auto;
+}

--- a/client/src/components/DungeonPage.tsx
+++ b/client/src/components/DungeonPage.tsx
@@ -1,0 +1,21 @@
+import React, { useState } from 'react';
+import DungeonMap from './DungeonMap';
+import PlayerStatsPanel from './PlayerStatsPanel';
+import styles from './DungeonPage.module.css';
+
+const DungeonPage: React.FC = () => {
+  const [position, setPosition] = useState({ x: 1, y: 1 });
+
+  return (
+    <div className={styles.container}>
+      <div className={styles.mapArea}>
+        <DungeonMap onPlayerMove={setPosition} />
+      </div>
+      <div className={styles.sidebar}>
+        <PlayerStatsPanel position={position} hp={100} energy={3} />
+      </div>
+    </div>
+  );
+};
+
+export default DungeonPage;

--- a/client/src/components/PartySetupScreen.tsx
+++ b/client/src/components/PartySetupScreen.tsx
@@ -96,9 +96,7 @@ const PartySetupScreen: React.FC = () => {
 
     try {
       localStorage.setItem('partyData', JSON.stringify(partyData));
-      // Navigate directly to the Phaser game. React Router does not have a /game
-      // route so we perform a full page change.
-      window.location.href = '/game';
+      navigate('/dungeon');
     } catch (error) {
       console.error('Error storing party data:', error);
       // Handle error, e.g., show a notification to the user

--- a/client/src/components/PlayerStatsPanel.module.css
+++ b/client/src/components/PlayerStatsPanel.module.css
@@ -1,0 +1,9 @@
+.panel {
+  padding: 10px;
+  background-color: #333;
+  color: #fff;
+}
+
+.stat {
+  margin-bottom: 0.5rem;
+}

--- a/client/src/components/PlayerStatsPanel.tsx
+++ b/client/src/components/PlayerStatsPanel.tsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import styles from './PlayerStatsPanel.module.css';
+
+interface PlayerStatsPanelProps {
+  position: { x: number; y: number };
+  hp: number;
+  energy: number;
+}
+
+const PlayerStatsPanel: React.FC<PlayerStatsPanelProps> = ({ position, hp, energy }) => (
+  <div className={styles.panel}>
+    <h2>Player Stats</h2>
+    <div className={styles.stat}>HP: {hp}</div>
+    <div className={styles.stat}>Energy: {energy}</div>
+    <div className={styles.stat}>Position: {position.x}, {position.y}</div>
+  </div>
+);
+
+export default PlayerStatsPanel;

--- a/client/src/phaser/DungeonScene.ts
+++ b/client/src/phaser/DungeonScene.ts
@@ -1,0 +1,116 @@
+import Phaser from 'phaser';
+import type { Dungeon, TileType } from './generateDungeon';
+
+interface SceneConfig {
+  dungeon: Dungeon;
+  onPlayerMove?: (pos: { x: number; y: number }) => void;
+}
+
+export default class DungeonScene extends Phaser.Scene {
+  private dungeon: Dungeon;
+  private onPlayerMove?: (pos: { x: number; y: number }) => void;
+  private tileSize = 32;
+  private playerPos!: { x: number; y: number };
+  private explored!: boolean[][];
+  private graphics!: Phaser.GameObjects.Graphics;
+  private hoverTile: { x: number; y: number } | null = null;
+
+  constructor(config: SceneConfig) {
+    super('dungeon');
+    this.dungeon = config.dungeon;
+    this.onPlayerMove = config.onPlayerMove;
+  }
+
+  create() {
+    this.playerPos = { ...this.dungeon.start };
+    this.explored = Array.from({ length: this.dungeon.height }, () =>
+      Array.from({ length: this.dungeon.width }, () => false),
+    );
+    this.explored[this.playerPos.y][this.playerPos.x] = true;
+    this.graphics = this.add.graphics();
+
+    this.input.on('pointerdown', this.handlePointerDown, this);
+    this.input.on('pointermove', this.handlePointerMove, this);
+
+    this.draw();
+  }
+
+  private handlePointerDown(pointer: Phaser.Input.Pointer) {
+    const tx = Math.floor(pointer.x / this.tileSize);
+    const ty = Math.floor(pointer.y / this.tileSize);
+    if (this.canMoveTo(tx, ty)) {
+      this.playerPos = { x: tx, y: ty };
+      this.explored[ty][tx] = true;
+      this.onPlayerMove?.(this.playerPos);
+      this.draw();
+    }
+  }
+
+  private handlePointerMove(pointer: Phaser.Input.Pointer) {
+    const tx = Math.floor(pointer.x / this.tileSize);
+    const ty = Math.floor(pointer.y / this.tileSize);
+    if (this.canMoveTo(tx, ty)) {
+      this.hoverTile = { x: tx, y: ty };
+    } else {
+      this.hoverTile = null;
+    }
+    this.draw();
+  }
+
+  private canMoveTo(x: number, y: number): boolean {
+    const { width, height, tiles } = this.dungeon;
+    if (x < 0 || y < 0 || x >= width || y >= height) return false;
+    if (tiles[y][x] === 'wall') return false;
+    const dist = Math.abs(x - this.playerPos.x) + Math.abs(y - this.playerPos.y);
+    return dist === 1; // only adjacent tiles
+  }
+
+  private draw() {
+    const { width, height, tiles } = this.dungeon;
+    const size = this.tileSize;
+    this.graphics.clear();
+
+    for (let y = 0; y < height; y++) {
+      for (let x = 0; x < width; x++) {
+        if (!this.explored[y][x] && this.isAdjacent(x, y, this.playerPos.x, this.playerPos.y)) {
+          this.explored[y][x] = true;
+        }
+        const visible = this.explored[y][x];
+        const tile = tiles[y][x];
+        let color = 0x000000;
+        if (visible) {
+          if (tile === 'wall') color = 0x222222;
+          if (tile === 'floor') color = 0x555555;
+          if (tile === 'start') color = 0x227722;
+          if (tile === 'end') color = 0x772222;
+        }
+        this.graphics.fillStyle(color, 1);
+        this.graphics.fillRect(x * size, y * size, size, size);
+        this.graphics.lineStyle(1, 0x444444, 0.5);
+        this.graphics.strokeRect(x * size, y * size, size, size);
+      }
+    }
+
+    if (this.hoverTile) {
+      this.graphics.fillStyle(0xffff00, 0.5);
+      this.graphics.fillRect(
+        this.hoverTile.x * size,
+        this.hoverTile.y * size,
+        size,
+        size,
+      );
+    }
+
+    // player indicator
+    this.graphics.fillStyle(0x0000ff, 1);
+    this.graphics.fillCircle(
+      this.playerPos.x * size + size / 2,
+      this.playerPos.y * size + size / 2,
+      size / 2 - 4,
+    );
+  }
+
+  private isAdjacent(x1: number, y1: number, x2: number, y2: number) {
+    return Math.abs(x1 - x2) <= 1 && Math.abs(y1 - y2) <= 1;
+  }
+}

--- a/client/src/phaser/generateDungeon.ts
+++ b/client/src/phaser/generateDungeon.ts
@@ -1,0 +1,43 @@
+export type TileType = 'wall' | 'floor' | 'start' | 'end';
+
+export interface Dungeon {
+  width: number;
+  height: number;
+  tiles: TileType[][];
+  start: { x: number; y: number };
+  end: { x: number; y: number };
+}
+
+// Simple random walk dungeon generator ensuring a path from start to end
+export function generateDungeon(width = 20, height = 15): Dungeon {
+  const tiles: TileType[][] = Array.from({ length: height }, () =>
+    Array.from({ length: width }, () => 'wall' as TileType),
+  );
+  const start = { x: 1, y: 1 };
+  const end = { x: width - 2, y: height - 2 };
+  let x = start.x;
+  let y = start.y;
+  tiles[y][x] = 'start';
+
+  while (x !== end.x || y !== end.y) {
+    const dirs: Array<{ x: number; y: number }> = [];
+    if (x < end.x) dirs.push({ x: 1, y: 0 });
+    if (x > end.x) dirs.push({ x: -1, y: 0 });
+    if (y < end.y) dirs.push({ x: 0, y: 1 });
+    if (y > end.y) dirs.push({ x: 0, y: -1 });
+    const step = dirs[Math.floor(Math.random() * dirs.length)];
+    x += step.x;
+    y += step.y;
+    tiles[y][x] = 'floor';
+  }
+  tiles[end.y][end.x] = 'end';
+
+  // Carve some additional random floors to make it interesting
+  for (let i = 0; i < width * height * 0.2; i++) {
+    const rx = 1 + Math.floor(Math.random() * (width - 2));
+    const ry = 1 + Math.floor(Math.random() * (height - 2));
+    tiles[ry][rx] = 'floor';
+  }
+
+  return { width, height, tiles, start, end };
+}


### PR DESCRIPTION
## Summary
- integrate new DungeonPage with Phaser map and PlayerStatsPanel
- procedural dungeon generation and fog-of-war support
- adjust PartySetupScreen to navigate into the dungeon

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_684222268b6c83278501e308cd5e0f4e