### PR TITLE
Fix Guardian class card availability

### DIFF
--- a/shared/models/classes.js
+++ b/shared/models/classes.js
@@ -11,7 +11,12 @@ export const classes = [
     name: 'Guardian',
     description: 'Sturdy protector that draws enemy attacks and shields allies.',
     role: Role.Tank,
-    allowedCards: ['shield_wall', 'taunt'],
+    allowedCards: [
+      'fortified_stance',
+      'intervene',
+      'guards_challenge',
+      'bulwark',
+    ],
   },
   {
     id: 'Warrior',


### PR DESCRIPTION
## Summary
- update Guardian class definition to include level 1 cards

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68431f5a13208327af7ad53b743d8d2b