### PR TITLE
Fix Totem Warden card draft

### DIFF
--- a/client/src/components/CharacterCard.tsx
+++ b/client/src/components/CharacterCard.tsx
@@ -17,7 +17,7 @@ const CharacterCard: React.FC<CharacterCardProps> = ({ character, onSelect, isSe
     DPS: '#e74c3c',
   }
 
-  const clsInfo = allClasses.find((c) => c.name === character.class)
+  const clsInfo = allClasses.find((c) => c.id === character.class)
   const roleColor = roleColors[clsInfo?.role || 'DPS']
 
   const cardStyle: React.CSSProperties = {
@@ -73,7 +73,7 @@ const CharacterCard: React.FC<CharacterCardProps> = ({ character, onSelect, isSe
       role="button"
       aria-pressed={isSelected}
       aria-disabled={isDisabled && !isSelected}
-      aria-label={`Select character ${character.name}, class ${character.class}. ${desc}`}
+      aria-label={`Select character ${character.name}, class ${clsInfo?.name ?? character.class}. ${desc}`}
       onMouseEnter={(e) => {
         if (!isDisabled || isSelected) {
           e.currentTarget.style.transform = 'scale(1.03)'
@@ -94,7 +94,7 @@ const CharacterCard: React.FC<CharacterCardProps> = ({ character, onSelect, isSe
         <span style={badgeStyle}>{clsInfo?.role}</span>
       </div>
       <h3 style={{ margin: '0 0 5px 0' }}>{character.name}</h3>
-      <p style={{ color: roleColor, fontWeight: 'bold', margin: '0 0 5px 0' }}>{character.class}</p>
+      <p style={{ color: roleColor, fontWeight: 'bold', margin: '0 0 5px 0' }}>{clsInfo?.name ?? character.class}</p>
       <p style={{ fontSize: '0.8em', height: '40px', overflow: 'hidden', fontStyle: !character.description ? 'italic' : 'normal', color: '#777' }}>
         {desc}
       </p>

--- a/client/src/components/PartySummary.tsx
+++ b/client/src/components/PartySummary.tsx
@@ -14,9 +14,14 @@ const roleColors: Record<string, string> = {
   DPS: '#e74c3c',
 };
 
-const getRole = (className: string): string => {
-  const cls = allClasses.find(c => c.name === className);
+const getRole = (classId: string): string => {
+  const cls = allClasses.find(c => c.id === classId);
   return cls?.role ?? 'Unknown';
+};
+
+const getClassName = (classId: string): string => {
+  const cls = allClasses.find(c => c.id === classId);
+  return cls?.name ?? classId;
 };
 
 const calculateAverage = (values: Array<number | undefined>): string => {
@@ -88,7 +93,7 @@ const PartySummary: React.FC<PartySummaryProps> = ({ selectedCharacters }) => {
             <div>
               <strong>{character.name}</strong>
               <div>
-                {character.class}
+                {getClassName(character.class)}
                 <span className={styles.roleBadge} style={badgeStyle}>{role}</span>
               </div>
               <ul className={styles.cardList}>

--- a/client/src/store/gameStore.ts
+++ b/client/src/store/gameStore.ts
@@ -34,9 +34,9 @@ interface Store {
   explored: Set<string>
   setExplored: (explored: Set<string>) => void
 
-  availableClasses: { name: string; description: string; role: Role; allowedCards: string[] }[]
+  availableClasses: { id: string; name: string; description: string; role: Role; allowedCards: string[] }[]
   setAvailableClasses: (
-    classes: { name: string; description: string; role: Role; allowedCards: string[] }[],
+    classes: { id: string; name: string; description: string; role: Role; allowedCards: string[] }[],
   ) => void
 
   save: () => void

--- a/client/src/utils/randomizeClasses.ts
+++ b/client/src/utils/randomizeClasses.ts
@@ -2,6 +2,7 @@ import { classes } from '../../../shared/models/classes.js'
 import type { Role } from '../../../shared/models/Card'
 
 export interface GameClass {
+  id: string
   name: string
   description: string
   role: Role

--- a/shared/models/classes.js
+++ b/shared/models/classes.js
@@ -67,7 +67,7 @@ export const classes = [
     name: 'Totem Warden',
     description: 'Places totems that bolster friends or weaken foes.',
     role: Role.Support,
-    allowedCards: ['totem_of_vitality', 'totem_of_fury'],
+    allowedCards: ['totem_of_vitality', 'totem_of_fury', 'totem_of_stoneskin', 'totem_recall'],
   },
   {
     id: 'Blademaster',


### PR DESCRIPTION
## Summary
- expose `id` in `GameClass` interface
- keep track of class id instead of name in Party Setup
- render class names by looking up id
- update Totem Warden allowed cards

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68431f512d00832784fba161acfa84ef