### PR TITLE
Implement responsive battlefield grid

### DIFF
--- a/client/src/components/BattleScene.module.css
+++ b/client/src/components/BattleScene.module.css
@@ -12,18 +12,32 @@
   max-width: 600px;
 }
 .side {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(100px, 1fr));
+  gap: 0.5rem;
+  justify-items: center;
 }
 .unit {
   background: #232429;
   color: #fff;
   border-radius: 8px;
   padding: 0.5rem;
-  margin: 0.25rem;
-  width: 100px;
+  width: 100%;
+  max-width: 120px;
   text-align: center;
+  position: relative;
+  transition: box-shadow 0.2s, transform 0.2s;
+}
+.unit.active {
+  box-shadow: 0 0 8px #646cff;
+  border: 2px solid #646cff;
+}
+.unit.inactive {
+  opacity: 0.4;
+}
+.status {
+  font-size: 0.75rem;
+  margin-top: 0.25rem;
 }
 .controls {
   margin-top: 1rem;
@@ -38,4 +52,10 @@
   width: 100%;
   max-width: 600px;
   text-align: left;
+}
+
+@media (max-width: 500px) {
+  .grid {
+    grid-template-columns: 1fr;
+  }
 }


### PR DESCRIPTION
## Summary
- enhance `BattleScene` with active/inactive unit highlights
- display KO status
- add responsive grid layout for combatants

## Testing
- `npm test`
- `cd client && npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68435871b5488327a44ed2618dd4b703