### PR TITLE
Implement basic automated combat engine

### DIFF
--- a/src/game/AIController.ts
+++ b/src/game/AIController.ts
@@ -1,0 +1,22 @@
+import type { Unit } from './BattleManager';
+
+export interface AIContext {
+  allies: Unit[];
+  opponents: Unit[];
+  round: number;
+}
+
+function selectTarget(opponents: Unit[]): Unit | null {
+  if (!opponents.length) return null;
+  return opponents.reduce((low, u) => (u.stats.hp < low.stats.hp ? u : low), opponents[0]);
+}
+
+function selectCard(unit: Unit): any {
+  return unit.deck[0] || null;
+}
+
+export function decideAction(unit: Unit, context: AIContext) {
+  const target = selectTarget(context.opponents);
+  const action = selectCard(unit);
+  return { action, target };
+}

--- a/src/game/BattleManager.ts
+++ b/src/game/BattleManager.ts
@@ -1,0 +1,79 @@
+export interface Unit {
+  id: string;
+  name: string;
+  team: 'player' | 'enemy';
+  stats: { hp: number; speed: number; [key: string]: any };
+  deck: any[];
+  statusEffects?: { type: string; duration: number; value?: number }[];
+}
+
+export interface TurnResult {
+  actor: Unit;
+  target: Unit | null;
+  action: any;
+}
+
+import { decideAction } from './AIController';
+import { executeAction } from './CombatResolver';
+
+export class BattleManager {
+  private units: Unit[];
+  private order: Unit[];
+  private turnIndex = 0;
+  round = 0;
+
+  constructor(units: Unit[]) {
+    this.units = units;
+    this.order = [...units].sort((a, b) => b.stats.speed - a.stats.speed);
+  }
+
+  start() {
+    this.round = 1;
+    this.turnIndex = 0;
+  }
+
+  private advanceRound() {
+    this.round += 1;
+    this.turnIndex = 0;
+    this.order = this.order.filter((u) => u.stats.hp > 0);
+    this.order.sort((a, b) => b.stats.speed - a.stats.speed);
+  }
+
+  private nextUnit(): Unit | null {
+    if (this.order.length === 0) return null;
+    if (this.turnIndex >= this.order.length) {
+      this.advanceRound();
+    }
+    return this.order[this.turnIndex++] || null;
+  }
+
+  step(): TurnResult | null {
+    if (this.isFinished()) return null;
+    const unit = this.nextUnit();
+    if (!unit) return null;
+    if (unit.stats.hp <= 0) return this.step();
+    const opponents = this.order.filter((u) => u.team !== unit.team && u.stats.hp > 0);
+    const allies = this.order.filter((u) => u.team === unit.team && u !== unit && u.stats.hp > 0);
+    const decision = decideAction(unit, { allies, opponents, round: this.round });
+    if (decision && decision.action && decision.target) {
+      executeAction(unit, decision.target, decision.action);
+      // remove dead units from order
+      this.order = this.order.filter((u) => u.stats.hp > 0);
+      return { actor: unit, target: decision.target, action: decision.action };
+    }
+    return { actor: unit, target: null, action: null };
+  }
+
+  isFinished(): boolean {
+    const playersAlive = this.order.some((u) => u.team === 'player' && u.stats.hp > 0);
+    const enemiesAlive = this.order.some((u) => u.team === 'enemy' && u.stats.hp > 0);
+    return !(playersAlive && enemiesAlive);
+  }
+
+  run() {
+    this.start();
+    while (!this.isFinished()) {
+      this.step();
+    }
+  }
+}

--- a/src/game/CombatResolver.ts
+++ b/src/game/CombatResolver.ts
@@ -1,0 +1,34 @@
+import type { Unit } from './BattleManager';
+
+export interface Effect {
+  type: string;
+  magnitude?: number;
+  value?: number;
+  target?: 'self' | 'enemy';
+}
+
+export interface Card {
+  id: string;
+  name: string;
+  effects: Effect[];
+}
+
+export function executeAction(actor: Unit, target: Unit, card: Card) {
+  for (const eff of card.effects) {
+    if (eff.type === 'damage') {
+      target.stats.hp -= eff.magnitude ?? eff.value ?? 0;
+    }
+    if (eff.type === 'heal') {
+      const healTarget = eff.target === 'self' ? actor : target;
+      healTarget.stats.hp += eff.magnitude ?? eff.value ?? 0;
+    }
+    if (eff.type === 'status') {
+      const tgt = eff.target === 'self' ? actor : target;
+      tgt.statusEffects = tgt.statusEffects || [];
+      tgt.statusEffects.push({
+        type: 'status',
+        duration: eff.magnitude ?? 1,
+      });
+    }
+  }
+}

--- a/src/game/index.ts
+++ b/src/game/index.ts
@@ -1,0 +1,3 @@
+export * from './BattleManager';
+export * from './AIController';
+export * from './CombatResolver';


### PR DESCRIPTION
## Summary
- add simple automated battle engine skeleton
- implement minimal AI decision making for units
- handle basic damage, healing and status effects

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684368e609908327b87cc8061ccf1f55