### PR TITLE
Add card pool validation test

### DIFF
--- a/shared/systems/cardAvailability.test.js
+++ b/shared/systems/cardAvailability.test.js
@@ -1,0 +1,11 @@
+import { test } from 'node:test'
+import assert from 'assert'
+import { classes } from '../models/classes.js'
+import { sampleCards as cards } from '../models/cards.js'
+
+classes.forEach(cls => {
+  test(`Class "${cls.name}" has at least 2 usable cards`, () => {
+    const usable = cards.filter(c => c.classRestriction === cls.id || c.roleTag === cls.role)
+    assert.ok(usable.length >= 2)
+  })
+})


### PR DESCRIPTION
## Summary
- add a test verifying each class has at least two usable cards

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684325e42c0483279ba116f0c9357759