### PR TITLE
Remove dungeon entry from party setup

### DIFF
--- a/client/src/components/PartySetup.module.css
+++ b/client/src/components/PartySetup.module.css
@@ -153,34 +153,6 @@
 }
 
 
-.startGameButton {
-  display: block;
-  width: 150px;
-  margin-top: 40px;
-  padding: 15px 20px; /* Increased padding */
-  font-size: 1.2em; /* Slightly larger font */
-  color: white;
-  background-color: #27ae60; /* Green */
-  border: none;
-  border-radius: 5px;
-  cursor: pointer;
-  transition: background-color 0.3s ease, transform 0.1s ease;
-  text-align: center;
-  font-weight: bold;
-}
-
-.startGameButton:active:not(:disabled) {
-  transform: scale(0.96);
-}
-
-.startGameButton:disabled {
-  background-color: #95a5a6; /* Grey when disabled */
-  cursor: not-allowed;
-}
-
-.startGameButton:hover:not(:disabled) {
-  background-color: #2ecc71; /* Lighter green on hover */
-}
 
 .navigationButtons {
   display: flex;
@@ -195,8 +167,7 @@
     gap: 10px;
     max-width: none;
   }
-  .backButton,
-  .startGameButton {
+  .backButton {
     width: 100%;
   }
 }

--- a/client/src/components/PartySetup.tsx
+++ b/client/src/components/PartySetup.tsx
@@ -191,44 +191,9 @@ const PartySetup: React.FC = () => {
   const { open, close } = useModal();
   const { notify } = useNotification();
 
-  const handleStartGame = () => {
-    const missing = selectedCharacters.find(pc => pc.assignedCards.length < 2)
-    if (missing) {
-      notify(`${missing.name} needs 2 cards assigned`, 'error')
-      return
-    }
-    const partyData: Party = {
-      characters: selectedCharacters.map(pc => ({
-        id: pc.id,
-        name: pc.name,
-        class: pc.class,
-        portrait: pc.portrait,
-        description: pc.description,
-        stats: pc.stats,
-        deck: pc.assignedCards,
-        survival: pc.survival,
-      })),
-    };
-
-    setParty(partyData);
-    updateGameState({ location: 'dungeon', currentFloor: 1 })
-    save()
-
-    const id = open(
-      <div style={{ textAlign: 'center' }}>
-        <p>Entering the Dungeon…</p>
-        <button onClick={() => close(id)}>Continue</button>
-      </div>
-    );
-
-    setTimeout(() => close(id), 1500);
-    navigate('/dungeon');
-  };
-
-  const isPartyValid =
-    selectedCharacters.length > 0 &&
-    selectedCharacters.length <= 5 &&
-    selectedCharacters.every(pc => pc.assignedCards.length === 2);
+  // Party setup no longer launches the dungeon directly. The player
+  // configures their party here and then returns to town to begin the
+  // adventure from there.
 
   // Basic JSX structure - will be expanded in subsequent steps
   return (
@@ -316,13 +281,6 @@ const PartySetup: React.FC = () => {
       <div className={styles.navigationButtons}>
         <button onClick={() => navigate('/town')} className={styles.backButton}>
           Back to Town
-        </button>
-        <button
-          onClick={handleStartGame}
-          disabled={!isPartyValid}
-          className={styles.startGameButton}
-        >
-          Enter Dungeon
         </button>
       </div>
       </div>


### PR DESCRIPTION
## Summary
- only allow returning to town from the Party Setup screen
- drop unused start game button styles

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68435b98c6a083278a6a4bbe3302796e