### PR TITLE
Add progression decision mechanic

### DIFF
--- a/client/src/components/DungeonMap.tsx
+++ b/client/src/components/DungeonMap.tsx
@@ -2,6 +2,7 @@ import React, { useEffect, useRef } from 'react'
 import Phaser from 'phaser'
 import DungeonScene from '../phaser/DungeonScene'
 import BattleScene from '../phaser/BattleScene'
+import DecisionScene from '../phaser/DecisionScene'
 import type { DungeonData } from '../utils/generateDungeon'
 
 interface Props {
@@ -21,7 +22,7 @@ export default function DungeonMap({ dungeon, playerPos, explored, onMove }: Pro
       width: 800,
       height: 600,
       parent: containerRef.current,
-      scene: [DungeonScene, BattleScene],
+      scene: [DungeonScene, BattleScene, DecisionScene],
     })
     game.scene.start('dungeon', { dungeon, playerPos, explored })
     const handler = (e: any) => {

--- a/client/src/phaser/BattleScene.ts
+++ b/client/src/phaser/BattleScene.ts
@@ -155,7 +155,11 @@ export default class BattleScene extends Phaser.Scene {
       const text = !playersAlive ? 'Defeat' : 'Victory'
       this.add.text(360, 300, text, { fontSize: '32px' }).setOrigin(0.5)
       this.time.delayedCall(1500, () => {
-        this.scene.start('dungeon')
+        if (playersAlive) {
+          this.scene.start('decision')
+        } else {
+          this.scene.start('dungeon')
+        }
       })
       return true
     }

--- a/client/src/phaser/DecisionScene.ts
+++ b/client/src/phaser/DecisionScene.ts
@@ -1,0 +1,56 @@
+import Phaser from 'phaser'
+import { loadGameState, saveGameState } from 'shared/gameState'
+
+export default class DecisionScene extends Phaser.Scene {
+  constructor() {
+    super('decision')
+  }
+
+  create() {
+    this.add
+      .text(400, 200, 'Continue deeper or retreat?', {
+        fontSize: '20px',
+      })
+      .setOrigin(0.5)
+
+    const advance = this.add
+      .text(300, 300, 'Advance', {
+        backgroundColor: '#2ecc71',
+        padding: { x: 10, y: 5 },
+      })
+      .setInteractive()
+      .on('pointerdown', () => this.handleAdvance())
+
+    const retreat = this.add
+      .text(500, 300, 'Retreat', {
+        backgroundColor: '#3498db',
+        padding: { x: 10, y: 5 },
+      })
+      .setInteractive()
+      .on('pointerdown', () => this.handleRetreat())
+
+    advance.setOrigin(0.5)
+    retreat.setOrigin(0.5)
+  }
+
+  private handleAdvance() {
+    const state = loadGameState()
+    state.currentFloor += 1
+    state.dungeonDifficulty += 1
+    state.playerStatus.fatigue += 1
+    state.playerStatus.hunger += 1
+    state.playerStatus.thirst += 1
+    state.location = 'dungeon'
+    saveGameState(state)
+    this.scene.start('dungeon')
+  }
+
+  private handleRetreat() {
+    const state = loadGameState()
+    state.currentFloor = 1
+    state.dungeonDifficulty = 1
+    state.location = 'town'
+    saveGameState(state)
+    this.scene.start('dungeon')
+  }
+}

--- a/game/src/index.js
+++ b/game/src/index.js
@@ -1,13 +1,14 @@
 import Phaser from 'phaser'
 import BattleScene from './scenes/BattleScene'
 import DungeonScene from './scenes/DungeonScene'
+import DecisionScene from './scenes/DecisionScene'
 
 const config = {
   type: Phaser.AUTO,
   width: 800,
   height: 600,
   parent: 'game-container',
-  scene: [DungeonScene, BattleScene],
+  scene: [DungeonScene, BattleScene, DecisionScene],
 }
 
 new Phaser.Game(config)

--- a/game/src/scenes/BattleScene.js
+++ b/game/src/scenes/BattleScene.js
@@ -145,7 +145,11 @@ export default class BattleScene extends Phaser.Scene {
         dungeon.rooms[this.roomIndex].cleared = true
       }
       this.time.delayedCall(1500, () => {
-        this.scene.start('dungeon')
+        if (playersAlive) {
+          this.scene.start('decision')
+        } else {
+          this.scene.start('dungeon')
+        }
       })
       return true
     }

