### PR TITLE
Persist party with context and router navigation

### DIFF
--- a/client/src/GameStateProvider.jsx
+++ b/client/src/GameStateProvider.jsx
@@ -1,0 +1,19 @@
+import React, { createContext, useContext } from 'react'
+import { useGameStore } from './store/gameStore'
+
+const GameStateContext = createContext(null)
+
+export const GameStateProvider = ({ children }) => {
+  const store = useGameStore()
+  return (
+    <GameStateContext.Provider value={store}>{children}</GameStateContext.Provider>
+  )
+}
+
+export const useGameState = () => {
+  const ctx = useContext(GameStateContext)
+  if (!ctx) {
+    throw new Error('useGameState must be used within a GameStateProvider')
+  }
+  return ctx
+}

--- a/client/src/components/PartySetup.tsx
+++ b/client/src/components/PartySetup.tsx
@@ -47,6 +47,23 @@ const PartySetup: React.FC = () => {
     })));
   }, []);
 
+  useEffect(() => {
+    const partyData: Party = {
+      characters: selectedCharacters.map(pc => ({
+        id: pc.id,
+        name: pc.name,
+        class: pc.class,
+        portrait: pc.portrait,
+        description: pc.description,
+        stats: pc.stats,
+        deck: pc.assignedCards,
+        survival: pc.survival,
+      })),
+    };
+
+    setParty(partyData);
+  }, [selectedCharacters, setParty]);
+
   const handleCharacterSelect = (character: Character) => {
     const isSelected = selectedCharacters.find(c => c.id === character.id);
     if (isSelected) {

--- a/client/src/main.jsx
+++ b/client/src/main.jsx
@@ -3,6 +3,7 @@ import { createRoot } from 'react-dom/client'
 import './index.css'
 import App from './App.jsx'
 import { useGameStore } from './store/gameStore'
+import { GameStateProvider } from './GameStateProvider.jsx'
 import { ModalProvider } from './components/ModalManager.jsx'
 import { NotificationProvider } from './components/NotificationManager.jsx'
 
@@ -11,10 +12,12 @@ useGameStore.getState().load()
 
 createRoot(document.getElementById('root')).render(
   <StrictMode>
-    <ModalProvider>
-      <NotificationProvider>
-        <App />
-      </NotificationProvider>
-    </ModalProvider>
+    <GameStateProvider>
+      <ModalProvider>
+        <NotificationProvider>
+          <App />
+        </NotificationProvider>
+      </ModalProvider>
+    </GameStateProvider>
   </StrictMode>,
 )


### PR DESCRIPTION
## Summary
- add a new `GameStateProvider` component that exposes `useGameStore` through context
- wrap the app with `GameStateProvider` in `main.jsx`
- sync party selections to global store in `PartySetup`

## Testing
- `npm run lint --prefix client`
- `npm test --prefix client` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68425469371c83279b307fc165119057