### PR TITLE
Fix party summary remove button

### DIFF
--- a/client/src/components/PartySetup.tsx
+++ b/client/src/components/PartySetup.tsx
@@ -299,7 +299,11 @@ const PartySetup: React.FC = () => {
       </div>
 
       {/* Party Summary Section */}
-      <PartySummary selectedCharacters={selectedCharacters} /> {/* PartySummary will have its own internal styling or use passed classNames */}
+      <PartySummary
+        selectedCharacters={selectedCharacters}
+        onRemoveCharacter={handleClassRemove}
+      />
+      {/* PartySummary will have its own internal styling or use passed classNames */}
 
       <div className={styles.navigationButtons}>
         <button onClick={() => navigate('/')} className={styles.backButton}>

--- a/client/src/components/PartySummary.tsx
+++ b/client/src/components/PartySummary.tsx
@@ -6,6 +6,7 @@ import styles from './PartySummary.module.css';
 
 interface PartySummaryProps {
   selectedCharacters: PartyCharacter[];
+  onRemoveCharacter?: (id: string) => void;
 }
 
 const roleColors: Record<string, string> = {
@@ -45,7 +46,10 @@ const handlePortraitError = (
   }
 };
 
-const PartySummary: React.FC<PartySummaryProps> = ({ selectedCharacters }) => {
+const PartySummary: React.FC<PartySummaryProps> = ({
+  selectedCharacters,
+  onRemoveCharacter,
+}) => {
   if (selectedCharacters.length === 0) {
     return (
       <div className={styles.summaryContainer} aria-live="polite" aria-atomic="true">
@@ -116,7 +120,13 @@ const PartySummary: React.FC<PartySummaryProps> = ({ selectedCharacters }) => {
               </ul>
             </div>
             <div className={styles.characterActions}>
-              <button className={styles.actionButton} aria-label={`Remove ${character.name}`}>❌</button>
+              <button
+                className={styles.actionButton}
+                aria-label={`Remove ${character.name}`}
+                onClick={() => onRemoveCharacter?.(character.id)}
+              >
+                ❌
+              </button>
               <button className={styles.actionButton} aria-label={`Edit ${character.name}`}>✏️</button>
             </div>
           </div>


### PR DESCRIPTION
## Summary
- sync party summary remove button with the same logic used for "Remove Class"
- add optional `onRemoveCharacter` prop to `PartySummary`
- wire the new handler from `PartySetup` so clicking ❌ removes the class

## Testing
- `npm test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68432ccb55bc83279858a14b7912c145