### PR TITLE
Add Back button to PartySetup

### DIFF
--- a/client/src/components/PartySetup.module.css
+++ b/client/src/components/PartySetup.module.css
@@ -79,9 +79,8 @@
 
 .startGameButton {
   display: block;
-  width: 100%;
-  max-width: 300px;
-  margin: 40px auto 20px; /* Increased top margin */
+  width: 150px;
+  margin-top: 40px;
   padding: 15px 20px; /* Increased padding */
   font-size: 1.2em; /* Slightly larger font */
   color: white;
@@ -101,6 +100,29 @@
 
 .startGameButton:hover:not(:disabled) {
   background-color: #2ecc71; /* Lighter green on hover */
+}
+
+.navigationButtons {
+  display: flex;
+  justify-content: space-between;
+  max-width: 320px;
+  margin: 0 auto 20px;
+}
+
+.backButton {
+  width: 150px;
+  padding: 15px 20px;
+  font-size: 1.2em;
+  color: white;
+  background-color: #7f8c8d;
+  border: none;
+  border-radius: 5px;
+  cursor: pointer;
+  transition: background-color 0.3s ease;
+}
+
+.backButton:hover {
+  background-color: #95a5a6;
 }
 
 .infoText {

--- a/client/src/components/PartySetup.tsx
+++ b/client/src/components/PartySetup.tsx
@@ -144,13 +144,18 @@ const PartySetup: React.FC = () => {
       {/* Party Summary Section */}
       <PartySummary selectedCharacters={selectedCharacters} /> {/* PartySummary will have its own internal styling or use passed classNames */}
 
-      <button
-        onClick={handleStartGame}
-        disabled={selectedCharacters.length === 0 || selectedCharacters.some(pc => pc.assignedCards.length !== 4)}
-        className={styles.startGameButton} // Apply .startGameButton
-      >
-        Start Game
-      </button>
+      <div className={styles.navigationButtons}>
+        <button onClick={() => navigate('/')} className={styles.backButton}>
+          Back
+        </button>
+        <button
+          onClick={handleStartGame}
+          disabled={selectedCharacters.length === 0 || selectedCharacters.some(pc => pc.assignedCards.length !== 4)}
+          className={styles.startGameButton}
+        >
+          Start Adventure
+        </button>
+      </div>
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- add Back button and navigation layout to PartySetup
- adjust CSS for navigation buttons

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68425307734483279092e54d53656b83