### PR TITLE
Add status effects system

### DIFF
--- a/client/src/components/UnitCard.module.css
+++ b/client/src/components/UnitCard.module.css
@@ -45,6 +45,16 @@
   font-size: 0.75rem;
   margin-top: 0.25rem;
 }
+.statusRow {
+  margin-top: 2px;
+  display: flex;
+  justify-content: center;
+  gap: 2px;
+  font-size: 0.9rem;
+}
+.statusIcon {
+  transition: transform 0.2s;
+}
 .actions {
   margin-top: 0.5rem;
   display: flex;

--- a/client/src/components/UnitCard.tsx
+++ b/client/src/components/UnitCard.tsx
@@ -1,6 +1,14 @@
 import React from 'react'
 import styles from './UnitCard.module.css'
 
+const STATUS_ICONS: Record<string, { icon: string; color: string }> = {
+  poison: { icon: '☠', color: '#88ff88' },
+  stun: { icon: '💫', color: '#ff66ff' },
+  defense: { icon: '🛡', color: '#99ccff' },
+  attack: { icon: '⚔', color: '#ffcc66' },
+  marked: { icon: '🎯', color: '#ff8844' },
+}
+
 interface Action {
   label: string
   onClick: () => void
@@ -12,6 +20,7 @@ interface UnitCardProps {
   hp: number
   maxHp: number
   status?: string
+  statuses?: { type: string; value?: number }[]
   actions?: Action[]
   isActive?: boolean
   isDisabled?: boolean
@@ -23,6 +32,7 @@ const UnitCard: React.FC<UnitCardProps> = ({
   hp,
   maxHp,
   status,
+  statuses = [],
   actions = [],
   isActive = false,
   isDisabled = false,
@@ -64,6 +74,23 @@ const UnitCard: React.FC<UnitCardProps> = ({
         {hp} / {maxHp}
       </div>
       <div className={styles.status}>{status}</div>
+      {statuses.length > 0 && (
+        <div className={styles.statusRow} aria-hidden="true">
+          {statuses.map((s, i) => {
+            const meta = STATUS_ICONS[s.type] || { icon: s.type[0], color: '#fff' }
+            return (
+              <span
+                key={i}
+                className={styles.statusIcon}
+                style={{ color: meta.color }}
+                title={s.type}
+              >
+                {meta.icon}
+              </span>
+            )
+          })}
+        </div>
+      )}
       {actions.length > 0 && (
         <div className={styles.actions}>
           {actions.map((a, i) => (

--- a/game/src/scenes/BattleScene.js
+++ b/game/src/scenes/BattleScene.js
@@ -5,6 +5,12 @@ import { applyEventEffects } from 'shared/systems/floorEvents.js'
 import { chooseEnemyAction, trackEnemyActions, chooseTarget } from 'shared/systems/enemyAI.js'
 import { floatingText } from '../effects.js'
 import { loadGameState } from '../state'
+import {
+  STATUS_META,
+  addStatusEffect,
+  getStatusValue,
+  applyStatusTick,
+} from '../statusSystem.js'
 
 
 export default class BattleScene extends Phaser.Scene {
@@ -31,8 +37,47 @@ export default class BattleScene extends Phaser.Scene {
     }
   }
 
+  updateStatusIcons(combatant) {
+    const sprite = this.getSprite(combatant)
+    if (!sprite) return
+    sprite.statusIcons = sprite.statusIcons || {}
+    const active = combatant.statusEffects.map((s) => s.type)
+    // remove missing
+    Object.keys(sprite.statusIcons).forEach((type) => {
+      if (!active.includes(type)) {
+        const icon = sprite.statusIcons[type]
+        this.tweens.add({
+          targets: icon,
+          alpha: 0,
+          duration: 300,
+          onComplete: () => icon.destroy(),
+        })
+        delete sprite.statusIcons[type]
+      }
+    })
+    active.forEach((type, idx) => {
+      let icon = sprite.statusIcons[type]
+      const meta = STATUS_META[type] || {}
+      if (!icon) {
+        icon = this.add
+          .text(0, 0, meta.icon || type[0], {
+            fontSize: '14px',
+            color: meta.color || '#ffffff',
+          })
+          .setAlpha(0)
+        this.tweens.add({ targets: icon, alpha: 1, duration: 300 })
+        sprite.statusIcons[type] = icon
+      }
+      icon.setText(meta.icon || type[0])
+      icon.setPosition(sprite.rect.x - 20 + idx * 20, sprite.rect.y - 50)
+    })
+  }
+
   calculateDamage(effect, attacker, defender) {
     let dmg = effect.magnitude || effect.value || 0
+    dmg += getStatusValue(attacker, 'attack')
+    dmg -= getStatusValue(defender, 'defense')
+    dmg += getStatusValue(defender, 'marked')
     if (effect.element === 'fire') {
       if (attacker.data?.stats?.firePower) {
         dmg += attacker.data.stats.firePower
@@ -41,27 +86,16 @@ export default class BattleScene extends Phaser.Scene {
         dmg *= 1 - defender.data.stats.fireResist
       }
     }
+    if (dmg < 0) dmg = 0
     return Math.round(dmg)
   }
 
   applyStatusEffects(combatant) {
-    combatant.statusEffects = combatant.statusEffects || []
-    let skip = false
-    const remaining = []
-    combatant.statusEffects.forEach((eff) => {
-      if (eff.type === 'poison') {
-        combatant.hp -= eff.value
-        this.showFloat(`-${eff.value}`, combatant, '#88ff88')
-      }
-      if (eff.type === 'stun') {
-        skip = true
-        this.showFloat('Stunned', combatant, '#ff66ff')
-      }
-      eff.duration -= 1
-      if (eff.duration > 0) remaining.push(eff)
-    })
-    combatant.statusEffects = remaining
+    const skip = applyStatusTick(this, combatant, (t, c, col) =>
+      this.showFloat(t, c, col)
+    )
     this.updateHealth()
+    this.updateStatusIcons(combatant)
     return skip
   }
 
@@ -141,14 +175,14 @@ export default class BattleScene extends Phaser.Scene {
       const y = startY + i * offsetY
       const rect = this.add.rectangle(150, y, 60, 60, 0x6699ff).setOrigin(0.5)
       const hpText = this.add.text(110, y + 40, '', { fontSize: '16px' })
-      this.playerSprites.push({ rect, hpText, data: p })
+      this.playerSprites.push({ rect, hpText, data: p, statusIcons: {} })
     })
 
     this.enemies.forEach((e, i) => {
       const y = startY + i * offsetY
       const rect = this.add.rectangle(650, y, 60, 60, 0xff6666).setOrigin(0.5)
       const hpText = this.add.text(610, y + 40, '', { fontSize: '16px' })
-      this.enemySprites.push({ rect, hpText, data: e })
+      this.enemySprites.push({ rect, hpText, data: e, statusIcons: {} })
     })
 
     this.turnText = this.add.text(350, 50, '', { fontSize: '20px' })
@@ -166,6 +200,7 @@ export default class BattleScene extends Phaser.Scene {
     }
     this.cardTexts = []
     this.updateHealth()
+    this.combatants.forEach((c) => this.updateStatusIcons(c))
   }
 
   updateHealth() {
@@ -276,12 +311,32 @@ export default class BattleScene extends Phaser.Scene {
         this.showFloat(`+${heal}`, actor, '#44ff44')
       }
       if (effect.type === 'status') {
-        target.statusEffects.push({
+        addStatusEffect(target, {
           type: effect.statusType,
           duration: effect.duration || 1,
           value: effect.magnitude || effect.value || 0,
         })
-        this.showFloat(effect.statusType, target, '#ffaa88')
+        this.updateStatusIcons(target)
+        this.showFloat(effect.statusType, target, STATUS_META[effect.statusType]?.color || '#ffaa88')
+      }
+      if (effect.type === 'buff') {
+        const tgt = effect.target === 'self' ? actor : target
+        addStatusEffect(tgt, {
+          type: effect.stat || 'attack',
+          duration: effect.duration || 1,
+          value: effect.magnitude || effect.value || 0,
+        })
+        this.updateStatusIcons(tgt)
+        this.showFloat(`+${effect.stat || 'buff'}`, tgt, STATUS_META[effect.stat]?.color || '#66ccff')
+      }
+      if (effect.type === 'debuff') {
+        addStatusEffect(target, {
+          type: 'marked',
+          duration: effect.duration || 1,
+          value: effect.magnitude || effect.value || 0,
+        })
+        this.updateStatusIcons(target)
+        this.showFloat('Marked', target, STATUS_META.marked.color)
       }
     })
     this.updateHealth()

--- a/game/src/statusSystem.js
+++ b/game/src/statusSystem.js
@@ -1,0 +1,48 @@
+export const STATUS_META = {
+  poison: { icon: '☠', color: '#88ff88' },
+  stun: { icon: '💫', color: '#ff66ff' },
+  defense: { icon: '🛡', color: '#99ccff' },
+  attack: { icon: '⚔', color: '#ffcc66' },
+  marked: { icon: '🎯', color: '#ff8844' },
+}
+
+export function addStatusEffect(target, { type, duration = 1, value = 0 }) {
+  target.statusEffects = target.statusEffects || []
+  const existing = target.statusEffects.find((s) => s.type === type)
+  if (existing) {
+    existing.duration = Math.max(existing.duration, duration)
+    existing.value = (existing.value || 0) + value
+  } else {
+    target.statusEffects.push({ type, duration, value })
+  }
+}
+
+export function getStatusValue(target, type) {
+  return (target.statusEffects || [])
+    .filter((s) => s.type === type)
+    .reduce((sum, s) => sum + (s.value || 0), 0)
+}
+
+export function applyStatusTick(scene, combatant, showFloat) {
+  combatant.statusEffects = combatant.statusEffects || []
+  let skip = false
+  const remaining = []
+  combatant.statusEffects.forEach((eff) => {
+    if (eff.type === 'poison') {
+      combatant.hp -= eff.value
+      showFloat(`-${eff.value}`, combatant, STATUS_META.poison.color)
+    }
+    if (eff.type === 'stun') {
+      skip = true
+      showFloat('Stunned', combatant, STATUS_META.stun.color)
+    }
+    eff.duration -= 1
+    if (eff.duration > 0) {
+      remaining.push(eff)
+    } else {
+      showFloat(`${eff.type} ends`, combatant, '#cccccc')
+    }
+  })
+  combatant.statusEffects = remaining
+  return skip
+}


### PR DESCRIPTION
## Summary
- manage status effects in a shared system
- show status icons on units and animate on changes
- support buffs and debuffs in battle logic

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6843658fcab4832785cc3de37d7bcef3