--- a/game/src/scenes/DecisionScene.js
+++ b/game/src/scenes/DecisionScene.js
@@ -1,0 +1,45 @@
+import Phaser from 'phaser'
+import { loadGameState, saveGameState } from 'shared/gameState'
+
+export default class DecisionScene extends Phaser.Scene {
+  constructor() {
+    super('decision')
+  }
+
+  create() {
+    this.add.text(400, 200, 'Continue deeper or retreat?', { fontSize: '20px' }).setOrigin(0.5)
+
+    const advance = this.add
+      .text(300, 300, 'Advance', { backgroundColor: '#2ecc71', padding: { x: 10, y: 5 } })
+      .setOrigin(0.5)
+      .setInteractive()
+      .on('pointerdown', () => this.handleAdvance())
+
+    const retreat = this.add
+      .text(500, 300, 'Retreat', { backgroundColor: '#3498db', padding: { x: 10, y: 5 } })
+      .setOrigin(0.5)
+      .setInteractive()
+      .on('pointerdown', () => this.handleRetreat())
+  }
+
+  handleAdvance() {
+    const state = loadGameState()
+    state.currentFloor += 1
+    state.dungeonDifficulty += 1
+    state.playerStatus.fatigue += 1
+    state.playerStatus.hunger += 1
+    state.playerStatus.thirst += 1
+    state.location = 'dungeon'
+    saveGameState(state)
+    this.scene.start('dungeon')
+  }
+
+  handleRetreat() {
+    const state = loadGameState()
+    state.currentFloor = 1
+    state.dungeonDifficulty = 1
+    state.location = 'town'
+    saveGameState(state)
+    this.scene.start('dungeon')
+  }
+}

--- a/shared/gameState.d.ts
+++ b/shared/gameState.d.ts
@@ -1,0 +1,5 @@
+import type { GameState } from './models/GameState'
+
+export const defaultGameState: GameState
+export function loadGameState(): GameState
+export function saveGameState(state: GameState): void

--- a/shared/gameState.js
+++ b/shared/gameState.js
@@ -1,0 +1,24 @@
+const DEFAULT_STATE = {
+  currentFloor: 1,
+  dungeonDifficulty: 1,
+  playerStatus: { fatigue: 0, hunger: 0, thirst: 0 },
+  inventory: [],
+  location: 'town',
+}
+
+export function loadGameState() {
+  const raw = localStorage.getItem('gameState')
+  if (!raw) return { ...DEFAULT_STATE }
+  try {
+    return { ...DEFAULT_STATE, ...JSON.parse(raw) }
+  } catch (e) {
+    console.error('Failed to parse game state', e)
+    return { ...DEFAULT_STATE }
+  }
+}
+
+export function saveGameState(state) {
+  localStorage.setItem('gameState', JSON.stringify(state))
+}
+
+export { DEFAULT_STATE as defaultGameState }

--- a/shared/index.js
+++ b/shared/index.js
@@ -1,2 +1,3 @@
 // shared utilities and data
 export * from './models/index.js'
+export * from './gameState.js'

--- a/shared/models/DecisionPoint.ts
+++ b/shared/models/DecisionPoint.ts
@@ -1,0 +1,4 @@
+export interface DecisionPoint {
+  options: ['Advance', 'Retreat']
+  consequences: { [option: string]: Function }
+}

--- a/shared/models/GameState.ts
+++ b/shared/models/GameState.ts
@@ -1,0 +1,15 @@
+import type { Item } from './Item'
+
+export interface PlayerStatus {
+  fatigue: number
+  hunger: number
+  thirst: number
+}
+
+export interface GameState {
+  currentFloor: number
+  dungeonDifficulty: number
+  playerStatus: PlayerStatus
+  inventory: Item[]
+  location: 'dungeon' | 'town'
+}

--- a/shared/models/Item.ts
+++ b/shared/models/Item.ts
@@ -1,0 +1,8 @@
+export interface Item {
+  /** Unique item id */
+  id: string
+  /** Display name */
+  name: string
+  /** Quantity held */
+  quantity: number
+}

--- a/shared/models/index.d.ts
+++ b/shared/models/index.d.ts
@@ -7,4 +7,7 @@ export * from './Party'; // Added
 export * from './Resource'
 export * from './Room'
 export * from './DungeonMap'
+export * from './Item'
+export * from './GameState'
+export * from './DecisionPoint'
 export const enemies: Enemy[]

--- a/shared/models/index.js
+++ b/shared/models/index.js
@@ -8,5 +8,8 @@ export * from './Party';
 export * from './Resource';
 export * from './Room';
 export * from './DungeonMap';
+export * from './Item';
+export * from './GameState';
+export * from './DecisionPoint';
 // Sample enemies used by the game during early development
 export { enemies } from './enemies.js';


### PR DESCRIPTION
## Summary
- model core GameState, DecisionPoint, and Item types
- add utilities for persisting game state
- create new Phaser `DecisionScene` with Advance/Retreat buttons
- invoke DecisionScene after battles
- include scene in both game packages

## Testing
- `npm run lint` within `client`
- `npm run build` within `client`
- `npm run build` within `game`


------
https://chatgpt.com/codex/tasks/task_e_68422e95d2ec83279c9fdea4110b33c7