### PR TITLE
Add global modal and notification managers

### DIFF
--- a/client/src/components/CombatPage.tsx
+++ b/client/src/components/CombatPage.tsx
@@ -2,6 +2,9 @@ import React, { useState } from 'react'
 import CombatOverlay from './CombatOverlay'
 import { useGameStore } from '../store/gameStore'
 import GameView from './GameView'
+import { useModal } from './ModalManager.jsx'
+import { useNotification } from './NotificationManager.jsx'
+import { useNavigate } from 'react-router-dom'
 
 interface Combatant { id: string; name: string; hp: number }
 
@@ -10,6 +13,9 @@ export default function CombatPage() {
   const [players, setPlayers] = useState<Combatant[]>([])
   const [enemies, setEnemies] = useState<Combatant[]>([])
   const [log, setLog] = useState<string[]>([])
+  const { open, close } = useModal()
+  const { notify } = useNotification()
+  const navigate = useNavigate()
 
   const handleBattleEvent = (detail: any) => {
     if (detail.type === 'state') {
@@ -28,6 +34,30 @@ export default function CombatPage() {
         onBattleEvent={handleBattleEvent}
       />
       <CombatOverlay players={players} enemies={enemies} log={log} />
+      <button
+        style={{ position: 'absolute', top: 10, right: 10 }}
+        onClick={() => {
+          const id = open(
+            <div>
+              <p>Retreat from battle?</p>
+              <div style={{ display: 'flex', gap: '1rem', marginTop: '1rem' }}>
+                <button
+                  onClick={() => {
+                    close(id)
+                    notify('You retreated to safety.', 'success')
+                    navigate('/dungeon')
+                  }}
+                >
+                  Yes
+                </button>
+                <button onClick={() => close(id)}>No</button>
+              </div>
+            </div>
+          )
+        }}
+      >
+        Retreat
+      </button>
     </div>
   )
 }

--- a/client/src/components/InventoryScreen.tsx
+++ b/client/src/components/InventoryScreen.tsx
@@ -1,4 +1,5 @@
 import React, { useState } from 'react'
+import { useNotification } from './NotificationManager.jsx'
 import { sampleCards } from '../../../shared/models/cards.js'
 import styles from './InventoryScreen.module.css'
 
@@ -18,6 +19,7 @@ const allItems: InventoryItem[] = sampleCards.map(c => ({
 
 export default function InventoryScreen() {
   const [filter, setFilter] = useState('All')
+  const { notify } = useNotification()
 
   const items = allItems.filter(i => filter === 'All' || i.type === filter)
 
@@ -46,9 +48,9 @@ export default function InventoryScreen() {
             <strong>{item.name}</strong>
             <span className={styles.meta}>{item.rarity}</span>
             <div className={styles.actions}>
-              <button>Use</button>
-              <button>Equip</button>
-              <button>Sell</button>
+              <button onClick={() => notify(`Used ${item.name}`, 'success')}>Use</button>
+              <button onClick={() => notify(`Equipped ${item.name}`, 'success')}>Equip</button>
+              <button onClick={() => notify(`Sold ${item.name}`, 'success')}>Sell</button>
             </div>
           </div>
         ))}

--- a/client/src/components/ModalManager.css
+++ b/client/src/components/ModalManager.css
@@ -1,0 +1,21 @@
+.modal-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: rgba(0, 0, 0, 0.6);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+}
+
+.modal {
+  background: #282828;
+  padding: 1.5rem;
+  border-radius: 8px;
+  max-width: 400px;
+  width: 90%;
+  color: #fff;
+}

--- a/client/src/components/ModalManager.jsx
+++ b/client/src/components/ModalManager.jsx
@@ -1,0 +1,33 @@
+import React, { createContext, useContext, useState, useCallback } from 'react'
+import './ModalManager.css'
+
+const ModalContext = createContext({ open: () => {}, close: () => {} })
+
+export function ModalProvider({ children }) {
+  const [modals, setModals] = useState([])
+
+  const open = useCallback((content) => {
+    const id = Math.random().toString(36).slice(2)
+    setModals((m) => [...m, { id, content }])
+    return id
+  }, [])
+
+  const close = useCallback((id) => {
+    setModals((m) => m.filter((modal) => modal.id !== id))
+  }, [])
+
+  return (
+    <ModalContext.Provider value={{ open, close }}>
+      {children}
+      {modals.map(({ id, content }) => (
+        <div key={id} className="modal-overlay" onClick={() => close(id)}>
+          <div className="modal" onClick={(e) => e.stopPropagation()}>
+            {content}
+          </div>
+        </div>
+      ))}
+    </ModalContext.Provider>
+  )
+}
+
+export const useModal = () => useContext(ModalContext)

--- a/client/src/components/NotificationManager.css
+++ b/client/src/components/NotificationManager.css
@@ -1,0 +1,25 @@
+.notification-container {
+  position: fixed;
+  top: 1rem;
+  right: 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  z-index: 1000;
+}
+
+.toast {
+  background: #333;
+  color: #fff;
+  padding: 0.5rem 1rem;
+  border-radius: 4px;
+  min-width: 160px;
+}
+
+.toast.success {
+  background: #2e7d32;
+}
+
+.toast.error {
+  background: #c62828;
+}

--- a/client/src/components/NotificationManager.jsx
+++ b/client/src/components/NotificationManager.jsx
@@ -1,0 +1,29 @@
+import React, { createContext, useContext, useState, useCallback } from 'react'
+import './NotificationManager.css'
+
+const NotificationContext = createContext({ notify: () => {} })
+
+export function NotificationProvider({ children }) {
+  const [toasts, setToasts] = useState([])
+
+  const notify = useCallback((message, type = 'info', timeout = 3000) => {
+    const id = Math.random().toString(36).slice(2)
+    setToasts((t) => [...t, { id, message, type }])
+    setTimeout(() => {
+      setToasts((t) => t.filter((toast) => toast.id !== id))
+    }, timeout)
+  }, [])
+
+  return (
+    <NotificationContext.Provider value={{ notify }}>
+      {children}
+      <div className="notification-container">
+        {toasts.map((t) => (
+          <div key={t.id} className={`toast ${t.type}`}>{t.message}</div>
+        ))}
+      </div>
+    </NotificationContext.Provider>
+  )
+}
+
+export const useNotification = () => useContext(NotificationContext)

--- a/client/src/main.jsx
+++ b/client/src/main.jsx
@@ -4,6 +4,8 @@ import { BrowserRouter } from 'react-router-dom'
 import './index.css'
 import App from './App.jsx'
 import { useGameStore } from './store/gameStore'
+import { ModalProvider } from './components/ModalManager.jsx'
+import { NotificationProvider } from './components/NotificationManager.jsx'
 
 // Load any saved state before the app renders
 useGameStore.getState().load()
@@ -11,7 +13,11 @@ useGameStore.getState().load()
 createRoot(document.getElementById('root')).render(
   <StrictMode>
     <BrowserRouter>
-      <App />
+      <ModalProvider>
+        <NotificationProvider>
+          <App />
+        </NotificationProvider>
+      </ModalProvider>
     </BrowserRouter>
   </StrictMode>,
 )


### PR DESCRIPTION
## Summary
- create `ModalManager` and `NotificationManager` components
- wrap the application with the new providers
- use modal confirm dialog for retreat in `CombatPage`
- display toasts for inventory actions

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6842483b8b548327a271a19dd0092e48