### PR TITLE
Implement floor progression and town screen

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -9,6 +9,7 @@ import { CSSTransition, SwitchTransition } from 'react-transition-group'
 import MainMenu from './components/MainMenu.jsx'
 import PartySetup from './components/PartySetup.tsx'
 import DungeonMap from './components/DungeonMap.tsx'
+import TownView from './components/TownView.jsx'
 
 function AnimatedRoutes() {
   const location = useLocation()
@@ -25,6 +26,7 @@ function AnimatedRoutes() {
           <Route path="/" element={<MainMenu />} />
           <Route path="/party-setup" element={<PartySetup />} />
           <Route path="/dungeon" element={<DungeonMap />} />
+          <Route path="/town" element={<TownView />} />
         </Routes>
       </CSSTransition>
     </SwitchTransition>

--- a/client/src/components/DungeonMap.tsx
+++ b/client/src/components/DungeonMap.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useMemo, useState } from 'react'
+import { useNavigate } from 'react-router-dom'
 import { useGameState } from '../GameStateProvider.jsx'
 import { generateDungeonMap } from '../utils/generateDungeonMap'
 import GameView from './GameView'
@@ -7,8 +8,11 @@ import './DungeonMap.module.css'
 
 const roomColors: Record<string, string> = {
   enemy: '#ff6666',
+  boss: '#ff3333',
   treasure: '#ffd700',
   trap: '#ff00ff',
+  rest: '#00aa7f',
+  exit: '#00ffff',
   empty: '#666666',
 }
 
@@ -21,21 +25,31 @@ export default function DungeonMap() {
   const explored = useGameState(s => s.explored)
   const setExplored = useGameState(s => s.setExplored)
   const gameState = useGameState(s => s.gameState)
-
+  const updateGameState = useGameState(s => s.updateGameState)
+  const save = useGameState(s => s.save)
+  
+  const navigate = useNavigate()
   const [battleRoom, setBattleRoom] = useState<string | null>(null)
   const [players, setPlayers] = useState([])
   const [enemies, setEnemies] = useState([])
   const [log, setLog] = useState<string[]>([])
   const [banner, setBanner] = useState(false)
+  const [roomEvent, setRoomEvent] = useState<string | null>(null)
+  const [summary, setSummary] = useState(false)
 
   useEffect(() => {
     if (!dungeonMap) {
-      const map = generateDungeonMap(5)
+      const size = 5 + gameState.currentFloor - 1
+      const map = generateDungeonMap(size)
       setDungeonMap(map)
       setCurrentRoom(map.startRoomId)
       setExplored(new Set([map.startRoomId]))
     }
-  }, [dungeonMap, setDungeonMap, setCurrentRoom, setExplored])
+  }, [dungeonMap, setDungeonMap, setCurrentRoom, setExplored, gameState.currentFloor])
+
+  useEffect(() => {
+    save()
+  }, [currentRoom, explored, gameState.currentFloor])
 
   const size = useMemo(() => {
     if (!dungeonMap) return 0
@@ -49,12 +63,16 @@ export default function DungeonMap() {
     setCurrentRoom(id)
     setExplored(new Set([...Array.from(explored), id]))
     const next = dungeonMap.rooms[id]
-    if (next.type === 'enemy') {
+    if (next.type === 'enemy' || next.type === 'boss') {
       setBanner(true)
       setTimeout(() => {
         setBanner(false)
         setBattleRoom(id)
       }, 600)
+    } else if (next.type === 'exit') {
+      setRoomEvent('exit')
+    } else if (next.type !== 'empty') {
+      setRoomEvent(next.type)
     }
   }
 
@@ -65,12 +83,41 @@ export default function DungeonMap() {
     } else if (detail.type === 'log') {
       setLog(l => [...l.slice(-10), detail.message])
     } else if (detail === 'Victory' || detail === 'Defeat') {
-      setTimeout(() => setBattleRoom(null), 800)
+      const roomType = battleRoom ? dungeonMap?.rooms[battleRoom].type : null
+      setTimeout(() => {
+        setBattleRoom(null)
+        if (roomType === 'boss') {
+          setSummary(true)
+        }
+      }, 800)
     }
+  }
+
+  const advanceFloor = () => {
+    const nextFloor = gameState.currentFloor + 1
+    updateGameState({ currentFloor: nextFloor, location: 'dungeon' })
+    const size = 5 + nextFloor - 1
+    const map = generateDungeonMap(size)
+    setDungeonMap(map)
+    setCurrentRoom(map.startRoomId)
+    setExplored(new Set([map.startRoomId]))
+    setSummary(false)
+    save()
+  }
+
+  const retreat = () => {
+    updateGameState({ location: 'town' })
+    setSummary(false)
+    save()
+    navigate('/town')
   }
 
   if (!party) return <p>No party selected.</p>
   if (!dungeonMap || !currentRoom) return <p>Entering Dungeon...</p>
+
+  const totalRooms = Object.keys(dungeonMap.rooms).length
+  const visitedRooms = explored.size
+  const remaining = totalRooms - visitedRooms
 
   const cells = []
   for (let y = 0; y < size; y++) {
@@ -86,7 +133,7 @@ export default function DungeonMap() {
         height: 40,
         background: isExplored ? roomColors[room.type] : '#000',
         opacity: isExplored ? 1 : 0.2,
-        border: '1px solid #444',
+        border: room.type === 'boss' || room.type === 'exit' ? '2px solid gold' : '1px solid #444',
         position: 'relative',
         cursor: isReachable && isExplored ? 'pointer' : 'default',
       }
@@ -112,6 +159,7 @@ export default function DungeonMap() {
   return (
     <div style={{ padding: 20, position: 'relative' }}>
       <h2>Dungeon - Floor {gameState.currentFloor}</h2>
+      <p style={{ marginBottom: 10 }}>Room {visitedRooms} of {totalRooms} (Remaining {remaining})</p>
       <div style={gridStyle}>{cells}</div>
       {banner && <div className="encounter-banner">Enemy Encountered!</div>}
       {battleRoom && !banner && (
@@ -123,6 +171,34 @@ export default function DungeonMap() {
             onBattleEvent={handleBattleEvent}
           />
           <CombatOverlay players={players} enemies={enemies} log={log} />
+        </div>
+      )}
+      {roomEvent && (
+        <div className="battle-overlay">
+          <div style={{ background: '#222', padding: 20, borderRadius: 8 }}>
+            <p>
+              {roomEvent === 'treasure' && 'You found treasure!'}
+              {roomEvent === 'trap' && 'A trap sprung!'}
+              {roomEvent === 'rest' && 'You take a moment to rest.'}
+              {roomEvent === 'exit' && 'You found the exit!'}
+            </p>
+            <div style={{ textAlign: 'center', marginTop: 10 }}>
+              <button onClick={() => { setRoomEvent(null); if (roomEvent === 'exit') setSummary(true) }}>Continue</button>
+            </div>
+          </div>
+        </div>
+      )}
+      {summary && (
+        <div className="battle-overlay">
+          <div style={{ background: '#222', padding: 20, borderRadius: 8, textAlign: 'center' }}>
+            <h3>Floor Complete!</h3>
+            <p>Loot earned: (placeholder)</p>
+            <p>Survival stats unchanged.</p>
+            <div style={{ marginTop: 10 }}>
+              <button onClick={advanceFloor} style={{ marginRight: 10 }}>Advance</button>
+              <button onClick={retreat}>Retreat</button>
+            </div>
+          </div>
         </div>
       )}
     </div>

--- a/client/src/components/PartySetup.tsx
+++ b/client/src/components/PartySetup.tsx
@@ -28,6 +28,8 @@ const PartySetup: React.FC = () => {
 
   const navigate = useNavigate();
   const setParty = useGameStore(state => state.setParty);
+  const updateGameState = useGameStore(state => state.updateGameState);
+  const save = useGameStore(state => state.save);
 
   useEffect(() => {
     // Initialize available characters and cards
@@ -117,6 +119,8 @@ const PartySetup: React.FC = () => {
     };
 
     setParty(partyData);
+    updateGameState({ location: 'dungeon', currentFloor: 1 })
+    save()
 
     const id = open(
       <div style={{ textAlign: 'center' }}>

--- a/client/src/components/TownView.jsx
+++ b/client/src/components/TownView.jsx
@@ -1,0 +1,23 @@
+import React from 'react'
+import { useNavigate } from 'react-router-dom'
+import { useGameState } from '../GameStateProvider.jsx'
+
+export default function TownView() {
+  const navigate = useNavigate()
+  const updateGameState = useGameState(s => s.updateGameState)
+  const save = useGameState(s => s.save)
+
+  const handleReturn = () => {
+    updateGameState({ location: 'dungeon' })
+    save()
+    navigate('/dungeon')
+  }
+
+  return (
+    <div style={{ padding: 20 }}>
+      <h2>Town Hub</h2>
+      <p>You may manage your inventory here. (placeholder)</p>
+      <button onClick={handleReturn}>Return to Dungeon</button>
+    </div>
+  )
+}

--- a/client/src/utils/generateDungeonMap.ts
+++ b/client/src/utils/generateDungeonMap.ts
@@ -2,7 +2,13 @@ import type { DungeonMap, Room, RoomType } from 'shared/models'
 
 export function generateDungeonMap(size = 5): DungeonMap {
   const rooms: Record<string, Room> = {}
-  const types: RoomType[] = ['empty', 'enemy', 'treasure', 'trap']
+  const types: RoomType[] = [
+    'empty',
+    'enemy',
+    'treasure',
+    'trap',
+    'rest',
+  ]
   for (let x = 0; x < size; x++) {
     for (let y = 0; y < size; y++) {
       const id = `${x}-${y}`
@@ -11,7 +17,14 @@ export function generateDungeonMap(size = 5): DungeonMap {
       if (x < size - 1) connections.push(`${x + 1}-${y}`)
       if (y > 0) connections.push(`${x}-${y - 1}`)
       if (y < size - 1) connections.push(`${x}-${y + 1}`)
-      const type: RoomType = x === 0 && y === 0 ? 'empty' : types[Math.floor(Math.random() * types.length)]
+      let type: RoomType = 'empty'
+      if (x === 0 && y === 0) {
+        type = 'empty'
+      } else if (x === size - 1 && y === size - 1) {
+        type = Math.random() < 0.5 ? 'exit' : 'boss'
+      } else {
+        type = types[Math.floor(Math.random() * types.length)] as RoomType
+      }
       rooms[id] = { id, x, y, type, connections }
     }
   }

--- a/shared/models/Room.ts
+++ b/shared/models/Room.ts
@@ -1,4 +1,11 @@
-export type RoomType = 'empty' | 'enemy' | 'treasure' | 'trap'
+export type RoomType =
+  | 'empty'
+  | 'enemy'
+  | 'treasure'
+  | 'trap'
+  | 'rest'
+  | 'boss'
+  | 'exit'
 
 export interface Room {
   /** Unique room identifier */


### PR DESCRIPTION
## Summary
- expand Room types with boss, rest and exit
- generate dungeon maps with a final exit/boss tile
- implement per-floor progression logic and progress display
- add room event and end-of-floor overlays
- persist game state and add a Town view

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6842e9494658832794fd9abb744b3251