### PR TITLE
Add modern combat overlay

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -1,22 +1,23 @@
-import './App.css'
-import { Routes, Route, useLocation } from 'react-router-dom'
-import { useEffect, useRef } from 'react'
-import { CSSTransition, SwitchTransition } from 'react-transition-group'
-import MainMenu from './components/MainMenu.jsx'
-import PartySetup from './components/PartySetup.tsx'
-import DungeonMap from './components/DungeonMap.tsx'
-import TownView from './components/TownView.tsx'
+import "./App.css";
+import { Routes, Route, useLocation } from "react-router-dom";
+import { useEffect, useRef } from "react";
+import { CSSTransition, SwitchTransition } from "react-transition-group";
+import MainMenu from "./components/MainMenu.jsx";
+import PartySetup from "./components/PartySetup.tsx";
+import DungeonMap from "./components/DungeonMap.tsx";
+import TownView from "./components/TownView.tsx";
+import CombatPage from "./components/CombatPage.tsx";
 
 function AnimatedRoutes() {
-  const location = useLocation()
-  const previousPath = useRef(location.pathname)
+  const location = useLocation();
+  const previousPath = useRef(location.pathname);
 
   useEffect(() => {
     if (previousPath.current !== location.pathname) {
-      window.location.reload()
+      window.location.reload();
     }
-    previousPath.current = location.pathname
-  }, [location.pathname])
+    previousPath.current = location.pathname;
+  }, [location.pathname]);
 
   return (
     <SwitchTransition>
@@ -29,16 +30,17 @@ function AnimatedRoutes() {
         <Routes location={location}>
           <Route path="/" element={<MainMenu />} />
           <Route path="/party-setup" element={<PartySetup />} />
+          <Route path="/battle" element={<CombatPage />} />
           <Route path="/dungeon" element={<DungeonMap />} />
           <Route path="/town" element={<TownView />} />
         </Routes>
       </CSSTransition>
     </SwitchTransition>
-  )
+  );
 }
 
 function App() {
-  return <AnimatedRoutes />
+  return <AnimatedRoutes />;
 }
 
-export default App
+export default App;

--- a/client/src/components/CombatOverlay.module.css
+++ b/client/src/components/CombatOverlay.module.css
@@ -1,24 +1,81 @@
 .overlay {
   position: absolute;
+  inset: 0;
+  pointer-events: none;
+}
+
+.turnInfo {
+  position: absolute;
   top: 0;
   left: 0;
-  right: 0;
-  bottom: 0;
+  right: 200px;
+  text-align: center;
+  padding: 4px;
+  color: #fff;
+  background: rgba(0, 0, 0, 0.5);
   pointer-events: none;
-  display: flex;
-  flex-direction: column;
-  justify-content: space-between;
 }
