### PR TITLE
Add screen transitions and button animations

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -1,15 +1,38 @@
 import './App.css'
-import { BrowserRouter, Routes, Route } from 'react-router-dom'
+import {
+  BrowserRouter,
+  Routes,
+  Route,
+  useLocation,
+} from 'react-router-dom'
+import { CSSTransition, SwitchTransition } from 'react-transition-group'
 import MainMenu from './components/MainMenu.jsx'
 import PartySetup from './components/PartySetup.tsx'
+
+function AnimatedRoutes() {
+  const location = useLocation()
+
+  return (
+    <SwitchTransition>
+      <CSSTransition
+        key={location.pathname}
+        classNames="fade"
+        timeout={300}
+        unmountOnExit
+      >
+        <Routes location={location}>
+          <Route path="/" element={<MainMenu />} />
+          <Route path="/party-setup" element={<PartySetup />} />
+        </Routes>
+      </CSSTransition>
+    </SwitchTransition>
+  )
+}
 
 function App() {
   return (
     <BrowserRouter>
-      <Routes>
-        <Route path="/" element={<MainMenu />} />
-        <Route path="/party-setup" element={<PartySetup />} />
-      </Routes>
+      <AnimatedRoutes />
     </BrowserRouter>
   )
 }

--- a/client/src/components/PartySetup.module.css
+++ b/client/src/components/PartySetup.module.css
@@ -88,9 +88,13 @@
   border: none;
   border-radius: 5px;
   cursor: pointer;
-  transition: background-color 0.3s ease;
+  transition: background-color 0.3s ease, transform 0.1s ease;
   text-align: center;
   font-weight: bold;
+}
+
+.startGameButton:active:not(:disabled) {
+  transform: scale(0.96);
 }
 
 .startGameButton:disabled {
@@ -118,7 +122,11 @@
   border: none;
   border-radius: 5px;
   cursor: pointer;
-  transition: background-color 0.3s ease;
+  transition: background-color 0.3s ease, transform 0.1s ease;
+}
+
+.backButton:active {
+  transform: scale(0.96);
 }
 
 .backButton:hover {


### PR DESCRIPTION
## Summary
- animate route transitions with `CSSTransition`
- add active state animations for PartySetup buttons

## Testing
- `npm run lint` in `client`
- `npm test`
- `npm run build` in `client`


------
https://chatgpt.com/codex/tasks/task_e_6842596f51e483279b071dcf8ff0c1dc