### PR TITLE
Clarify starting hand size

### DIFF
--- a/GAME_DESIGN.md
+++ b/GAME_DESIGN.md
@@ -37,6 +37,7 @@ Players control a party of **1–5 characters**, assigning **up to 4 ability car
 
 ### 🔁 Core Combat Loop
 - Players assign up to **4 ability cards** per character pre-combat.
+- At the start of each battle, a character draws **two** of those cards to form their initial hand.
 - Characters act **automatically** in combat based on AI, speed, and context.
 - Combat is resolved in **turns**, ordered by each unit’s `SpeedModifier`.
 

--- a/README.md
+++ b/README.md
@@ -105,7 +105,8 @@ intact.
 
 The React client includes a revamped party setup flow. Players can reroll
 available classes and then draft a starting deck of ability cards for each
-character before entering the dungeon. These features live under the
+character before entering the dungeon. Only **two** of these cards are
+drawn at the start of a battle, so choose wisely. These features live under the
 `PartySetup` route and make early game decisions more dynamic.
 
 ## Codex Reference

--- a/client/src/components/CardAssignmentPanel.tsx
+++ b/client/src/components/CardAssignmentPanel.tsx
@@ -115,8 +115,11 @@ const CardAssignmentPanel: React.FC<CardAssignmentPanelProps> = ({ character, av
 
   return (
     <div style={panelStyle}>
-      <h5 style={subSectionTitleStyle}>
-        Selected Cards: {character.assignedCards.length}/4
+      <h5
+        style={subSectionTitleStyle}
+        title="Only two cards will be available at the start of battle"
+      >
+        Battle Deck (draws 2): {character.assignedCards.length}/4
       </h5>
       {character.assignedCards.length === 0 && (
         <p style={{ fontStyle: 'italic', color: '#7f8c8d' }}>No cards assigned yet.</p>

--- a/client/src/components/PartySummary.module.css
+++ b/client/src/components/PartySummary.module.css
@@ -103,3 +103,11 @@
 .actionButton:hover {
   color: #e74c3c;
 }
+
+.cardNote {
+  text-align: center;
+  font-size: 0.9em;
+  margin-top: -10px;
+  margin-bottom: 10px;
+  color: #ccc;
+}

--- a/client/src/components/PartySummary.tsx
+++ b/client/src/components/PartySummary.tsx
@@ -55,6 +55,9 @@ const PartySummary: React.FC<PartySummaryProps> = ({
     return (
       <div className={styles.summaryContainer} aria-live="polite" aria-atomic="true">
         <h2 className={styles.heading}>Party Summary</h2>
+        <p className={styles.cardNote}>
+          Each character draws <strong>two</strong> of their assigned cards at battle start.
+        </p>
         <p style={{ textAlign: 'center', fontStyle: 'italic', color: '#bbb' }}>
           No characters selected yet to display a summary.
         </p>
@@ -71,6 +74,9 @@ const PartySummary: React.FC<PartySummaryProps> = ({
   return (
     <div className={styles.summaryContainer} aria-live="polite" aria-atomic="true">
       <h2 className={styles.heading}>Party Summary</h2>
+      <p className={styles.cardNote}>
+        Each character draws <strong>two</strong> of their assigned cards at battle start.
+      </p>
       <div className={styles.statsList}>
         <div className={styles.statItem} title="Average of party health points">
           <strong>Avg HP:</strong> {averageHp}


### PR DESCRIPTION
## Summary
- clarify the starting hand in PartySetup UI
- note the rule in PartySummary and docs
- document that only two cards are drawn at battle start

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6843388294708327b3b3714c067674a5