### PR TITLE
Update card UI layout

### DIFF
--- a/client/src/components/CardDisplay.module.css
+++ b/client/src/components/CardDisplay.module.css
@@ -7,6 +7,8 @@
   box-shadow: 0 2px 6px rgba(0, 0, 0, 0.3);
   background: linear-gradient(180deg, #fefefe 0%, #ececec 100%);
   transition: transform 0.2s ease, box-shadow 0.2s ease;
+  display: flex;
+  flex-direction: column;
 }
 .card:hover {
   transform: translateY(-4px);
@@ -77,16 +79,13 @@
   text-transform: uppercase;
 }
 .classBanner {
-  position: absolute;
-  right: -40px;
-  top: 50%;
-  transform: rotate(45deg);
-  width: 120px;
+  width: 100%;
   text-align: center;
   background: var(--rarity-color, #888);
   color: #fff;
   font-size: 0.65rem;
-  pointer-events: none;
+  text-transform: uppercase;
+  padding: 2px 0;
 }
 .description {
   background: #f9f5e9;
@@ -95,6 +94,7 @@
   font-size: 0.75rem;
   line-height: 1.2;
   min-height: 60px;
+  flex-grow: 1;
 }
 .stats {
   display: flex;

--- a/client/src/components/CardDisplay.tsx
+++ b/client/src/components/CardDisplay.tsx
@@ -49,8 +49,8 @@ const CardDisplay: React.FC<CardDisplayProps> = ({ card, onSelect, isSelected, i
         )}
         <span className={styles.nameRibbon}>{card.name}</span>
         <span className={styles.typeBadge}>{card.category}</span>
-        {classText && <span className={styles.classBanner}>{classText}</span>}
       </div>
+      {classText && <span className={styles.classBanner}>{classText}</span>}
       <div className={styles.description}>{card.description || 'No effect description.'}</div>
       {('attack' in card || 'defense' in card) && (
         <div className={styles.stats}>

--- a/shared/models/cards.js
+++ b/shared/models/cards.js
@@ -99,7 +99,7 @@ export const sampleCards = [
     roleTag: 'Support',
     synergyTag: 'Execute',
     isComboStarter: true,
-    classes: ['Shadowblade', 'Ranger'], // Level 1
+    classes: ['Ranger'], // Level 1
   },
   {
     id: 'shadow_execution',

--- a/shared/models/classes.js
+++ b/shared/models/classes.js
@@ -117,7 +117,7 @@ export const classes = [
     name: 'Shadowblade',
     description: 'Stealthy assassin striking from the darkness.',
     role: Role.DPS,
-    allowedCards: ['mark_target', 'shadow_execution', 'backstab', 'smoke_bomb'],
+    allowedCards: ['shadow_execution', 'backstab', 'smoke_bomb', 'shadowstep'],
     portrait: shadowbladePortrait,
   },
   {


### PR DESCRIPTION
## Summary
- display card layout with flexible column
- show class banners horizontally under the card image
- adjust Shadowblade starter cards to keep 4 level 1 abilities
- keep class data aligned with card restrictions

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68433ae8c90c8327a2c658edd36319b4