### PR TITLE
Improve party setup UI and class reroll

### DIFF
--- a/client/src/components/CharacterCard.tsx
+++ b/client/src/components/CharacterCard.tsx
@@ -1,7 +1,6 @@
-import React from 'react';
-import type { Character } from '../../../shared/models/Character';
-// Optional: import a CSS module for styling
-// import styles from './CharacterCard.module.css';
+import React from 'react'
+import type { Character } from '../../../shared/models/Character'
+import { classes as allClasses } from '../../../shared/models/classes.js'
 
 interface CharacterCardProps {
   character: Character;
@@ -11,20 +10,29 @@ interface CharacterCardProps {
 }
 
 const CharacterCard: React.FC<CharacterCardProps> = ({ character, onSelect, isSelected, isDisabled }) => {
+  const roleColors: Record<string, string> = {
+    Tank: '#2980b9',
+    Healer: '#27ae60',
+    Support: '#9b59b6',
+    DPS: '#e74c3c',
+  }
+
+  const clsInfo = allClasses.find((c) => c.name === character.class)
+  const roleColor = roleColors[clsInfo?.role || 'DPS']
+
   const cardStyle: React.CSSProperties = {
-    border: isSelected ? '3px solid #3498db' : '1px solid #bdc3c7', // Blue border if selected
+    border: isSelected ? `3px solid ${roleColor}` : '1px solid #bdc3c7',
     padding: '15px',
     margin: '5px',
     cursor: isDisabled && !isSelected ? 'not-allowed' : 'pointer',
     opacity: isDisabled && !isSelected ? 0.5 : 1,
-    width: '180px', // Slightly wider
+    width: '180px',
     textAlign: 'center' as React.CSSProperties['textAlign'],
-    borderRadius: '8px',
-    backgroundColor: isSelected ? '#eaf5ff' : '#ffffff', // Light blue background if selected
+    borderRadius: '12px',
+    backgroundColor: '#ffffff',
     boxShadow: '0 2px 5px rgba(0,0,0,0.1)',
     transition: 'transform 0.2s ease-in-out, box-shadow 0.2s ease-in-out',
-    // Add a hover effect using pseudo-classes if using CSS modules, or manage via JS for inline
-  };
+  }
 
   // For a hover effect with inline styles, you'd need onMouseEnter/onMouseLeave handlers
   // to change a state variable that adjusts the style. CSS modules are better for this.
@@ -43,26 +51,55 @@ const CharacterCard: React.FC<CharacterCardProps> = ({ character, onSelect, isSe
     }
   };
 
+  const badgeStyle: React.CSSProperties = {
+    position: 'absolute',
+    top: '5px',
+    right: '5px',
+    backgroundColor: roleColor,
+    color: '#fff',
+    padding: '2px 6px',
+    borderRadius: '12px',
+    fontSize: '0.7em',
+  }
+
+  const desc = character.description || 'No description available.'
+
   return (
     <div
       style={cardStyle}
       onClick={handleClick}
       onKeyDown={handleKeyDown}
-      tabIndex={isDisabled && !isSelected ? -1 : 0} // Only focusable if interactive
+      tabIndex={isDisabled && !isSelected ? -1 : 0}
       role="button"
       aria-pressed={isSelected}
       aria-disabled={isDisabled && !isSelected}
-      // Add aria-label or ensure content is descriptive enough
-      aria-label={`Select character ${character.name}, class ${character.class}. ${character.description}`}
-      onMouseEnter={(e) => { if (!isDisabled || isSelected) e.currentTarget.style.transform = 'scale(1.03)'; e.currentTarget.style.boxShadow = '0 4px 10px rgba(0,0,0,0.15)';}}
-      onMouseLeave={(e) => { e.currentTarget.style.transform = 'scale(1)'; e.currentTarget.style.boxShadow = '0 2px 5px rgba(0,0,0,0.1)';}}
+      aria-label={`Select character ${character.name}, class ${character.class}. ${desc}`}
+      onMouseEnter={(e) => {
+        if (!isDisabled || isSelected) {
+          e.currentTarget.style.transform = 'scale(1.03)'
+          e.currentTarget.style.boxShadow = '0 4px 10px rgba(0,0,0,0.15)'
+        }
+      }}
+      onMouseLeave={(e) => {
+        e.currentTarget.style.transform = 'scale(1)'
+        e.currentTarget.style.boxShadow = '0 2px 5px rgba(0,0,0,0.1)'
+      }}
     >
-      <img src={character.portrait || 'default-portrait.png'} alt={character.name} style={{ width: '100px', height: '100px', objectFit: 'cover', borderRadius: '50%', marginBottom: '10px' }} />
-      <h3>{character.name}</h3>
-      <p style={{color: '#555'}}>{character.class}</p>
-      <p style={{ fontSize: '0.8em', height: '40px', overflow: 'hidden', color: '#777' }}>{character.description}</p>
+      <div style={{ position: 'relative', marginBottom: '10px' }}>
+        <img
+          src={character.portrait || 'default-portrait.png'}
+          alt={character.name}
+          style={{ width: '110px', height: '110px', objectFit: 'cover', borderRadius: '50%', border: `3px solid ${roleColor}` }}
+        />
+        <span style={badgeStyle}>{clsInfo?.role}</span>
+      </div>
+      <h3 style={{ margin: '0 0 5px 0' }}>{character.name}</h3>
+      <p style={{ color: roleColor, fontWeight: 'bold', margin: '0 0 5px 0' }}>{character.class}</p>
+      <p style={{ fontSize: '0.8em', height: '40px', overflow: 'hidden', fontStyle: !character.description ? 'italic' : 'normal', color: '#777' }}>
+        {desc}
+      </p>
     </div>
-  );
+  )
 };
 
 export default CharacterCard;

