### PR TITLE
Add basic post-battle management system

### DIFF
--- a/shared/index.js
+++ b/shared/index.js
@@ -1,2 +1,3 @@
 // shared utilities and data
 export * from './models/index.js'
+export * from './systems/index.js'

--- a/shared/models/Encounter.ts
+++ b/shared/models/Encounter.ts
@@ -1,0 +1,8 @@
+export interface Encounter {
+  /** Enemy archetypes present */
+  enemyTypes: string[]
+  /** Dungeon biome */
+  biome: string
+  /** Difficulty rating */
+  difficulty: number
+}

--- a/shared/models/Inventory.ts
+++ b/shared/models/Inventory.ts
@@ -1,0 +1,6 @@
+import type { LootItem } from './LootItem'
+
+export interface Inventory {
+  /** Items held by the player */
+  items: LootItem[]
+}

--- a/shared/models/LootItem.ts
+++ b/shared/models/LootItem.ts
@@ -1,0 +1,10 @@
+export interface LootItem {
+  /** Unique loot id */
+  id: string
+  /** Category of loot */
+  type: 'Ability' | 'Equipment' | 'Ingredient' | 'FoodDrink' | 'Elixir' | 'Utility'
+  /** Loot rarity */
+  rarity: 'Common' | 'Uncommon' | 'Rare' | 'Legendary'
+  /** Effects applied when used (for consumables) */
+  effects: { type: 'RestoreFatigue' | 'RestoreHunger' | 'RestoreThirst'; value: number }[]
+}

--- a/shared/models/index.d.ts
+++ b/shared/models/index.d.ts
@@ -7,4 +7,7 @@ export * from './Party'; // Added
 export * from './Resource'
 export * from './Room'
 export * from './DungeonMap'
+export * from './LootItem'
+export * from './Inventory'
+export * from './Encounter'
 export const enemies: Enemy[]

--- a/shared/models/index.js
+++ b/shared/models/index.js
@@ -8,5 +8,8 @@ export * from './Party';
 export * from './Resource';
 export * from './Room';
 export * from './DungeonMap';
+export * from './LootItem';
+export * from './Inventory';
+export * from './Encounter';
 // Sample enemies used by the game during early development
 export { enemies } from './enemies.js';

--- a/shared/systems/index.d.ts
+++ b/shared/systems/index.d.ts
@@ -1,0 +1,10 @@
+import type { Character } from '../models/Character'
+import type { LootItem } from '../models/LootItem'
+import type { Inventory } from '../models/Inventory'
+import type { Encounter } from '../models/Encounter'
+
+export function applySurvivalPenalties(party: Character[]): void
+export function generateLoot(encounter: Encounter): LootItem[]
+export function distributeLoot(loot: LootItem[], inventory: Inventory): void
+export function useConsumable(item: LootItem, character: Character): void
+export function rest(party: Character[], duration: number): void

--- a/shared/systems/index.js
+++ b/shared/systems/index.js
@@ -1,0 +1,1 @@
+export * from './postBattle.js'

--- a/shared/systems/postBattle.js
+++ b/shared/systems/postBattle.js
@@ -1,0 +1,75 @@
+import { enemies } from '../models/enemies.js'
+
+/**
+ * Apply survival penalties to each character after a battle
+ * @param {import('../models').Character[]} party
+ */
+export function applySurvivalPenalties(party) {
+  party.forEach((c) => {
+    if (!c.survival) c.survival = { hunger: 0, thirst: 0, fatigue: 0 }
+    c.survival.fatigue += 1
+    c.survival.hunger += 1
+    c.survival.thirst += 1
+  })
+}
+
+/**
+ * Generate loot based on the encounter
+ * @param {import('../models').Encounter} encounter
+ * @returns {import('../models').LootItem[]}
+ */
+export function generateLoot(encounter) {
+  const loot = []
+  const baseRarity = ['Common', 'Uncommon', 'Rare']
+  const types = ['Ability', 'Equipment', 'Ingredient', 'FoodDrink', 'Elixir', 'Utility']
+  const count = Math.max(1, Math.floor(encounter.difficulty))
+  for (let i = 0; i < count; i++) {
+    loot.push({
+      id: `${encounter.biome}-${Date.now()}-${i}`,
+      type: types[Math.floor(Math.random() * types.length)],
+      rarity: baseRarity[Math.min(baseRarity.length - 1, Math.floor(Math.random() * encounter.difficulty))],
+      effects: [],
+    })
+  }
+  return loot
+}
+
+/**
+ * Add loot items to the inventory
+ * @param {import('../models').LootItem[]} loot
+ * @param {import('../models').Inventory} inventory
+ */
+export function distributeLoot(loot, inventory) {
+  inventory.items.push(...loot)
+}
+
+/**
+ * Use a consumable item on a character
+ * @param {import('../models').LootItem} item
+ * @param {import('../models').Character} character
+ */
+export function useConsumable(item, character) {
+  if (!item.effects) return
+  item.effects.forEach((e) => {
+    if (e.type === 'RestoreFatigue') {
+      character.survival.fatigue = Math.max(0, character.survival.fatigue - e.value)
+    }
+    if (e.type === 'RestoreHunger') {
+      character.survival.hunger = Math.max(0, character.survival.hunger - e.value)
+    }
+    if (e.type === 'RestoreThirst') {
+      character.survival.thirst = Math.max(0, character.survival.thirst - e.value)
+    }
+  })
+}
+
+/**
+ * Rest the party, reducing fatigue
+ * @param {import('../models').Character[]} party
+ * @param {number} duration
+ */
+export function rest(party, duration) {
+  party.forEach((c) => {
+    c.survival.fatigue = Math.max(0, c.survival.fatigue - duration)
+  })
+}


### PR DESCRIPTION
## Summary
- define `LootItem`, `Inventory` and `Encounter` data models
- export new models from shared package
- implement post-battle helper functions (`applySurvivalPenalties`, `generateLoot`, `distributeLoot`, `useConsumable`, `rest`)
- expose new helpers via shared package

## Testing
- `npm run lint` within `client`
- `npm run build` within `game`
- `npm run build` within `client`


------
https://chatgpt.com/codex/tasks/task_e_68422e0a53e88327acdaccdb66447792