### PR TITLE
Fix crafting tests import

### DIFF
--- a/shared/systems/crafting.test.js
+++ b/shared/systems/crafting.test.js
@@ -24,7 +24,6 @@ test('craftWithInventory crafts item and updates progression', () => {
 })
 
 import { attemptCraft } from './crafting.js'
-import { sampleRecipes } from '../models/recipes.js'
 
 const dummyCards = {
   herb: { id: 'herb', name: 'Herb' },


### PR DESCRIPTION
## Summary
- remove duplicate `sampleRecipes` import in crafting.test.js

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6842fed68c148327be6fc6db595bbdc3