### PR TITLE
Add pre-battle setup phase

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -4,6 +4,7 @@ import { useEffect, useRef } from 'react'
 import { CSSTransition, SwitchTransition } from 'react-transition-group'
 import MainMenu from './components/MainMenu.jsx'
 import PartySetup from './components/PartySetup.tsx'
+import PreBattleSetup from './components/PreBattleSetup.tsx'
 import DungeonMap from './components/DungeonMap.tsx'
 import TownView from './components/TownView.tsx'
 import InventoryPage from './components/InventoryPage.tsx'
@@ -41,6 +42,7 @@ function AnimatedRoutes() {
           <Route path="/cards" element={<CollectionPage />} />
           <Route path="/crafting" element={<CraftingPage />} />
           <Route path="/shop" element={<ShopPage />} />
+          <Route path="/pre-battle" element={<PreBattleSetup />} />
           <Route path="/battle" element={<BattleScene />} />
           <Route path="/decks" element={<DeckManager />} />
         </Routes>

--- a/client/src/components/PreBattleSetup.module.css
+++ b/client/src/components/PreBattleSetup.module.css
@@ -1,0 +1,70 @@
+.screen {
+  padding: 20px;
+  font-family: 'Trebuchet MS', sans-serif;
+  background: linear-gradient(180deg, #1e1e2f, #0f0f17);
+  color: #f5f5f5;
+  min-height: 100vh;
+  display: flex;
+  justify-content: center;
+  align-items: flex-start;
+}
+
+.setupCard {
+  background-color: #212121;
+  padding: 2rem;
+  border-radius: 1rem;
+  box-shadow: 0 0 15px rgba(0, 0, 0, 0.5);
+  width: 100%;
+  max-width: 1000px;
+}
+
+.title {
+  text-align: center;
+  color: #e0e0e0;
+  margin-bottom: 30px;
+  font-size: 2.2em;
+}
+
+.grid {
+  display: grid;
+  grid-template-columns: repeat(3, 100px);
+  grid-template-rows: repeat(3, 100px);
+  gap: 8px;
+  justify-content: center;
+  margin-bottom: 1rem;
+}
+
+.cell {
+  background: #333;
+  border: 1px dashed #555;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: #fff;
+  font-size: 0.9em;
+}
+
+.unitList {
+  display: flex;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+  margin-bottom: 1rem;
+}
+
+.unit {
+  background: #444;
+  padding: 0.5rem 0.75rem;
+  border-radius: 0.5rem;
+  cursor: grab;
+}
+
+.unitSelected {
+  outline: 2px solid #3498db;
+}
+
+.buttons {
+  margin-top: 1rem;
+  display: flex;
+  gap: 1rem;
+  justify-content: center;
+}

--- a/client/src/components/PreBattleSetup.tsx
+++ b/client/src/components/PreBattleSetup.tsx
@@ -1,0 +1,158 @@
+import React, { useState, useEffect } from 'react'
+import { useNavigate } from 'react-router-dom'
+import { useGameStore } from '../store/gameStore'
+import type { PartyCharacter } from './PartySetup'
+import type { Card } from '../../../shared/models/Card'
+import { sampleCards } from '../../../shared/models/cards.js'
+import CardAssignmentPanel from './CardAssignmentPanel'
+import { saveFormation, loadFormation } from '../../game/SetupManager'
+import type { Formation, Position } from '../../game/Formation'
+import styles from './PreBattleSetup.module.css'
+
+const GRID_SIZE = 3
+
+const emptyFormation = (): Formation => ({ gridSize: GRID_SIZE, units: [] })
+
+const PreBattleSetup: React.FC = () => {
+  const navigate = useNavigate()
+  const party = useGameStore(state => state.party)
+  const [characters, setCharacters] = useState<PartyCharacter[]>([])
+  const [placement, setPlacement] = useState<Record<string, Position>>({})
+  const [selectedId, setSelectedId] = useState<string | null>(null)
+  const [dragId, setDragId] = useState<string | null>(null)
+  const [availableCards, setAvailableCards] = useState<Card[]>([])
+
+  useEffect(() => {
+    if (party) {
+      const chars: PartyCharacter[] = party.characters.map(c => ({
+        ...c,
+        assignedCards: c.deck || [],
+      }))
+      setCharacters(chars)
+    }
+  }, [party])
+
+  useEffect(() => {
+    setAvailableCards(sampleCards.map(c => ({ ...c, description: c.description || 'No description.' })))
+  }, [])
+
+  useEffect(() => {
+    const saved = loadFormation()
+    if (saved && saved.gridSize === GRID_SIZE) {
+      const map: Record<string, Position> = {}
+      saved.units.forEach(u => { map[u.unitId] = u.position })
+      setPlacement(map)
+    }
+  }, [])
+
+  const handleDragStart = (id: string) => {
+    setDragId(id)
+  }
+
+  const handleDrop = (x: number, y: number) => {
+    if (dragId) {
+      setPlacement(prev => ({ ...prev, [dragId]: { x, y } }))
+      setDragId(null)
+    }
+  }
+
+  const handleAssignCard = (characterId: string, card: Card) => {
+    setCharacters(chars =>
+      chars.map(c => (c.id === characterId ? { ...c, assignedCards: [...c.assignedCards, card] } : c)),
+    )
+  }
+
+  const handleRemoveCard = (characterId: string, cardId: string) => {
+    setCharacters(chars =>
+      chars.map(c =>
+        c.id === characterId
+          ? { ...c, assignedCards: c.assignedCards.filter(cd => cd.id !== cardId) }
+          : c,
+      ),
+    )
+  }
+
+  const saveSetup = () => {
+    const formation: Formation = {
+      gridSize: GRID_SIZE,
+      units: characters.map(c => ({
+        unitId: c.id,
+        position: placement[c.id] || { x: 0, y: 0 },
+        cardIds: c.assignedCards.map(card => card.id),
+      })),
+    }
+    saveFormation(formation)
+  }
+
+  const selectedChar = characters.find(c => c.id === selectedId) || null
+
+  return (
+    <div className={styles.screen}>
+      <div className={styles.setupCard}>
+        <h1 className={styles.title}>Pre-Battle Setup</h1>
+        <div className={styles.grid}>
+          {Array.from({ length: GRID_SIZE }).map((_, y) =>
+            Array.from({ length: GRID_SIZE }).map((__, x) => {
+              const occupant = characters.find(c => placement[c.id]?.x === x && placement[c.id]?.y === y)
+              return (
+                <div
+                  key={`${x}-${y}`}
+                  className={styles.cell}
+                  onDragOver={e => e.preventDefault()}
+                  onDrop={() => handleDrop(x, y)}
+                >
+                  {occupant ? (
+                    <div
+                      draggable
+                      onDragStart={() => handleDragStart(occupant.id)}
+                      onClick={() => setSelectedId(occupant.id)}
+                      className={`${styles.unit} ${selectedId === occupant.id ? styles.unitSelected : ''}`}
+                    >
+                      {occupant.name}
+                    </div>
+                  ) : (
+                    'Empty'
+                  )}
+                </div>
+              )
+            }),
+          )}
+        </div>
+        <div className={styles.unitList}>
+          {characters.map(c => (
+            <div
+              key={c.id}
+              draggable
+              onDragStart={() => handleDragStart(c.id)}
+              onClick={() => setSelectedId(c.id)}
+              className={`${styles.unit} ${selectedId === c.id ? styles.unitSelected : ''}`}
+            >
+              {c.name}
+            </div>
+          ))}
+        </div>
+        {selectedChar && (
+          <CardAssignmentPanel
+            character={selectedChar}
+            availableCards={availableCards}
+            onAssignCard={handleAssignCard}
+            onRemoveCard={handleRemoveCard}
+          />
+        )}
+        <div className={styles.buttons}>
+          <button onClick={saveSetup}>Save</button>
+          <button
+            onClick={() => {
+              saveSetup()
+              navigate('/battle')
+            }}
+          >
+            Start Battle
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+export default PreBattleSetup

--- a/client/src/components/TownView.tsx
+++ b/client/src/components/TownView.tsx
@@ -64,7 +64,7 @@ export default function TownView() {
         </button>
         <button
           className={styles.card}
-          onClick={() => navigate('/battle')}
+          onClick={() => navigate('/pre-battle')}
           aria-label="Battle"
         >
           <span className={styles.icon}>⚔️</span>

--- a/src/game/Formation.ts
+++ b/src/game/Formation.ts
@@ -1,0 +1,32 @@
+export interface Position {
+  x: number
+  y: number
+}
+
+export interface UnitPlacement {
+  unitId: string
+  position: Position
+  cardIds: string[]
+}
+
+export interface Formation {
+  gridSize: number
+  units: UnitPlacement[]
+}
+
+export function isPositionValid(pos: Position, gridSize: number): boolean {
+  return pos.x >= 0 && pos.y >= 0 && pos.x < gridSize && pos.y < gridSize
+}
+
+export function validateFormation(formation: Formation): boolean {
+  const occupied = new Set<string>()
+  for (const unit of formation.units) {
+    const { position } = unit
+    const key = `${position.x},${position.y}`
+    if (!isPositionValid(position, formation.gridSize)) return false
+    if (occupied.has(key)) return false
+    if (new Set(unit.cardIds).size !== unit.cardIds.length) return false
+    occupied.add(key)
+  }
+  return true
+}

--- a/src/game/SetupManager.ts
+++ b/src/game/SetupManager.ts
@@ -1,0 +1,21 @@
+import type { Formation } from './Formation'
+
+const KEY = 'preBattleFormation'
+
+export function saveFormation(formation: Formation) {
+  localStorage.setItem(KEY, JSON.stringify(formation))
+}
+
+export function loadFormation(): Formation | null {
+  const raw = localStorage.getItem(KEY)
+  if (!raw) return null
+  try {
+    return JSON.parse(raw) as Formation
+  } catch {
+    return null
+  }
+}
+
+export function clearFormation() {
+  localStorage.removeItem(KEY)
+}


### PR DESCRIPTION
## Summary
- add PreBattleSetup component for placing units and assigning cards
- persist setups via new Formation and SetupManager modules
- link new planning route from town and routing table

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684368f3ce608327bb8d14fe10777a96