### PR TITLE
Implement modern CCG card UI

### DIFF
--- a/client/src/assets/placeholder-card-art.svg
+++ b/client/src/assets/placeholder-card-art.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 120" preserveAspectRatio="xMidYMid slice">
+  <rect width="200" height="120" fill="#cccccc"/>
+  <text x="100" y="65" text-anchor="middle" font-size="24" fill="#666666" font-family="Arial">Art</text>
+</svg>

--- a/client/src/components/CardDisplay.module.css
+++ b/client/src/components/CardDisplay.module.css
@@ -1,0 +1,123 @@
+.card {
+  position: relative;
+  width: 140px;
+  max-width: 180px;
+  border-radius: 12px;
+  overflow: hidden;
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.3);
+  background: linear-gradient(180deg, #fefefe 0%, #ececec 100%);
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+.card:hover {
+  transform: translateY(-4px);
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.4);
+}
+.selected {
+  box-shadow: 0 0 10px var(--rarity-color);
+}
+.disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.rarity-Common { --rarity-color: #b5b5b5; }
+.rarity-Uncommon { --rarity-color: #27ae60; }
+.rarity-Rare { --rarity-color: #3498db; }
+.rarity-Legendary { --rarity-color: #f1c40f; }
+
+.frame {
+  border: 3px solid var(--rarity-color, #999);
+  border-radius: 10px;
+  overflow: hidden;
+  position: relative;
+}
+.art {
+  width: 100%;
+  padding-top: 60%;
+  background-size: cover;
+  background-position: center;
+}
+.nameRibbon {
+  position: absolute;
+  top: 6px;
+  left: 50%;
+  transform: translateX(-50%);
+  background: rgba(0, 0, 0, 0.7);
+  color: #fff;
+  padding: 2px 6px;
+  border-radius: 4px;
+  font-size: 0.85rem;
+  font-weight: bold;
+}
+.costBadge {
+  position: absolute;
+  top: 6px;
+  left: 6px;
+  width: 28px;
+  height: 28px;
+  border-radius: 50%;
+  background: var(--rarity-color, #888);
+  color: #fff;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-weight: bold;
+  font-size: 0.8rem;
+  box-shadow: 0 0 2px rgba(0,0,0,0.5);
+}
+.typeBadge {
+  position: absolute;
+  top: 6px;
+  right: 6px;
+  background: rgba(0, 0, 0, 0.7);
+  color: #fff;
+  padding: 2px 5px;
+  border-radius: 4px;
+  font-size: 0.65rem;
+  text-transform: uppercase;
+}
+.classBanner {
+  position: absolute;
+  right: -40px;
+  top: 50%;
+  transform: rotate(45deg);
+  width: 120px;
+  text-align: center;
+  background: var(--rarity-color, #888);
+  color: #fff;
+  font-size: 0.65rem;
+  pointer-events: none;
+}
+.description {
+  background: #f9f5e9;
+  font-family: Georgia, 'Times New Roman', serif;
+  padding: 8px;
+  font-size: 0.75rem;
+  line-height: 1.2;
+  min-height: 60px;
+}
+.stats {
+  display: flex;
+  justify-content: center;
+  gap: 6px;
+  padding: 4px;
+  background: #fff;
+}
+.stat {
+  display: flex;
+  align-items: center;
+  gap: 2px;
+  border-radius: 4px;
+  font-size: 0.7rem;
+  font-weight: bold;
+  color: #fff;
+  padding: 2px 4px;
+}
+.attack { background: #e74c3c; }
+.defense { background: #2980b9; }
+
+@media (max-width: 600px) {
+  .card {
+    width: 110px;
+  }
+}

--- a/client/src/components/CardDisplay.tsx
+++ b/client/src/components/CardDisplay.tsx
@@ -1,62 +1,69 @@
-import React from 'react';
-import type { Card } from '../../../shared/models/Card';
+import React from 'react'
+import type { Card } from '../../../shared/models/Card'
+import placeholderArt from '../assets/placeholder-card-art.svg'
+import styles from './CardDisplay.module.css'
 
 interface CardDisplayProps {
-  card: Card;
-  onSelect: (card: Card) => void;
-  isSelected: boolean;
-  isDisabled: boolean; // e.g., if card is already assigned to this character or max cards assigned
+  card: Card
+  onSelect: (card: Card) => void
+  isSelected: boolean
+  isDisabled: boolean // e.g., if card is already assigned to this character or max cards assigned
 }
 
 const CardDisplay: React.FC<CardDisplayProps> = ({ card, onSelect, isSelected, isDisabled }) => {
-  const style: React.CSSProperties = {
-    border: isSelected ? '2px solid #27ae60' : '1px solid #e0e0e0',
-    padding: '10px',
-    margin: '5px',
-    cursor: isDisabled ? 'not-allowed' : 'pointer',
-    opacity: isDisabled ? 0.5 : 1,
-    backgroundColor: isSelected ? '#e9f7ef' : '#f9f9f9',
-    borderRadius: '6px',
-    boxShadow: isSelected
-      ? '0 3px 6px rgba(0,0,0,0.15)'
-      : '0 1px 3px rgba(0,0,0,0.05)',
-    transform: isSelected ? 'scale(1.05)' : 'none',
-    transition: 'transform 0.2s ease, box-shadow 0.2s ease',
-    width: '150px',
-    fontSize: '0.9em',
-  }
+  const rarityClass = styles[`rarity-${card.rarity}`] || styles['rarity-Common']
+  const classes = [styles.card, rarityClass]
+  if (isSelected) classes.push(styles.selected)
+  if (isDisabled) classes.push(styles.disabled)
 
   const handleClick = () => {
     if (!isDisabled) {
-      onSelect(card);
+      onSelect(card)
     }
-  };
+  }
 
   const handleKeyDown = (event: React.KeyboardEvent) => {
     if (event.key === 'Enter' || event.key === ' ') {
-      event.preventDefault();
-      handleClick();
+      event.preventDefault()
+      handleClick()
     }
-  };
+  }
 
+  const art = (card as any).image || placeholderArt
+  const classText = (card as any).classRestriction || (card as any).roleTag
   return (
     <div
-      style={style}
+      className={classes.join(' ')}
       onClick={handleClick}
       onKeyDown={handleKeyDown}
       tabIndex={isDisabled ? -1 : 0}
       role="button"
-      aria-pressed={isSelected} // This might be more like aria-checked if it's a selection from a list
+      aria-pressed={isSelected}
       aria-disabled={isDisabled}
-      aria-label={`Select card ${card.name}, type ${card.type}. ${card.description || 'No effect description.'}`}
-      onMouseEnter={(e) => { if (!isDisabled) e.currentTarget.style.transform = 'translateY(-2px)'; e.currentTarget.style.boxShadow = '0 3px 6px rgba(0,0,0,0.1)';}}
-      onMouseLeave={(e) => { e.currentTarget.style.transform = 'translateY(0)'; e.currentTarget.style.boxShadow = '0 1px 3px rgba(0,0,0,0.05)';}}
+      aria-label={`Select card ${card.name}, type ${card.category}. ${card.description || 'No effect description.'}`}
     >
-      <strong style={{ color: '#333', display: 'block', marginBottom: '4px' }}>{card.name}</strong>
-      <em style={{ color: '#555', display: 'block', marginBottom: '6px' }}>Type: {card.type}</em>
-      <p style={{ fontSize: '0.85em', color: '#666', minHeight: '3em' }}>{card.description || 'No effect description.'}</p>
+      <div className={styles.frame}>
+        <div className={styles.art} style={{ backgroundImage: `url(${art})` }} />
+        {'energyCost' in card && (
+          <span className={styles.costBadge}>{(card as any).energyCost}</span>
+        )}
+        <span className={styles.nameRibbon}>{card.name}</span>
+        <span className={styles.typeBadge}>{card.category}</span>
+        {classText && <span className={styles.classBanner}>{classText}</span>}
+      </div>
+      <div className={styles.description}>{card.description || 'No effect description.'}</div>
+      {('attack' in card || 'defense' in card) && (
+        <div className={styles.stats}>
+          {'attack' in card && (
+            <span className={`${styles.stat} ${styles.attack}`}>🗡 {(card as any).attack}</span>
+          )}
+          {'defense' in card && (
+            <span className={`${styles.stat} ${styles.defense}`}>🛡 {(card as any).defense}</span>
+          )}
+        </div>
+      )}
     </div>
-  );
+  )
 };
 
 export default CardDisplay;


### PR DESCRIPTION
## Summary
- add CCG style CardDisplay component
- use new CSS module for card frames
- include placeholder art asset for cards

## Testing
- `npm test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6843344c4ba883278c0942496a11b6f1