### PR TITLE
Fix missing portraits in party summary

### DIFF
--- a/client/src/components/CharacterCard.tsx
+++ b/client/src/components/CharacterCard.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
 import type { Character } from '../../../shared/models/Character'
 import { classes as allClasses } from '../../../shared/models/classes.js'
+import defaultPortrait from '../../../shared/images/default-portrait.png'
 
 interface CharacterCardProps {
   character: Character;
@@ -87,8 +88,14 @@ const CharacterCard: React.FC<CharacterCardProps> = ({ character, onSelect, isSe
     >
       <div style={{ position: 'relative', marginBottom: '10px' }}>
         <img
-          src={character.portrait || 'default-portrait.png'}
+          src={character.portrait || defaultPortrait}
           alt={character.name}
+          title={clsInfo?.name ?? character.class}
+          onError={(e) => {
+            if (e.currentTarget.src !== defaultPortrait) {
+              e.currentTarget.src = defaultPortrait
+            }
+          }}
           style={{ width: '110px', height: '110px', objectFit: 'cover', borderRadius: '50%', border: `3px solid ${roleColor}` }}
         />
         <span style={badgeStyle}>{clsInfo?.role}</span>

--- a/client/src/components/PartySetup.tsx
+++ b/client/src/components/PartySetup.tsx
@@ -14,6 +14,7 @@ import { getRandomClasses, type GameClass } from '../utils/randomizeClasses';
 import ClassCard from './ClassCard';
 import CardAssignmentPanel from './CardAssignmentPanel'; // Import
 import PartySummary from './PartySummary'; // Import PartySummary
+import defaultPortrait from '../../../shared/images/default-portrait.png';
 import { useModal } from './ModalManager.jsx';
 import styles from './PartySetup.module.css';
 
@@ -98,7 +99,7 @@ const PartySetup: React.FC = () => {
       id: `${cls.id}-${Date.now()}-${Math.random()}`,
       name: cls.name,
       class: cls.id,
-      portrait: 'default-portrait.png',
+      portrait: defaultPortrait,
       description: cls.description || 'No description available.',
       stats: { hp: 30, energy: 3 },
       deck: [],

--- a/client/src/components/PartySummary.tsx
+++ b/client/src/components/PartySummary.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import type { PartyCharacter } from './PartySetup';
 import { classes as allClasses } from '../../../shared/models/classes.js';
+import defaultPortrait from '../../../shared/images/default-portrait.png';
 import styles from './PartySummary.module.css';
 
 interface PartySummaryProps {
@@ -29,6 +30,19 @@ const calculateAverage = (values: Array<number | undefined>): string => {
   if (valid.length === 0) return '—';
   const sum = valid.reduce((acc, v) => acc + v, 0);
   return (sum / valid.length).toFixed(2);
+};
+
+const getPortraitSrc = (character: PartyCharacter): string => {
+  return character.portrait || defaultPortrait;
+};
+
+const handlePortraitError = (
+  e: React.SyntheticEvent<HTMLImageElement, Event>,
+) => {
+  const target = e.currentTarget;
+  if (target.src !== defaultPortrait) {
+    target.src = defaultPortrait;
+  }
 };
 
 const PartySummary: React.FC<PartySummaryProps> = ({ selectedCharacters }) => {
@@ -73,23 +87,15 @@ const PartySummary: React.FC<PartySummaryProps> = ({ selectedCharacters }) => {
       {selectedCharacters.map(character => {
         const role = getRole(character.class);
         const badgeStyle = { backgroundColor: roleColors[role] } as React.CSSProperties;
-        const initials = character.name
-          .split(' ')
-          .map(w => w[0])
-          .join('')
-          .slice(0, 2)
-          .toUpperCase();
         return (
           <div key={character.id} className={styles.characterItem}>
-            {character.portrait ? (
-              <img
-                src={character.portrait}
-                alt={character.name}
-                className={styles.characterIcon}
-              />
-            ) : (
-              <div className={styles.characterIcon}>{initials}</div>
-            )}
+            <img
+              src={getPortraitSrc(character)}
+              alt={character.name}
+              title={getClassName(character.class)}
+              className={styles.characterIcon}
+              onError={handlePortraitError}
+            />
             <div>
               <strong>{character.name}</strong>
               <div>


### PR DESCRIPTION
## Summary
- always display a portrait for characters using a default fallback
- fall back to default image when a portrait fails to load

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684323f1786c8327b5d02c1bed3c0a75