### PR TITLE
Add dungeon transition overlay and back button

### DIFF
--- a/client/src/components/DungeonMap.tsx
+++ b/client/src/components/DungeonMap.tsx
@@ -1,12 +1,21 @@
 import React, { useEffect } from 'react'
+import { useNavigate } from 'react-router-dom'
 import { useGameState } from '../GameStateProvider.jsx'
 import { generateDungeon } from '../utils/generateDungeon'
 
 export default function DungeonMap() {
+  const navigate = useNavigate()
   const party = useGameState(state => state.party)
   const gameState = useGameState(state => state.gameState)
   const dungeon = useGameState(state => state.dungeon)
   const setDungeon = useGameState(state => state.setDungeon)
+
+  const handleBack = () => {
+    if (window.confirm('Return to party setup? This will reset your dungeon progress.')) {
+      setDungeon(null)
+      navigate('/party-setup')
+    }
+  }
 
   useEffect(() => {
     if (!dungeon) {
@@ -45,6 +54,12 @@ export default function DungeonMap() {
 
   return (
     <div style={{ padding: 20 }}>
+      <button
+        onClick={handleBack}
+        style={{ position: 'fixed', top: 20, left: 20, zIndex: 100 }}
+      >
+        Back
+      </button>
       <h2>Dungeon - Floor {gameState.currentFloor}</h2>
       <div style={{ display: 'flex', gap: '2rem' }}>
         <div>{renderGrid()}</div>

--- a/client/src/components/PartySetup.tsx
+++ b/client/src/components/PartySetup.tsx
@@ -13,6 +13,7 @@ import { sampleCards } from '../../../shared/models/cards.js';
 import CharacterCard from './CharacterCard'; // Import CharacterCard
 import CardAssignmentPanel from './CardAssignmentPanel'; // Import
 import PartySummary from './PartySummary'; // Import PartySummary
+import { useModal } from './ModalManager.jsx';
 import styles from './PartySetup.module.css';
 
 // Make sure PartyCharacter is exported
@@ -99,6 +100,8 @@ const PartySetup: React.FC = () => {
     }));
   };
 
+  const { open, close } = useModal();
+
   const handleStartGame = () => {
     const partyData: Party = {
       characters: selectedCharacters.map(pc => ({
@@ -113,8 +116,17 @@ const PartySetup: React.FC = () => {
       })),
     };
 
-    setParty(partyData)
-    navigate('/dungeon')
+    setParty(partyData);
+
+    const id = open(
+      <div style={{ textAlign: 'center' }}>
+        <p>Entering the Dungeon…</p>
+        <button onClick={() => close(id)}>Continue</button>
+      </div>
+    );
+
+    setTimeout(() => close(id), 1500);
+    navigate('/dungeon');
   };
 
   const isPartyValid =


### PR DESCRIPTION
## Summary
- show a modal overlay when entering the dungeon
- allow returning to Party Setup from the dungeon map

## Testing
- `npm test`
- `cd client && npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6842677a3a8483279fb9496742595b6b