### PR TITLE
Improve navigation persistence and transitions

### DIFF
--- a/client/src/App.css
+++ b/client/src/App.css
@@ -70,3 +70,24 @@
   transform: translateX(-100%);
   transition: transform 300ms ease;
 }
+
+.loading-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: rgba(0, 0, 0, 0.5);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: #fff;
+  font-size: 1.5rem;
+  pointer-events: none;
+  opacity: 0;
+  transition: opacity 200ms ease;
+}
+
+.loading-overlay.show {
+  opacity: 1;
+}

--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -1,6 +1,7 @@
 import './App.css'
-import { Routes, Route, useLocation } from 'react-router-dom'
+import { Routes, Route, useLocation, useNavigate } from 'react-router-dom'
 import { CSSTransition, SwitchTransition } from 'react-transition-group'
+import { useEffect, useRef, useState } from 'react'
 import MainMenu from './components/MainMenu.jsx'
 import NewGame from './components/NewGame.jsx'
 import LoadGame from './components/LoadGame.jsx'
@@ -15,18 +16,52 @@ import CombatPage from './components/CombatPage.tsx'
 const demoProfession = { name: 'Cooking', level: 1, experience: 0, unlockedRecipes: [], professionOnlyCards: [] };
 const demoPlayer = { id: '1', name: 'Hero', professions: { Cooking: demoProfession }, discoveredRecipes: [] };
 
+function useReturnPoint(navigate, location) {
+  const restored = useRef(false)
+
+  // Restore saved location on first mount
+  useEffect(() => {
+    if (restored.current) return
+    const saved = localStorage.getItem('returnPath')
+    if (saved && saved !== location.pathname) {
+      restored.current = true
+      navigate(saved, { replace: true })
+    } else {
+      restored.current = true
+    }
+  }, [navigate, location.pathname])
+
+  // Save location on changes
+  useEffect(() => {
+    if (!restored.current) return
+    localStorage.setItem('returnPath', location.pathname)
+  }, [location.pathname])
+}
+
 function App() {
   const location = useLocation()
+  const navigate = useNavigate()
+  const [loading, setLoading] = useState(false)
+
+  useReturnPoint(navigate, location)
+
+  useEffect(() => {
+    setLoading(true)
+    const t = setTimeout(() => setLoading(false), 300)
+    return () => clearTimeout(t)
+  }, [location.pathname])
 
   return (
-    <SwitchTransition>
-      <CSSTransition
-        key={location.pathname}
-        classNames="slide"
-        timeout={300}
-        unmountOnExit
-      >
-        <Routes location={location}>
+    <>
+      {loading && <div className="loading-overlay show">Loading...</div>}
+      <SwitchTransition>
+        <CSSTransition
+          key={location.pathname}
+          classNames="slide"
+          timeout={300}
+          unmountOnExit
+        >
+          <Routes location={location}>
           <Route path="/" element={<MainMenu />} />
           <Route path="/new-game" element={<NewGame />} />
           <Route path="/party-setup" element={<PartySetupScreen />} /> {/* Add this route */}
@@ -37,9 +72,10 @@ function App() {
           <Route path="/inventory" element={<InventoryScreen />} />
           <Route path="/cards" element={<CardCollection />} />
           <Route path="/battle" element={<CombatPage />} />
-        </Routes>
-      </CSSTransition>
-    </SwitchTransition>
+          </Routes>
+        </CSSTransition>
+      </SwitchTransition>
+    </>
   )
 }
 


### PR DESCRIPTION
## Summary
- store last visited route and restore on app start
- display a loading overlay during route transitions

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6842474190e08327aa12c9b6a27bf82d