### PR TITLE
Add floating text visual effects

### DIFF
--- a/client/src/components/CardDisplay.tsx
+++ b/client/src/components/CardDisplay.tsx
@@ -10,18 +10,21 @@ interface CardDisplayProps {
 
 const CardDisplay: React.FC<CardDisplayProps> = ({ card, onSelect, isSelected, isDisabled }) => {
   const style: React.CSSProperties = {
-    border: isSelected ? '2px solid #27ae60' : '1px solid #e0e0e0', // Green border if selected
+    border: isSelected ? '2px solid #27ae60' : '1px solid #e0e0e0',
     padding: '10px',
     margin: '5px',
     cursor: isDisabled ? 'not-allowed' : 'pointer',
     opacity: isDisabled ? 0.5 : 1,
-    backgroundColor: isSelected ? '#e9f7ef' : '#f9f9f9', // Light green background if selected
+    backgroundColor: isSelected ? '#e9f7ef' : '#f9f9f9',
     borderRadius: '6px',
-    boxShadow: '0 1px 3px rgba(0,0,0,0.05)',
+    boxShadow: isSelected
+      ? '0 3px 6px rgba(0,0,0,0.15)'
+      : '0 1px 3px rgba(0,0,0,0.05)',
+    transform: isSelected ? 'scale(1.05)' : 'none',
     transition: 'transform 0.2s ease, box-shadow 0.2s ease',
-    width: '150px', // Give a fixed width for better alignment in flex container
+    width: '150px',
     fontSize: '0.9em',
-  };
+  }
 
   const handleClick = () => {
     if (!isDisabled) {

--- a/client/src/phaser/BattleScene.ts
+++ b/client/src/phaser/BattleScene.ts
@@ -1,6 +1,7 @@
 import Phaser from 'phaser'
 import { enemies } from 'shared/models'
 import { chooseEnemyAction, trackEnemyActions } from 'shared/systems/enemyAI.js'
+import { floatingText } from './effects'
 
 interface SceneData {
   enemyIndex?: number
@@ -34,6 +35,20 @@ export default class BattleScene extends Phaser.Scene {
             .map((c) => ({ id: c.data.id, name: c.data.name, hp: c.hp })),
         }
     window.dispatchEvent(new CustomEvent('battleState', { detail }))
+  }
+
+  private getSprite(combatant: any) {
+    return (
+      this.playerSprites.find((s) => s.data.id === combatant.data.id) ||
+      this.enemySprites.find((s) => s.data.id === combatant.data.id)
+    )
+  }
+
+  private showFloat(text: string, combatant: any, color: string) {
+    const sprite = this.getSprite(combatant)
+    if (sprite) {
+      floatingText(this, text, sprite.rect.x, sprite.rect.y - 40, color)
+    }
   }
 
   constructor() {
@@ -162,9 +177,11 @@ export default class BattleScene extends Phaser.Scene {
     card.effects.forEach((effect: any) => {
       if (effect.type === 'damage') {
         target.hp -= effect.value
+        this.showFloat(`-${effect.value}`, target, '#ff4444')
       }
       if (effect.type === 'heal') {
         actor.hp = Math.min(actor.data.stats.hp, actor.hp + effect.value)
+        this.showFloat(`+${effect.value}`, actor, '#44ff44')
       }
     })
     this.emitState(`${actor.data.name} used ${card.name}`)

--- a/client/src/phaser/effects.ts
+++ b/client/src/phaser/effects.ts
@@ -1,0 +1,21 @@
+import Phaser from 'phaser'
+
+/** Simple floating text animation */
+export function floatingText(
+  scene: Phaser.Scene,
+  text: string,
+  x: number,
+  y: number,
+  color = '#ffffff',
+  duration = 800,
+) {
+  const txt = scene.add.text(x, y, text, { fontSize: '16px', color })
+  scene.tweens.add({
+    targets: txt,
+    y: y - 30,
+    alpha: 0,
+    duration,
+    ease: 'Cubic.easeOut',
+    onComplete: () => txt.destroy(),
+  })
+}

--- a/shared/models/VisualEffect.ts
+++ b/shared/models/VisualEffect.ts
@@ -1,0 +1,19 @@
+export interface VisualEffect {
+  /** When this effect is triggered */
+  trigger:
+    | 'cardPlay'
+    | 'attack'
+    | 'heal'
+    | 'combo'
+    | 'status'
+    | 'uiTransition'
+    | string
+  /** Rendering type for this effect */
+  type: 'particle' | 'spriteAnim' | 'floatText' | 'screenOverlay' | string
+  /** Optional tint or text color */
+  color?: string
+  /** Duration in milliseconds */
+  duration?: number
+  /** Animation key or descriptor */
+  animationName?: string
+}

--- a/shared/models/index.js
+++ b/shared/models/index.js
@@ -27,3 +27,4 @@ export { enemies } from './enemies.js';
 export { biomes } from './biomes.js';
 export { dungeonEvents } from './events.js';
 export * from './DungeonEvent';
+export * from './VisualEffect';


### PR DESCRIPTION
## Summary
- add `VisualEffect` interface to shared models
- export new model in index file
- create Phaser `floatingText` helper
- show floating text for damage/heal in `BattleScene`
- scale selected card for clearer feedback

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68423ebc1dac8327b291c71c6e84d003