### PR TITLE
Add inventory, card collection and combat UI

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -8,6 +8,9 @@ import Settings from './components/Settings.jsx'
 import PartySetupScreen from './components/PartySetupScreen.tsx'; // Import the new screen
 import DungeonPage from './components/DungeonPage.tsx';
 import MagicalPouch from './components/MagicalPouch.tsx';
+import InventoryScreen from './components/InventoryScreen.tsx'
+import CardCollection from './components/CardCollection.tsx'
+import CombatPage from './components/CombatPage.tsx'
 
 const demoProfession = { name: 'Cooking', level: 1, experience: 0, unlockedRecipes: [], professionOnlyCards: [] };
 const demoPlayer = { id: '1', name: 'Hero', professions: { Cooking: demoProfession }, discoveredRecipes: [] };
@@ -31,6 +34,9 @@ function App() {
           <Route path="/settings" element={<Settings />} />
           <Route path="/dungeon" element={<DungeonPage />} />
           <Route path="/pouch" element={<MagicalPouch player={demoPlayer} profession={demoProfession} />} />
+          <Route path="/inventory" element={<InventoryScreen />} />
+          <Route path="/cards" element={<CardCollection />} />
+          <Route path="/battle" element={<CombatPage />} />
         </Routes>
       </CSSTransition>
     </SwitchTransition>

--- a/client/src/components/CardCollection.module.css
+++ b/client/src/components/CardCollection.module.css
@@ -1,0 +1,23 @@
+.container {
+  padding: 20px;
+}
+.title {
+  margin-bottom: 20px;
+  text-align: center;
+}
+.controls {
+  margin-bottom: 15px;
+}
+.grid {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+}
+.cardWrapper {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+.checkbox {
+  margin-bottom: 4px;
+}

--- a/client/src/components/CardCollection.tsx
+++ b/client/src/components/CardCollection.tsx
@@ -1,0 +1,49 @@
+import React, { useState } from 'react'
+import { sampleCards } from '../../../shared/models/cards.js'
+import CardDisplay from './CardDisplay'
+import styles from './CardCollection.module.css'
+
+export default function CardCollection() {
+  const [rarity, setRarity] = useState('All')
+  const [selected, setSelected] = useState<string[]>([])
+
+  const rarities = Array.from(new Set(sampleCards.map(c => c.rarity)))
+
+  const filtered = sampleCards.filter(c => rarity === 'All' || c.rarity === rarity)
+
+  const toggle = (id: string) => {
+    setSelected(prev => prev.includes(id) ? prev.filter(p => p !== id) : [...prev, id])
+  }
+
+  return (
+    <div className={styles.container}>
+      <h1 className={styles.title}>Card Collection</h1>
+      <div className={styles.controls}>
+        <label htmlFor="rarity">Rarity:</label>
+        <select id="rarity" value={rarity} onChange={e => setRarity(e.target.value)}>
+          <option value="All">All</option>
+          {rarities.map(r => (<option key={r} value={r}>{r}</option>))}
+        </select>
+      </div>
+      <div className={styles.grid}>
+        {filtered.map(card => (
+          <div key={card.id} className={styles.cardWrapper}>
+            <input
+              type="checkbox"
+              checked={selected.includes(card.id)}
+              onChange={() => toggle(card.id)}
+              className={styles.checkbox}
+              aria-label={`Select ${card.name}`}
+            />
+            <CardDisplay
+              card={card}
+              onSelect={() => toggle(card.id)}
+              isSelected={selected.includes(card.id)}
+              isDisabled={false}
+            />
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/client/src/components/CombatOverlay.module.css
+++ b/client/src/components/CombatOverlay.module.css
@@ -1,0 +1,42 @@
+.overlay {
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  pointer-events: none;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+}
+.party, .enemies {
+  display: flex;
+  gap: 10px;
+  padding: 10px;
+}
+.combatant {
+  background: rgba(255,255,255,0.8);
+  border-radius: 4px;
+  padding: 4px 8px;
+}
+.bar {
+  background: #ccc;
+  height: 6px;
+  width: 100px;
+  margin-top: 2px;
+  position: relative;
+}
+.bar span {
+  display: block;
+  background: #4caf50;
+  height: 100%;
+  width: 0;
+}
+.log {
+  background: rgba(0,0,0,0.5);
+  color: #fff;
+  padding: 4px;
+  font-size: 0.8em;
+  max-height: 100px;
+  overflow-y: auto;
+}

--- a/client/src/components/CombatOverlay.tsx
+++ b/client/src/components/CombatOverlay.tsx
@@ -1,0 +1,46 @@
+import React from 'react'
+import styles from './CombatOverlay.module.css'
+
+interface Combatant {
+  id: string
+  name: string
+  hp: number
+}
+
+interface Props {
+  players: Combatant[]
+  enemies: Combatant[]
+  log: string[]
+}
+
+export default function CombatOverlay({ players, enemies, log }: Props) {
+  return (
+    <div className={styles.overlay}>
+      <div className={styles.party}>
+        {players.map(p => (
+          <div key={p.id} className={styles.combatant}>
+            <strong>{p.name}</strong>
+            <div className={styles.bar}>
+              <span style={{ width: `${p.hp}%` }} />
+            </div>
+          </div>
+        ))}
+      </div>
+      <div className={styles.enemies}>
+        {enemies.map(e => (
+          <div key={e.id} className={styles.combatant}>
+            <strong>{e.name}</strong>
+            <div className={styles.bar}>
+              <span style={{ width: `${e.hp}%` }} />
+            </div>
+          </div>
+        ))}
+      </div>
+      <div className={styles.log} aria-live="polite">
+        {log.map((l, i) => (
+          <div key={i}>{l}</div>
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/client/src/components/CombatPage.tsx
+++ b/client/src/components/CombatPage.tsx
@@ -1,0 +1,45 @@
+import React, { useEffect, useRef, useState } from 'react'
+import Phaser from 'phaser'
+import BattleScene from '../phaser/BattleScene'
+import CombatOverlay from './CombatOverlay'
+import type { Card } from '../../../shared/models/Card'
+
+interface Combatant { id: string; name: string; hp: number }
+
+export default function CombatPage() {
+  const containerRef = useRef<HTMLDivElement | null>(null)
+  const [players, setPlayers] = useState<Combatant[]>([])
+  const [enemies, setEnemies] = useState<Combatant[]>([])
+  const [log, setLog] = useState<string[]>([])
+
+  useEffect(() => {
+    if (!containerRef.current) return
+    const game = new Phaser.Game({
+      type: Phaser.AUTO,
+      width: 800,
+      height: 600,
+      parent: containerRef.current,
+      scene: [BattleScene],
+    })
+    const handler = (e: any) => {
+      if (e.detail.type === 'state') {
+        setPlayers(e.detail.players)
+        setEnemies(e.detail.enemies)
+      } else if (e.detail.type === 'log') {
+        setLog(l => [...l.slice(-10), e.detail.message])
+      }
+    }
+    window.addEventListener('battleState', handler)
+    return () => {
+      window.removeEventListener('battleState', handler)
+      game.destroy(true)
+    }
+  }, [])
+
+  return (
+    <div style={{ position: 'relative' }}>
+      <div ref={containerRef} />
+      <CombatOverlay players={players} enemies={enemies} log={log} />
+    </div>
+  )
+}

--- a/client/src/components/InventoryScreen.module.css
+++ b/client/src/components/InventoryScreen.module.css
@@ -1,0 +1,39 @@
+.container {
+  padding: 20px;
+}
+.title {
+  margin-bottom: 20px;
+}
+.filterRow {
+  margin-bottom: 15px;
+}
+.select {
+  margin-left: 8px;
+}
+.grid {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+}
+.item {
+  border: 1px solid #ccc;
+  border-radius: 6px;
+  padding: 10px;
+  width: 150px;
+  background: #fff;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+.meta {
+  font-size: 0.8em;
+  color: #666;
+}
+.actions {
+  margin-top: 8px;
+  display: flex;
+  gap: 4px;
+}
+.actions button {
+  flex: 1 1 auto;
+}

--- a/client/src/components/InventoryScreen.tsx
+++ b/client/src/components/InventoryScreen.tsx
@@ -1,0 +1,58 @@
+import React, { useState } from 'react'
+import { sampleCards } from '../../../shared/models/cards.js'
+import styles from './InventoryScreen.module.css'
+
+interface InventoryItem {
+  id: string
+  name: string
+  type: string
+  rarity: string
+}
+
+const allItems: InventoryItem[] = sampleCards.map(c => ({
+  id: c.id,
+  name: c.name,
+  type: c.category || c.type || 'Unknown',
+  rarity: c.rarity || 'Common',
+}))
+
+export default function InventoryScreen() {
+  const [filter, setFilter] = useState('All')
+
+  const items = allItems.filter(i => filter === 'All' || i.type === filter)
+
+  const uniqueTypes = Array.from(new Set(allItems.map(i => i.type)))
+
+  return (
+    <div className={styles.container}>
+      <h1 className={styles.title}>Inventory</h1>
+      <div className={styles.filterRow}>
+        <label htmlFor="filter">Filter:</label>
+        <select
+          id="filter"
+          value={filter}
+          onChange={e => setFilter(e.target.value)}
+          className={styles.select}
+        >
+          <option value="All">All</option>
+          {uniqueTypes.map(t => (
+            <option key={t} value={t}>{t}</option>
+          ))}
+        </select>
+      </div>
+      <div className={styles.grid}>
+        {items.map(item => (
+          <div key={item.id} className={styles.item} tabIndex={0} aria-label={`${item.name} ${item.rarity} ${item.type}`}>
+            <strong>{item.name}</strong>
+            <span className={styles.meta}>{item.rarity}</span>
+            <div className={styles.actions}>
+              <button>Use</button>
+              <button>Equip</button>
+              <button>Sell</button>
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/client/src/components/MainMenu.jsx
+++ b/client/src/components/MainMenu.jsx
@@ -10,6 +10,9 @@ function MainMenu() {
         <Link className={styles.button} to="/load-game">Load Game</Link>
         <Link className={styles.button} to="/settings">Settings</Link>
         <Link className={styles.button} to="/pouch">Magical Pouch</Link>
+        <Link className={styles.button} to="/inventory">Inventory</Link>
+        <Link className={styles.button} to="/cards">Card Collection</Link>
+        <Link className={styles.button} to="/battle">Combat Demo</Link>
       </nav>
     </main>
   )


### PR DESCRIPTION
## Summary
- build inventory screen and card collection panels
- add combat overlay with Phaser integration
- wire up new screens in router and main menu
- emit battle state updates from Phaser scene

## Testing
- `npm test --silent`
- `npm -w client run lint`

------
https://chatgpt.com/codex/tasks/task_e_68423d05b8b883278b1e30b30d9ce19f