### PR TITLE
Add card validation script

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "shared"
   ],
   "scripts": {
-    "test": "node --test"
+    "validate:cards": "node scripts/validateCards.js",
+    "test": "npm run validate:cards && node --test"
   }
 }

--- a/scripts/validateCards.js
+++ b/scripts/validateCards.js
@@ -1,0 +1,31 @@
+import { sampleCards as cards } from '../shared/models/cards.js';
+import { classes } from '../shared/models/classes.js';
+
+let hasError = false;
+
+for (const cls of classes) {
+  const cardIds = new Set(
+    cards
+      .filter(card => {
+        const belongs =
+          card.classRestriction === cls.id ||
+          (Array.isArray(card.classes) && card.classes.includes(cls.id));
+        const level = card.level ?? 1;
+        return belongs && level === 1;
+      })
+      .map(card => card.id)
+  );
+
+  if (cardIds.size !== 4) {
+    console.error(
+      `Class ${cls.id} has ${cardIds.size} level-1 cards: ${[...cardIds].join(', ')}`
+    );
+    hasError = true;
+  }
+}
+
+if (hasError) {
+  process.exit(1);
+} else {
+  console.log('All classes have exactly four distinct level-1 cards.');
+}


### PR DESCRIPTION
## Summary
- ensure classes have 4 level-1 cards via `scripts/validateCards.js`
- add `validate:cards` npm script
- run validation as part of `npm test`

## Testing
- `npm test` *(fails: Class Shadowblade has 5 level-1 cards)*

------
https://chatgpt.com/codex/tasks/task_e_68433884c33c832780bfe2d0dd34a837