### PR TITLE
Implement interactive dungeon map with battle overlay

### DIFF
--- a/client/src/components/DungeonMap.module.css
+++ b/client/src/components/DungeonMap.module.css
@@ -1,0 +1,41 @@
+.player-marker {
+  width: 30px;
+  height: 30px;
+  border-radius: 50%;
+  background: #00ff00;
+  position: absolute;
+  top: 5px;
+  left: 5px;
+  transition: transform 0.3s ease;
+}
+
+.encounter-banner {
+  position: absolute;
+  top: 40%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  background: rgba(255, 255, 255, 0.9);
+  padding: 10px 20px;
+  border-radius: 6px;
+  animation: fade 0.6s linear;
+  pointer-events: none;
+}
+
+@keyframes fade {
+  0% { opacity: 0; }
+  20% { opacity: 1; }
+  80% { opacity: 1; }
+  100% { opacity: 0; }
+}
+
+.battle-overlay {
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: rgba(0, 0, 0, 0.8);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}

--- a/client/src/components/DungeonMap.tsx
+++ b/client/src/components/DungeonMap.tsx
@@ -1,88 +1,130 @@
-import React, { useEffect } from 'react'
-import { useNavigate } from 'react-router-dom'
+import React, { useEffect, useMemo, useState } from 'react'
 import { useGameState } from '../GameStateProvider.jsx'
-import { generateDungeon } from '../utils/generateDungeon'
+import { generateDungeonMap } from '../utils/generateDungeonMap'
+import GameView from './GameView'
+import CombatOverlay from './CombatOverlay'
+import './DungeonMap.module.css'
+
+const roomColors: Record<string, string> = {
+  enemy: '#ff6666',
+  treasure: '#ffd700',
+  trap: '#ff00ff',
+  empty: '#666666',
+}
 
 export default function DungeonMap() {
-  const navigate = useNavigate()
-  const party = useGameState(state => state.party)
-  const gameState = useGameState(state => state.gameState)
-  const dungeon = useGameState(state => state.dungeon)
-  const setDungeon = useGameState(state => state.setDungeon)
+  const party = useGameState(s => s.party)
+  const dungeonMap = useGameState(s => s.dungeonMap)
+  const setDungeonMap = useGameState(s => s.setDungeonMap)
+  const currentRoom = useGameState(s => s.currentRoom)
+  const setCurrentRoom = useGameState(s => s.setCurrentRoom)
+  const explored = useGameState(s => s.explored)
+  const setExplored = useGameState(s => s.setExplored)
+  const gameState = useGameState(s => s.gameState)
 
-  const handleBack = () => {
-    if (window.confirm('Return to party setup? This will reset your dungeon progress.')) {
-      setDungeon(null)
-      navigate('/party-setup')
-    }
-  }
+  const [battleRoom, setBattleRoom] = useState<string | null>(null)
+  const [players, setPlayers] = useState([])
+  const [enemies, setEnemies] = useState([])
+  const [log, setLog] = useState<string[]>([])
+  const [banner, setBanner] = useState(false)
 
   useEffect(() => {
-    if (!dungeon) {
-      const d = generateDungeon(9, 9)
-      setDungeon(d)
+    if (!dungeonMap) {
+      const map = generateDungeonMap(5)
+      setDungeonMap(map)
+      setCurrentRoom(map.startRoomId)
+      setExplored(new Set([map.startRoomId]))
     }
-  }, [dungeon, setDungeon])
+  }, [dungeonMap, setDungeonMap, setCurrentRoom, setExplored])
 
