### PR TITLE
Add interactive unit cards

### DIFF
--- a/client/src/components/BattleScene.module.css
+++ b/client/src/components/BattleScene.module.css
@@ -17,28 +17,6 @@
   gap: 0.5rem;
   justify-items: center;
 }
-.unit {
-  background: #232429;
-  color: #fff;
-  border-radius: 8px;
-  padding: 0.5rem;
-  width: 100%;
-  max-width: 120px;
-  text-align: center;
-  position: relative;
-  transition: box-shadow 0.2s, transform 0.2s;
-}
-.unit.active {
-  box-shadow: 0 0 8px #646cff;
-  border: 2px solid #646cff;
-}
-.unit.inactive {
-  opacity: 0.4;
-}
-.status {
-  font-size: 0.75rem;
-  margin-top: 0.25rem;
-}
 .controls {
   margin-top: 1rem;
 }

--- a/client/src/components/BattleScene.tsx
+++ b/client/src/components/BattleScene.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from 'react'
 import { useGameStore } from '../store/gameStore'
+import UnitCard from './UnitCard'
 import styles from './BattleScene.module.css'
 
 interface Unit {
@@ -90,38 +91,37 @@ export default function BattleScene() {
       <div className={styles.grid}>
         <div className={styles.side}>
           {players.map(p => (
-            <div
+            <UnitCard
               key={p.id}
-              className={`${styles.unit} ${p.hp <= 0 ? styles.inactive : ''} ${
-                activeId === p.id ? styles.active : ''
-              }`}
-              aria-label={`${p.name} HP ${p.hp}`}
-            >
-              <strong>{p.name}</strong>
-              <div>
-                {p.hp} / {p.maxHp}
-              </div>
-              <div className={styles.status}>{p.hp <= 0 ? 'KO' : p.status}</div>
-            </div>
+              id={p.id}
+              name={p.name}
+              hp={p.hp}
+              maxHp={p.maxHp}
+              status={p.hp <= 0 ? 'KO' : p.status}
+              isActive={activeId === p.id}
+              isDisabled={p.hp <= 0}
+              actions={[{ label: 'Info', onClick: () => setLog(l => [...l, `${p.name} details`]) }]}
+            />
           ))}
         </div>
         <div className={styles.side}>
           {enemies.map(e => (
-            <div
+            <UnitCard
               key={e.id}
-              className={`${styles.unit} ${e.hp <= 0 ? styles.inactive : ''} ${
-                activeId === e.id ? styles.active : ''
-              }`}
-              onClick={() => attack(e.id)}
-              aria-label={`${e.name} HP ${e.hp}`}
-              style={{ cursor: turn === 'player' && !battleOver ? 'pointer' : 'default' }}
-            >
-              <strong>{e.name}</strong>
-              <div>
-                {e.hp} / {e.maxHp}
-              </div>
-              <div className={styles.status}>{e.hp <= 0 ? 'KO' : e.status}</div>
-            </div>
+              id={e.id}
+              name={e.name}
+              hp={e.hp}
+              maxHp={e.maxHp}
+              status={e.hp <= 0 ? 'KO' : e.status}
+              isActive={activeId === e.id}
+              isDisabled={turn !== 'player' || battleOver || e.hp <= 0}
+              onSelect={() => attack(e.id)}
+              actions={
+                turn === 'player' && !battleOver && e.hp > 0
+                  ? [{ label: 'Attack', onClick: () => attack(e.id) }]
+                  : []
+              }
+            />
           ))}
         </div>
       </div>

--- a/client/src/components/UnitCard.module.css
+++ b/client/src/components/UnitCard.module.css
@@ -1,0 +1,66 @@
+.card {
+  background: #232429;
+  color: #fff;
+  border-radius: 8px;
+  padding: 0.5rem;
+  width: 100%;
+  max-width: 120px;
+  text-align: center;
+  position: relative;
+  transition: box-shadow 0.2s, transform 0.2s;
+  cursor: pointer;
+}
+.card:hover {
+  transform: translateY(-2px);
+}
+.card.active {
+  box-shadow: 0 0 8px #646cff;
+  border: 2px solid #646cff;
+}
+.card.disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+.name {
+  font-weight: bold;
+}
+.healthBar {
+  background: #555;
+  border-radius: 4px;
+  height: 6px;
+  margin-top: 4px;
+  overflow: hidden;
+}
+.health {
+  display: block;
+  background: #4caf50;
+  height: 100%;
+  width: var(--hp, 100%);
+}
+.hpText {
+  font-size: 0.75rem;
+  margin-top: 2px;
+}
+.status {
+  font-size: 0.75rem;
+  margin-top: 0.25rem;
+}
+.actions {
+  margin-top: 0.5rem;
+  display: flex;
+  gap: 4px;
+  justify-content: center;
+}
+.actions button {
+  background: #646cff;
+  border: none;
+  color: #fff;
+  padding: 2px 6px;
+  border-radius: 4px;
+  font-size: 0.7rem;
+  cursor: pointer;
+}
+.actions button:hover,
+.actions button:focus-visible {
+  background: #767aff;
+}

--- a/client/src/components/UnitCard.tsx
+++ b/client/src/components/UnitCard.tsx
@@ -1,0 +1,86 @@
+import React from 'react'
+import styles from './UnitCard.module.css'
+
+interface Action {
+  label: string
+  onClick: () => void
+}
+
+interface UnitCardProps {
+  id: string
+  name: string
+  hp: number
+  maxHp: number
+  status?: string
+  actions?: Action[]
+  isActive?: boolean
+  isDisabled?: boolean
+  onSelect?: () => void
+}
+
+const UnitCard: React.FC<UnitCardProps> = ({
+  name,
+  hp,
+  maxHp,
+  status,
+  actions = [],
+  isActive = false,
+  isDisabled = false,
+  onSelect,
+}) => {
+  const percent = Math.max(0, Math.min(100, (hp / maxHp) * 100))
+
+  const handleClick = () => {
+    if (!isDisabled) {
+      onSelect?.()
+    }
+  }
+
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === 'Enter' || e.key === ' ') {
+      e.preventDefault()
+      handleClick()
+    }
+  }
+
+  return (
+    <div
+      className={`${styles.card} ${isActive ? styles.active : ''} ${
+        isDisabled ? styles.disabled : ''
+      }`}
+      onClick={handleClick}
+      onKeyDown={handleKeyDown}
+      tabIndex={isDisabled ? -1 : 0}
+      role="button"
+      aria-pressed={isActive}
+      aria-disabled={isDisabled}
+      aria-label={`${name} HP ${hp}`}
+    >
+      <div className={styles.name}>{name}</div>
+      <div className={styles.healthBar} aria-hidden="true">
+        <span className={styles.health} style={{ width: `${percent}%` }} />
+      </div>
+      <div className={styles.hpText}>
+        {hp} / {maxHp}
+      </div>
+      <div className={styles.status}>{status}</div>
+      {actions.length > 0 && (
+        <div className={styles.actions}>
+          {actions.map((a, i) => (
+            <button
+              key={i}
+              onClick={(e) => {
+                e.stopPropagation()
+                if (!isDisabled) a.onClick()
+              }}
+            >
+              {a.label}
+            </button>
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}
+
+export default UnitCard


### PR DESCRIPTION
## Summary
- add new `UnitCard` component for unit display and actions
- update battle scene to use `UnitCard`
- trim unused CSS from battle scene module

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68435aedd6f88327a5f55c7be7133831