### PR TITLE
Add descriptions for sample cards and show them in UI

### DIFF
--- a/client/src/components/InventoryScreen.module.css
+++ b/client/src/components/InventoryScreen.module.css
@@ -25,6 +25,12 @@
   flex-direction: column;
   align-items: center;
 }
+.desc {
+  font-size: 0.8em;
+  color: #555;
+  text-align: center;
+  margin: 4px 0;
+}
 .meta {
   font-size: 0.8em;
   color: #666;

--- a/client/src/components/InventoryScreen.tsx
+++ b/client/src/components/InventoryScreen.tsx
@@ -8,6 +8,7 @@ interface InventoryItem {
   name: string
   type: string
   rarity: string
+  description: string
 }
 
 const allItems: InventoryItem[] = sampleCards.map(c => ({
@@ -15,6 +16,7 @@ const allItems: InventoryItem[] = sampleCards.map(c => ({
   name: c.name,
   type: c.category || c.type || 'Unknown',
   rarity: c.rarity || 'Common',
+  description: c.description || ''
 }))
 
 export default function InventoryScreen() {
@@ -44,9 +46,15 @@ export default function InventoryScreen() {
       </div>
       <div className={styles.grid}>
         {items.map(item => (
-          <div key={item.id} className={styles.item} tabIndex={0} aria-label={`${item.name} ${item.rarity} ${item.type}`}>
+          <div
+            key={item.id}
+            className={styles.item}
+            tabIndex={0}
+            aria-label={`${item.name} ${item.rarity} ${item.type}. ${item.description}`}
+          >
             <strong>{item.name}</strong>
             <span className={styles.meta}>{item.rarity}</span>
+            <p className={styles.desc}>{item.description}</p>
             <div className={styles.actions}>
               <button onClick={() => notify(`Used ${item.name}`, 'success')}>Use</button>
               <button onClick={() => notify(`Equipped ${item.name}`, 'success')}>Equip</button>

--- a/client/src/components/MagicalPouch.tsx
+++ b/client/src/components/MagicalPouch.tsx
@@ -75,8 +75,10 @@ const MagicalPouch: React.FC<{ player: Player; profession: Profession }> = ({ pl
               key={card.id}
               style={{ border: '1px solid #ccc', margin: 4, padding: 4, cursor: 'pointer' }}
               onClick={() => handleAdd(card)}
+              title={card.description}
             >
-              {card.name}
+              <strong>{card.name}</strong>
+              <p style={{ fontSize: '0.75em', margin: 0 }}>{card.description}</p>
             </div>
           ))}
       </div>

--- a/client/src/components/PartyBuilder.jsx
+++ b/client/src/components/PartyBuilder.jsx
@@ -98,7 +98,14 @@ function PartyBuilder() {
                   const card = sampleCards.find((c) => c.id === cid)
                   return (
                     <li key={cid}>
-                      {card ? card.name : cid}{' '}
+                      <span title={card ? card.description : ''}>
+                        {card ? card.name : cid}
+                      </span>{' '}
+                      {card && (
+                        <em style={{ fontSize: '0.8em', color: '#555' }}>
+                          {' - ' + card.description}
+                        </em>
+                      )}
                       <button onClick={() => removeCard(idx, cid)}>X</button>
                     </li>
                   )
@@ -117,7 +124,7 @@ function PartyBuilder() {
                   >
                     <option value="">Select card</option>
                     {sampleCards.map((c) => (
-                      <option key={c.id} value={c.id}>
+                      <option key={c.id} value={c.id} title={c.description}>
                         {c.name}
                       </option>
                     ))}

--- a/client/src/components/PartySummary.tsx
+++ b/client/src/components/PartySummary.tsx
@@ -90,7 +90,10 @@ const PartySummary: React.FC<PartySummaryProps> = ({ selectedCharacters }) => {
           <strong style={{color: '#2980b9', fontSize: '1.1em'}}>{character.name} ({character.class})</strong>
           <ul style={cardListStyle}>
             {character.assignedCards.map(card => (
-              <li key={card.id} style={{marginBottom: '3px'}}>{card.name}</li>
+              <li key={card.id} style={{marginBottom: '3px'}}>
+                <span title={card.description}>{card.name}</span>
+                <em style={{fontSize: '0.8em', color: '#555'}}> - {card.description}</em>
+              </li>
             ))}
             {character.assignedCards.length === 0 && <li style={{fontStyle: 'italic'}}>No cards assigned</li>}
           </ul>

--- a/client/src/phaser/BattleScene.ts
+++ b/client/src/phaser/BattleScene.ts
@@ -137,7 +137,12 @@ export default class BattleScene extends Phaser.Scene {
     const hand = this.current.data.deck
     hand.forEach((card: any, idx: number) => {
       const txt = this.add
-        .text(100 + idx * 120, 500, card.name, { fontSize: '16px', backgroundColor: '#ddd', padding: 5 })
+        .text(
+          100 + idx * 120,
+          500,
+          `${card.name}\n${card.description}`,
+          { fontSize: '16px', backgroundColor: '#ddd', padding: 5, align: 'center' },
+        )
         .setInteractive()
         .on('pointerdown', () => {
           this.resolveCard(card, this.current, this.enemies[0])

--- a/shared/models/cards.js
+++ b/shared/models/cards.js
@@ -2,6 +2,7 @@ export const sampleCards = [
   {
     id: 'strike',
     name: 'Strike',
+    description: 'Deal 5 damage and begins a Frenzy combo.',
     category: 'Ability',
     rarity: 'Common',
     energyCost: 1,
@@ -15,6 +16,7 @@ export const sampleCards = [
   {
     id: 'heal',
     name: 'Heal',
+    description: 'Restore 5 health to an ally.',
     category: 'Ability',
     rarity: 'Common',
     energyCost: 1,
@@ -25,6 +27,7 @@ export const sampleCards = [
   {
     id: 'inspire',
     name: 'Inspire',
+    description: "Boost an ally's stats by 1.",
     category: 'Ability',
     rarity: 'Common',
     energyCost: 1,
@@ -35,6 +38,7 @@ export const sampleCards = [
   {
     id: 'iron_sword',
     name: 'Iron Sword',
+    description: 'Weapon that increases attack by 2.',
     category: 'Equipment',
     rarity: 'Common',
     statModifiers: [{ stat: 'attack', value: 2 }],
@@ -43,6 +47,7 @@ export const sampleCards = [
   {
     id: 'herb',
     name: 'Medicinal Herb',
+    description: 'Ingredient for basic remedies.',
     category: 'Ingredient',
     rarity: 'Common',
     ingredientType: 'Herb',
@@ -50,6 +55,7 @@ export const sampleCards = [
   {
     id: 'bread',
     name: 'Stale Bread',
+    description: 'Slightly restores hunger.',
     category: 'FoodDrink',
     rarity: 'Common',
     restoreHunger: 5,
@@ -58,6 +64,7 @@ export const sampleCards = [
   {
     id: 'haste_elixir',
     name: 'Haste Elixir',
+    description: 'Gain +1 speed for 3 turns.',
     category: 'Elixir',
     rarity: 'Uncommon',
     effects: [{ type: 'speed', magnitude: 1, duration: 3 }],
@@ -66,6 +73,7 @@ export const sampleCards = [
   {
     id: 'campfire',
     name: 'Campfire Kit',
+    description: 'Rest to recover 5 health.',
     category: 'Utility',
     rarity: 'Common',
     utilityType: 'Campfire',
@@ -74,6 +82,7 @@ export const sampleCards = [
   {
     id: 'mark_target',
     name: 'Mark Target',
+    description: 'Debuff an enemy to enable Execute combo.',
     category: 'Ability',
     rarity: 'Common',
     energyCost: 1,
@@ -86,6 +95,7 @@ export const sampleCards = [
   {
     id: 'shadow_execution',
     name: 'Shadow Execution',
+    description: 'Deal 8 damage as the Execute finisher.',
     category: 'Ability',
     rarity: 'Common',
     energyCost: 1,


### PR DESCRIPTION
## Summary
- populate `description` for every card in `sampleCards`
- display descriptions on the inventory screen
- show card descriptions in party builder and party summary
- add card info in the magical pouch
- render descriptions on cards in the battle scene

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6842f67c0d248327ab12538be83a1858