### PR TITLE
Add mana ability system modules

### DIFF
--- a/src/game/Ability.ts
+++ b/src/game/Ability.ts
@@ -1,0 +1,34 @@
+export type AbilityEffect = (unit: Unit, manager: UnitManager) => void;
+
+export interface AbilityConfig {
+  id: string;
+  name: string;
+  manaCost: number;
+  /** If true ability triggers automatically when mana is available */
+  autoTrigger?: boolean;
+  effect: AbilityEffect;
+}
+
+export class Ability {
+  id: string;
+  name: string;
+  manaCost: number;
+  autoTrigger: boolean;
+  effect: AbilityEffect;
+
+  constructor(config: AbilityConfig) {
+    this.id = config.id;
+    this.name = config.name;
+    this.manaCost = config.manaCost;
+    this.autoTrigger = Boolean(config.autoTrigger);
+    this.effect = config.effect;
+  }
+
+  execute(unit: Unit, manager: UnitManager) {
+    this.effect(unit, manager);
+  }
+}
+
+// circular type imports
+import type { Unit } from './Unit';
+import type { UnitManager } from './UnitManager';

--- a/src/game/Unit.ts
+++ b/src/game/Unit.ts
@@ -1,0 +1,59 @@
+import type { Ability } from './Ability';
+import type { UnitManager } from './UnitManager';
+
+export interface UnitConfig {
+  id: string;
+  name: string;
+  health: number;
+  maxMana: number;
+  manaRegen?: number;
+}
+
+export class Unit {
+  id: string;
+  name: string;
+  health: number;
+  maxMana: number;
+  mana: number;
+  manaRegen: number;
+  abilities: Ability[] = [];
+
+  constructor(config: UnitConfig) {
+    this.id = config.id;
+    this.name = config.name;
+    this.health = config.health;
+    this.maxMana = config.maxMana;
+    this.mana = 0;
+    this.manaRegen = config.manaRegen ?? 1;
+  }
+
+  /** Gain mana and attempt to activate abilities */
+  gainMana(amount: number, manager: UnitManager) {
+    this.mana = Math.min(this.maxMana, this.mana + amount);
+    this.checkAutoAbilities(manager);
+  }
+
+  /** Called each update tick to accumulate passive mana */
+  tick(manager: UnitManager) {
+    if (this.manaRegen > 0) {
+      this.gainMana(this.manaRegen, manager);
+    }
+  }
+
+  /**
+   * Attempt to activate any auto-trigger abilities if enough mana
+   */
+  checkAutoAbilities(manager: UnitManager) {
+    for (const ability of this.abilities) {
+      if (ability.autoTrigger && this.mana >= ability.manaCost) {
+        this.mana -= ability.manaCost;
+        ability.execute(this, manager);
+      }
+    }
+  }
+
+  /** Assign a new ability */
+  addAbility(ability: Ability) {
+    this.abilities.push(ability);
+  }
+}

--- a/src/game/UnitManager.ts
+++ b/src/game/UnitManager.ts
@@ -1,0 +1,28 @@
+import { Unit } from './Unit';
+import { Ability } from './Ability';
+
+export class UnitManager {
+  units: Map<string, Unit> = new Map();
+
+  addUnit(unit: Unit) {
+    this.units.set(unit.id, unit);
+  }
+
+  getUnit(id: string): Unit | undefined {
+    return this.units.get(id);
+  }
+
+  assignAbility(unitId: string, ability: Ability) {
+    const unit = this.getUnit(unitId);
+    if (unit) {
+      unit.addAbility(ability);
+    }
+  }
+
+  /** Update all units each tick */
+  update() {
+    for (const unit of this.units.values()) {
+      unit.tick(this);
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add a small game systems folder
- implement `Ability`, `Unit`, and `UnitManager`
- include support for mana regen and automatic ability use

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684368d70f48832785b78e4c0746dc80