### PR TITLE
Improve Town hub layout

### DIFF
--- a/client/src/components/TownView.module.css
+++ b/client/src/components/TownView.module.css
@@ -29,7 +29,7 @@
 
 .grid {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
   gap: 1rem;
 }
 
@@ -43,12 +43,18 @@
   border-radius: 8px;
   color: #fff;
   text-decoration: none;
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.5);
   transition: transform 0.2s, box-shadow 0.2s;
 }
 
 .card:hover {
   transform: scale(1.05);
-  box-shadow: 0 0 8px rgba(255, 255, 255, 0.3);
+  box-shadow: 0 0 8px rgba(255, 255, 255, 0.3), 0 4px 12px rgba(0, 0, 0, 0.6);
+}
+
+.card:focus {
+  outline: none;
+  box-shadow: 0 0 0 2px #fff, 0 2px 6px rgba(0, 0, 0, 0.5);
 }
 
 .icon {


### PR DESCRIPTION
## Summary
- tweak TownView grid to use larger cards
- add drop shadow and focus styles to town hub cards

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68434eeca0b88327bfabaac91cf7535e