### PR TITLE
Add crafting professions and magical pouch UI

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -7,6 +7,10 @@ import LoadGame from './components/LoadGame.jsx'
 import Settings from './components/Settings.jsx'
 import PartySetupScreen from './components/PartySetupScreen.tsx'; // Import the new screen
 import DungeonPage from './components/DungeonPage.tsx';
+import MagicalPouch from './components/MagicalPouch.tsx';
+
+const demoProfession = { name: 'Cooking', level: 1, experience: 0, unlockedRecipes: [], professionOnlyCards: [] };
+const demoPlayer = { id: '1', name: 'Hero', professions: { Cooking: demoProfession }, discoveredRecipes: [] };
 
 function App() {
   const location = useLocation()
@@ -26,6 +30,7 @@ function App() {
           <Route path="/load-game" element={<LoadGame />} />
           <Route path="/settings" element={<Settings />} />
           <Route path="/dungeon" element={<DungeonPage />} />
+          <Route path="/pouch" element={<MagicalPouch player={demoPlayer} profession={demoProfession} />} />
         </Routes>
       </CSSTransition>
     </SwitchTransition>

--- a/client/src/components/MagicalPouch.tsx
+++ b/client/src/components/MagicalPouch.tsx
@@ -1,0 +1,87 @@
+import React, { useState } from 'react'
+import type { Card } from '../../../shared/models/Card'
+import { sampleCards } from '../../../shared/models/cards.js'
+import { sampleRecipes } from '../../../shared/models/recipes.js'
+import { attemptCraft, registerRecipeDiscovery } from '../../../shared/systems/crafting.js'
+import type { Profession, Player } from '../../../shared/models'
+
+interface SlotProps {
+  card: Card | null
+  onRemove: () => void
+}
+
+const Slot: React.FC<SlotProps> = ({ card, onRemove }) => {
+  return (
+    <div
+      style={{ width: 80, height: 120, border: '1px dashed #999', margin: 4, display: 'flex', alignItems: 'center', justifyContent: 'center' }}
+      onClick={onRemove}
+    >
+      {card ? card.name : 'Empty'}
+    </div>
+  )
+}
+
+/** Simple Magical Pouch crafting UI */
+const MagicalPouch: React.FC<{ player: Player; profession: Profession }> = ({ player, profession }) => {
+  const [slots, setSlots] = useState<(Card | null)[]>(Array(5).fill(null))
+  const [result, setResult] = useState<string>('')
+
+  const handleAdd = (card: Card) => {
+    const idx = slots.findIndex((s) => s === null)
+    if (idx !== -1) {
+      const copy = [...slots]
+      copy[idx] = card
+      setSlots(copy)
+    }
+  }
+
+  const handleRemove = (index: number) => {
+    const copy = [...slots]
+    copy[index] = null
+    setSlots(copy)
+  }
+
+  const craft = () => {
+    const used = slots.filter(Boolean) as Card[]
+    const attempt = attemptCraft(profession, used, sampleRecipes)
+    if (attempt.success && attempt.result) {
+      attempt.result.craftedBy = player.name
+      setResult(`Crafted: ${attempt.result.name}`)
+      if (attempt.newRecipeDiscovered) {
+        registerRecipeDiscovery(player, sampleRecipes.find(r => r.id === attempt.result?.id.split('_')[0])!)
+      }
+    } else {
+      setResult('Experiment failed')
+    }
+    setSlots(Array(5).fill(null))
+  }
+
+  return (
+    <div>
+      <h2>Magical Pouch</h2>
+      <div style={{ display: 'flex' }}>
+        {slots.map((s, i) => (
+          <Slot key={i} card={s} onRemove={() => handleRemove(i)} />
+        ))}
+      </div>
+      <button onClick={craft}>Craft</button>
+      {result && <p>{result}</p>}
+      <h3>Inventory</h3>
+      <div style={{ display: 'flex', flexWrap: 'wrap' }}>
+        {sampleCards
+          .filter((c) => c.category === 'Ingredient' || c.category === 'Equipment')
+          .map((card) => (
+            <div
+              key={card.id}
+              style={{ border: '1px solid #ccc', margin: 4, padding: 4, cursor: 'pointer' }}
+              onClick={() => handleAdd(card)}
+            >
+              {card.name}
+            </div>
+          ))}
+      </div>
+    </div>
+  )
+}
+
+export default MagicalPouch

--- a/client/src/components/MainMenu.jsx
+++ b/client/src/components/MainMenu.jsx
@@ -9,6 +9,7 @@ function MainMenu() {
         <Link className={styles.button} to="/new-game">Start New Game</Link>
         <Link className={styles.button} to="/load-game">Load Game</Link>
         <Link className={styles.button} to="/settings">Settings</Link>
+        <Link className={styles.button} to="/pouch">Magical Pouch</Link>
       </nav>
     </main>
   )

--- a/shared/models/Card.ts
+++ b/shared/models/Card.ts
@@ -86,6 +86,8 @@ export interface BaseCard {
   rarity: Rarity
   /** Category */
   category: CardCategory
+  /** Optional crafter tag for crafted items */
+  craftedBy?: string
 }
 
 export interface AbilityCard extends BaseCard {

--- a/shared/models/CraftingAttempt.ts
+++ b/shared/models/CraftingAttempt.ts
@@ -1,0 +1,12 @@
+import type { Card } from './Card'
+
+export interface CraftingAttempt {
+  /** Cards used in the attempt */
+  usedCards: Card[]
+  /** Crafted result if successful */
+  result: Card | null
+  /** Whether the crafting succeeded */
+  success: boolean
+  /** True if this attempt discovered a new recipe */
+  newRecipeDiscovered: boolean
+}

--- a/shared/models/Player.ts
+++ b/shared/models/Player.ts
@@ -1,0 +1,12 @@
+import type { Profession } from './Profession'
+
+export interface Player {
+  /** Unique id */
+  id: string
+  /** Display name */
+  name: string
+  /** Professions the player has */
+  professions: Record<string, Profession>
+  /** Discovered recipe ids */
+  discoveredRecipes: string[]
+}

--- a/shared/models/Profession.ts
+++ b/shared/models/Profession.ts
@@ -1,0 +1,16 @@
+export type ProfessionName = 'Cooking' | 'Smithing' | 'Alchemy'
+
+import type { Card } from './Card'
+
+export interface Profession {
+  /** Profession identifier */
+  name: ProfessionName
+  /** Current level (1-10) */
+  level: number
+  /** Accumulated experience points */
+  experience: number
+  /** Recipe ids the player has discovered */
+  unlockedRecipes: string[]
+  /** Special cards awarded for this profession */
+  professionOnlyCards: Card[]
+}

--- a/shared/models/Recipe.ts
+++ b/shared/models/Recipe.ts
@@ -1,0 +1,15 @@
+import type { Card } from './Card'
+import type { ProfessionName } from './Profession'
+
+export interface Recipe {
+  /** Unique recipe id */
+  id: string
+  /** Card ids or ingredient ids required */
+  ingredients: string[]
+  /** Resulting crafted card */
+  result: Card
+  /** Profession that can craft this recipe */
+  profession: ProfessionName
+  /** Minimum profession level required */
+  levelRequirement: number
+}

--- a/shared/models/index.js
+++ b/shared/models/index.js
@@ -13,5 +13,10 @@ export * from './Inventory';
 export * from './Encounter';
 export * from './GameState';
 export * from './DecisionPoint';
+export { sampleRecipes } from './recipes.js';
+export * from './Profession';
+export * from './Recipe';
+export * from './CraftingAttempt';
+export * from './Player';
 // Sample enemies used by the game during early development
 export { enemies } from './enemies.js';

--- a/shared/models/recipes.js
+++ b/shared/models/recipes.js
@@ -1,0 +1,47 @@
+export const sampleRecipes = [
+  {
+    id: 'cooked_meat',
+    ingredients: ['herb', 'bread'],
+    result: {
+      id: 'cooked_meat',
+      name: 'Cooked Meat',
+      description: 'Restores hunger and grants small buff.',
+      rarity: 'Common',
+      category: 'FoodDrink',
+      restoreHunger: 10,
+      restoreThirst: 0,
+    },
+    profession: 'Cooking',
+    levelRequirement: 1,
+  },
+  {
+    id: 'flame_sword',
+    ingredients: ['iron_sword', 'herb'],
+    result: {
+      id: 'flame_sword',
+      name: 'Flame Sword',
+      description: 'A sword engulfed in flames.',
+      rarity: 'Uncommon',
+      category: 'Equipment',
+      statModifiers: [{ stat: 'attack', value: 4 }],
+      slot: 'Weapon',
+    },
+    profession: 'Smithing',
+    levelRequirement: 2,
+  },
+  {
+    id: 'healing_elixir',
+    ingredients: ['herb', 'herb'],
+    result: {
+      id: 'healing_elixir',
+      name: 'Healing Elixir',
+      description: 'Restores health during dungeon runs.',
+      rarity: 'Uncommon',
+      category: 'Elixir',
+      effects: [{ type: 'heal', magnitude: 10 }],
+      duration: 1,
+    },
+    profession: 'Alchemy',
+    levelRequirement: 1,
+  },
+]

--- a/shared/systems/crafting.js
+++ b/shared/systems/crafting.js
@@ -1,0 +1,75 @@
+/**
+ * Crafting utilities for professions and magical pouch experiments.
+ * @module crafting
+ */
+
+/**
+ * Attempt to craft using the supplied cards and profession.
+ * Checks recipes by matching ingredient ids regardless of order.
+ * @param {import('../models').Profession} profession
+ * @param {import('../models').Card[]} usedCards
+ * @param {import('../models').Recipe[]} recipes
+ * @returns {import('../models').CraftingAttempt}
+ */
+export function attemptCraft(profession, usedCards, recipes) {
+  const ingredientIds = usedCards.map((c) => c.id).sort().join('|')
+  const recipe = recipes.find(
+    (r) =>
+      r.profession === profession.name &&
+      r.ingredients.slice().sort().join('|') === ingredientIds &&
+      profession.level >= r.levelRequirement,
+  )
+
+  if (recipe) {
+    const crafted = { ...recipe.result, id: `${recipe.result.id}_${Date.now()}` }
+    return {
+      usedCards,
+      result: crafted,
+      success: true,
+      newRecipeDiscovered: !profession.unlockedRecipes.includes(recipe.id),
+    }
+  }
+
+  return { usedCards, result: null, success: false, newRecipeDiscovered: false }
+}
+
+/**
+ * Retrieve all recipes available to the profession's current level.
+ * @param {import('../models').Profession} profession
+ * @param {import('../models').Recipe[]} recipes
+ * @returns {import('../models').Recipe[]}
+ */
+export function getAvailableRecipes(profession, recipes) {
+  return recipes.filter(
+    (r) => r.profession === profession.name && r.levelRequirement <= profession.level,
+  )
+}
+
+/**
+ * Add experience and level up if threshold met.
+ * @param {import('../models').Profession} profession
+ * @param {number} exp
+ */
+export function levelUpProfession(profession, exp) {
+  profession.experience += exp
+  const needed = profession.level * 100
+  if (profession.experience >= needed && profession.level < 10) {
+    profession.level += 1
+    profession.experience = 0
+  }
+}
+
+/**
+ * Record a discovered recipe for a player and profession.
+ * @param {import('../models').Player} player
+ * @param {import('../models').Recipe} recipe
+ */
+export function registerRecipeDiscovery(player, recipe) {
+  if (!player.discoveredRecipes.includes(recipe.id)) {
+    player.discoveredRecipes.push(recipe.id)
+  }
+  const prof = player.professions[recipe.profession]
+  if (prof && !prof.unlockedRecipes.includes(recipe.id)) {
+    prof.unlockedRecipes.push(recipe.id)
+  }
+}

--- a/shared/systems/index.d.ts
+++ b/shared/systems/index.d.ts
@@ -11,3 +11,17 @@ export function rest(party: Character[], duration: number): void
 export function handleAdvance(state: import('../models').GameState): void
 export function handleRetreat(state: import('../models').GameState): void
 export function presentDecisionPoint(): void
+export function attemptCraft(
+  profession: import('../models').Profession,
+  usedCards: import('../models').Card[],
+  recipes: import('../models').Recipe[],
+): import('../models').CraftingAttempt
+export function getAvailableRecipes(
+  profession: import('../models').Profession,
+  recipes: import('../models').Recipe[],
+): import('../models').Recipe[]
+export function levelUpProfession(profession: import('../models').Profession, exp: number): void
+export function registerRecipeDiscovery(
+  player: import('../models').Player,
+  recipe: import('../models').Recipe,
+): void

--- a/shared/systems/index.js
+++ b/shared/systems/index.js
@@ -1,2 +1,3 @@
 export * from './postBattle.js'
 export * from './progression.js'
+export * from './crafting.js'


### PR DESCRIPTION
## Summary
- implement profession, recipe and crafting attempt data models
- add crafting system utility functions
- create sample recipes and export new models
- tag cards with optional `craftedBy`
- add Magical Pouch React component and route
- expose new crafting helpers via `shared` index

## Testing
- `npm -w client run lint`

------
https://chatgpt.com/codex/tasks/task_e_6842320a1c40832798f23a6d6930d406