### PR TITLE
Fix duplicate key warning in PartySetup

### DIFF
--- a/client/src/components/PartySetup.tsx
+++ b/client/src/components/PartySetup.tsx
@@ -184,9 +184,9 @@ const PartySetup: React.FC = () => {
       <div className={styles.setupCard}>
         <h1 className={styles.title}>Party Setup</h1>
         <div className={styles.classList}>
-          {availableClasses.map(cls => (
+          {availableClasses.map((cls, index) => (
             <ClassCard
-              key={cls.id}
+              key={`${cls.id}-${index}`}
               cls={cls}
               onSelect={handleClassSelect}
               disabled={!!selectedCharacters.find(c => c.class === cls.id)}


### PR DESCRIPTION
## Summary
- ensure unique keys when rendering available class cards

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68432196bf908327b3ff459b212aa3d9