### PR TITLE
Fix UI cursor and class mapping

### DIFF
--- a/client/src/components/CardAssignmentPanel.tsx
+++ b/client/src/components/CardAssignmentPanel.tsx
@@ -30,7 +30,10 @@ const CardAssignmentPanel: React.FC<CardAssignmentPanelProps> = ({ character, av
     let pool = [...getUsablePool()]
     // Fallback to role-based picks if no class-restricted cards exist
     if (pool.length === 0) {
-      const cls = allClasses.find(c => c.id === character.class)
+      const cls = allClasses.find(c => c.id === character.class || c.name === character.class)
+      if (!cls) {
+        console.error(`Unknown class id: ${character.class}`)
+      }
       if (cls) {
         pool = availableCards.filter(
           c => c.roleTag === cls.role && !assignedCardIds.has(c.id)

--- a/client/src/components/CardDisplay.module.css
+++ b/client/src/components/CardDisplay.module.css
@@ -71,6 +71,7 @@
   text-overflow: ellipsis;
   background: rgba(0, 0, 0, 0.7);
   color: #fff;
+  cursor: pointer;
   padding: 2px 6px;
   border-radius: 4px;
   font-size: 0.85rem;
@@ -96,6 +97,7 @@
   font-size: 0.75rem;
   line-height: 1.2;
   flex-grow: 1;
+  cursor: pointer;
 }
 .stats {
   display: flex;

--- a/client/src/components/CharacterCard.tsx
+++ b/client/src/components/CharacterCard.tsx
@@ -18,7 +18,10 @@ const CharacterCard: React.FC<CharacterCardProps> = ({ character, onSelect, isSe
     DPS: '#e74c3c',
   }
 
-  const clsInfo = allClasses.find((c) => c.id === character.class)
+  const clsInfo = allClasses.find((c) => c.id === character.class || c.name === character.class)
+  if (!clsInfo) {
+    console.error(`Unknown class id: ${character.class}`)
+  }
   const roleColor = roleColors[clsInfo?.role || 'DPS']
 
   const cardStyle: React.CSSProperties = {

--- a/client/src/components/PartySetup.tsx
+++ b/client/src/components/PartySetup.tsx
@@ -285,11 +285,14 @@ const PartySetup: React.FC = () => {
           </p>
         )}
         {selectedCharacters.map(pc => {
-          const clsDef = allClasses.find(c => c.id === pc.class);
+          const clsDef = allClasses.find(c => c.id === pc.class || c.name === pc.class);
+          if (!clsDef) {
+            console.error(`Unknown class id: ${pc.class}`);
+          }
           return (
             <div key={pc.id} className={styles.selectedCharacterPanel}> {/* Apply .selectedCharacterPanel */}
               <div className={styles.characterPanelHeader}> {/* Apply .characterPanelHeader */}
-                <h3>{pc.name} (Class: {clsDef ? clsDef.name : pc.class || 'Unknown'})</h3>
+                <h3>{pc.name} (Class: {clsDef ? clsDef.name : 'Unknown'})</h3>
                 <button onClick={() => handleClassRemove(pc.id)} className={styles.removeButton}>Remove Class</button>
               </div>
               <CardAssignmentPanel

--- a/client/src/components/PartySummary.tsx
+++ b/client/src/components/PartySummary.tsx
@@ -17,12 +17,18 @@ const roleColors: Record<string, string> = {
 };
 
 const getRole = (classId: string): string => {
-  const cls = allClasses.find(c => c.id === classId);
+  const cls = allClasses.find(c => c.id === classId || c.name === classId);
+  if (!cls) {
+    console.error(`Unknown class id: ${classId}`);
+  }
   return cls?.role ?? 'Unknown';
 };
 
 const getClassName = (classId: string): string => {
-  const cls = allClasses.find(c => c.id === classId);
+  const cls = allClasses.find(c => c.id === classId || c.name === classId);
+  if (!cls) {
+    console.error(`Unknown class id: ${classId}`);
+  }
   return cls?.name ?? classId;
 };
 
@@ -34,7 +40,10 @@ const calculateAverage = (values: Array<number | undefined>): string => {
 };
 
 const getPortraitSrc = (character: PartyCharacter): string => {
-  const cls = allClasses.find(c => c.id === character.class);
+  const cls = allClasses.find(c => c.id === character.class || c.name === character.class);
+  if (!cls) {
+    console.error(`Unknown class id: ${character.class}`);
+  }
   return character.portrait || cls?.portrait || defaultPortrait;
 };
 

--- a/shared/systems/classMapping.test.js
+++ b/shared/systems/classMapping.test.js
@@ -1,0 +1,13 @@
+import { test } from 'node:test'
+import assert from 'assert'
+import { classes } from '../models/classes.js'
+
+// Ensure each defined class can be looked up by id and returns its display name
+// similar to the client UI logic.
+test('every class id resolves to a display name', () => {
+  for (const cls of classes) {
+    const found = classes.find(c => c.id === cls.id)
+    const name = found ? found.name : 'Unknown'
+    assert.notStrictEqual(name, 'Unknown', `Missing mapping for ${cls.id}`)
+  }
+})


### PR DESCRIPTION
## Summary
- keep pointer cursor over card titles and descriptions
- robustly map party member class IDs to details
- log an error when class lookup fails
- add regression unit test for class ID mapping

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684340964e548327bd197c70b5a031a3