### PR TITLE
Limit rerolls and undos

### DIFF
--- a/client/src/components/PartySetup.module.css
+++ b/client/src/components/PartySetup.module.css
@@ -77,6 +77,11 @@
   cursor: pointer;
 }
 
+.rerollButton:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
 .rerollButton::before {
   content: '🎲';
   position: absolute;
@@ -231,4 +236,25 @@
 
 .undoButton {
   margin-left: 1rem;
+}
+
+/* Counters for remaining actions */
+.actionCounter {
+  font-size: 0.9rem;
+  color: #ccc;
+  margin-left: 0.5rem;
+}
+
+/* Visual flash when a button becomes disabled */
+.disabledFlash {
+  animation: flashDisable 0.5s ease;
+}
+
+@keyframes flashDisable {
+  from {
+    box-shadow: 0 0 0 2px #f39c12;
+  }
+  to {
+    box-shadow: none;
+  }
 }


### PR DESCRIPTION
## Summary
- limit reroll/undo actions in party setup
- show remaining rerolls/undos and disable buttons at limit
- add simple flash animation when the limit is reached

## Testing
- `npm test` *(fails: Cannot use import statement outside a module)*

------
https://chatgpt.com/codex/tasks/task_e_6843260a227883278928df40fc3c4aa6