### PR TITLE
Normalize Level 1 class cards and add Class Codex

### DIFF
--- a/docs/ClassCodex.md
+++ b/docs/ClassCodex.md
@@ -1,0 +1,160 @@
+# Class Codex
+
+This codex lists every playable class and their Level 1 cards with concise technical data.
+
+## Guardian
+
+Sturdy protector that draws enemy attacks and shields allies.
+
+| Card Name | Cost | Effect | Target | Duration | Notes |
+|-----------|------|--------|--------|----------|-------|
+| Fortified Stance | 1 | damage_reduction 30 | - | 1 turn | |
+| Intervene | 1 | redirect 1 | - | 1 turn | |
+| Guard's Challenge | 1 | taunt 1 | enemies | 1 turn | |
+| Bulwark | 2 | shield 8 | party | 1 turn | |
+
+## Warrior
+
+Aggressive melee combatant excelling at frontline skirmishes.
+
+| Card Name | Cost | Effect | Target | Duration | Notes |
+|-----------|------|--------|--------|----------|-------|
+| Strike | 1 | damage 5 | - | - | |
+| Iron Sword | 0 |  | - | - | |
+| Shield Wall | 1 | buff 3 | - | 2 turns | |
+| Taunt | 1 | debuff 1 | enemy | - | |
+
+**Future Unlocks**: Power Strike, Battle Cry
+
+## Runestone Sentinel
+
+Tank that channels rune magic to harden defenses.
+
+| Card Name | Cost | Effect | Target | Duration | Notes |
+|-----------|------|--------|--------|----------|-------|
+| Rune Slam | 1 | damage 6 | - | - | |
+| Stone Guard | 1 | buff 2 | - | 3 turns | |
+| Earthen Grasp | 1 | debuff 1 | - | 1 turn | |
+| Runic Pulse | 1 | damage 3 | - | - | |
+
+## Cleric
+
+Devout healer who mends wounds with holy magic.
+
+| Card Name | Cost | Effect | Target | Duration | Notes |
+|-----------|------|--------|--------|----------|-------|
+| Heal | 1 | heal 5 | - | - | |
+| Holy Light | 1 | heal 6 | - | - | |
+| Smite | 1 | damage 4 | - | - | |
+| Sanctuary | 1 | damage_reduction 20 | party | 1 turn | |
+
+## Herbalist
+
+Nature healer brewing restorative and toxic concoctions.
+
+| Card Name | Cost | Effect | Target | Duration | Notes |
+|-----------|------|--------|--------|----------|-------|
+| Haste Elixir | 0 |  | - | - | |
+| Healing Herbs | 1 | heal 5 | - | - | |
+| Toxic Spores | 1 | damage 3 | - | 2 turns | |
+| Growth Burst | 1 | buff 25 | ally | 1 turn | |
+
+## Bloodweaver
+
+Mystic manipulating life essence to heal or harm.
+
+| Card Name | Cost | Effect | Target | Duration | Notes |
+|-----------|------|--------|--------|----------|-------|
+| Blood Leech | 1 | damage 4 | - | - | |
+| Sanguine Gift | 1 | heal 6 | - | - | |
+| Hemorrhage | 1 | damage 2 | - | 2 turns | |
+| Blood Pact | 1 | swap_hp | - | - | |
+
+## Bard
+
+Inspirational performer empowering allies through song.
+
+| Card Name | Cost | Effect | Target | Duration | Notes |
+|-----------|------|--------|--------|----------|-------|
+| Inspire | 1 | buff 1 | ally | - | |
+| Song of Swiftness | 1 | buff 1 | party | 2 turns | |
+| Lullaby | 1 | sleep 1 | - | 1 turn | |
+| Motivational Tune | 1 | energize 2 | party | - | |
+
+## Chronomancer
+
+Temporal magician bending time to aid the party.
+
+| Card Name | Cost | Effect | Target | Duration | Notes |
+|-----------|------|--------|--------|----------|-------|
+| Time Warp | 1 | buff 1 | ally | - | |
+| Temporal Strike | 1 | damage 5 | - | - | |
+| Rewind | 1 | heal 4 | - | - | |
+| Accelerate | 1 | buff 1 | party | 1 turn | |
+
+## Totem Warden
+
+Places totems that bolster friends or weaken foes.
+
+| Card Name | Cost | Effect | Target | Duration | Notes |
+|-----------|------|--------|--------|----------|-------|
+| Totem of Vitality | 1 | heal 2 | - | 3 turns | |
+| Totem of Fury | 1 | buff 1 | - | 3 turns | |
+| Totem of Stoneskin | 1 | buff 3 | party | 2 turns | |
+| Totem Recall | 1 | trigger_totems | - | - | |
+
+## Blademaster
+
+Master of blades delivering relentless attacks.
+
+| Card Name | Cost | Effect | Target | Duration | Notes |
+|-----------|------|--------|--------|----------|-------|
+| Quick Slash | 1 | damage 4 | - | - | |
+| Blade Fury | 1 | damage 4 | - | - | |
+| Deflect | 1 | block 1 | - | 1 turn | |
+| Deadly Focus | 1 | buff 4 | - | 1 turn | |
+
+## Wizard
+
+Arcane caster wielding destructive and protective spells.
+
+| Card Name | Cost | Effect | Target | Duration | Notes |
+|-----------|------|--------|--------|----------|-------|
+| Arcane Bolt | 1 | damage 5 | - | - | |
+| Mana Shield | 1 | buff 4 | - | 2 turns | |
+| Frost Nova | 1 | damage 2 | - | 1 turn | |
+| Energize | 0 | mana 3 | self | - | |
+
+## Shadowblade
+
+Stealthy assassin striking from the darkness.
+
+| Card Name | Cost | Effect | Target | Duration | Notes |
+|-----------|------|--------|--------|----------|-------|
+| Mark Target | 1 | debuff 1 | enemy | - | |
+| Shadow Execution | 1 | damage 8 | - | - | |
+| Backstab | 1 | damage 6 | - | - | |
+| Smoke Bomb | 1 | buff 1 | - | 1 turn | |
+
+## Ranger
+
+Expert archer adept at controlling the battlefield.
+
+| Card Name | Cost | Effect | Target | Duration | Notes |
+|-----------|------|--------|--------|----------|-------|
+| Mark Target | 1 | debuff 1 | enemy | - | |
+| Arrow Shot | 1 | damage 5 | - | - | |
+| Entangling Trap | 1 | debuff 1 | - | 1 turn | |
+| Eagle Eye | 1 | buff 25 | - | 2 turns | |
+
+## Pyromancer
+
+Sorcerer harnessing fire for offense and defense.
+
+| Card Name | Cost | Effect | Target | Duration | Notes |
+|-----------|------|--------|--------|----------|-------|
+| Fireball | 1 | damage 6 | - | - | |
+| Flame Shield | 1 | buff 2 | - | 2 turns | |
+| Ignite | 1 | damage 2 | - | 2 turns | |
+| Cauterize | 1 | heal 3 | - | - | |
+

