### PR TITLE
Update card availability tests

### DIFF
--- a/shared/systems/cardAvailability.test.js
+++ b/shared/systems/cardAvailability.test.js
@@ -3,9 +3,13 @@ import assert from 'assert'
 import { classes } from '../models/classes.js'
 import { sampleCards as cards } from '../models/cards.js'
 
-classes.forEach(cls => {
-  test(`Class "${cls.name}" has at least 2 usable cards`, () => {
-    const usable = cards.filter(c => c.classRestriction === cls.id || c.roleTag === cls.role)
-    assert.ok(usable.length >= 2)
+classes.forEach((cls) => {
+  test(`Class "${cls.name}" has exactly 4 level 1 cards`, () => {
+    const usable = cards.filter(
+      (c) =>
+        (c.classRestriction === cls.id || c.classes?.includes(cls.id)) &&
+        (!c.level || c.level === 1),
+    )
+    assert.strictEqual(usable.length, 4)
   })
 })


### PR DESCRIPTION
## Summary
- update card availability test to verify 4 level-1 cards per class

## Testing
- `npm test` *(fails: Class "Shadowblade" has exactly 4 level 1 cards)*

------
https://chatgpt.com/codex/tasks/task_e_68433879e35083278c5c0495c8c7d1c3