### PR TITLE
Implement player hand drawing in BattleScene

### DIFF
--- a/client/src/phaser/BattleScene.ts
+++ b/client/src/phaser/BattleScene.ts
@@ -45,6 +45,16 @@ export default class BattleScene extends Phaser.Scene {
     )
   }
 
+  private draw(combatant: any, count = 1) {
+    if (!combatant.data.hand) {
+      combatant.data.hand = []
+    }
+    for (let i = 0; i < count; i++) {
+      const card = Phaser.Math.RND.pick(combatant.data.deck)
+      combatant.data.hand.push(card)
+    }
+  }
+
   private showFloat(text: string, combatant: any, color: string) {
     const sprite = this.getSprite(combatant)
     if (sprite) {
@@ -124,6 +134,8 @@ export default class BattleScene extends Phaser.Scene {
     this.emitState(`${this.current.data.name}'s turn`)
 
     if (this.current.type === 'player') {
+      this.current.data.hand = []
+      this.draw(this.current, 2)
       this.showPlayerCards()
     } else {
       this.time.delayedCall(500, () => {
@@ -134,7 +146,7 @@ export default class BattleScene extends Phaser.Scene {
 
   private showPlayerCards() {
     this.clearCards()
-    const hand = this.current.data.deck
+    const hand = this.current.data.hand || []
     hand.forEach((card: any, idx: number) => {
       const txt = this.add
         .text(

--- a/game/src/scenes/BattleScene.js
+++ b/game/src/scenes/BattleScene.js
@@ -39,6 +39,16 @@ export default class BattleScene extends Phaser.Scene {
     return Math.round(dmg)
   }
 
+  draw(combatant, count = 1) {
+    if (!combatant.data.hand) {
+      combatant.data.hand = []
+    }
+    for (let i = 0; i < count; i++) {
+      const card = Phaser.Math.RND.pick(combatant.data.deck)
+      combatant.data.hand.push(card)
+    }
+  }
+
   init(data) {
     this.roomIndex = data.roomIndex || 0
   }
@@ -143,6 +153,8 @@ export default class BattleScene extends Phaser.Scene {
     })
 
     if (this.current.type === 'player') {
+      this.current.data.hand = []
+      this.draw(this.current, 2)
       this.showPlayerCards()
     } else {
       this.time.delayedCall(500, () => {
@@ -153,7 +165,7 @@ export default class BattleScene extends Phaser.Scene {
 
   showPlayerCards() {
     this.clearCards()
-    const hand = this.current.data.deck
+    const hand = this.current.data.hand || []
     hand.forEach((card, idx) => {
       const txt = this.add
         .text(100 + idx * 120, 500, card.name, { fontSize: '16px', backgroundColor: '#ddd', padding: 5 })


### PR DESCRIPTION
## Summary
- add draw helper for dealing cards
- populate each player's hand at the start of their turn
- render cards from the hand instead of the whole deck

## Testing
- `node --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6843387fdb088327ad126665ae428c8f