### PR TITLE
Fix TownView rendering

### DIFF
--- a/client/src/GameStateProvider.jsx
+++ b/client/src/GameStateProvider.jsx
@@ -4,16 +4,18 @@ import { useGameStore } from './store/gameStore'
 const GameStateContext = createContext(null)
 
 export const GameStateProvider = ({ children }) => {
-  const store = useGameStore()
+  // Provide the useGameStore hook itself so consumers can select slices
   return (
-    <GameStateContext.Provider value={store}>{children}</GameStateContext.Provider>
+    <GameStateContext.Provider value={useGameStore}>
+      {children}
+    </GameStateContext.Provider>
   )
 }
 
-export const useGameState = () => {
-  const ctx = useContext(GameStateContext)
-  if (!ctx) {
+export const useGameState = selector => {
+  const useStore = useContext(GameStateContext)
+  if (!useStore) {
     throw new Error('useGameState must be used within a GameStateProvider')
   }
-  return ctx
+  return useStore(selector)
 }

--- a/client/src/components/TownView.tsx
+++ b/client/src/components/TownView.tsx
@@ -6,7 +6,7 @@ import styles from './TownView.module.css'
 export default function TownView() {
   const party = useGameState(s => s.party)
 
-  const members = party?.characters.map(c => c.name).join(', ') || 'No party'
+  const members = party?.characters?.map(c => c.name).join(', ') || 'No party'
 
   return (
     <div className={styles.container}>


### PR DESCRIPTION
## Summary
- expose useGameStore hook via GameStateProvider so consumers can select parts of the store
- guard against missing party data when listing members

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68434c1c6a34832793d900ebe63eb047