### PR TITLE
Improve Town hub navigation

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -6,6 +6,10 @@ import MainMenu from './components/MainMenu.jsx'
 import PartySetup from './components/PartySetup.tsx'
 import DungeonMap from './components/DungeonMap.tsx'
 import TownView from './components/TownView.tsx'
+import InventoryPage from './components/InventoryPage.tsx'
+import CollectionPage from './components/CollectionPage.tsx'
+import CraftingPage from './components/CraftingPage.tsx'
+import ShopPage from './components/ShopPage.tsx'
 
 function AnimatedRoutes() {
   const location = useLocation()
@@ -31,6 +35,10 @@ function AnimatedRoutes() {
           <Route path="/party-setup" element={<PartySetup />} />
           <Route path="/dungeon" element={<DungeonMap />} />
           <Route path="/town" element={<TownView />} />
+          <Route path="/inventory" element={<InventoryPage />} />
+          <Route path="/cards" element={<CollectionPage />} />
+          <Route path="/crafting" element={<CraftingPage />} />
+          <Route path="/shop" element={<ShopPage />} />
         </Routes>
       </CSSTransition>
     </SwitchTransition>

--- a/client/src/components/CollectionPage.tsx
+++ b/client/src/components/CollectionPage.tsx
@@ -1,0 +1,13 @@
+import React from 'react'
+import { Link } from 'react-router-dom'
+import CardCollection from './CardCollection.tsx'
+import styles from './TownFeaturePage.module.css'
+
+export default function CollectionPage() {
+  return (
+    <div className={styles.container}>
+      <Link to="/town" className={styles.back}>Back to Town</Link>
+      <CardCollection />
+    </div>
+  )
+}

--- a/client/src/components/CraftingPage.tsx
+++ b/client/src/components/CraftingPage.tsx
@@ -1,0 +1,13 @@
+import React from 'react'
+import { Link } from 'react-router-dom'
+import MagicalPouch from './MagicalPouch.tsx'
+import styles from './TownFeaturePage.module.css'
+
+export default function CraftingPage() {
+  return (
+    <div className={styles.container}>
+      <Link to="/town" className={styles.back}>Back to Town</Link>
+      <MagicalPouch player={{ id: 'p1', name: 'Hero' }} profession={{ id: 'p', name: 'Crafter', description: '' }} />
+    </div>
+  )
+}

--- a/client/src/components/InventoryPage.tsx
+++ b/client/src/components/InventoryPage.tsx
@@ -1,0 +1,13 @@
+import React from 'react'
+import { Link } from 'react-router-dom'
+import InventoryScreen from './InventoryScreen.tsx'
+import styles from './TownFeaturePage.module.css'
+
+export default function InventoryPage() {
+  return (
+    <div className={styles.container}>
+      <Link to="/town" className={styles.back}>Back to Town</Link>
+      <InventoryScreen />
+    </div>
+  )
+}

--- a/client/src/components/ShopPage.tsx
+++ b/client/src/components/ShopPage.tsx
@@ -1,0 +1,13 @@
+import React from 'react'
+import { Link } from 'react-router-dom'
+import MarketScreen from './MarketScreen.tsx'
+import styles from './TownFeaturePage.module.css'
+
+export default function ShopPage() {
+  return (
+    <div className={styles.container}>
+      <Link to="/town" className={styles.back}>Back to Town</Link>
+      <MarketScreen marketType="Town" playerId="p1" />
+    </div>
+  )
+}

--- a/client/src/components/TownFeaturePage.module.css
+++ b/client/src/components/TownFeaturePage.module.css
@@ -1,0 +1,17 @@
+.container {
+  padding: 1rem;
+}
+
+.back {
+  display: inline-block;
+  margin-bottom: 1rem;
+  color: #fff;
+  background: #333;
+  padding: 0.4rem 0.8rem;
+  border-radius: 4px;
+  text-decoration: none;
+}
+
+.back:hover {
+  background: #444;
+}

--- a/client/src/components/TownView.module.css
+++ b/client/src/components/TownView.module.css
@@ -2,24 +2,61 @@
   padding: 20px;
   display: flex;
   flex-direction: column;
+  text-align: center;
 }
-.nav {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 0.5rem;
+
+.header {
   margin-bottom: 1rem;
 }
-.nav button {
-  padding: 0.5rem 1rem;
-  border: none;
-  background: #333;
+
+.summary {
+  font-size: 0.9rem;
+  margin: 0.25rem 0 0.5rem;
+}
+
+.mainMenu {
   color: #fff;
+  background: #333;
+  padding: 0.4rem 0.8rem;
   border-radius: 4px;
-  cursor: pointer;
+  text-decoration: none;
+  font-size: 0.9rem;
 }
-.nav button[aria-selected="true"] {
-  background: #555;
+
+.mainMenu:hover {
+  background: #444;
 }
-.content {
-  flex: 1;
+
+.grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  gap: 1rem;
+}
+
+.card {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding: 1rem;
+  background: #222;
+  border: 1px solid #444;
+  border-radius: 8px;
+  color: #fff;
+  text-decoration: none;
+  transition: transform 0.2s, box-shadow 0.2s;
+}
+
+.card:hover {
+  transform: scale(1.05);
+  box-shadow: 0 0 8px rgba(255, 255, 255, 0.3);
+}
+
+.icon {
+  font-size: 2rem;
+  margin-bottom: 0.5rem;
+}
+
+.disabled {
+  opacity: 0.5;
+  pointer-events: none;
 }

--- a/client/src/components/TownView.tsx
+++ b/client/src/components/TownView.tsx
@@ -1,77 +1,56 @@
-import React, { useState } from 'react'
-import { useNavigate } from 'react-router-dom'
+import React from 'react'
+import { Link } from 'react-router-dom'
 import { useGameState } from '../GameStateProvider.jsx'
-import InventoryScreen from './InventoryScreen.tsx'
-import CardCollection from './CardCollection.tsx'
-import MagicalPouch from './MagicalPouch.tsx'
-import MarketScreen from './MarketScreen.tsx'
 import styles from './TownView.module.css'
 
 export default function TownView() {
-  const navigate = useNavigate()
-  const updateGameState = useGameState(s => s.updateGameState)
-  const save = useGameState(s => s.save)
+  const party = useGameState(s => s.party)
 
-  const [tab, setTab] = useState<'inventory' | 'cards' | 'craft' | 'market'>('inventory')
-
-  const handleReturn = () => {
-    updateGameState({ location: 'dungeon' })
-    save()
-    navigate('/dungeon')
-  }
-
-  const renderContent = () => {
-    switch (tab) {
-      case 'inventory':
-        return <InventoryScreen />
-      case 'cards':
-        return <CardCollection />
-      case 'craft':
-        return <MagicalPouch player={{ id: 'p1', name: 'Hero' }} profession={{ id: 'p', name: 'Crafter', description: '' }} />
-      case 'market':
-        return <MarketScreen marketType="Town" playerId="p1" />
-      default:
-        return null
-    }
-  }
+  const members = party?.characters.map(c => c.name).join(', ') || 'No party'
 
   return (
     <div className={styles.container}>
-      <h2>Town Hub</h2>
-      <nav className={styles.nav} aria-label="Town navigation">
-        <button
-          onClick={() => setTab('inventory')}
-          aria-selected={tab === 'inventory'}
-          title="View your items"
+      <header className={styles.header}>
+        <h2>Town Hub</h2>
+        <p className={styles.summary}>Party: {members}</p>
+        <Link to="/" className={styles.mainMenu}>Return to Main Menu</Link>
+      </header>
+      <div className={styles.grid}>
+        <Link to="/party-setup" className={styles.card} aria-label="Manage party">
+          <span className={styles.icon}>⚔️</span>
+          <h3>Party</h3>
+          <p>Manage your heroes</p>
+        </Link>
+        <Link to="/inventory" className={styles.card} aria-label="View inventory">
+          <span className={styles.icon}>🎒</span>
+          <h3>Inventory</h3>
+          <p>View your items</p>
+        </Link>
+        <Link to="/cards" className={styles.card} aria-label="Browse cards">
+          <span className={styles.icon}>📜</span>
+          <h3>Cards</h3>
+          <p>Browse your card collection</p>
+        </Link>
+        <Link to="/crafting" className={styles.card} aria-label="Craft items">
+          <span className={styles.icon}>🛠️</span>
+          <h3>Crafting</h3>
+          <p>Prepare for battle</p>
+        </Link>
+        <Link to="/shop" className={styles.card} aria-label="Visit shop">
+          <span className={styles.icon}>🛒</span>
+          <h3>Shop</h3>
+          <p>Browse wares</p>
+        </Link>
+        <Link
+          to="/dungeon"
+          className={`${styles.card} ${!party ? styles.disabled : ''}`}
+          aria-label="Enter dungeon"
         >
-          Inventory
-        </button>
-        <button
-          onClick={() => setTab('cards')}
-          aria-selected={tab === 'cards'}
-          title="Browse your card collection"
-        >
-          Cards
-        </button>
-        <button
-          onClick={() => setTab('craft')}
-          aria-selected={tab === 'craft'}
-          title="Open crafting interface"
-        >
-          Crafting
-        </button>
-        <button
-          onClick={() => setTab('market')}
-          aria-selected={tab === 'market'}
-          title="Trade items at the market"
-        >
-          Market
-        </button>
-        <button onClick={handleReturn} style={{ marginLeft: 'auto' }} title="Return to the dungeon">
-          Return
-        </button>
-      </nav>
-      <div className={styles.content}>{renderContent()}</div>
+          <span className={styles.icon}>🏰</span>
+          <h3>Enter Dungeon</h3>
+          <p>Begin an adventure</p>
+        </Link>
+      </div>
     </div>
   )
 }


### PR DESCRIPTION
## Summary
- overhaul TownView into a grid-based hub with navigation cards
- add individual pages for inventory, card collection, crafting and shop
- route new pages in `App.jsx`
- style the hub and feature pages

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68434857228c8327ab37d5319ea05fd9