### PR TITLE
Fix Totem Warden draft pool

### DIFF
--- a/client/src/components/CardAssignmentPanel.tsx
+++ b/client/src/components/CardAssignmentPanel.tsx
@@ -3,6 +3,7 @@ import type { PartyCharacter } from './PartySetup';
 import type { Card } from '../../../shared/models/Card';
 import CardDisplay from './CardDisplay';
 import { canUseCard } from '../../../shared/systems/classRole.js';
+import { classes as allClasses } from '../../../shared/models/classes.js';
 import styles from './PartySetup.module.css';
 
 interface CardAssignmentPanelProps {
@@ -26,14 +27,23 @@ const CardAssignmentPanel: React.FC<CardAssignmentPanelProps> = ({ character, av
   }
 
   const generateDraft = () => {
-    const pool = [...getUsablePool()]
+    let pool = [...getUsablePool()]
+    // Fallback to role-based picks if no class-restricted cards exist
+    if (pool.length === 0) {
+      const cls = allClasses.find(c => c.id === character.class)
+      if (cls) {
+        pool = availableCards.filter(
+          c => c.roleTag === cls.role && !assignedCardIds.has(c.id)
+        )
+      }
+    }
     const picks: Card[] = []
     while (pool.length && picks.length < 4) {
       const idx = Math.floor(Math.random() * pool.length)
       picks.push(pool.splice(idx, 1)[0])
     }
     setDraftCards(picks)
-    setDraftKey((k) => k + 1)
+    setDraftKey(k => k + 1)
   }
 
   useEffect(() => {

--- a/client/src/components/PartySetup.tsx
+++ b/client/src/components/PartySetup.tsx
@@ -228,7 +228,7 @@ const PartySetup: React.FC = () => {
           return (
             <div key={pc.id} className={styles.selectedCharacterPanel}> {/* Apply .selectedCharacterPanel */}
               <div className={styles.characterPanelHeader}> {/* Apply .characterPanelHeader */}
-                <h3>{pc.name} (Class: {clsDef?.name ?? pc.class})</h3>
+                <h3>{pc.name} (Class: {clsDef ? clsDef.name : pc.class || 'Unknown'})</h3>
                 <button onClick={() => handleClassRemove(pc.id)} className={styles.removeButton}>Remove Class</button>
               </div>
               <CardAssignmentPanel

--- a/shared/systems/classRole.test.js
+++ b/shared/systems/classRole.test.js
@@ -8,6 +8,9 @@ const strike = { id: 'strike', name: 'Strike', category: 'Ability', rarity: 'Com
 const sentinel = { id: 's', name: 'Runestone Sentinel', class: 'RunestoneSentinel', stats: { hp: 10, energy: 3 }, deck: [], survival: { hunger:0, thirst:0, fatigue:0 } }
 const stoneGuard = { id: 'stone_guard', name: 'Stone Guard', category: 'Ability', rarity: 'Common', energyCost:1, cooldown:0, effect:{ type:'buff', magnitude: 2, duration:3 }, roleTag:'Tank', classRestriction: 'RunestoneSentinel' }
 
+const warden = { id: 'tw', name: 'Totem Warden', class: 'TotemWarden', stats: { hp: 10, energy: 3 }, deck: [], survival: { hunger:0, thirst:0, fatigue:0 } }
+const totem = { id: 'totem_of_vitality', name: 'Totem of Vitality', category: 'Ability', rarity: 'Common', energyCost:2, cooldown:2, effect:{ type:'heal', magnitude:1 }, roleTag:'Support', classRestriction: 'TotemWarden' }
+
 test('canUseCard false when role mismatch', () => {
   assert.strictEqual(canUseCard(warrior, strike), false)
 })
@@ -24,4 +27,8 @@ test('applyClassSynergy activates for class match', () => {
 
 test('canUseCard works for Runestone Sentinel with id-based lookup', () => {
   assert.strictEqual(canUseCard(sentinel, stoneGuard), true)
+})
+
+test('Totem Warden can use its own cards', () => {
+  assert.strictEqual(canUseCard(warden, totem), true)
 })


### PR DESCRIPTION
## Summary
- show a fallback class name if lookup fails
- broaden card drafts when class-specific pool is empty
- test Totem Warden card usability

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6843231bc5a08327a9829400d65084d2