### PR TITLE
Refactor battle deck limit

### DIFF
--- a/client/src/components/CardAssignmentPanel.tsx
+++ b/client/src/components/CardAssignmentPanel.tsx
@@ -18,7 +18,7 @@ const CardAssignmentPanel: React.FC<CardAssignmentPanelProps> = ({ character, av
   const [draftKey, setDraftKey] = useState(0)
 
   const assignedCardIds = new Set(character.assignedCards.map((c) => c.id))
-  const canAssignMoreCards = character.assignedCards.length < 4
+  const canAssignMoreCards = character.assignedCards.length < 2
 
   const getUsablePool = () => {
     return availableCards.filter(
@@ -122,7 +122,7 @@ const CardAssignmentPanel: React.FC<CardAssignmentPanelProps> = ({ character, av
         style={subSectionTitleStyle}
         title="Only two cards will be available at the start of battle"
       >
-        Battle Deck (draws 2): {character.assignedCards.length}/4
+        Battle Deck: {character.assignedCards.length}/2
       </h5>
       {character.assignedCards.length === 0 && (
         <p style={{ fontStyle: 'italic', color: '#7f8c8d' }}>No cards assigned yet.</p>

--- a/client/src/components/PartySetup.tsx
+++ b/client/src/components/PartySetup.tsx
@@ -130,7 +130,7 @@ const PartySetup: React.FC = () => {
 
   const handleCardAssign = (characterId: string, card: Card) => {
     setSelectedCharacters(selectedCharacters.map(pc => {
-      if (pc.id === characterId && pc.assignedCards.length < 4 && !pc.assignedCards.find(c => c.id === card.id)) {
+      if (pc.id === characterId && pc.assignedCards.length < 2 && !pc.assignedCards.find(c => c.id === card.id)) {
         return { ...pc, assignedCards: [...pc.assignedCards, card] };
       }
       return pc;
@@ -192,9 +192,9 @@ const PartySetup: React.FC = () => {
   const { notify } = useNotification();
 
   const handleStartGame = () => {
-    const missing = selectedCharacters.find(pc => pc.assignedCards.length < 4)
+    const missing = selectedCharacters.find(pc => pc.assignedCards.length < 2)
     if (missing) {
-      notify(`${missing.name} needs 4 cards assigned`, 'error')
+      notify(`${missing.name} needs 2 cards assigned`, 'error')
       return
     }
     const partyData: Party = {
@@ -228,7 +228,7 @@ const PartySetup: React.FC = () => {
   const isPartyValid =
     selectedCharacters.length > 0 &&
     selectedCharacters.length <= 5 &&
-    selectedCharacters.every(pc => pc.assignedCards.length === 4);
+    selectedCharacters.every(pc => pc.assignedCards.length === 2);
 
   // Basic JSX structure - will be expanded in subsequent steps
   return (


### PR DESCRIPTION
## Summary
- update card assignment logic to limit characters to 2 cards
- remove "draws 2" label text and show `x/2` count
- validate the party requires exactly two cards per character before starting the game

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684347f75ce083279761ff88af8b7ee0