### PR TITLE
Update docs with party setup and codex info

### DIFF
--- a/GAME_DESIGN.md
+++ b/GAME_DESIGN.md
@@ -14,6 +14,7 @@
 - [Biome Synergy Bonuses](#biome-synergy-bonuses)
 - [Floor-Wide Dynamic Events](#floor-wide-dynamic-events)
 - [Combo-Aware Enemy AI](#combo-aware-enemy-ai)
+- [Party Setup & Drafting](#party-setup--drafting)
 - [Implementation Notes](#implementation-notes)
 
 ## 🎯 Game Concept
@@ -266,6 +267,18 @@ public string[] preferredComboTags;
 
 - **Turn 1**: Spore Witch casts "Mark Target" (isComboStarter, synergyTag: Execute)
 - **Turn 2**: Mushroom Shaman casts "Shadow Execution" (isComboFinisher, synergyTag: Execute)
+
+---
+
+## Party Setup & Drafting
+
+Before entering the dungeon, players choose their party composition in a
+dedicated setup screen. Available classes can be rerolled and each selected
+character drafts a small hand of Level&nbsp;1 ability cards. These early choices
+set the tone for the run and encourage experimentation.
+
+Codex files in the repository provide reference tables for all classes and
+enemies at Level&nbsp;1.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -96,6 +96,21 @@ an enemy room briefly displays an "encounter" banner before the battle overlay
 opens. After victory or defeat, you return to the map with your explored rooms
 intact.
 
+## Party Setup and Card Drafting
+
+The React client includes a revamped party setup flow. Players can reroll
+available classes and then draft a starting deck of ability cards for each
+character before entering the dungeon. These features live under the
+`PartySetup` route and make early game decisions more dynamic.
+
+## Codex Reference
+
+Lists of all playable classes and enemy archetypes are maintained under the
+[`docs`](docs) directory. See
+[`docs/ClassCodex.md`](docs/ClassCodex.md) and
+[`docs/EnemyCodex.md`](docs/EnemyCodex.md) for the currently implemented
+Level&nbsp;1 cards.
+
 
 ## License
 

--- a/client/README.md
+++ b/client/README.md
@@ -8,6 +8,10 @@ Key components include:
 - **`DungeonMap.js`**: Renders the interactive grid-based dungeon map. Players click on rooms in this component to navigate the dungeon.
 - **`CombatOverlay.js`**: Displays when a battle starts, showing character statuses, enemy information, and combat logs. It overlays the `GameView` where the actual Phaser battle scene is running.
 - **Various UI components**: For displaying player inventory, party selection, crafting menus, and interacting with different game systems.
+- **`PartySetup` screens**: Allow rerolling available classes and drafting a
+  starting deck of cards for each character.
+- **`TownView` and `MarketScreen`**: Provide an interface to interact with the
+  in-game markets before delving back into the dungeon.
 
 The UI communicates with the Phaser game primarily through `localStorage` for game state like party composition and dungeon progress, as described in the main repository README.
 

--- a/game/README.md
+++ b/game/README.md
@@ -7,6 +7,10 @@ The game is structured into several key Phaser scenes:
 - **`DungeonScene.js`**: Manages the procedural generation of dungeon floors, player movement on the map, fog-of-war effects, and interactions with map nodes (e.g., initiating combat, finding loot, triggering events). It reads initial party data from `localStorage`.
 - **`BattleScene.js`**: Handles the auto-battler combat logic. It takes the player's party and encountered enemies, then executes turns based on character speed and assigned abilities. This scene is typically rendered within the `CombatOverlay` in the React client. It also reports battle outcomes.
 - **`UIScene.js`**: (If applicable, or integrated into other scenes) Manages in-game UI elements that are part of the Phaser canvas, such as health bars, turn indicators, or temporary combat messages.
+- **`TownScene.js`**: A simple hub where players can access markets before
+  returning to the dungeon.
+- **`DecisionScene.js`**: Appears after clearing a floor and lets the player
+  advance deeper or retreat back to town.
 
 These scenes can run independently for development purposes or be embedded and controlled by the React client via the `GameView` component. The `game` package relies on the `shared` package for data models (characters, cards) and core system logic (AI, combat rules).
 

--- a/shared/README.md
+++ b/shared/README.md
@@ -31,6 +31,11 @@ The `systems` directory provides helper modules for various game mechanics.
 -   **Progression (`progression.js`)**: Governs character leveling, unlocking card rarities, and profession skill advancement.
 -   **Room Events (`roomEvents.js`)**: Logic for various non-combat encounters or discoveries that can occur when navigating dungeon map nodes.
 
+Class and enemy definitions used by these systems are cataloged in the
+[`docs`](../docs) directory under
+[`ClassCodex.md`](../docs/ClassCodex.md) and
+[`EnemyCodex.md`](../docs/EnemyCodex.md).
+
 Developers should refer to JSDoc comments within these modules for detailed API information.
 
 ## Contributing


### PR DESCRIPTION
## Summary
- document the new party setup flow and reference codex files in the main README
- mention PartySetup screens and town interface in the client README
- list new scenes in the game README
- link codex docs from shared package README
- add Party Setup & Drafting section to the GDD

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68431bc6e9c88327a5ab7545f2a24f5d