### PR TITLE
Fix Party Setup blank screen on navigation

### DIFF
--- a/client/src/components/PartySetup.tsx
+++ b/client/src/components/PartySetup.tsx
@@ -40,13 +40,21 @@ const PartySetup: React.FC = () => {
   const save = useGameStore(state => state.save);
   const availableClasses = useGameStore(state => state.availableClasses);
   const setAvailableClasses = useGameStore(state => state.setAvailableClasses);
+  const load = useGameStore(state => state.load);
+
+  // Ensure game state is loaded when arriving via client-side navigation
+  useEffect(() => {
+    if (availableClasses.length === 0 && selectedCharacters.length === 0) {
+      load();
+    }
+  }, [availableClasses.length, selectedCharacters.length, load]);
 
   useEffect(() => {
     if (availableClasses.length === 0 && selectedCharacters.length < 5) {
       const remaining = allClasses.filter(c => !selectedCharacters.find(pc => pc.class === c.name));
       setAvailableClasses(getRandomClasses(Math.min(4, remaining.length), remaining));
     }
-  }, [availableClasses.length, selectedCharacters, setAvailableClasses]);
+  }, [availableClasses.length, selectedCharacters, setAvailableClasses, load]);
 
   useEffect(() => {
     setAvailableCards(


### PR DESCRIPTION
## Summary
- load game state on PartySetup mount
- add load dependency to class initialization logic

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68430ed93c848327b87cf8b4542ed02f