### PR TITLE
Simplify card title layout

### DIFF
--- a/client/src/assets/placeholder-card-art.svg
+++ b/client/src/assets/placeholder-card-art.svg
@@ -1,4 +1,3 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 120" preserveAspectRatio="xMidYMid slice">
   <rect width="200" height="120" fill="#cccccc"/>
-  <text x="100" y="65" text-anchor="middle" font-size="24" fill="#666666" font-family="Arial">Art</text>
 </svg>

--- a/client/src/components/CardDisplay.module.css
+++ b/client/src/components/CardDisplay.module.css
@@ -38,6 +38,7 @@
   padding-top: 60%;
   background-size: cover;
   background-position: center;
+  position: relative;
 }
 .cardTop {
   position: absolute;
@@ -63,19 +64,18 @@
   box-shadow: 0 0 2px rgba(0,0,0,0.5);
 }
 .cardTitle {
-  flex: 1 1 auto;
-  text-align: right;
-  margin-left: 8px;
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  background: rgba(0, 0, 0, 0.7);
-  color: #fff;
-  cursor: pointer;
-  padding: 2px 6px;
-  border-radius: 4px;
-  font-size: 0.85rem;
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  color: #333;
   font-weight: bold;
+  font-size: 1rem;
+  text-align: center;
+  padding: 0 4px;
+  background: none;
+  border-radius: 0;
+  white-space: normal;
 }
 .classBanner {
   width: 100%;
@@ -127,7 +127,6 @@
 
 @media (max-width: 500px) {
   .cardTitle {
-    font-size: 0.95em;
-    max-width: 70%;
+    font-size: 0.9rem;
   }
 }

--- a/client/src/components/CardDisplay.tsx
+++ b/client/src/components/CardDisplay.tsx
@@ -47,9 +47,10 @@ const CardDisplay: React.FC<CardDisplayProps> = ({ card, onSelect, isSelected, i
           {'energyCost' in card && (
             <span className={styles.cardCost}>{(card as any).energyCost}</span>
           )}
+        </div>
+        <div className={styles.art} style={{ backgroundImage: `url(${art})` }}>
           <span className={styles.cardTitle}>{card.name}</span>
         </div>
-        <div className={styles.art} style={{ backgroundImage: `url(${art})` }} />
         {/* type badge removed per design update */}
       </div>
       {classText && <span className={styles.classBanner}>{classText}</span>}


### PR DESCRIPTION
## Summary
- reposition card titles inside the art area
- adjust CSS for centered title
- remove placeholder "Art" text from default SVG

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6843421074d083279e44ea9544718d2c