### PR TITLE
Remove Town option from main menu

### DIFF
--- a/client/src/components/MainMenu.jsx
+++ b/client/src/components/MainMenu.jsx
@@ -47,14 +47,6 @@ function MainMenu() {
         >
           Deck Manager
         </button>
-        {import.meta.env.DEV && (
-          <button
-            className={styles.button}
-            onClick={() => navigate('/town')}
-          >
-            Town
-          </button>
-        )}
       </nav>
     </main>
   )


### PR DESCRIPTION
## Summary
- remove the dev-only **Town** option from the MainMenu component

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68435425de9c83279b9bca291083d2b9