### PR TITLE
Integrate React SPA state

### DIFF
--- a/client/src/App.css
+++ b/client/src/App.css
@@ -55,3 +55,18 @@
   opacity: 0;
   transition: opacity 300ms;
 }
+
+.slide-enter {
+  transform: translateX(100%);
+}
+.slide-enter-active {
+  transform: translateX(0);
+  transition: transform 300ms ease;
+}
+.slide-exit {
+  transform: translateX(0);
+}
+.slide-exit-active {
+  transform: translateX(-100%);
+  transition: transform 300ms ease;
+}

--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -22,7 +22,7 @@ function App() {
     <SwitchTransition>
       <CSSTransition
         key={location.pathname}
-        classNames="fade"
+        classNames="slide"
         timeout={300}
         unmountOnExit
       >

--- a/client/src/GameContext.tsx
+++ b/client/src/GameContext.tsx
@@ -1,0 +1,44 @@
+import React, { createContext, useContext, useState, ReactNode, useEffect } from 'react'
+import type { Party } from '../../shared/models/Party'
+
+interface GameState {
+  party: Party | null
+  setParty: (party: Party) => void
+}
+
+const GameContext = createContext<GameState | undefined>(undefined)
+
+export const GameProvider = ({ children }: { children: ReactNode }) => {
+  const [party, setPartyState] = useState<Party | null>(null)
+
+  // Load party from localStorage once on mount to allow reloads
+  useEffect(() => {
+    const stored = localStorage.getItem('partyData')
+    if (stored) {
+      try {
+        setPartyState(JSON.parse(stored))
+      } catch {
+        setPartyState(null)
+      }
+    }
+  }, [])
+
+  const setParty = (p: Party) => {
+    setPartyState(p)
+    // Persist for reloads
+    localStorage.setItem('partyData', JSON.stringify(p))
+  }
+
+  return (
+    <GameContext.Provider value={{ party, setParty }}>
+      {children}
+    </GameContext.Provider>
+  )
+}
+
+export const useGame = () => {
+  const ctx = useContext(GameContext)
+  if (!ctx) throw new Error('useGame must be inside GameProvider')
+  return ctx
+}
+

--- a/client/src/components/CombatPage.tsx
+++ b/client/src/components/CombatPage.tsx
@@ -2,12 +2,13 @@ import React, { useEffect, useRef, useState } from 'react'
 import Phaser from 'phaser'
 import BattleScene from '../phaser/BattleScene'
 import CombatOverlay from './CombatOverlay'
-import type { Card } from '../../../shared/models/Card'
+import { useGame } from '../GameContext'
 
 interface Combatant { id: string; name: string; hp: number }
 
 export default function CombatPage() {
   const containerRef = useRef<HTMLDivElement | null>(null)
+  const { party } = useGame()
   const [players, setPlayers] = useState<Combatant[]>([])
   const [enemies, setEnemies] = useState<Combatant[]>([])
   const [log, setLog] = useState<string[]>([])
@@ -19,8 +20,8 @@ export default function CombatPage() {
       width: 800,
       height: 600,
       parent: containerRef.current,
-      scene: [BattleScene],
     })
+    game.scene.add('battle', BattleScene, true, { party: party?.characters || [] })
     const handler = (e: any) => {
       if (e.detail.type === 'state') {
         setPlayers(e.detail.players)

--- a/client/src/components/DungeonMap.tsx
+++ b/client/src/components/DungeonMap.tsx
@@ -8,10 +8,11 @@ interface Props {
   dungeon: DungeonData
   playerPos: { x: number; y: number }
   explored: Set<string>
+  party: any[]
   onMove: (pos: { x: number; y: number }, explored: Set<string>) => void
 }
 
-export default function DungeonMap({ dungeon, playerPos, explored, onMove }: Props) {
+export default function DungeonMap({ dungeon, playerPos, explored, party, onMove }: Props) {
   const containerRef = useRef<HTMLDivElement | null>(null)
 
   useEffect(() => {
@@ -23,7 +24,7 @@ export default function DungeonMap({ dungeon, playerPos, explored, onMove }: Pro
       parent: containerRef.current,
       scene: [DungeonScene, BattleScene],
     })
-    game.scene.start('dungeon', { dungeon, playerPos, explored })
+    game.scene.start('dungeon', { dungeon, playerPos, explored, party })
     const handler = (e: any) => {
       onMove(e.detail.position, new Set(e.detail.explored))
     }
@@ -32,7 +33,7 @@ export default function DungeonMap({ dungeon, playerPos, explored, onMove }: Pro
       window.removeEventListener('playerMove', handler)
       game.destroy(true)
     }
-  }, [dungeon])
+  }, [dungeon, party])
 
   return <div ref={containerRef} />
 }

--- a/client/src/components/DungeonPage.tsx
+++ b/client/src/components/DungeonPage.tsx
@@ -2,11 +2,13 @@ import React, { useState } from 'react'
 import DungeonMap from './DungeonMap'
 import PlayerStatsPanel from './PlayerStatsPanel'
 import { generateDungeon } from '../utils/generateDungeon'
+import { useGame } from '../GameContext'
 
 export default function DungeonPage() {
   const [dungeon] = useState(() => generateDungeon())
   const [playerPos, setPlayerPos] = useState(dungeon.start)
   const [explored, setExplored] = useState<Set<string>>(new Set([`${playerPos.x},${playerPos.y}`]))
+  const { party } = useGame()
 
   const handleMove = (pos: { x: number; y: number }, exploredSet: Set<string>) => {
     setPlayerPos(pos)
@@ -15,7 +17,7 @@ export default function DungeonPage() {
 
   return (
     <div style={{ display: 'flex', gap: 20 }}>
-      <DungeonMap dungeon={dungeon} playerPos={playerPos} explored={explored} onMove={handleMove} />
+      <DungeonMap dungeon={dungeon} playerPos={playerPos} explored={explored} party={party?.characters || []} onMove={handleMove} />
       <PlayerStatsPanel position={playerPos} />
     </div>
   )

--- a/client/src/components/PartyBuilder.jsx
+++ b/client/src/components/PartyBuilder.jsx
@@ -1,9 +1,13 @@
 import { useState } from 'react'
+import { useNavigate } from 'react-router-dom'
+import { useGame } from '../GameContext'
 import { sampleCharacters } from 'shared/models/characters.js'
 import { sampleCards } from 'shared/models/cards.js'
 
 function PartyBuilder() {
   const [party, setParty] = useState([])
+  const navigate = useNavigate()
+  const { setParty: storeParty } = useGame()
   const [selectedCards, setSelectedCards] = useState({})
 
   const availableCharacters = sampleCharacters.filter(
@@ -59,14 +63,8 @@ function PartyBuilder() {
       survival: { hunger: 0, thirst: 0, fatigue: 0 },
     }))
 
-    try {
-      localStorage.setItem('partyData', JSON.stringify(fullParty))
-      // Navigate to the Phaser game. In a production app this could be a route
-      // change or modal. For simplicity we load the bundled game directly.
-      window.location.href = '/game'
-    } catch (error) {
-      console.error('Error storing party data:', error)
-    }
+    storeParty({ characters: fullParty })
+    navigate('/dungeon')
   }
 
   return (

--- a/client/src/components/PartySetupScreen.tsx
+++ b/client/src/components/PartySetupScreen.tsx
@@ -1,5 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
+import { useGame } from '../GameContext';
 // Import data models. Adjust paths if necessary.
 import type { Character } from '../../../shared/models/Character';
 import type { Card } from '../../../shared/models/Card';
@@ -25,6 +26,7 @@ const PartySetupScreen: React.FC = () => {
   const [availableCards, setAvailableCards] = useState<Card[]>([]);
 
   const navigate = useNavigate();
+  const { setParty } = useGame();
 
   useEffect(() => {
     // Initialize available characters and cards
@@ -94,13 +96,8 @@ const PartySetupScreen: React.FC = () => {
       })),
     };
 
-    try {
-      localStorage.setItem('partyData', JSON.stringify(partyData));
-      navigate('/dungeon');
-    } catch (error) {
-      console.error('Error storing party data:', error);
-      // Handle error, e.g., show a notification to the user
-    }
+    setParty(partyData)
+    navigate('/dungeon')
   };
 
   // Basic JSX structure - will be expanded in subsequent steps

--- a/client/src/main.jsx
+++ b/client/src/main.jsx
@@ -3,11 +3,14 @@ import { createRoot } from 'react-dom/client'
 import { BrowserRouter } from 'react-router-dom'
 import './index.css'
 import App from './App.jsx'
+import { GameProvider } from './GameContext'
 
 createRoot(document.getElementById('root')).render(
   <StrictMode>
     <BrowserRouter>
-      <App />
+      <GameProvider>
+        <App />
+      </GameProvider>
     </BrowserRouter>
   </StrictMode>,
 )

--- a/client/src/phaser/BattleScene.ts
+++ b/client/src/phaser/BattleScene.ts
@@ -5,6 +5,7 @@ import { floatingText } from './effects'
 
 interface SceneData {
   enemyIndex?: number
+  party?: any[]
 }
 
 export default class BattleScene extends Phaser.Scene {
@@ -57,19 +58,11 @@ export default class BattleScene extends Phaser.Scene {
 
   init(data: SceneData) {
     this.enemyIndex = data.enemyIndex || 0
+    this.party = data.party || []
   }
 
   create() {
-    const partyDataJSON = localStorage.getItem('partyData')
-    if (partyDataJSON) {
-      try {
-        const parsed = JSON.parse(partyDataJSON)
-        this.party = Array.isArray(parsed) ? parsed : parsed.characters || []
-      } catch (e) {
-        console.error('Failed to parse party data', e)
-        this.party = []
-      }
-    }
+    // party populated from init
 
     this.enemy = enemies[this.enemyIndex]
     this.enemies = [JSON.parse(JSON.stringify(this.enemy))]

--- a/client/src/phaser/DungeonScene.ts
+++ b/client/src/phaser/DungeonScene.ts
@@ -6,12 +6,14 @@ type SceneData = {
   dungeon: DungeonData
   playerPos: { x: number; y: number }
   explored: Set<string>
+  party?: any[]
 }
 
 export default class DungeonScene extends Phaser.Scene {
   private dungeon!: DungeonData
   private playerPos!: { x: number; y: number }
   private explored!: Set<string>
+  private party: any[] = []
   private tileSize = 32
   private mapGraphics!: Phaser.GameObjects.Graphics
   private fogGraphics!: Phaser.GameObjects.Graphics
@@ -28,6 +30,7 @@ export default class DungeonScene extends Phaser.Scene {
     this.dungeon = data.dungeon
     this.playerPos = { ...data.playerPos }
     this.explored = new Set(data.explored)
+    this.party = data.party || []
   }
 
   create() {
@@ -80,7 +83,7 @@ export default class DungeonScene extends Phaser.Scene {
         this.playerPos.y === this.dungeon.end.y
       ) {
         this.battleStarted = true
-        this.scene.start('battle', { enemyIndex: 0 })
+        this.scene.start('battle', { enemyIndex: 0, party: this.party })
       }
     }
   }


### PR DESCRIPTION
## Summary
- add `GameContext` provider to hold persistent party state
- use the provider in `main.jsx` and screens
- pass party data into Phaser scenes instead of using localStorage
- update PartyBuilder and PartySetup to store party via context
- enable slide transitions between routes

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684242494d6c83278cab78d864318fce