-  if (!party) {
-    return <p>No party selected.</p>
+  const size = useMemo(() => {
+    if (!dungeonMap) return 0
+    return Math.max(...Object.values(dungeonMap.rooms).map(r => r.x)) + 1
+  }, [dungeonMap])
+
+  const moveTo = (id: string) => {
+    if (!dungeonMap || !currentRoom) return
+    const room = dungeonMap.rooms[currentRoom]
+    if (!room.connections.includes(id)) return
+    setCurrentRoom(id)
+    setExplored(new Set([...Array.from(explored), id]))
+    const next = dungeonMap.rooms[id]
+    if (next.type === 'enemy') {
+      setBanner(true)
+      setTimeout(() => {
+        setBanner(false)
+        setBattleRoom(id)
+      }, 600)
+    }
   }
 
-  const renderGrid = () => {
-    if (!dungeon) return <p>Entering Dungeon...</p>
-    const rows = []
-    for (let y = 0; y < dungeon.height; y++) {
-      const cells = []
-      for (let x = 0; x < dungeon.width; x++) {
-        const tile = dungeon.tiles[y][x]
-        const style: React.CSSProperties = {
-          width: 20,
-          height: 20,
-          backgroundColor: tile === 'wall' ? '#333' : '#888',
-          border: '1px solid #222',
-        }
-        cells.push(<div key={x} style={style} />)
+  const handleBattleEvent = (detail: any) => {
+    if (detail.type === 'state') {
+      setPlayers(detail.players)
+      setEnemies(detail.enemies)
+    } else if (detail.type === 'log') {
+      setLog(l => [...l.slice(-10), detail.message])
+    } else if (detail === 'Victory' || detail === 'Defeat') {
+      setTimeout(() => setBattleRoom(null), 800)
+    }
+  }
+
+  if (!party) return <p>No party selected.</p>
+  if (!dungeonMap || !currentRoom) return <p>Entering Dungeon...</p>
+
+  const cells = []
+  for (let y = 0; y < size; y++) {
+    for (let x = 0; x < size; x++) {
+      const id = `${x}-${y}`
+      const room = dungeonMap.rooms[id]
+      if (!room) continue
+      const isExplored = explored.has(id)
+      const isCurrent = id === currentRoom
+      const isReachable = dungeonMap.rooms[currentRoom].connections.includes(id)
+      const style: React.CSSProperties = {
+        width: 40,
+        height: 40,
+        background: isExplored ? roomColors[room.type] : '#000',
+        opacity: isExplored ? 1 : 0.2,
+        border: '1px solid #444',
+        position: 'relative',
+        cursor: isReachable && isExplored ? 'pointer' : 'default',
       }
-      rows.push(
-        <div key={y} style={{ display: 'flex' }}>
-          {cells}
+      cells.push(
+        <div
+          key={id}
+          style={style}
+          onClick={() => isReachable && isExplored && moveTo(id)}
+        >
+          {isCurrent && <div className="player-marker" />}
         </div>,
       )
     }
-    return <div>{rows}</div>
+  }
+
+  const gridStyle: React.CSSProperties = {
+    display: 'grid',
+    gridTemplateColumns: `repeat(${size}, 40px)`,
+    gap: '2px',
+    position: 'relative',
   }
 
   return (
-    <div style={{ padding: 20 }}>
-      {import.meta.env.DEV && (
-        <button
-          onClick={handleBack}
-          style={{ position: 'fixed', top: 20, left: 20, zIndex: 100 }}
-        >
-          Back
-        </button>
-      )}
+    <div style={{ padding: 20, position: 'relative' }}>
       <h2>Dungeon - Floor {gameState.currentFloor}</h2>
-      <div style={{ display: 'flex', gap: '2rem' }}>
-        <div>{renderGrid()}</div>
-        <div>
-          <h3>Party</h3>
-          <ul>
-            {party.characters.map((c) => (
-              <li key={c.id}>
-                {c.name}
-                <ul>
-                  {c.deck.map((card) => (
-                    <li key={card.id}>{card.name}</li>
-                  ))}
-                </ul>
-              </li>
-            ))}
-          </ul>
-          <h3>Inventory</h3>
-          <p>{gameState.inventory.length} items</p>
+      <div style={gridStyle}>{cells}</div>
+      {banner && <div className="encounter-banner">Enemy Encountered!</div>}
+      {battleRoom && !banner && (
+        <div className="battle-overlay">
+          <GameView
+            scene="battle"
+            party={party.characters}
+            enemyIndex={0}
+            onBattleEvent={handleBattleEvent}
+          />
+          <CombatOverlay players={players} enemies={enemies} log={log} />
         </div>
-      </div>
+      )}
     </div>
   )
 }

--- a/client/src/store/gameStore.ts
+++ b/client/src/store/gameStore.ts
@@ -2,6 +2,7 @@ import { create } from 'zustand'
 import type { Party } from '../../shared/models/Party'
 import type { GameState } from '../../shared/models/GameState'
 import type { DungeonData } from '../utils/generateDungeon'
+import type { DungeonMap } from '../../shared/models/DungeonMap'
 
 const defaultState: GameState = {
   currentFloor: 1,
@@ -23,6 +24,10 @@ interface Store {
 
   dungeon: DungeonData | null
   setDungeon: (dungeon: DungeonData) => void
+  dungeonMap: DungeonMap | null
+  setDungeonMap: (map: DungeonMap) => void
+  currentRoom: string | null
+  setCurrentRoom: (id: string) => void
   playerPos: { x: number; y: number } | null
   setPlayerPos: (pos: { x: number; y: number }) => void
   explored: Set<string>
@@ -43,17 +48,23 @@ export const useGameStore = create<Store>((set, get) => ({
 
   dungeon: null,
   setDungeon: (dungeon) => set({ dungeon }),
+  dungeonMap: null,
+  setDungeonMap: (map) => set({ dungeonMap: map }),
+  currentRoom: null,
+  setCurrentRoom: (id) => set({ currentRoom: id }),
   playerPos: null,
   setPlayerPos: (pos) => set({ playerPos: pos }),
   explored: new Set<string>(),
   setExplored: (explored) => set({ explored }),
 
   save: () => {
-    const { party, gameState, dungeon, playerPos, explored } = get()
+    const { party, gameState, dungeon, dungeonMap, currentRoom, playerPos, explored } = get()
     const data = {
       party,
       gameState,
       dungeon,
+      dungeonMap,
+      currentRoom,
       playerPos,
       explored: Array.from(explored),
     }
@@ -68,6 +79,8 @@ export const useGameStore = create<Store>((set, get) => ({
         party: data.party ?? null,
         gameState: data.gameState ?? defaultState,
         dungeon: data.dungeon ?? null,
+        dungeonMap: data.dungeonMap ?? null,
+        currentRoom: data.currentRoom ?? null,
         playerPos: data.playerPos ?? null,
         explored: new Set<string>(data.explored || []),
       })

--- a/client/src/utils/generateDungeonMap.ts
+++ b/client/src/utils/generateDungeonMap.ts
@@ -1,0 +1,19 @@
+import type { DungeonMap, Room, RoomType } from 'shared/models'
+
+export function generateDungeonMap(size = 5): DungeonMap {
+  const rooms: Record<string, Room> = {}
+  const types: RoomType[] = ['empty', 'enemy', 'treasure', 'trap']
+  for (let x = 0; x < size; x++) {
+    for (let y = 0; y < size; y++) {
+      const id = `${x}-${y}`
+      const connections: string[] = []
+      if (x > 0) connections.push(`${x - 1}-${y}`)
+      if (x < size - 1) connections.push(`${x + 1}-${y}`)
+      if (y > 0) connections.push(`${x}-${y - 1}`)
+      if (y < size - 1) connections.push(`${x}-${y + 1}`)
+      const type: RoomType = x === 0 && y === 0 ? 'empty' : types[Math.floor(Math.random() * types.length)]
+      rooms[id] = { id, x, y, type, connections }
+    }
+  }
+  return { rooms, startRoomId: '0-0' }
+}


### PR DESCRIPTION
## Summary
- add simple dungeon map generator
- expand game store to manage new dungeon map state and current room
- replace old DungeonMap with interactive grid that handles movement and enemy encounters
- style player marker, encounter banner and battle overlay

## Testing
- `npm run build` in `client`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6842e41e34048327b77288b5504f3310