### PR TITLE
Implement dynamic class selection reroll

### DIFF
--- a/client/src/components/ClassCard.tsx
+++ b/client/src/components/ClassCard.tsx
@@ -1,0 +1,34 @@
+import React from 'react';
+import type { GameClass } from '../utils/randomizeClasses';
+import styles from './PartySetup.module.css';
+
+interface ClassCardProps {
+  cls: GameClass;
+  onSelect: (cls: GameClass) => void;
+  disabled?: boolean;
+}
+
+const roleColors: Record<string, string> = {
+  Tank: '#2980b9',
+  Healer: '#27ae60',
+  Support: '#9b59b6',
+  DPS: '#e74c3c',
+};
+
+const ClassCard: React.FC<ClassCardProps> = ({ cls, onSelect, disabled }) => {
+  return (
+    <div
+      className={`${styles.classCard} ${disabled ? styles.disabledCard : ''}`}
+      style={{ '--role-color': roleColors[cls.role] } as React.CSSProperties}
+      onClick={() => !disabled && onSelect(cls)}
+    >
+      <span className={styles.roleBadge}>{cls.role}</span>
+      <strong>{cls.name}</strong>
+      <p style={{ fontStyle: cls.description ? 'normal' : 'italic', fontSize: '0.8rem' }}>
+        {cls.description || 'No description available.'}
+      </p>
+    </div>
+  );
+};
+
+export default ClassCard;

--- a/client/src/components/PartySetup.module.css
+++ b/client/src/components/PartySetup.module.css
@@ -223,3 +223,12 @@
   margin-bottom: 20px; /* Increased margin */
   font-size: 1.1em;
 }
+
+.disabledCard {
+  opacity: 0.3;
+  pointer-events: none;
+}
+
+.undoButton {
+  margin-left: 1rem;
+}


### PR DESCRIPTION
## Summary
- allow classes to be chosen from a rotating pool
- add Undo button to revert last pick
- refactor PartySetup to show class cards instead of character cards

## Testing
- `npm test`
- `npm --workspace client run lint`


------
https://chatgpt.com/codex/tasks/task_e_684305854b94832787d7a9abcbae48c7