### PR TITLE
Enable ES modules for tests

### DIFF
--- a/game/package.json
+++ b/game/package.json
@@ -11,5 +11,6 @@
   },
   "devDependencies": {
     "vite": "^6.3.5"
-  }
+  },
+  "type": "module"
 }

--- a/package.json
+++ b/package.json
@@ -9,5 +9,6 @@
   ],
   "scripts": {
     "test": "node --test"
-  }
+  },
+  "type": "module"
 }

--- a/shared/package.json
+++ b/shared/package.json
@@ -2,5 +2,6 @@
   "name": "shared",
   "private": true,
   "version": "0.0.0",
-  "main": "index.js"
+  "main": "index.js",
+  "type": "module"
 }


### PR DESCRIPTION
## Summary
- add `type: module` to workspaces so Node.js loads ESM

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6843385704488327b1cd562d8433ec0e