### PR TITLE
Add basic main menu

### DIFF
--- a/client/src/components/MainMenu.jsx
+++ b/client/src/components/MainMenu.jsx
@@ -1,18 +1,46 @@
-import { Link } from 'react-router-dom'
+import { useNavigate } from 'react-router-dom'
+import { useModal } from './ModalManager.jsx'
 import styles from './MainMenu.module.css'
 
 function MainMenu() {
+  const navigate = useNavigate()
+  const { open, close } = useModal()
+
+  const showPlaceholder = (message) => {
+    const id = open(
+      <div>
+        <p>{message}</p>
+        <div style={{ textAlign: 'center', marginTop: '1rem' }}>
+          <button className={styles.button} onClick={() => close(id)}>
+            Close
+          </button>
+        </div>
+      </div>
+    )
+  }
+
   return (
     <main className={styles.container}>
       <h1 className={styles.title}>Survival Dungeon</h1>
       <nav className={styles.menu}>
-        <Link className={styles.button} to="/new-game">Start New Game</Link>
-        <Link className={styles.button} to="/load-game">Load Game</Link>
-        <Link className={styles.button} to="/settings">Settings</Link>
-        <Link className={styles.button} to="/pouch">Magical Pouch</Link>
-        <Link className={styles.button} to="/inventory">Inventory</Link>
-        <Link className={styles.button} to="/cards">Card Collection</Link>
-        <Link className={styles.button} to="/battle">Combat Demo</Link>
+        <button
+          className={styles.button}
+          onClick={() => navigate('/party-setup')}
+        >
+          New Game
+        </button>
+        <button
+          className={styles.button}
+          onClick={() => showPlaceholder('Continue feature coming soon!')}
+        >
+          Continue
+        </button>
+        <button
+          className={styles.button}
+          onClick={() => showPlaceholder('Settings are not available yet.')}
+        >
+          Settings
+        </button>
       </nav>
     </main>
   )

--- a/client/src/components/MainMenu.module.css
+++ b/client/src/components/MainMenu.module.css
@@ -4,11 +4,13 @@
   align-items: center;
   justify-content: center;
   min-height: 100vh;
+  padding: 1rem;
   text-align: center;
 }
 
 .title {
   font-size: 3rem;
+  font-weight: bold;
   margin-bottom: 2rem;
 }
 
@@ -16,29 +18,30 @@
   display: flex;
   flex-direction: column;
   gap: 1rem;
-  width: 200px;
+  width: 100%;
+  max-width: 280px;
 }
 
 .button {
   padding: 0.8rem 1.2rem;
   border-radius: 8px;
-  border: 1px solid transparent;
+  border: 1px solid #444;
+  background-color: #222;
+  color: #fff;
   text-decoration: none;
-  color: inherit;
-  background-color: #1a1a1a;
-  transition: border-color 0.25s, transform 0.1s;
+  font-size: 1.1rem;
+  cursor: pointer;
+  transition: background-color 0.25s, transform 0.1s, border-color 0.25s;
+  width: 100%;
 }
 
 .button:hover {
-  border-color: #646cff;
+  background-color: #333;
+  border-color: #888;
 }
 
 .button:active {
   transform: scale(0.96);
-}
-
-.button:focus {
-  outline: 4px auto -webkit-focus-ring-color;
 }
 
 @media (max-width: 600px) {


### PR DESCRIPTION
## Summary
- revamp `<MainMenu />` layout
- add placeholder modals for continue and settings
- style menu buttons for a mobile-friendly layout

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68424d1bc4e48327af8e41587ae69822