### PR TITLE
Add ability art to card UI

### DIFF
--- a/client/src/components/CardDisplay.module.css
+++ b/client/src/components/CardDisplay.module.css
@@ -39,6 +39,18 @@
   background-size: cover;
   background-position: center;
   position: relative;
+  border-radius: 10px 10px 0 0;
+  overflow: hidden;
+}
+
+.art::after {
+  content: '';
+  position: absolute;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  height: 40%;
+  background: linear-gradient(to bottom, rgba(0, 0, 0, 0) 0%, rgba(0, 0, 0, 0.4) 100%);
 }
 .cardTop {
   position: absolute;
@@ -68,7 +80,8 @@
   top: 50%;
   left: 50%;
   transform: translate(-50%, -50%);
-  color: #333;
+  color: #fff;
+  text-shadow: 0 1px 2px rgba(0, 0, 0, 0.8);
   font-weight: bold;
   font-size: 1rem;
   text-align: center;

--- a/client/src/components/CardDisplay.tsx
+++ b/client/src/components/CardDisplay.tsx
@@ -1,6 +1,17 @@
 import React from 'react'
 import type { Card } from '../../../shared/models/Card'
 import placeholderArt from '../assets/placeholder-card-art.svg'
+
+const abilityImages = import.meta.glob('../../../shared/images/ability_*.png', {
+  eager: true,
+  import: 'default',
+}) as Record<string, string>
+
+const getAbilityImage = (cardName: string): string => {
+  const key = cardName.toLowerCase().replace(/ /g, '_')
+  const path = `../../../shared/images/ability_${key}.png`
+  return abilityImages[path] || abilityImages['../../../shared/images/ability_default.png'] || placeholderArt
+}
 import styles from './CardDisplay.module.css'
 
 interface CardDisplayProps {
@@ -29,7 +40,7 @@ const CardDisplay: React.FC<CardDisplayProps> = ({ card, onSelect, isSelected, i
     }
   }
 
-  const art = (card as any).image || placeholderArt
+  const art = getAbilityImage(card.name)
   const classText = (card as any).classRestriction || (card as any).roleTag
   return (
     <div


### PR DESCRIPTION
## Summary
- load ability art dynamically based on card name
- display ability art in CardDisplay with gradient overlay
- tweak card title style for readability
- remove placeholder ability images

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6843466496048327920fc2636cc710ec