### PR TITLE
Add direct Town access from Main Menu

### DIFF
--- a/client/src/components/MainMenu.jsx
+++ b/client/src/components/MainMenu.jsx
@@ -41,6 +41,14 @@ function MainMenu() {
         >
           Settings
         </button>
+        {import.meta.env.DEV && (
+          <button
+            className={styles.button}
+            onClick={() => navigate('/town')}
+          >
+            Town
+          </button>
+        )}
       </nav>
     </main>
   )


### PR DESCRIPTION
## Summary
- add a new `Town` button in the Main Menu when running in development mode

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68434a9d72448327852ca2181957a26b