### PR TITLE
Add cleric portrait support

### DIFF
--- a/client/src/components/CharacterCard.tsx
+++ b/client/src/components/CharacterCard.tsx
@@ -88,7 +88,7 @@ const CharacterCard: React.FC<CharacterCardProps> = ({ character, onSelect, isSe
     >
       <div style={{ position: 'relative', marginBottom: '10px' }}>
         <img
-          src={character.portrait || defaultPortrait}
+          src={character.portrait || clsInfo?.portrait || defaultPortrait}
           alt={character.name}
           title={clsInfo?.name ?? character.class}
           onError={(e) => {

--- a/client/src/components/PartySummary.tsx
+++ b/client/src/components/PartySummary.tsx
@@ -33,7 +33,8 @@ const calculateAverage = (values: Array<number | undefined>): string => {
 };
 
 const getPortraitSrc = (character: PartyCharacter): string => {
-  return character.portrait || defaultPortrait;
+  const cls = allClasses.find(c => c.id === character.class);
+  return character.portrait || cls?.portrait || defaultPortrait;
 };
 
 const handlePortraitError = (

--- a/shared/models/characters.js
+++ b/shared/models/characters.js
@@ -1,5 +1,7 @@
 import { sampleCards } from './cards.js'
 import { classes } from './classes.js'
+const clericPortrait = new URL('../images/cleric-portrait.png', import.meta.url).href
+const defaultPortrait = new URL('../images/default-portrait.png', import.meta.url).href
 
 export const Class = {
   Guardian: 'Guardian',
@@ -23,7 +25,7 @@ export const sampleCharacters = [
     id: 'warrior',
     name: 'Warrior',
     class: Class.Warrior,
-    portrait: '',
+    portrait: defaultPortrait,
     description: '',
     stats: { hp: 30, energy: 3, speed: 2 },
     deck: [sampleCards[0], sampleCards[3], sampleCards[0], sampleCards[0]],
@@ -33,7 +35,7 @@ export const sampleCharacters = [
     id: 'cleric',
     name: 'Cleric',
     class: Class.Cleric,
-    portrait: '../../../shared/images/cleric-portrait.png',
+    portrait: clericPortrait,
     description: '',
     stats: { hp: 25, energy: 3, speed: 1 },
     deck: [sampleCards[1], sampleCards[0], sampleCards[3], sampleCards[1]],
@@ -43,7 +45,7 @@ export const sampleCharacters = [
     id: 'blademaster',
     name: 'Blademaster',
     class: Class.Blademaster,
-    portrait: '',
+    portrait: defaultPortrait,
     description: '',
     stats: { hp: 22, energy: 3, speed: 3 },
     deck: [sampleCards[0], sampleCards[4], sampleCards[0], sampleCards[5]],

--- a/shared/models/classes.js
+++ b/shared/models/classes.js
@@ -1,3 +1,6 @@
+const clericPortrait = new URL('../images/cleric-portrait.png', import.meta.url).href
+const defaultPortrait = new URL('../images/default-portrait.png', import.meta.url).href
+
 export const Role = {
   Tank: 'Tank',
   Healer: 'Healer',
@@ -17,6 +20,7 @@ export const classes = [
       'guards_challenge',
       'bulwark',
     ],
+    portrait: defaultPortrait,
   },
   {
     id: 'Warrior',
@@ -24,6 +28,7 @@ export const classes = [
     description: 'Aggressive melee combatant excelling at frontline skirmishes.',
     role: Role.Tank,
     allowedCards: ['power_strike', 'battle_cry'],
+    portrait: defaultPortrait,
   },
   {
     id: 'RunestoneSentinel',
@@ -31,6 +36,7 @@ export const classes = [
     description: 'Tank that channels rune magic to harden defenses.',
     role: Role.Tank,
     allowedCards: ['rune_slam', 'stone_guard'],
+    portrait: defaultPortrait,
   },
   {
     id: 'Cleric',
@@ -38,7 +44,7 @@ export const classes = [
     description: 'Devout healer who mends wounds with holy magic.',
     role: Role.Healer,
     allowedCards: ['holy_light', 'smite'],
-    portrait: '../../../shared/images/cleric-portrait.png',
+    portrait: clericPortrait,
   },
   {
     id: 'Herbalist',
@@ -46,6 +52,7 @@ export const classes = [
     description: 'Nature healer brewing restorative and toxic concoctions.',
     role: Role.Healer,
     allowedCards: ['healing_herbs', 'toxic_spores'],
+    portrait: defaultPortrait,
   },
   {
     id: 'Bloodweaver',
@@ -53,6 +60,7 @@ export const classes = [
     description: 'Mystic manipulating life essence to heal or harm.',
     role: Role.Healer,
     allowedCards: ['blood_leech', 'sanguine_gift'],
+    portrait: defaultPortrait,
   },
   {
     id: 'Bard',
@@ -60,6 +68,7 @@ export const classes = [
     description: 'Inspirational performer empowering allies through song.',
     role: Role.Support,
     allowedCards: ['inspire', 'song_of_swiftness'],
+    portrait: defaultPortrait,
   },
   {
     id: 'Chronomancer',
@@ -67,6 +76,7 @@ export const classes = [
     description: 'Temporal magician bending time to aid the party.',
     role: Role.Support,
     allowedCards: ['time_warp', 'temporal_strike'],
+    portrait: defaultPortrait,
   },
   {
     id: 'TotemWarden',
@@ -74,6 +84,7 @@ export const classes = [
     description: 'Places totems that bolster friends or weaken foes.',
     role: Role.Support,
     allowedCards: ['totem_of_vitality', 'totem_of_fury', 'totem_of_stoneskin', 'totem_recall'],
+    portrait: defaultPortrait,
   },
   {
     id: 'Blademaster',
@@ -81,6 +92,7 @@ export const classes = [
     description: 'Master of blades delivering relentless attacks.',
     role: Role.DPS,
     allowedCards: ['quick_slash', 'blade_fury'],
+    portrait: defaultPortrait,
   },
   {
     id: 'Wizard',
@@ -88,6 +100,7 @@ export const classes = [
     description: 'Arcane caster wielding destructive and protective spells.',
     role: Role.DPS,
     allowedCards: ['arcane_bolt', 'mana_shield'],
+    portrait: defaultPortrait,
   },
   {
     id: 'Shadowblade',
@@ -95,6 +108,7 @@ export const classes = [
     description: 'Stealthy assassin striking from the darkness.',
     role: Role.DPS,
     allowedCards: ['backstab', 'smoke_bomb'],
+    portrait: defaultPortrait,
   },
   {
     id: 'Ranger',
@@ -102,6 +116,7 @@ export const classes = [
     description: 'Expert archer adept at controlling the battlefield.',
     role: Role.DPS,
     allowedCards: ['arrow_shot', 'entangling_trap'],
+    portrait: defaultPortrait,
   },
   {
     id: 'Pyromancer',
@@ -109,5 +124,6 @@ export const classes = [
     description: 'Sorcerer harnessing fire for offense and defense.',
     role: Role.DPS,
     allowedCards: ['fireball', 'flame_shield'],
+    portrait: defaultPortrait,
   },
 ]


### PR DESCRIPTION
## Summary
- add portrait fields for classes and sample characters
- use new fallback logic for portraits in PartySummary and CharacterCard

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68432d587b708327a839b9df32bad2a6