### PR TITLE
Improve card layout responsiveness

### DIFF
--- a/client/src/components/CardDisplay.module.css
+++ b/client/src/components/CardDisplay.module.css
@@ -39,22 +39,17 @@
   background-size: cover;
   background-position: center;
 }
-.nameRibbon {
-  position: absolute;
-  top: 6px;
-  left: 50%;
-  transform: translateX(-50%);
-  background: rgba(0, 0, 0, 0.7);
-  color: #fff;
-  padding: 2px 6px;
-  border-radius: 4px;
-  font-size: 0.85rem;
-  font-weight: bold;
-}
-.costBadge {
+.cardTop {
   position: absolute;
   top: 6px;
   left: 6px;
+  right: 6px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+.cardCost {
+  flex: 0 0 auto;
   width: 28px;
   height: 28px;
   border-radius: 50%;
@@ -67,16 +62,19 @@
   font-size: 0.8rem;
   box-shadow: 0 0 2px rgba(0,0,0,0.5);
 }
-.typeBadge {
-  position: absolute;
-  top: 6px;
-  right: 6px;
+.cardTitle {
+  flex: 1 1 auto;
+  text-align: right;
+  margin-left: 8px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
   background: rgba(0, 0, 0, 0.7);
   color: #fff;
-  padding: 2px 5px;
+  padding: 2px 6px;
   border-radius: 4px;
-  font-size: 0.65rem;
-  text-transform: uppercase;
+  font-size: 0.85rem;
+  font-weight: bold;
 }
 .classBanner {
   width: 100%;
@@ -87,13 +85,16 @@
   text-transform: uppercase;
   padding: 2px 0;
 }
-.description {
-  background: #f9f5e9;
+.cardDescription {
+  background: #fffbe5;
+  border-radius: 0 0 10px 10px;
+  padding: 10px 8px;
+  min-height: 42px;
+  color: #333;
+  font-weight: 500;
   font-family: Georgia, 'Times New Roman', serif;
-  padding: 8px;
   font-size: 0.75rem;
   line-height: 1.2;
-  min-height: 60px;
   flex-grow: 1;
 }
 .stats {
@@ -119,5 +120,12 @@
 @media (max-width: 600px) {
   .card {
     width: 110px;
+  }
+}
+
+@media (max-width: 500px) {
+  .cardTitle {
+    font-size: 0.95em;
+    max-width: 70%;
   }
 }

--- a/client/src/components/CardDisplay.tsx
+++ b/client/src/components/CardDisplay.tsx
@@ -43,15 +43,17 @@ const CardDisplay: React.FC<CardDisplayProps> = ({ card, onSelect, isSelected, i
       aria-label={`Select card ${card.name}, type ${card.category}. ${card.description || 'No effect description.'}`}
     >
       <div className={styles.frame}>
+        <div className={styles.cardTop}>
+          {'energyCost' in card && (
+            <span className={styles.cardCost}>{(card as any).energyCost}</span>
+          )}
+          <span className={styles.cardTitle}>{card.name}</span>
+        </div>
         <div className={styles.art} style={{ backgroundImage: `url(${art})` }} />
-        {'energyCost' in card && (
-          <span className={styles.costBadge}>{(card as any).energyCost}</span>
-        )}
-        <span className={styles.nameRibbon}>{card.name}</span>
-        <span className={styles.typeBadge}>{card.category}</span>
+        {/* type badge removed per design update */}
       </div>
       {classText && <span className={styles.classBanner}>{classText}</span>}
-      <div className={styles.description}>{card.description || 'No effect description.'}</div>
+      <div className={styles.cardDescription}>{card.description || 'No effect description.'}</div>
       {('attack' in card || 'defense' in card) && (
         <div className={styles.stats}>
           {'attack' in card && (


### PR DESCRIPTION
## Summary
- update card display CSS for responsive header and description highlight
- remove ability tag and replace with cost/title flex layout

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68433e3e464483279fcfc248a10d52ec