-.party, .enemies {
+
+.enemies {
+  position: absolute;
+  top: 40px;
+  left: 0;
+  right: 200px;
   display: flex;
+  justify-content: center;
   gap: 10px;
   padding: 10px;
+  pointer-events: auto;
 }
+
+.party {
+  position: absolute;
+  bottom: 110px;
+  left: 0;
+  right: 200px;
+  display: flex;
+  justify-content: center;
+  gap: 10px;
+  padding: 10px;
+  pointer-events: auto;
+}
+
+.hand {
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  right: 200px;
+  display: flex;
+  justify-content: center;
+  gap: 10px;
+  padding: 10px;
+  pointer-events: auto;
+}
+
+.log {
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  right: 0;
+  width: 200px;
+  background: rgba(0, 0, 0, 0.6);
+  color: #fff;
+  padding: 6px;
+  font-size: 0.8em;
+  overflow-y: auto;
+  pointer-events: auto;
+}
+
 .combatant {
-  background: rgba(255,255,255,0.8);
+  background: rgba(255, 255, 255, 0.8);
   border-radius: 4px;
   padding: 4px 8px;
 }
+
+.combatant.active {
+  outline: 2px solid gold;
+}
+
 .bar {
   background: #ccc;
   height: 6px;
@@ -26,17 +83,19 @@
   margin-top: 2px;
   position: relative;
 }
+
 .bar span {
   display: block;
   background: #4caf50;
   height: 100%;
   width: 0;
 }
-.log {
-  background: rgba(0,0,0,0.5);
-  color: #fff;
-  padding: 4px;
-  font-size: 0.8em;
-  max-height: 100px;
-  overflow-y: auto;
+
+.endTurn {
+  margin-left: 10px;
+  pointer-events: auto;
+}
+
+.cardWrapper {
+  pointer-events: auto;
 }

--- a/client/src/components/CombatOverlay.tsx
+++ b/client/src/components/CombatOverlay.tsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import CardDisplay from './CardDisplay'
 import styles from './CombatOverlay.module.css'
 
 interface Combatant {
@@ -10,29 +11,75 @@ interface Combatant {
 interface Props {
   players: Combatant[]
   enemies: Combatant[]
+  hand: any[]
   log: string[]
+  turn: number
+  active?: string | null
+  onPlayCard?: (id: string) => void
+  onEndTurn?: () => void
 }
 
-export default function CombatOverlay({ players, enemies, log }: Props) {
+export default function CombatOverlay({
+  players,
+  enemies,
+  hand,
+  log,
+  turn,
+  active,
+  onPlayCard,
+  onEndTurn,
+}: Props) {
   return (
     <div className={styles.overlay}>
+      <div className={styles.turnInfo}>Turn {turn}</div>
+      <div className={styles.enemies}>
+        {enemies.map(e => (
+          <div
+            key={e.id}
+            className={
+              active === e.id
+                ? `${styles.combatant} ${styles.active}`
+                : styles.combatant
+            }
+          >
+            <strong>{e.name}</strong>
+            <div className={styles.bar}>
+              <span style={{ width: `${e.hp}%` }} />
+            </div>
+          </div>
+        ))}
+      </div>
       <div className={styles.party}>
         {players.map(p => (
-          <div key={p.id} className={styles.combatant}>
+          <div
+            key={p.id}
+            className={
+              active === p.id
+                ? `${styles.combatant} ${styles.active}`
+                : styles.combatant
+            }
+          >
             <strong>{p.name}</strong>
             <div className={styles.bar}>
               <span style={{ width: `${p.hp}%` }} />
             </div>
           </div>
         ))}
+        {onEndTurn && (
+          <button className={styles.endTurn} onClick={onEndTurn}>
+            End Turn
+          </button>
+        )}
       </div>
-      <div className={styles.enemies}>
-        {enemies.map(e => (
-          <div key={e.id} className={styles.combatant}>
-            <strong>{e.name}</strong>
-            <div className={styles.bar}>
-              <span style={{ width: `${e.hp}%` }} />
-            </div>
+      <div className={styles.hand}>
+        {hand.map(card => (
+          <div key={card.id} className={styles.cardWrapper}>
+            <CardDisplay
+              card={card}
+              onSelect={() => onPlayCard?.(card.id)}
+              isSelected={false}
+              isDisabled={false}
+            />
           </div>
         ))}
       </div>

--- a/client/src/components/CombatPage.tsx
+++ b/client/src/components/CombatPage.tsx
@@ -12,6 +12,9 @@ export default function CombatPage() {
   const party = useGameStore(state => state.party)
   const [players, setPlayers] = useState<Combatant[]>([])
   const [enemies, setEnemies] = useState<Combatant[]>([])
+  const [hand, setHand] = useState<any[]>([])
+  const [turn, setTurn] = useState(0)
+  const [active, setActive] = useState<string | null>(null)
   const [log, setLog] = useState<string[]>([])
   const { open, close } = useModal()
   const { notify } = useNotification()
@@ -21,9 +24,24 @@ export default function CombatPage() {
     if (detail.type === 'state') {
       setPlayers(detail.players)
       setEnemies(detail.enemies)
+      setHand(detail.hand || [])
+      setTurn(detail.turn)
+      setActive(detail.current || null)
     } else if (detail.type === 'log') {
       setLog(l => [...l.slice(-10), detail.message])
     }
+  }
+
+  const playCard = (id: string) => {
+    window.dispatchEvent(
+      new CustomEvent('battleCommand', { detail: { action: 'playCard', cardId: id } }),
+    )
+  }
+
+  const endTurn = () => {
+    window.dispatchEvent(
+      new CustomEvent('battleCommand', { detail: { action: 'endTurn' } }),
+    )
   }
 
   return (
@@ -33,7 +51,16 @@ export default function CombatPage() {
         party={party?.characters || []}
         onBattleEvent={handleBattleEvent}
       />
-      <CombatOverlay players={players} enemies={enemies} log={log} />
+        <CombatOverlay
+          players={players}
+          enemies={enemies}
+          hand={hand}
+          log={log}
+          turn={turn}
+          active={active}
+          onPlayCard={playCard}
+          onEndTurn={endTurn}
+        />
       <button
         style={{ position: 'absolute', top: 10, right: 10 }}
         onClick={() => {

--- a/client/src/components/DungeonMap.tsx
+++ b/client/src/components/DungeonMap.tsx
@@ -34,6 +34,9 @@ export default function DungeonMap() {
   const [battleRoom, setBattleRoom] = useState<string | null>(null)
   const [players, setPlayers] = useState([])
   const [enemies, setEnemies] = useState([])
+  const [hand, setHand] = useState<any[]>([])
+  const [turn, setTurn] = useState(0)
+  const [active, setActive] = useState<string | null>(null)
   const [log, setLog] = useState<string[]>([])
   const [banner, setBanner] = useState(false)
   const [roomEvent, setRoomEvent] = useState<any | null>(null)
@@ -98,6 +101,9 @@ export default function DungeonMap() {
     if (detail.type === 'state') {
       setPlayers(detail.players)
       setEnemies(detail.enemies)
+      setHand(detail.hand || [])
+      setTurn(detail.turn)
+      setActive(detail.current || null)
     } else if (detail.type === 'log') {
       setLog(l => [...l.slice(-10), detail.message])
     } else if (detail === 'Victory' || detail === 'Defeat') {
@@ -129,6 +135,18 @@ export default function DungeonMap() {
     setSummary(false)
     save()
     navigate('/town')
+  }
+
+  const playCard = (id: string) => {
+    window.dispatchEvent(
+      new CustomEvent('battleCommand', { detail: { action: 'playCard', cardId: id } }),
+    )
+  }
+
+  const endTurn = () => {
+    window.dispatchEvent(
+      new CustomEvent('battleCommand', { detail: { action: 'endTurn' } }),
+    )
   }
 
   if (!party) return <p>No party selected.</p>
@@ -189,7 +207,16 @@ export default function DungeonMap() {
             enemyIndex={0}
             onBattleEvent={handleBattleEvent}
           />
-          <CombatOverlay players={players} enemies={enemies} log={log} />
+          <CombatOverlay
+            players={players}
+            enemies={enemies}
+            hand={hand}
+            log={log}
+            turn={turn}
+            active={active}
+            onPlayCard={playCard}
+            onEndTurn={endTurn}
+          />
         </div>
       )}
       {roomEvent && (

--- a/client/src/components/MainMenu.jsx
+++ b/client/src/components/MainMenu.jsx
@@ -1,23 +1,23 @@
-import { useNavigate } from 'react-router-dom'
-import { useModal } from './ModalManager.jsx'
-import styles from './MainMenu.module.css'
+import { useNavigate } from "react-router-dom";
+import { useModal } from "./ModalManager.jsx";
+import styles from "./MainMenu.module.css";
 
 function MainMenu() {
-  const navigate = useNavigate()
-  const { open, close } = useModal()
+  const navigate = useNavigate();
+  const { open, close } = useModal();
 
   const showPlaceholder = (message) => {
     const id = open(
       <div>
         <p>{message}</p>
-        <div style={{ textAlign: 'center', marginTop: '1rem' }}>
+        <div style={{ textAlign: "center", marginTop: "1rem" }}>
           <button className={styles.button} onClick={() => close(id)}>
             Close
           </button>
         </div>
-      </div>
-    )
-  }
+      </div>,
+    );
+  };
 
   return (
     <main className={styles.container}>
@@ -25,25 +25,28 @@ function MainMenu() {
       <nav className={styles.menu}>
         <button
           className={styles.button}
-          onClick={() => navigate('/party-setup')}
+          onClick={() => navigate("/party-setup")}
         >
           New Game
         </button>
+        <button className={styles.button} onClick={() => navigate("/battle")}>
+          Battle
+        </button>
         <button
           className={styles.button}
-          onClick={() => showPlaceholder('Continue feature coming soon!')}
+          onClick={() => showPlaceholder("Continue feature coming soon!")}
         >
           Continue
         </button>
         <button
           className={styles.button}
-          onClick={() => showPlaceholder('Settings are not available yet.')}
+          onClick={() => showPlaceholder("Settings are not available yet.")}
         >
           Settings
         </button>
       </nav>
     </main>
-  )
+  );
 }
 
-export default MainMenu
+export default MainMenu;


### PR DESCRIPTION
## Summary
- modernize CombatOverlay layout to show turn info, hand and log
- allow React UI to command Phaser battle scene
- extend CombatPage and DungeonMap to use new overlay
- emit richer state events from BattleScene
- add quick battle button and route

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684348f380708327bc39b37a8392a3db