### PR TITLE
Fix card pointer & class lookup

### DIFF
--- a/client/src/components/CardAssignmentPanel.tsx
+++ b/client/src/components/CardAssignmentPanel.tsx
@@ -4,6 +4,7 @@ import type { Card } from '../../../shared/models/Card';
 import CardDisplay from './CardDisplay';
 import { canUseCard } from '../../../shared/systems/classRole.js';
 import { classes as allClasses } from '../../../shared/models/classes.js';
+import { getClassById } from '../utils/getClassById';
 import styles from './PartySetup.module.css';
 
 interface CardAssignmentPanelProps {
@@ -30,7 +31,7 @@ const CardAssignmentPanel: React.FC<CardAssignmentPanelProps> = ({ character, av
     let pool = [...getUsablePool()]
     // Fallback to role-based picks if no class-restricted cards exist
     if (pool.length === 0) {
-      const cls = allClasses.find(c => c.id === character.class)
+      const cls = getClassById(character.class)
       if (cls) {
         pool = availableCards.filter(
           c => c.roleTag === cls.role && !assignedCardIds.has(c.id)

--- a/client/src/components/CardDisplay.module.css
+++ b/client/src/components/CardDisplay.module.css
@@ -50,6 +50,10 @@
   border-radius: 4px;
   font-size: 0.85rem;
   font-weight: bold;
+  cursor: pointer;
+}
+.card-title {
+  cursor: pointer;
 }
 .costBadge {
   position: absolute;
@@ -95,6 +99,10 @@
   line-height: 1.2;
   min-height: 60px;
   flex-grow: 1;
+  cursor: pointer;
+}
+.card-description {
+  cursor: pointer;
 }
 .stats {
   display: flex;

--- a/client/src/components/CardDisplay.tsx
+++ b/client/src/components/CardDisplay.tsx
@@ -47,11 +47,11 @@ const CardDisplay: React.FC<CardDisplayProps> = ({ card, onSelect, isSelected, i
         {'energyCost' in card && (
           <span className={styles.costBadge}>{(card as any).energyCost}</span>
         )}
-        <span className={styles.nameRibbon}>{card.name}</span>
+        <span className={`${styles.nameRibbon} ${styles.cardTitle}`}>{card.name}</span>
         <span className={styles.typeBadge}>{card.category}</span>
       </div>
       {classText && <span className={styles.classBanner}>{classText}</span>}
-      <div className={styles.description}>{card.description || 'No effect description.'}</div>
+      <div className={`${styles.description} ${styles.cardDescription}`}>{card.description || 'No effect description.'}</div>
       {('attack' in card || 'defense' in card) && (
         <div className={styles.stats}>
           {'attack' in card && (

--- a/client/src/components/CharacterCard.tsx
+++ b/client/src/components/CharacterCard.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
 import type { Character } from '../../../shared/models/Character'
 import { classes as allClasses } from '../../../shared/models/classes.js'
+import { getClassById } from '../utils/getClassById'
 import defaultPortrait from '../../../shared/images/default-portrait.png'
 
 interface CharacterCardProps {
@@ -18,7 +19,7 @@ const CharacterCard: React.FC<CharacterCardProps> = ({ character, onSelect, isSe
     DPS: '#e74c3c',
   }
 
-  const clsInfo = allClasses.find((c) => c.id === character.class)
+  const clsInfo = getClassById(character.class)
   const roleColor = roleColors[clsInfo?.role || 'DPS']
 
   const cardStyle: React.CSSProperties = {

--- a/client/src/components/PartySetup.tsx
+++ b/client/src/components/PartySetup.tsx
@@ -10,6 +10,7 @@ import type { Party } from '../../../shared/models/Party';
 import { sampleCards } from '../../../shared/models/cards.js';
 import { classes as allClasses } from '../../../shared/models/classes.js';
 import { getRandomClasses, type GameClass } from '../utils/randomizeClasses';
+import { getClassById } from '../utils/getClassById';
 
 import ClassCard from './ClassCard';
 import CardAssignmentPanel from './CardAssignmentPanel'; // Import
@@ -285,7 +286,7 @@ const PartySetup: React.FC = () => {
           </p>
         )}
         {selectedCharacters.map(pc => {
-          const clsDef = allClasses.find(c => c.id === pc.class);
+          const clsDef = getClassById(pc.class);
           return (
             <div key={pc.id} className={styles.selectedCharacterPanel}> {/* Apply .selectedCharacterPanel */}
               <div className={styles.characterPanelHeader}> {/* Apply .characterPanelHeader */}

--- a/client/src/components/PartySummary.tsx
+++ b/client/src/components/PartySummary.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import type { PartyCharacter } from './PartySetup';
 import { classes as allClasses } from '../../../shared/models/classes.js';
+import { getClassById } from '../utils/getClassById';
 import defaultPortrait from '../../../shared/images/default-portrait.png';
 import styles from './PartySummary.module.css';
 
@@ -17,12 +18,12 @@ const roleColors: Record<string, string> = {
 };
 
 const getRole = (classId: string): string => {
-  const cls = allClasses.find(c => c.id === classId);
+  const cls = getClassById(classId);
   return cls?.role ?? 'Unknown';
 };
 
 const getClassName = (classId: string): string => {
-  const cls = allClasses.find(c => c.id === classId);
+  const cls = getClassById(classId);
   return cls?.name ?? classId;
 };
 
@@ -34,7 +35,7 @@ const calculateAverage = (values: Array<number | undefined>): string => {
 };
 
 const getPortraitSrc = (character: PartyCharacter): string => {
-  const cls = allClasses.find(c => c.id === character.class);
+  const cls = getClassById(character.class);
   return character.portrait || cls?.portrait || defaultPortrait;
 };
 

--- a/client/src/utils/getClassById.ts
+++ b/client/src/utils/getClassById.ts
@@ -1,0 +1,9 @@
+import { classes } from '../../../shared/models/classes.js'
+
+export function getClassById(id: string) {
+  const cls = classes.find(c => c.id === id)
+  if (!cls) {
+    console.error(`Unknown class id '${id}'`)
+  }
+  return cls
+}


### PR DESCRIPTION
## Summary
- keep pointer cursor on card titles and descriptions
- add utility for class lookups by ID with error logging
- use new getClassById helper in UI components

## Testing
- `npm test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68433e4b4d008327b87fcb9feaa72900