### PR TITLE
Fix class ID lookup and add data integrity tests

### DIFF
--- a/.github/workflows/data-integrity.yml
+++ b/.github/workflows/data-integrity.yml
@@ -1,0 +1,15 @@
+name: Data Integrity Checks
+
+on: [push, pull_request]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Setup Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: '18'
+      - run: npm install
+      - run: npm test

--- a/client/src/components/PartySetup.tsx
+++ b/client/src/components/PartySetup.tsx
@@ -281,6 +281,9 @@ const PartySetup: React.FC = () => {
         )}
         {selectedCharacters.map(pc => {
           const clsDef = allClasses.find(c => c.id === pc.class);
+          if (!clsDef) {
+            console.warn(`Class ID "${pc.class}" not found in classes definition.`);
+          }
           return (
             <div key={pc.id} className={styles.selectedCharacterPanel}> {/* Apply .selectedCharacterPanel */}
               <div className={styles.characterPanelHeader}> {/* Apply .characterPanelHeader */}

--- a/client/src/components/PartySummary.tsx
+++ b/client/src/components/PartySummary.tsx
@@ -18,11 +18,17 @@ const roleColors: Record<string, string> = {
 
 const getRole = (classId: string): string => {
   const cls = allClasses.find(c => c.id === classId);
+  if (!cls) {
+    console.warn(`Class ID "${classId}" not found in classes definition.`);
+  }
   return cls?.role ?? 'Unknown';
 };
 
 const getClassName = (classId: string): string => {
   const cls = allClasses.find(c => c.id === classId);
+  if (!cls) {
+    console.warn(`Class ID "${classId}" not found in classes definition.`);
+  }
   return cls?.name ?? classId;
 };
 

--- a/shared/models/dataIntegrity.test.js
+++ b/shared/models/dataIntegrity.test.js
@@ -1,0 +1,27 @@
+import { test } from 'node:test'
+import assert from 'assert'
+import { classes } from './classes.js'
+import { sampleCards as cards } from './cards.js'
+
+// Ensure every class has a unique id and name
+test('every class has a unique id and name', () => {
+  const ids = new Set()
+  classes.forEach(cls => {
+    assert.ok(cls.id, `Class missing id: ${cls.name}`)
+    assert.ok(cls.name, `Class missing name for id: ${cls.id}`)
+    assert.ok(!ids.has(cls.id), `Duplicate class id: ${cls.id}`)
+    ids.add(cls.id)
+  })
+})
+
+// Verify card restrictions reference real class ids
+test('every card with a classRestriction references an existing class id', () => {
+  cards.forEach(card => {
+    if (card.classRestriction) {
+      assert.ok(
+        classes.some(c => c.id === card.classRestriction),
+        `Unknown classRestriction ${card.classRestriction} on card ${card.id}`
+      )
+    }
+  })
+})


### PR DESCRIPTION
## Summary
- warn when a selected class ID isn't found
- add warnings in `PartySummary` lookups
- test class and card references for consistency
- run the tests automatically in CI

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684331c8c0608327aff77dab0c1202df