### PR TITLE
Add deck manager support

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -10,6 +10,7 @@ import InventoryPage from './components/InventoryPage.tsx'
 import CollectionPage from './components/CollectionPage.tsx'
 import CraftingPage from './components/CraftingPage.tsx'
 import ShopPage from './components/ShopPage.tsx'
+import DeckManager from './components/DeckManager.jsx'
 
 function AnimatedRoutes() {
   const location = useLocation()
@@ -39,6 +40,7 @@ function AnimatedRoutes() {
           <Route path="/cards" element={<CollectionPage />} />
           <Route path="/crafting" element={<CraftingPage />} />
           <Route path="/shop" element={<ShopPage />} />
+          <Route path="/decks" element={<DeckManager />} />
         </Routes>
       </CSSTransition>
     </SwitchTransition>

--- a/client/src/components/DeckManager.jsx
+++ b/client/src/components/DeckManager.jsx
@@ -1,0 +1,49 @@
+import { useState } from 'react'
+import { useNavigate } from 'react-router-dom'
+import { useGameStore } from '../store/gameStore'
+import { sampleCards } from 'shared/models/cards.js'
+
+function DeckManager() {
+  const decks = useGameStore(state => state.decks)
+  const addDeck = useGameStore(state => state.addDeck)
+  const removeDeck = useGameStore(state => state.removeDeck)
+  const selectDeck = useGameStore(state => state.selectDeck)
+  const activeDeckId = useGameStore(state => state.activeDeckId)
+  const [name, setName] = useState('')
+  const navigate = useNavigate()
+
+  const createDeck = () => {
+    if (!name.trim()) return
+    addDeck({ id: Date.now().toString(), name: name.trim(), cards: sampleCards.slice(0, 4).map(c => c.id) })
+    setName('')
+  }
+
+  return (
+    <div style={{ padding: '1rem' }}>
+      <h1>Deck Manager</h1>
+      <ul>
+        {decks.map((d) => (
+          <li key={d.id} style={{ marginBottom: '0.5rem' }}>
+            <button onClick={() => selectDeck(d.id)} style={{ marginRight: '0.5rem' }}>
+              {d.name} {activeDeckId === d.id ? '(Active)' : ''}
+            </button>
+            <button onClick={() => removeDeck(d.id)}>Delete</button>
+          </li>
+        ))}
+      </ul>
+      <div style={{ marginTop: '1rem' }}>
+        <input
+          placeholder="New deck name"
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+        />
+        <button onClick={createDeck} style={{ marginLeft: '0.5rem' }}>Add Deck</button>
+      </div>
+      <div style={{ marginTop: '1rem' }}>
+        <button onClick={() => navigate('/')}>Back</button>
+      </div>
+    </div>
+  )
+}
+
+export default DeckManager

--- a/client/src/components/MainMenu.jsx
+++ b/client/src/components/MainMenu.jsx
@@ -41,6 +41,12 @@ function MainMenu() {
         >
           Settings
         </button>
+        <button
+          className={styles.button}
+          onClick={() => navigate('/decks')}
+        >
+          Deck Manager
+        </button>
         {import.meta.env.DEV && (
           <button
             className={styles.button}

--- a/client/src/store/gameStore.ts
+++ b/client/src/store/gameStore.ts
@@ -4,6 +4,7 @@ import type { GameState } from '../../shared/models/GameState'
 import type { DungeonData } from '../utils/generateDungeon'
 import type { DungeonMap } from '../../shared/models/DungeonMap'
 import type { Role } from '../../shared/models/Card'
+import type { Deck } from '../../shared/models/Deck'
 
 const defaultState: GameState = {
   currentFloor: 1,
@@ -39,6 +40,13 @@ interface Store {
     classes: { id: string; name: string; description: string; role: Role; allowedCards: string[] }[],
   ) => void
 
+  decks: Deck[]
+  activeDeckId: string | null
+  addDeck: (deck: Deck) => void
+  removeDeck: (id: string) => void
+  updateDeck: (id: string, cards: string[]) => void
+  selectDeck: (id: string) => void
+
   save: () => void
   load: () => void
 }
@@ -66,6 +74,14 @@ export const useGameStore = create<Store>((set, get) => ({
   availableClasses: [],
   setAvailableClasses: (classes) => set({ availableClasses: classes }),
 
+  decks: [],
+  activeDeckId: null,
+  addDeck: (deck) => set({ decks: [...get().decks, deck] }),
+  removeDeck: (id) => set({ decks: get().decks.filter((d) => d.id !== id) }),
+  updateDeck: (id, cards) =>
+    set({ decks: get().decks.map((d) => (d.id === id ? { ...d, cards } : d)) }),
+  selectDeck: (id) => set({ activeDeckId: id }),
+
   save: () => {
     const {
       party,
@@ -76,6 +92,8 @@ export const useGameStore = create<Store>((set, get) => ({
       playerPos,
       explored,
       availableClasses,
+      decks,
+      activeDeckId,
     } = get()
     const data = {
       party,
@@ -86,6 +104,8 @@ export const useGameStore = create<Store>((set, get) => ({
       playerPos,
       explored: Array.from(explored),
       availableClasses,
+      decks,
+      activeDeckId,
     }
     localStorage.setItem('gameData', JSON.stringify(data))
   },
@@ -103,6 +123,8 @@ export const useGameStore = create<Store>((set, get) => ({
         playerPos: data.playerPos ?? null,
         explored: new Set<string>(data.explored || []),
         availableClasses: data.availableClasses ?? [],
+        decks: data.decks ?? [],
+        activeDeckId: data.activeDeckId ?? null,
       })
     } catch (e) {
       console.error('Failed to load game data', e)

--- a/shared/models/Deck.ts
+++ b/shared/models/Deck.ts
@@ -1,0 +1,5 @@
+export interface Deck {
+  id: string
+  name: string
+  cards: string[]
+}


### PR DESCRIPTION
## Summary
- add new Deck model
- extend game store to handle multiple decks
- add DeckManager UI component
- wire Deck Manager route and menu entry

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68434e13f0888327a044151b079750eb