### PR TITLE
Fix sellItem argument order

### DIFF
--- a/shared/systems/index.d.ts
+++ b/shared/systems/index.d.ts
@@ -41,8 +41,8 @@ export function buyItem(
 ): boolean
 export function sellItem(
   playerId: string,
-  marketType: import('../models').MarketType,
   item: import('../models').MarketItem,
+  marketType: import('../models').MarketType,
   price: number,
   currency: import('../models').CurrencyType,
 ): import('../models').MarketListing

--- a/shared/systems/market.js
+++ b/shared/systems/market.js
@@ -58,7 +58,7 @@ export function getAvailableListings(marketType, filters = {}) {
  * @param {number} price
  * @param {CurrencyType} currencyType
  */
-export function sellItem(playerId, marketType, item, price, currencyType) {
+export function sellItem(playerId, item, marketType, price, currencyType) {
   const listing = {
     item,
     marketType,
@@ -120,5 +120,5 @@ export function restockMarketplace(marketType, newItems = []) {
 
 /** Add a guild only listing */
 export function listGuildItem(playerId, item, price) {
-  return sellItem(playerId, 'Guild', item, price, 'GuildCredit')
+  return sellItem(playerId, item, 'Guild', price, 'GuildCredit')
 }

--- a/shared/systems/market.test.js
+++ b/shared/systems/market.test.js
@@ -1,0 +1,13 @@
+import { test } from 'node:test'
+import assert from 'assert'
+import { sellItem, getAvailableListings, updatePlayerBalance } from './market.js'
+
+// simple market listing test
+
+test('sellItem adds listing in correct market', () => {
+  // reset player's balances & listings - can't easily because not exported, but we can rely on zero state since tests run fresh
+  const item = { id: '1', name: 'Sword', category: 'Weapon', price: 10, currencyType: 'Gold', rarity: 'Common' }
+  const listing = sellItem('player1', item, 'Town', 10, 'Gold')
+  const townListings = getAvailableListings('Town')
+  assert.deepStrictEqual(townListings[0], listing)
+})


### PR DESCRIPTION
## Summary
- fix the argument order for `sellItem`
- update guild helper accordingly
- adjust TypeScript declarations
- add regression test for market listings

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6842f5d51e948327bf00c6fbde175668