### PR TITLE
Add dev back button to DungeonMap

### DIFF
--- a/client/src/components/DungeonMap.tsx
+++ b/client/src/components/DungeonMap.tsx
@@ -54,12 +54,14 @@ export default function DungeonMap() {
 
   return (
     <div style={{ padding: 20 }}>
-      <button
-        onClick={handleBack}
-        style={{ position: 'fixed', top: 20, left: 20, zIndex: 100 }}
-      >
-        Back
-      </button>
+      {import.meta.env.DEV && (
+        <button
+          onClick={handleBack}
+          style={{ position: 'fixed', top: 20, left: 20, zIndex: 100 }}
+        >
+          Back
+        </button>
+      )}
       <h2>Dungeon - Floor {gameState.currentFloor}</h2>
       <div style={{ display: 'flex', gap: '2rem' }}>
         <div>{renderGrid()}</div>


### PR DESCRIPTION
## Summary
- show the party setup back button only in dev builds

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6842e0d961a88327ab672a13d4f39822