--- a/client/src/components/PartySetup.module.css
+++ b/client/src/components/PartySetup.module.css
@@ -1,37 +1,108 @@
 /* client/src/components/PartySetup.module.css */
 .screen {
   padding: 20px;
-  font-family: Arial, sans-serif;
-  background-color: #f0f0f0; /* Light gray background for the whole screen */
-  color: #333;
+  font-family: 'Trebuchet MS', sans-serif;
+  background: linear-gradient(180deg, #1e1e2f, #0f0f17);
+  color: #f5f5f5;
   min-height: 100vh;
+  display: flex;
+  justify-content: center;
+  align-items: flex-start;
+}
+
+.setupCard {
+  background-color: #212121;
+  padding: 2rem;
+  border-radius: 1rem;
+  box-shadow: 0 0 15px rgba(0, 0, 0, 0.5);
+  width: 100%;
+  max-width: 1000px;
 }
 
 .title {
   text-align: center;
-  color: #2c3e50; /* Dark blue/grey */
+  color: #e0e0e0;
   margin-bottom: 30px;
   font-size: 2.5em;
 }
 
 .sectionTitle {
-  color: #34495e; /* Slightly lighter blue/grey */
-  border-bottom: 2px solid #3498db; /* Blue accent */
+  color: #f5f5f5;
+  border-bottom: 2px solid #3498db;
   padding-bottom: 5px;
   margin-top: 20px;
   margin-bottom: 15px;
-  font-size: 1.8em;
+  font-size: 1.6em;
 }
 
 .characterSelectionArea {
   margin-bottom: 30px;
 }
 
-.characterSelectionGrid {
+.classList {
   display: flex;
+  justify-content: center;
+  gap: 1rem;
   flex-wrap: wrap;
-  gap: 15px; /* Space between character cards */
-  justify-content: center; /* Center cards if they don't fill the row */
+  margin-bottom: 1rem;
+}
+
+.classCard {
+  position: relative;
+  background-color: #fdfdfd;
+  color: #333;
+  padding: 0.5rem 1rem;
+  border-radius: 0.75rem;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.2);
+  border-top: 4px solid var(--role-color, #3498db);
+  width: 120px;
+  text-align: center;
+  font-size: 0.9rem;
+}
+
+.roleBadge {
+  position: absolute;
+  top: -0.6rem;
+  right: -0.6rem;
+  background-color: var(--role-color, #3498db);
+  color: #fff;
+  padding: 2px 6px;
+  border-radius: 1rem;
+  font-size: 0.7rem;
+}
+
+.rerollButton {
+  position: relative;
+  padding-left: 1.8rem;
+  cursor: pointer;
+}
+
+.rerollButton::before {
+  content: '🎲';
+  position: absolute;
+  left: 0.5rem;
+  top: 50%;
+  transform: translateY(-50%);
+}
+
+.fade {
+  animation: fadeIn 0.3s ease;
+}
+
+@keyframes fadeIn {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+}
+
+.characterSelectionGrid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(170px, 1fr));
+  gap: 15px;
+  justify-items: center;
   margin-bottom: 20px;
 }
 
@@ -40,11 +111,11 @@
 }
 
 .selectedCharacterPanel {
-  background-color: #ecf0f1; /* Light greyish blue */
+  background-color: #2a2a2a;
   padding: 15px;
   margin-bottom: 15px;
   border-radius: 8px;
-  box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+  box-shadow: 0 2px 4px rgba(0,0,0,0.4);
 }
 
 .characterPanelHeader {
@@ -111,6 +182,18 @@
   justify-content: space-between;
   max-width: 320px;
   margin: 0 auto 20px;
+  }
+
+@media (max-width: 600px) {
+  .navigationButtons {
+    flex-direction: column;
+    gap: 10px;
+    max-width: none;
+  }
+  .backButton,
+  .startGameButton {
+    width: 100%;
+  }
 }
 
 .backButton {

--- a/client/src/components/PartySetup.tsx
+++ b/client/src/components/PartySetup.tsx
@@ -27,6 +27,14 @@ const PartySetup: React.FC = () => {
   const [selectedCharacters, setSelectedCharacters] = useState<PartyCharacter[]>([]);
   const [availableCharacters, setAvailableCharacters] = useState<Character[]>([]);
   const [availableCards, setAvailableCards] = useState<Card[]>([]);
+  const [isRerolling, setIsRerolling] = useState(false);
+
+  const roleColors: Record<string, string> = {
+    Tank: '#2980b9',
+    Healer: '#27ae60',
+    Support: '#9b59b6',
+    DPS: '#e74c3c',
+  }
 
   const navigate = useNavigate();
   const setParty = useGameStore(state => state.setParty);
@@ -116,8 +124,11 @@ const PartySetup: React.FC = () => {
   };
 
   const handleRerollClasses = () => {
+    if (isRerolling) return;
+    setIsRerolling(true);
     setAvailableClasses(getRandomClasses(4, allClasses));
     setSelectedCharacters([]);
+    setTimeout(() => setIsRerolling(false), 500);
   };
 
   const { open, close } = useModal();
@@ -158,17 +169,40 @@ const PartySetup: React.FC = () => {
 
   // Basic JSX structure - will be expanded in subsequent steps
   return (
-    <div className={styles.screen}> {/* Apply .screen class */}
-      <h1 className={styles.title}>Party Setup</h1> {/* Apply .title class */}
-      <div style={{ textAlign: 'center', marginBottom: '1rem' }}>
-        <p>Available Classes: {availableClasses.map(c => c.name).join(', ')}</p>
-        <button onClick={handleRerollClasses}>Reroll Classes</button>
-      </div>
+    <div className={styles.screen}>
+      <div className={styles.setupCard}>
+        <h1 className={styles.title}>Party Setup</h1>
+        <div className={styles.classList}>
+          {availableClasses.map(cls => (
+            <div
+              key={cls.name}
+              className={styles.classCard}
+              style={{ '--role-color': roleColors[cls.role] } as React.CSSProperties}
+            >
+              <span className={styles.roleBadge}>{cls.role}</span>
+              <strong>{cls.name}</strong>
+              <p style={{ fontStyle: cls.description ? 'normal' : 'italic', fontSize: '0.8rem' }}>
+                {cls.description || 'No description available.'}
+              </p>
+            </div>
+          ))}
+          <button
+            className={styles.rerollButton}
+            onClick={handleRerollClasses}
+            disabled={isRerolling}
+            title="Try a new set of classes for your adventure!"
+          >
+            Reroll Classes
+          </button>
+        </div>
 
       {/* Character Selection Section */}
       <div className={styles.characterSelectionArea}>
         <h2 className={styles.sectionTitle}>Select Characters (up to 5)</h2>
-        <div className={styles.characterSelectionGrid}> {/* Apply .characterSelectionGrid */}
+        <div
+          key={availableClasses.map(c => c.name).join('-')}
+          className={`${styles.characterSelectionGrid} ${isRerolling ? styles.fade : ''}`}
+        >
           {availableCharacters.filter(ac => !selectedCharacters.find(sc => sc.id === ac.id)).map(character => (
             <CharacterCard
               key={character.id}
@@ -215,6 +249,7 @@ const PartySetup: React.FC = () => {
         >
           Enter Dungeon
         </button>
+      </div>
       </div>
     </div>
   );

--- a/client/src/components/PartySummary.tsx
+++ b/client/src/components/PartySummary.tsx
@@ -9,15 +9,16 @@ const PartySummary: React.FC<PartySummaryProps> = ({ selectedCharacters }) => {
   const summaryStyle: React.CSSProperties = {
     marginTop: '30px',
     padding: '20px',
-    border: '1px solid #bdc3c7', // Consistent with other borders
+    border: '1px solid #444',
     borderRadius: '8px',
-    backgroundColor: '#f9fafb', // Very light grey, almost white
-    boxShadow: '0 2px 4px rgba(0,0,0,0.05)', // Subtle shadow
-  };
+    backgroundColor: '#2a2a2a',
+    boxShadow: '0 2px 4px rgba(0,0,0,0.4)',
+    color: '#f5f5f5',
+  }
 
   const titleStyle: React.CSSProperties = {
-    color: '#34495e', // From PartySetup.module.css sectionTitle
-    borderBottom: '2px solid #3498db', // From PartySetup.module.css sectionTitle
+    color: '#f5f5f5',
+    borderBottom: '2px solid #3498db',
     paddingBottom: '5px',
     marginBottom: '20px', // Increased margin
     fontSize: '1.6em', // Slightly smaller than main section titles
@@ -25,30 +26,34 @@ const PartySummary: React.FC<PartySummaryProps> = ({ selectedCharacters }) => {
   };
 
   const characterItemStyle: React.CSSProperties = {
-    marginBottom: '15px',
-    paddingLeft: '15px',
-    borderLeft: '3px solid #3498db', // Blue accent line
-  };
+    marginBottom: '10px',
+    display: 'flex',
+    alignItems: 'center',
+    gap: '10px',
+    backgroundColor: '#383838',
+    padding: '8px',
+    borderRadius: '6px',
+  }
 
   const cardListStyle: React.CSSProperties = {
-    listStyleType: 'disc', // Default disc
-    paddingLeft: '20px', // Indent list items
-    color: '#555',
-  };
+    display: 'flex',
+    flexWrap: 'wrap',
+    gap: '6px',
+    margin: 0,
+    padding: 0,
+    listStyle: 'none',
+  }
 
 
   if (selectedCharacters.length === 0) {
     return (
-      <div
-        className="party-summary"
-        style={summaryStyle}
-        aria-live="polite"
-        aria-atomic="true"
-      >
+      <div className="party-summary" style={summaryStyle} aria-live="polite" aria-atomic="true">
         <h2 style={titleStyle}>Party Summary</h2>
-        <p style={{textAlign: 'center', fontStyle: 'italic', color: '#7f8c8d'}}>No characters selected yet to display a summary.</p>
+        <p style={{ textAlign: 'center', fontStyle: 'italic', color: '#bbb' }}>
+          No characters selected yet to display a summary.
+        </p>
       </div>
-    );
+    )
   }
 
   let totalAttack = 0;
@@ -71,36 +76,35 @@ const PartySummary: React.FC<PartySummaryProps> = ({ selectedCharacters }) => {
   const averageDefense = defenseCount > 0 ? (totalDefense / defenseCount).toFixed(2) : 'N/A';
 
   return (
-    <div
-      className="party-summary"
-      style={summaryStyle}
-      aria-live="polite"
-      aria-atomic="true"
-    >
+    <div className="party-summary" style={summaryStyle} aria-live="polite" aria-atomic="true">
       <h2 style={titleStyle}>Party Summary</h2>
-      <p style={{textAlign: 'center', marginBottom: '15px', fontSize: '1.1em'}}>Total Characters: {selectedCharacters.length}</p>
+      <p style={{ textAlign: 'center', marginBottom: '15px', fontSize: '1.1em' }}>Total Characters: {selectedCharacters.length}</p>
 
-      <h3 style={{color: '#34495e', marginBottom: '5px'}}>Overall Party Stats:</h3>
-      <p style={{marginLeft: '10px'}}>Average Attack: <strong>{averageAttack}</strong></p>
-      <p style={{marginLeft: '10px', marginBottom: '20px'}}>Average Defense: <strong>{averageDefense}</strong></p>
+      <h3 style={{ color: '#f5f5f5', marginBottom: '5px' }}>Overall Party Stats:</h3>
+      <p style={{ marginLeft: '10px' }}>Average Attack: <strong>{averageAttack}</strong></p>
+      <p style={{ marginLeft: '10px', marginBottom: '20px' }}>Average Defense: <strong>{averageDefense}</strong></p>
 
-      <h3 style={{color: '#34495e', marginBottom: '10px'}}>Selected Characters & Cards:</h3>
-      {selectedCharacters.map(character => (
+      <h3 style={{ color: '#f5f5f5', marginBottom: '10px' }}>Selected Characters & Cards:</h3>
+      {selectedCharacters.map((character) => (
         <div key={character.id} style={characterItemStyle}>
-          <strong style={{color: '#2980b9', fontSize: '1.1em'}}>{character.name} ({character.class})</strong>
-          <ul style={cardListStyle}>
-            {character.assignedCards.map(card => (
-              <li key={card.id} style={{marginBottom: '3px'}}>
-                <span title={card.description}>{card.name}</span>
-                <em style={{fontSize: '0.8em', color: '#555'}}> - {card.description}</em>
-              </li>
-            ))}
-            {character.assignedCards.length === 0 && <li style={{fontStyle: 'italic'}}>No cards assigned</li>}
-          </ul>
+          <img src={character.portrait || 'default-portrait.png'} alt={character.name} style={{ width: '40px', height: '40px', borderRadius: '50%', objectFit: 'cover', border: '2px solid #3498db' }} />
+          <div>
+            <strong style={{ color: '#fff', fontSize: '1em' }}>{character.name}</strong>
+            <ul style={cardListStyle}>
+              {character.assignedCards.map((card) => (
+                <li key={card.id} style={{ backgroundColor: '#555', padding: '2px 6px', borderRadius: '12px', fontSize: '0.75em', color: '#fff' }} title={card.description}>
+                  {card.name}
+                </li>
+              ))}
+              {character.assignedCards.length === 0 && (
+                <li style={{ fontStyle: 'italic', color: '#ccc' }}>No cards</li>
+              )}
+            </ul>
+          </div>
         </div>
       ))}
     </div>
-  );
+  )
 };
 
 export default PartySummary;


### PR DESCRIPTION
## Summary
- enhance character card visuals with role badges
- redesign party setup page with centered card and class list
- animate character grid on reroll and reset selections
- add modern party summary layout

## Testing
- `npm test` *(fails: SyntaxError in shared tests)*
- `npm run lint` in `client`

------
https://chatgpt.com/codex/tasks/task_e_6843002136288327ab19e60c339a1920