### PR TITLE
Add health-aware enemy AI

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,10 @@ chains. Enemies remember recently played starter cards and will prioritize
 playing matching finishers within the combo window. When no finisher is
 available the AI will attempt to start a preferred combo. Targeting also adapts
 to focus the lowest health party member for a more dynamic challenge.
+The AI now scores available actions based on unit health and ability effects,
+allowing enemies to choose healing or defensive options when injured. A debug
+listener can be registered via `setAIDebugListener` to inspect each decision
+during development.
 
 ## Testing
 

--- a/client/src/phaser/BattleScene.ts
+++ b/client/src/phaser/BattleScene.ts
@@ -78,8 +78,8 @@ export default class BattleScene extends Phaser.Scene {
     this.enemies = [JSON.parse(JSON.stringify(this.enemy))]
 
     this.combatants = [
-      ...this.party.map((c: any) => ({ type: 'player', data: c, hp: c.stats.hp, speed: c.stats.speed })),
-      ...this.enemies.map((e: any) => ({ type: 'enemy', data: e, hp: e.stats.hp, speed: e.stats.speed })),
+      ...this.party.map((c: any, idx: number) => ({ type: 'player', data: c, hp: c.stats.hp, speed: c.stats.speed, position: idx })),
+      ...this.enemies.map((e: any, idx: number) => ({ type: 'enemy', data: e, hp: e.stats.hp, speed: e.stats.speed, position: idx })),
     ]
     this.turnOrder = this.combatants.sort((a, b) => b.speed - a.speed)
     this.turnIndex = 0
@@ -169,9 +169,15 @@ export default class BattleScene extends Phaser.Scene {
   }
 
   private enemyAction() {
-    const context = { currentTurn: this.turnNumber, group: this.enemyGroup }
-    const card = chooseEnemyAction(this.current.data, context)
     const players = this.turnOrder.filter((c) => c.type === 'player')
+    const context = {
+      currentTurn: this.turnNumber,
+      group: this.enemyGroup,
+      enemyHP: this.current.hp,
+      enemyMaxHP: this.current.data.stats.hp,
+      players,
+    }
+    const card = chooseEnemyAction(this.current.data, context)
     const targetCombat = chooseTarget(players) || players[0]
     if (card.isComboFinisher) {
       console.log(`${this.current.data.name} executes combo ${card.synergyTag}`)

--- a/game/src/scenes/BattleScene.js
+++ b/game/src/scenes/BattleScene.js
@@ -105,19 +105,21 @@ export default class BattleScene extends Phaser.Scene {
     this.activeEvent = state.activeEvent || null
 
     this.combatants = [
-      ...this.party.map((c) => ({
+      ...this.party.map((c, idx) => ({
         type: 'player',
         data: c,
         hp: c.stats.hp,
         speed: c.stats.speed,
         statusEffects: [],
+        position: idx,
       })),
-      ...this.enemies.map((e) => ({
+      ...this.enemies.map((e, idx) => ({
         type: 'enemy',
         data: e,
         hp: e.stats.hp,
         speed: e.stats.speed,
         statusEffects: [],
+        position: idx,
       })),
     ]
     this.turnOrder = this.combatants.sort((a, b) => b.speed - a.speed)
@@ -227,9 +229,15 @@ export default class BattleScene extends Phaser.Scene {
   }
 
   enemyAction() {
-    const context = { currentTurn: this.turnNumber, group: this.enemyGroup }
-    const card = chooseEnemyAction(this.current.data, context)
     const players = this.turnOrder.filter((c) => c.type === 'player')
+    const context = {
+      currentTurn: this.turnNumber,
+      group: this.enemyGroup,
+      enemyHP: this.current.hp,
+      enemyMaxHP: this.current.data.stats.hp,
+      players,
+    }
+    const card = chooseEnemyAction(this.current.data, context)
     const targetCombat = chooseTarget(players) || players[0]
     if (card.isComboFinisher) {
       console.log(`${this.current.data.name} executes combo ${card.synergyTag}`)

--- a/shared/README.md
+++ b/shared/README.md
@@ -28,7 +28,9 @@ The `systems` directory provides helper modules for various game mechanics.
 -   **Market (`market.js`)**: Handles all economic transactions, including player balances for Gold and Guild Credits, and interactions with different market types (Town, Black Market, Guild Exchange, Auction House).
 -   **Biome (`biome.js`)**: Implements biome-specific synergy bonuses that affect enemies within particular dungeon environments.
 -   **Floor Events (`floorEvents.js`)**: Manages dynamic, floor-wide events that can alter combat flow and add variety to dungeon runs.
--   **Enemy AI (`enemyAI.js`)**: Contains the logic for combo-aware enemy behavior, including tracking card synergies and prioritizing finishers.
+-   **Enemy AI (`enemyAI.js`)**: Provides modular logic for enemy decision making.
+    It tracks card synergies, evaluates actions based on health, and exposes a
+    debugging hook for monitoring AI choices.
 -   **Post Battle (`postBattle.js`)**: Handles the resolution of combat, including awarding loot, and applying fatigue, hunger, and thirst to party members.
 -   **Progression (`progression.js`)**: Governs character leveling, unlocking card rarities, and profession skill advancement.
 -   **Room Events (`roomEvents.js`)**: Logic for various non-combat encounters or discoveries that can occur when navigating dungeon map nodes.

--- a/shared/systems/index.d.ts
+++ b/shared/systems/index.d.ts
@@ -110,12 +110,24 @@ export function trackEnemyActions(
 ): void
 export function findComboStarter(cards: import('../models').Card[], comboTag: string): import('../models').Card | null
 export function findComboFinisher(cards: import('../models').Card[], comboTag: string): import('../models').Card | null
+export function evaluateCard(
+  enemy: import('../models').Enemy,
+  card: import('../models').Card,
+  context?: { enemyHP?: number; enemyMaxHP?: number },
+): number
 export function shouldExecuteCombo(
   enemy: import('../models').Enemy,
   context: { currentTurn: number; group?: { lastUsedCards?: { card: import('../models').Card; turn: number }[] } },
 ): boolean
 export function chooseEnemyAction(
   enemy: import('../models').Enemy,
-  context: { currentTurn: number; group?: { lastUsedCards?: { card: import('../models').Card; turn: number }[] } },
+  context: {
+    currentTurn: number
+    group?: { lastUsedCards?: { card: import('../models').Card; turn: number }[] }
+    enemyHP?: number
+    enemyMaxHP?: number
+    players?: { hp: number; position?: number }[]
+  },
 ): import('../models').Card
-export function chooseTarget(players: { hp: number }[]): any
+export function chooseTarget(players: { hp: number; position?: number }[]): any
+export function setAIDebugListener(fn: (info: any) => void): void


### PR DESCRIPTION
## Summary
- expand enemy AI to evaluate healing and damage
- expose `setAIDebugListener` for decision debugging
- track combatant positions and pass HP info when choosing actions
- adjust Phaser battle scenes to supply new context
- document the improved AI system
- test new functionality

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684363338c8c8327b44c8cd03f860622