--- a/shared/models/cards.js
+++ b/shared/models/cards.js
@@ -12,6 +12,7 @@ export const sampleCards = [
     synergyTag: 'Frenzy',
     synergyEffect: { type: 'extra_attack', magnitude: 1 },
     isComboStarter: true,
+    classRestriction: 'Warrior', // Level 1
   },
   {
     id: 'heal',
@@ -23,6 +24,7 @@ export const sampleCards = [
     cooldown: 0,
     effect: { type: 'heal', magnitude: 5 },
     roleTag: 'Healer',
+    classRestriction: 'Cleric', // Level 1
   },
   {
     id: 'inspire',
@@ -34,6 +36,7 @@ export const sampleCards = [
     cooldown: 0,
     effect: { type: 'buff', magnitude: 1, target: 'ally' },
     roleTag: 'Support',
+    classRestriction: 'Bard', // Level 1
   },
   {
     id: 'iron_sword',
@@ -43,6 +46,7 @@ export const sampleCards = [
     rarity: 'Common',
     statModifiers: [{ stat: 'attack', value: 2 }],
     slot: 'Weapon',
+    classRestriction: 'Warrior', // Level 1
   },
   {
     id: 'herb',
@@ -69,6 +73,7 @@ export const sampleCards = [
     rarity: 'Uncommon',
     effects: [{ type: 'speed', magnitude: 1, duration: 3 }],
     duration: 3,
+    classRestriction: 'Herbalist', // Level 1
   },
   {
     id: 'campfire',
@@ -91,6 +96,7 @@ export const sampleCards = [
     roleTag: 'Support',
     synergyTag: 'Execute',
     isComboStarter: true,
+    classes: ['Shadowblade', 'Ranger'], // Level 1
   },
   {
     id: 'shadow_execution',
@@ -104,6 +110,7 @@ export const sampleCards = [
     roleTag: 'DPS',
     synergyTag: 'Execute',
     isComboFinisher: true,
+    classRestriction: 'Shadowblade', // Level 1
   },
   {
     id: 'fireball',
@@ -115,6 +122,7 @@ export const sampleCards = [
     cooldown: 0,
     effect: { type: 'damage', magnitude: 6, element: 'fire' },
     roleTag: 'DPS',
+    classRestriction: 'Pyromancer', // Level 1
   },
   {
     id: 'shield_wall',
@@ -126,7 +134,7 @@ export const sampleCards = [
     cooldown: 1,
     effect: { type: 'buff', magnitude: 3, duration: 2 },
     roleTag: 'Tank',
-    classRestriction: 'Guardian',
+    classRestriction: 'Warrior', // Level 1
   },
   {
     id: 'taunt',
@@ -138,7 +146,7 @@ export const sampleCards = [
     cooldown: 1,
     effect: { type: 'debuff', magnitude: 1, target: 'enemy' },
     roleTag: 'Tank',
-    classRestriction: 'Guardian',
+    classRestriction: 'Warrior', // Level 1
   },
   {
     id: 'power_strike',
@@ -151,6 +159,7 @@ export const sampleCards = [
     effect: { type: 'damage', magnitude: 7 },
     roleTag: 'Tank',
     classRestriction: 'Warrior',
+    level: 2,
   },
   {
     id: 'battle_cry',
@@ -163,6 +172,7 @@ export const sampleCards = [
     effect: { type: 'buff', magnitude: 1, duration: 2, target: 'party' },
     roleTag: 'Tank',
     classRestriction: 'Warrior',
+    level: 2,
   },
   {
     id: 'rune_slam',
@@ -428,5 +438,282 @@ export const sampleCards = [
     effect: { type: 'buff', magnitude: 2, duration: 2 },
     roleTag: 'DPS',
     classRestriction: 'Pyromancer',
+  },
+  // ----- Added Level 1 cards -----
+  {
+    id: 'fortified_stance',
+    name: 'Fortified Stance',
+    description: 'Reduce all damage taken by 30% for one turn.',
+    category: 'Ability',
+    rarity: 'Common',
+    energyCost: 1,
+    cooldown: 1,
+    effect: { type: 'damage_reduction', magnitude: 30, duration: 1 },
+    roleTag: 'Tank',
+    classRestriction: 'Guardian', // Level 1
+  },
+  {
+    id: 'intervene',
+    name: 'Intervene',
+    description: 'Redirect the next attack against an ally to yourself.',
+    category: 'Ability',
+    rarity: 'Common',
+    energyCost: 1,
+    cooldown: 2,
+    effect: { type: 'redirect', magnitude: 1, duration: 1 },
+    roleTag: 'Tank',
+    classRestriction: 'Guardian', // Level 1
+  },
+  {
+    id: 'guards_challenge',
+    name: "Guard's Challenge",
+    description: 'Taunt all enemies for one turn.',
+    category: 'Ability',
+    rarity: 'Common',
+    energyCost: 1,
+    cooldown: 2,
+    effect: { type: 'taunt', magnitude: 1, duration: 1, target: 'enemies' },
+    roleTag: 'Tank',
+    classRestriction: 'Guardian', // Level 1
+  },
+  {
+    id: 'bulwark',
+    name: 'Bulwark',
+    description: 'Shield self and allies for 8 points for one turn.',
+    category: 'Ability',
+    rarity: 'Common',
+    energyCost: 2,
+    cooldown: 2,
+    effect: { type: 'shield', magnitude: 8, duration: 1, target: 'party' },
+    roleTag: 'Tank',
+    classRestriction: 'Guardian', // Level 1
+  },
+  {
+    id: 'earthen_grasp',
+    name: 'Earthen Grasp',
+    description: 'Immobilize one enemy for a turn.',
+    category: 'Ability',
+    rarity: 'Common',
+    energyCost: 1,
+    cooldown: 1,
+    effect: { type: 'debuff', magnitude: 1, duration: 1 },
+    roleTag: 'Tank',
+    classRestriction: 'RunestoneSentinel', // Level 1
+  },
+  {
+    id: 'runic_pulse',
+    name: 'Runic Pulse',
+    description: 'Deal 2–4 magic damage and shield self for 1 turn.',
+    category: 'Ability',
+    rarity: 'Common',
+    energyCost: 1,
+    cooldown: 1,
+    effect: { type: 'damage', magnitude: 3, element: 'arcane' },
+    roleTag: 'Tank',
+    classRestriction: 'RunestoneSentinel', // Level 1
+  },
+  {
+    id: 'sanctuary',
+    name: 'Sanctuary',
+    description: 'Reduce all incoming damage to allies by 20% for one turn.',
+    category: 'Ability',
+    rarity: 'Common',
+    energyCost: 1,
+    cooldown: 2,
+    effect: { type: 'damage_reduction', magnitude: 20, duration: 1, target: 'party' },
+    roleTag: 'Healer',
+    classRestriction: 'Cleric', // Level 1
+  },
+  {
+    id: 'growth_burst',
+    name: 'Growth Burst',
+    description: 'Boost an ally\'s speed by 25% for 1 turn.',
+    category: 'Ability',
+    rarity: 'Common',
+    energyCost: 1,
+    cooldown: 1,
+    effect: { type: 'buff', magnitude: 25, duration: 1, target: 'ally' },
+    roleTag: 'Healer',
+    classRestriction: 'Herbalist', // Level 1
+  },
+  {
+    id: 'hemorrhage',
+    name: 'Hemorrhage',
+    description: 'Inflict 2 bleeding damage per turn for 2 turns.',
+    category: 'Ability',
+    rarity: 'Common',
+    energyCost: 1,
+    cooldown: 1,
+    effect: { type: 'damage', magnitude: 2, duration: 2, element: 'bleed' },
+    roleTag: 'Healer',
+    classRestriction: 'Bloodweaver', // Level 1
+  },
+  {
+    id: 'blood_pact',
+    name: 'Blood Pact',
+    description: 'Swap HP percentages with an ally.',
+    category: 'Ability',
+    rarity: 'Common',
+    energyCost: 1,
+    cooldown: 2,
+    effect: { type: 'swap_hp' },
+    roleTag: 'Healer',
+    classRestriction: 'Bloodweaver', // Level 1
+  },
+  {
+    id: 'lullaby',
+    name: 'Lullaby',
+    description: 'Put an enemy to sleep for 1 turn.',
+    category: 'Ability',
+    rarity: 'Common',
+    energyCost: 1,
+    cooldown: 2,
+    effect: { type: 'sleep', magnitude: 1, duration: 1 },
+    roleTag: 'Support',
+    classRestriction: 'Bard', // Level 1
+  },
+  {
+    id: 'motivational_tune',
+    name: 'Motivational Tune',
+    description: 'Restore 2 energy to all allies.',
+    category: 'Ability',
+    rarity: 'Common',
+    energyCost: 1,
+    cooldown: 1,
+    effect: { type: 'energize', magnitude: 2, target: 'party' },
+    roleTag: 'Support',
+    classRestriction: 'Bard', // Level 1
+  },
+  {
+    id: 'rewind',
+    name: 'Rewind',
+    description: 'Undo the last 4 damage taken by an ally.',
+    category: 'Ability',
+    rarity: 'Common',
+    energyCost: 1,
+    cooldown: 2,
+    effect: { type: 'heal', magnitude: 4 },
+    roleTag: 'Support',
+    classRestriction: 'Chronomancer', // Level 1
+  },
+  {
+    id: 'accelerate',
+    name: 'Accelerate',
+    description: 'Speed up all allies by 1 initiative for 1 turn.',
+    category: 'Ability',
+    rarity: 'Common',
+    energyCost: 1,
+    cooldown: 1,
+    effect: { type: 'buff', magnitude: 1, duration: 1, target: 'party' },
+    roleTag: 'Support',
+    classRestriction: 'Chronomancer', // Level 1
+  },
+  {
+    id: 'totem_of_stoneskin',
+    name: 'Totem of Stoneskin',
+    description: 'Totem grants +3 defense to allies for 2 turns.',
+    category: 'Ability',
+    rarity: 'Common',
+    energyCost: 1,
+    cooldown: 2,
+    effect: { type: 'buff', magnitude: 3, duration: 2, target: 'party' },
+    roleTag: 'Support',
+    classRestriction: 'TotemWarden', // Level 1
+  },
+  {
+    id: 'totem_recall',
+    name: 'Totem Recall',
+    description: 'Trigger all totem effects immediately.',
+    category: 'Ability',
+    rarity: 'Common',
+    energyCost: 1,
+    cooldown: 3,
+    effect: { type: 'trigger_totems' },
+    roleTag: 'Support',
+    classRestriction: 'TotemWarden', // Level 1
+  },
+  {
+    id: 'deflect',
+    name: 'Deflect',
+    description: 'Block the next attack this turn.',
+    category: 'Ability',
+    rarity: 'Common',
+    energyCost: 1,
+    cooldown: 1,
+    effect: { type: 'block', magnitude: 1, duration: 1 },
+    roleTag: 'DPS',
+    classRestriction: 'Blademaster', // Level 1
+  },
+  {
+    id: 'deadly_focus',
+    name: 'Deadly Focus',
+    description: 'Next attack this turn deals +4 damage.',
+    category: 'Ability',
+    rarity: 'Common',
+    energyCost: 1,
+    cooldown: 1,
+    effect: { type: 'buff', magnitude: 4, duration: 1 },
+    roleTag: 'DPS',
+    classRestriction: 'Blademaster', // Level 1
+  },
+  {
+    id: 'frost_nova',
+    name: 'Frost Nova',
+    description: 'Deal 2 cold damage and slow enemies by 1 initiative for 1 turn.',
+    category: 'Ability',
+    rarity: 'Common',
+    energyCost: 1,
+    cooldown: 1,
+    effect: { type: 'damage', magnitude: 2, element: 'cold', duration: 1 },
+    roleTag: 'DPS',
+    classRestriction: 'Wizard', // Level 1
+  },
+  {
+    id: 'energize',
+    name: 'Energize',
+    description: 'Restore 3 mana to self.',
+    category: 'Ability',
+    rarity: 'Common',
+    energyCost: 0,
+    cooldown: 2,
+    effect: { type: 'mana', magnitude: 3, target: 'self' },
+    roleTag: 'DPS',
+    classRestriction: 'Wizard', // Level 1
+  },
+  {
+    id: 'eagle_eye',
+    name: 'Eagle Eye',
+    description: 'Increase critical hit chance by 25% for 2 turns.',
+    category: 'Ability',
+    rarity: 'Common',
+    energyCost: 1,
+    cooldown: 2,
+    effect: { type: 'buff', magnitude: 25, duration: 2 },
+    roleTag: 'DPS',
+    classRestriction: 'Ranger', // Level 1
+  },
+  {
+    id: 'ignite',
+    name: 'Ignite',
+    description: 'Burn a target for 2 fire damage per turn for 2 turns.',
+    category: 'Ability',
+    rarity: 'Common',
+    energyCost: 1,
+    cooldown: 1,
+    effect: { type: 'damage', magnitude: 2, duration: 2, element: 'fire' },
+    roleTag: 'DPS',
+    classRestriction: 'Pyromancer', // Level 1
+  },
+  {
+    id: 'cauterize',
+    name: 'Cauterize',
+    description: 'Remove one debuff or heal self for 3 HP.',
+    category: 'Ability',
+    rarity: 'Common',
+    energyCost: 1,
+    cooldown: 2,
+    effect: { type: 'heal', magnitude: 3 },
+    roleTag: 'DPS',
+    classRestriction: 'Pyromancer', // Level 1
   },
 ]


### PR DESCRIPTION
## Summary
- ensure each class has exactly four Level 1 cards
- assign new or existing cards to the correct classes
- mark higher level Warrior cards
- document all class cards in `docs/ClassCodex.md`

## Testing
- `npm test` *(fails: SyntaxError: Cannot use import statement outside a module)*

------
https://chatgpt.com/codex/tasks/task_e_684314e048788327a36f2e3b66f61db4