### PR TITLE
Fix portrait not loading for Cleric

### DIFF
--- a/client/src/components/PartySetup.tsx
+++ b/client/src/components/PartySetup.tsx
@@ -110,7 +110,7 @@ const PartySetup: React.FC = () => {
       id: `${cls.id}-${Date.now()}-${Math.random()}`,
       name: cls.name,
       class: cls.id,
-      portrait: defaultPortrait,
+      portrait: cls.portrait || defaultPortrait,
       description: cls.description || 'No description available.',
       stats: { hp: 30, energy: 3 },
       deck: [],

--- a/client/src/utils/randomizeClasses.ts
+++ b/client/src/utils/randomizeClasses.ts
@@ -7,6 +7,7 @@ export interface GameClass {
   description: string
   role: Role
   allowedCards: string[]
+  portrait?: string
 }
 
 /**

--- a/shared/models/classes.js
+++ b/shared/models/classes.js
@@ -38,6 +38,7 @@ export const classes = [
     description: 'Devout healer who mends wounds with holy magic.',
     role: Role.Healer,
     allowedCards: ['holy_light', 'smite'],
+    portrait: '../../../shared/images/cleric-portrait.png',
   },
   {
     id: 'Herbalist',

--- a/shared/models/index.d.ts
+++ b/shared/models/index.d.ts
@@ -27,6 +27,7 @@ export const classes: {
   description: string
   role: import('./Card').Role
   allowedCards: string[]
+  portrait?: string
 }[]
 export const biomes: Biome[]
 export const dungeonEvents: DungeonEvent[]


### PR DESCRIPTION
## Summary
- allow classes to define an optional `portrait`
- provide `portrait` for Cleric in the class data
- expose portrait field in TypeScript declarations
- when adding a class to the party, prefer the class portrait over the default

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68432a5b46648327822a72a81236099e