### PR TITLE
Implement economy integration

### DIFF
--- a/GAME_DESIGN.md
+++ b/GAME_DESIGN.md
@@ -109,6 +109,8 @@ Each profession has a **level 1–10 progression system** with rewards such as:
 3. **Guild Exchange** — Player run listings restricted to guild members. All trades consume **Guild Credits**.
 4. **Auction House** *(Player Economy)* — Global bidding system for crafted and looted cards. Common items use **Gold** while higher rarities require **Guild Credits**.
 
+Crafting recipes consume currency based on rarity and profession expertise. Loot drops award Gold and occasionally Guild Credits, ensuring a steady flow of money into the economy while keeping high tier currency scarce.
+
 ---
 
 ## 🧑‍🤝‍🧑 Classes & Roles

--- a/README.md
+++ b/README.md
@@ -104,4 +104,6 @@ Two currencies are tracked:
 
 Four market types are supported: Town, Black, Guild Exchange and Auction House.
 Helper functions in `shared/systems/market.js` manage listings, player balances
-and bidding logic.
+and bidding logic. Crafting recipes include a currency cost which is deducted
+when a craft succeeds. Loot generation now awards Gold and occasionally Guild
+Credits that can be applied to a player's balances via `awardCurrency`.

--- a/client/src/components/MagicalPouch.tsx
+++ b/client/src/components/MagicalPouch.tsx
@@ -43,7 +43,7 @@ const MagicalPouch: React.FC<{ player: Player; profession: Profession }> = ({ pl
 
   const craft = () => {
     const used = slots.filter(Boolean) as Card[]
-    const attempt = attemptCraft(profession, used, sampleRecipes)
+    const attempt = attemptCraft(profession, used, sampleRecipes, player)
     if (attempt.success && attempt.result) {
       attempt.result.craftedBy = player.name
       setResult(`Crafted: ${attempt.result.name}`)

--- a/shared/models/Recipe.ts
+++ b/shared/models/Recipe.ts
@@ -12,4 +12,6 @@ export interface Recipe {
   profession: ProfessionName
   /** Minimum profession level required */
   levelRequirement: number
+  /** Currency cost to craft */
+  cost?: { amount: number; currency: import('./Currency').CurrencyType }
 }

--- a/shared/models/recipes.js
+++ b/shared/models/recipes.js
@@ -13,6 +13,7 @@ export const sampleRecipes = [
     },
     profession: 'Cooking',
     levelRequirement: 1,
+    cost: { amount: 5, currency: 'Gold' },
   },
   {
     id: 'flame_sword',
@@ -28,6 +29,7 @@ export const sampleRecipes = [
     },
     profession: 'Smithing',
     levelRequirement: 2,
+    cost: { amount: 1, currency: 'GuildCredit' },
   },
   {
     id: 'healing_elixir',
@@ -43,5 +45,6 @@ export const sampleRecipes = [
     },
     profession: 'Alchemy',
     levelRequirement: 1,
+    cost: { amount: 10, currency: 'Gold' },
   },
 ]

--- a/shared/systems/crafting.js
+++ b/shared/systems/crafting.js
@@ -11,7 +11,7 @@
  * @param {import('../models').Recipe[]} recipes
  * @returns {import('../models').CraftingAttempt}
  */
-export function attemptCraft(profession, usedCards, recipes) {
+export function attemptCraft(profession, usedCards, recipes, player) {
   const ingredientIds = usedCards.map((c) => c.id).sort().join('|')
   const recipe = recipes.find(
     (r) =>
@@ -21,6 +21,13 @@ export function attemptCraft(profession, usedCards, recipes) {
   )
 
   if (recipe) {
+    if (recipe.cost && player) {
+      const bal = player.currencies[recipe.cost.currency] || 0
+      if (bal < recipe.cost.amount) {
+        return { usedCards, result: null, success: false, newRecipeDiscovered: false }
+      }
+      player.currencies[recipe.cost.currency] = bal - recipe.cost.amount
+    }
     const crafted = { ...recipe.result, id: `${recipe.result.id}_${Date.now()}` }
     return {
       usedCards,

--- a/shared/systems/crafting.test.js
+++ b/shared/systems/crafting.test.js
@@ -1,0 +1,40 @@
+import { test } from 'node:test'
+import assert from 'assert'
+import { attemptCraft } from './crafting.js'
+import { sampleRecipes } from '../models/recipes.js'
+
+const dummyCards = {
+  herb: { id: 'herb', name: 'Herb' },
+  bread: { id: 'bread', name: 'Bread' },
+  iron_sword: { id: 'iron_sword', name: 'Iron Sword' },
+}
+
+test('attemptCraft deducts currency on success', () => {
+  const prof = { name: 'Cooking', level: 1, experience: 0, unlockedRecipes: [] }
+  const player = {
+    id: 'p1',
+    name: 'Test',
+    professions: { Cooking: prof },
+    discoveredRecipes: [],
+    currencies: { Gold: 10, GuildCredit: 0 },
+  }
+  const used = [dummyCards.herb, dummyCards.bread]
+  const result = attemptCraft(prof, used, sampleRecipes, player)
+  assert.strictEqual(result.success, true)
+  assert.strictEqual(player.currencies.Gold, 5)
+})
+
+test('attemptCraft fails without funds', () => {
+  const prof = { name: 'Smithing', level: 2, experience: 0, unlockedRecipes: [] }
+  const player = {
+    id: 'p2',
+    name: 'NoMoney',
+    professions: { Smithing: prof },
+    discoveredRecipes: [],
+    currencies: { Gold: 0, GuildCredit: 0 },
+  }
+  const used = [dummyCards.iron_sword, dummyCards.herb]
+  const result = attemptCraft(prof, used, sampleRecipes, player)
+  assert.strictEqual(result.success, false)
+})
+

--- a/shared/systems/index.d.ts
+++ b/shared/systems/index.d.ts
@@ -5,6 +5,13 @@ import type { Encounter } from '../models/Encounter'
 
 export function applySurvivalPenalties(party: Character[]): void
 export function generateLoot(encounter: Encounter): LootItem[]
+export function generateCurrencyReward(
+  encounter: Encounter,
+): { Gold: number; GuildCredit: number }
+export function awardCurrency(
+  player: import('../models').Player,
+  reward: { Gold: number; GuildCredit: number },
+): void
 export function distributeLoot(loot: LootItem[], inventory: Inventory): void
 export function useConsumable(item: LootItem, character: Character): void
 export function rest(party: Character[], duration: number): void
@@ -15,6 +22,7 @@ export function attemptCraft(
   profession: import('../models').Profession,
   usedCards: import('../models').Card[],
   recipes: import('../models').Recipe[],
+  player: import('../models').Player,
 ): import('../models').CraftingAttempt
 export function getAvailableRecipes(
   profession: import('../models').Profession,

--- a/shared/systems/postBattle.js
+++ b/shared/systems/postBattle.js
@@ -35,6 +35,30 @@ export function generateLoot(encounter) {
 }
 
 /**
+ * Generate currency rewards for an encounter
+ * @param {import('../models').Encounter} encounter
+ * @returns {{Gold:number, GuildCredit:number}}
+ */
+export function generateCurrencyReward(encounter) {
+  const gold = Math.floor(encounter.difficulty * 5)
+  const guildCredit = Math.random() < 0.1 * encounter.difficulty ? 1 : 0
+  return { Gold: gold, GuildCredit: guildCredit }
+}
+
+/**
+ * Apply currency rewards to a player
+ * @param {import('../models').Player} player
+ * @param {{Gold:number, GuildCredit:number}} reward
+ */
+export function awardCurrency(player, reward) {
+  if (reward.Gold)
+    player.currencies.Gold = (player.currencies.Gold || 0) + reward.Gold
+  if (reward.GuildCredit)
+    player.currencies.GuildCredit =
+      (player.currencies.GuildCredit || 0) + reward.GuildCredit
+}
+
+/**
  * Add loot items to the inventory
  * @param {import('../models').LootItem[]} loot
  * @param {import('../models').Inventory} inventory

--- a/shared/systems/postBattle.test.js
+++ b/shared/systems/postBattle.test.js
@@ -1,0 +1,16 @@
+import { test } from 'node:test'
+import assert from 'assert'
+import { awardCurrency, generateCurrencyReward } from './postBattle.js'
+
+test('awardCurrency increases player balances', () => {
+  const player = { currencies: { Gold: 0, GuildCredit: 0 } }
+  awardCurrency(player, { Gold: 5, GuildCredit: 1 })
+  assert.strictEqual(player.currencies.Gold, 5)
+  assert.strictEqual(player.currencies.GuildCredit, 1)
+})
+
+test('generateCurrencyReward returns numbers', () => {
+  const reward = generateCurrencyReward({ difficulty: 2 })
+  assert.ok(reward.Gold >= 0)
+})
+


### PR DESCRIPTION
## Summary
- add crafting costs to recipes and player currency checks
- award currency as battle rewards
- include new currency helper functions
- wire up player parameter in MagicalPouch
- document the updated economy and add tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6842fa047edc832793c0dae9ef2c53bc