### PR TITLE
Redesign town hub navigation and layout

### DIFF
--- a/client/src/components/MainMenu.jsx
+++ b/client/src/components/MainMenu.jsx
@@ -25,13 +25,13 @@ function MainMenu() {
       <nav className={styles.menu}>
         <button
           className={styles.button}
-          onClick={() => navigate('/party-setup')}
+          onClick={() => navigate('/town')}
         >
           New Game
         </button>
         <button
           className={styles.button}
-          onClick={() => showPlaceholder('Continue feature coming soon!')}
+          onClick={() => navigate('/town')}
         >
           Continue
         </button>

--- a/client/src/components/PartySetup.tsx
+++ b/client/src/components/PartySetup.tsx
@@ -314,8 +314,8 @@ const PartySetup: React.FC = () => {
       {/* PartySummary will have its own internal styling or use passed classNames */}
 
       <div className={styles.navigationButtons}>
-        <button onClick={() => navigate('/')} className={styles.backButton}>
-          Back
+        <button onClick={() => navigate('/town')} className={styles.backButton}>
+          Back to Town
         </button>
         <button
           onClick={handleStartGame}

--- a/client/src/components/TownView.module.css
+++ b/client/src/components/TownView.module.css
@@ -2,6 +2,7 @@
   padding: 20px;
   display: flex;
   flex-direction: column;
+  align-items: center;
   text-align: center;
 }
 
@@ -29,31 +30,67 @@
 
 .grid {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
-  gap: 1rem;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: 2rem;
+  justify-content: center;
+  align-items: stretch;
+  margin: 2rem auto;
+  max-width: 1000px;
+  width: 90vw;
 }
 
 .card {
   display: flex;
   flex-direction: column;
   align-items: center;
-  padding: 1rem;
-  background: #222;
-  border: 1px solid #444;
-  border-radius: 8px;
+  min-width: 240px;
+  max-width: 340px;
+  padding: 1.5rem 1rem;
+  background: #232429;
+  border-radius: 16px;
   color: #fff;
   text-decoration: none;
-  transition: transform 0.2s, box-shadow 0.2s;
+  transition: transform 0.2s, box-shadow 0.2s, border-color 0.2s;
+  box-shadow: 0 2px 6px rgba(0,0,0,0.4);
+  border: 1px solid transparent;
+  animation: fadeInUp 0.3s ease both;
 }
-
-.card:hover {
-  transform: scale(1.05);
-  box-shadow: 0 0 8px rgba(255, 255, 255, 0.3);
+.card:hover,
+.card:focus {
+  transform: scale(1.03);
+  box-shadow: 0 4px 12px rgba(0,0,0,0.5);
+  border-color: #646cff;
+  cursor: pointer;
+}
+.card:active {
+  transform: scale(0.98);
 }
 
 .icon {
-  font-size: 2rem;
-  margin-bottom: 0.5rem;
+  font-size: 2.25rem;
+  margin-bottom: 0.75rem;
+}
+
+.title {
+  font-weight: bold;
+  font-size: 1.2rem;
+  margin-bottom: 0.25rem;
+}
+
+.subtitle {
+  font-size: 0.9rem;
+  color: #ccc;
+}
+
+@keyframes fadeInUp {
+  from {
+    opacity: 0;
+    transform: translateY(20px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
 }
 
 .disabled {

--- a/client/src/components/TownView.tsx
+++ b/client/src/components/TownView.tsx
@@ -1,9 +1,10 @@
 import React from 'react'
-import { Link } from 'react-router-dom'
+import { useNavigate, Link } from 'react-router-dom'
 import { useGameState } from '../GameStateProvider.jsx'
 import styles from './TownView.module.css'
 
 export default function TownView() {
+  const navigate = useNavigate()
   const party = useGameState(s => s.party)
 
   const members = party?.characters?.map(c => c.name).join(', ') || 'No party'
@@ -16,40 +17,60 @@ export default function TownView() {
         <Link to="/" className={styles.mainMenu}>Return to Main Menu</Link>
       </header>
       <div className={styles.grid}>
-        <Link to="/party-setup" className={styles.card} aria-label="Manage party">
+        <button
+          className={styles.card}
+          onClick={() => navigate('/party-setup')}
+          aria-label="Manage Party"
+        >
           <span className={styles.icon}>⚔️</span>
-          <h3>Party</h3>
-          <p>Manage your heroes</p>
-        </Link>
-        <Link to="/inventory" className={styles.card} aria-label="View inventory">
+          <span className={styles.title}>Party</span>
+          <span className={styles.subtitle}>Manage your heroes</span>
+        </button>
+        <button
+          className={styles.card}
+          onClick={() => navigate('/inventory')}
+          aria-label="View Inventory"
+        >
           <span className={styles.icon}>🎒</span>
-          <h3>Inventory</h3>
-          <p>View your items</p>
-        </Link>
-        <Link to="/cards" className={styles.card} aria-label="Browse cards">
+          <span className={styles.title}>Inventory</span>
+          <span className={styles.subtitle}>View your items</span>
+        </button>
+        <button
+          className={styles.card}
+          onClick={() => navigate('/cards')}
+          aria-label="Browse Cards"
+        >
           <span className={styles.icon}>📜</span>
-          <h3>Cards</h3>
-          <p>Browse your card collection</p>
-        </Link>
-        <Link to="/crafting" className={styles.card} aria-label="Craft items">
+          <span className={styles.title}>Cards</span>
+          <span className={styles.subtitle}>Browse your card collection</span>
+        </button>
+        <button
+          className={styles.card}
+          onClick={() => navigate('/crafting')}
+          aria-label="Craft Items"
+        >
           <span className={styles.icon}>🛠️</span>
-          <h3>Crafting</h3>
-          <p>Prepare for battle</p>
-        </Link>
-        <Link to="/shop" className={styles.card} aria-label="Visit shop">
+          <span className={styles.title}>Crafting</span>
+          <span className={styles.subtitle}>Prepare for battle</span>
+        </button>
+        <button
+          className={styles.card}
+          onClick={() => navigate('/shop')}
+          aria-label="Visit Shop"
+        >
           <span className={styles.icon}>🛒</span>
-          <h3>Shop</h3>
-          <p>Browse wares</p>
-        </Link>
-        <Link
-          to="/dungeon"
+          <span className={styles.title}>Shop</span>
+          <span className={styles.subtitle}>Browse wares</span>
+        </button>
+        <button
           className={`${styles.card} ${!party ? styles.disabled : ''}`}
-          aria-label="Enter dungeon"
+          onClick={() => party && navigate('/dungeon')}
+          aria-label="Enter Dungeon"
         >
           <span className={styles.icon}>🏰</span>
-          <h3>Enter Dungeon</h3>
-          <p>Begin an adventure</p>
-        </Link>
+          <span className={styles.title}>Enter Dungeon</span>
+          <span className={styles.subtitle}>Begin an adventure</span>
+        </button>
       </div>
     </div>
   )


### PR DESCRIPTION
## Summary
- redirect `New Game` and `Continue` buttons to town hub
- rework town hub to use button cards and responsive grid
- add styling for grid cards with hover/active effects
- allow returning to town from party setup

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684350ebcec083279adb3abd9d1ff096