### PR TITLE
Add accessible unit card component

### DIFF
--- a/client/src/components/BattleScene.tsx
+++ b/client/src/components/BattleScene.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from 'react'
 import { useGameStore } from '../store/gameStore'
 import styles from './BattleScene.module.css'
+import UnitCard from './UnitCard'
 
 interface Unit {
   id: string
@@ -76,28 +77,17 @@ export default function BattleScene() {
       <div className={styles.grid}>
         <div className={styles.side}>
           {players.map(p => (
-            <div key={p.id} className={styles.unit} aria-label={`${p.name} HP ${p.hp}`}> 
-              <strong>{p.name}</strong>
-              <div>
-                {p.hp} / {p.maxHp}
-              </div>
-            </div>
+            <UnitCard key={p.id} unit={p} actionLabel="Stats" onAction={() => console.log('View', p.name)} />
           ))}
         </div>
         <div className={styles.side}>
           {enemies.map(e => (
-            <div
+            <UnitCard
               key={e.id}
-              className={styles.unit}
-              onClick={() => attack(e.id)}
-              aria-label={`${e.name} HP ${e.hp}`}
-              style={{ cursor: turn === 'player' && !battleOver ? 'pointer' : 'default' }}
-            >
-              <strong>{e.name}</strong>
-              <div>
-                {e.hp} / {e.maxHp}
-              </div>
-            </div>
+              unit={e}
+              actionLabel="Attack"
+              onAction={() => turn === 'player' && !battleOver && attack(e.id)}
+            />
           ))}
         </div>
       </div>

--- a/client/src/components/CombatOverlay.module.css
+++ b/client/src/components/CombatOverlay.module.css
@@ -9,10 +9,12 @@
   flex-direction: column;
   justify-content: space-between;
 }
-.party, .enemies {
+.party,
+.enemies {
   display: flex;
   gap: 10px;
   padding: 10px;
+  pointer-events: auto;
 }
 .combatant {
   background: rgba(255,255,255,0.8);
@@ -39,4 +41,5 @@
   font-size: 0.8em;
   max-height: 100px;
   overflow-y: auto;
+  pointer-events: auto;
 }

--- a/client/src/components/CombatOverlay.tsx
+++ b/client/src/components/CombatOverlay.tsx
@@ -1,10 +1,13 @@
 import React from 'react'
 import styles from './CombatOverlay.module.css'
+import UnitCard from './UnitCard'
 
 interface Combatant {
   id: string
   name: string
   hp: number
+  maxHp?: number
+  status?: string[]
 }
 
 interface Props {
@@ -18,22 +21,39 @@ export default function CombatOverlay({ players, enemies, log }: Props) {
     <div className={styles.overlay}>
       <div className={styles.party}>
         {players.map(p => (
-          <div key={p.id} className={styles.combatant}>
-            <strong>{p.name}</strong>
-            <div className={styles.bar}>
-              <span style={{ width: `${p.hp}%` }} />
-            </div>
-          </div>
+          <UnitCard
+            key={p.id}
+            unit={{
+              id: p.id,
+              name: p.name,
+              hp: p.hp,
+              maxHp: p.maxHp || 100,
+              status: p.status,
+            }}
+            actionLabel="Stats"
+            onAction={() => {
+              /* placeholder for stats modal */
+              console.log('View', p.name)
+            }}
+          />
         ))}
       </div>
       <div className={styles.enemies}>
         {enemies.map(e => (
-          <div key={e.id} className={styles.combatant}>
-            <strong>{e.name}</strong>
-            <div className={styles.bar}>
-              <span style={{ width: `${e.hp}%` }} />
-            </div>
-          </div>
+          <UnitCard
+            key={e.id}
+            unit={{
+              id: e.id,
+              name: e.name,
+              hp: e.hp,
+              maxHp: e.maxHp || 100,
+              status: e.status,
+            }}
+            actionLabel="Target"
+            onAction={() => {
+              console.log('Target', e.name)
+            }}
+          />
         ))}
       </div>
       <div className={styles.log} aria-live="polite">

--- a/client/src/components/UnitCard.module.css
+++ b/client/src/components/UnitCard.module.css
@@ -1,0 +1,72 @@
+.card {
+  background: #232429;
+  color: #fff;
+  border-radius: 8px;
+  padding: 0.5rem;
+  width: 110px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.4);
+  transition: transform 0.2s, box-shadow 0.2s;
+}
+
+.card:hover,
+.card:focus {
+  transform: scale(1.05);
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.5);
+  cursor: pointer;
+  outline: none;
+}
+
+.name {
+  margin-bottom: 0.25rem;
+}
+
+.bar {
+  background: #555;
+  width: 100%;
+  height: 6px;
+  border-radius: 4px;
+  overflow: hidden;
+  margin-bottom: 0.25rem;
+}
+
+.bar span {
+  display: block;
+  background: #4caf50;
+  height: 100%;
+  width: 0;
+}
+
+.statusList {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 2px;
+  justify-content: center;
+  margin-bottom: 0.25rem;
+}
+
+.status {
+  background: #444;
+  padding: 0 4px;
+  border-radius: 4px;
+  font-size: 0.7rem;
+}
+
+.actionButton {
+  margin-top: 0.25rem;
+  background: #444;
+  color: #fff;
+  border: none;
+  border-radius: 4px;
+  padding: 0.2rem 0.5rem;
+  cursor: pointer;
+  font-size: 0.8rem;
+}
+
+.actionButton:hover,
+.actionButton:focus {
+  background: #646cff;
+  outline: none;
+}

--- a/client/src/components/UnitCard.tsx
+++ b/client/src/components/UnitCard.tsx
@@ -1,0 +1,67 @@
+import React from 'react'
+import styles from './UnitCard.module.css'
+
+export interface UnitInfo {
+  id: string
+  name: string
+  hp: number
+  maxHp: number
+  status?: string[]
+}
+
+interface Props {
+  unit: UnitInfo
+  onAction?: (unit: UnitInfo) => void
+  actionLabel?: string
+  className?: string
+}
+
+export default function UnitCard({ unit, onAction, actionLabel = 'Info', className }: Props) {
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === 'Enter' || e.key === ' ') {
+      e.preventDefault()
+      onAction?.(unit)
+    }
+  }
+
+  const pct = Math.max(0, Math.min(100, (unit.hp / unit.maxHp) * 100))
+
+  return (
+    <div
+      className={`${styles.card} ${className || ''}`}
+      onClick={() => onAction?.(unit)}
+      onKeyDown={handleKeyDown}
+      tabIndex={0}
+      role="button"
+      aria-label={`${unit.name} ${unit.hp} of ${unit.maxHp} HP${
+        unit.status && unit.status.length ? ', ' + unit.status.join(', ') : ''
+      }`}
+    >
+      <strong className={styles.name}>{unit.name}</strong>
+      <div className={styles.bar} aria-hidden="true">
+        <span style={{ width: `${pct}%` }} />
+      </div>
+      {unit.status && unit.status.length > 0 && (
+        <div className={styles.statusList}>
+          {unit.status.map((s) => (
+            <span key={s} className={styles.status}>
+              {s}
+            </span>
+          ))}
+        </div>
+      )}
+      {onAction && (
+        <button
+          className={styles.actionButton}
+          onClick={(e) => {
+            e.stopPropagation()
+            onAction(unit)
+          }}
+          onKeyDown={(e) => e.stopPropagation()}
+        >
+          {actionLabel}
+        </button>
+      )}
+    </div>
+  )
+}

--- a/client/src/phaser/BattleScene.ts
+++ b/client/src/phaser/BattleScene.ts
@@ -30,10 +30,10 @@ export default class BattleScene extends Phaser.Scene {
           type: 'state',
           players: this.turnOrder
             .filter((c) => c.type === 'player')
-            .map((c) => ({ id: c.data.id, name: c.data.name, hp: c.hp })),
+            .map((c) => ({ id: c.data.id, name: c.data.name, hp: c.hp, maxHp: c.data.stats.hp })),
           enemies: this.turnOrder
             .filter((c) => c.type === 'enemy')
-            .map((c) => ({ id: c.data.id, name: c.data.name, hp: c.hp })),
+            .map((c) => ({ id: c.data.id, name: c.data.name, hp: c.hp, maxHp: c.data.stats.hp })),
         }
     window.dispatchEvent(new CustomEvent('battleState', { detail }))
   }


### PR DESCRIPTION
## Summary
- create reusable `UnitCard` component with health bar, status list and action button
- integrate `UnitCard` in `CombatOverlay` and both battle scene UIs
- allow pointer interaction on overlay containers
- include maxHP values in Phaser battle state events

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68435878034c83279f3952a17704e96a