### PR TITLE
Enhance Pre-Battle setup visuals

### DIFF
--- a/client/src/components/PreBattleSetup.module.css
+++ b/client/src/components/PreBattleSetup.module.css
@@ -10,10 +10,10 @@
 }
 
 .setupCard {
-  background-color: #212121;
+  background: linear-gradient(180deg, #2a2a3a, #1a1a26);
   padding: 2rem;
   border-radius: 1rem;
-  box-shadow: 0 0 15px rgba(0, 0, 0, 0.5);
+  box-shadow: 0 4px 20px rgba(0, 0, 0, 0.6);
   width: 100%;
   max-width: 1000px;
 }
@@ -22,44 +22,95 @@
   text-align: center;
   color: #e0e0e0;
   margin-bottom: 30px;
-  font-size: 2.2em;
+  font-size: 2.5em;
+  font-weight: bold;
 }
 
 .grid {
   display: grid;
-  grid-template-columns: repeat(3, 100px);
-  grid-template-rows: repeat(3, 100px);
-  gap: 8px;
+  grid-template-columns: repeat(3, 110px);
+  grid-template-rows: repeat(3, 110px);
+  gap: 12px;
   justify-content: center;
   margin-bottom: 1rem;
 }
 
 .cell {
-  background: #333;
-  border: 1px dashed #555;
+  background: #2f2f2f;
+  border: 2px dashed #555;
   display: flex;
   align-items: center;
   justify-content: center;
   color: #fff;
   font-size: 0.9em;
+  border-radius: 0.75rem;
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.4);
+  transition: background 0.2s, transform 0.2s;
+}
+
+.cell:hover {
+  background: #3a3a3a;
+  transform: translateY(-2px);
 }
 
 .unitList {
   display: flex;
-  gap: 0.5rem;
+  gap: 0.75rem;
   flex-wrap: wrap;
+  justify-content: center;
   margin-bottom: 1rem;
 }
 
 .unit {
-  background: #444;
-  padding: 0.5rem 0.75rem;
-  border-radius: 0.5rem;
+  background: #333;
+  padding: 0.4rem 0.6rem;
+  border-radius: 0.6rem;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.4);
   cursor: grab;
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+  transition: transform 0.2s;
+}
+
+.unit:hover {
+  transform: translateY(-2px);
 }
 
 .unitSelected {
   outline: 2px solid #3498db;
+}
+
+.unitCard {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  text-align: center;
+}
+
+.portrait {
+  width: 64px;
+  height: 64px;
+  border-radius: 50%;
+  object-fit: cover;
+  margin-bottom: 4px;
+}
+
+.portraitSmall {
+  width: 32px;
+  height: 32px;
+  border-radius: 50%;
+  object-fit: cover;
+}
+
+.unitName {
+  font-size: 0.8rem;
+  font-weight: bold;
+}
+
+.emptySlot {
+  color: #777;
+  font-size: 2rem;
 }
 
 .buttons {

--- a/client/src/components/PreBattleSetup.tsx
+++ b/client/src/components/PreBattleSetup.tsx
@@ -8,6 +8,7 @@ import CardAssignmentPanel from './CardAssignmentPanel'
 import { saveFormation, loadFormation } from '../../../src/game/SetupManager'
 import type { Formation, Position } from '../../../src/game/Formation'
 import styles from './PreBattleSetup.module.css'
+import defaultPortrait from '../../../shared/images/default-portrait.png'
 
 const GRID_SIZE = 3
 
@@ -106,12 +107,22 @@ const PreBattleSetup: React.FC = () => {
                       draggable
                       onDragStart={() => handleDragStart(occupant.id)}
                       onClick={() => setSelectedId(occupant.id)}
-                      className={`${styles.unit} ${selectedId === occupant.id ? styles.unitSelected : ''}`}
+                      className={`${styles.unitCard} ${selectedId === occupant.id ? styles.unitSelected : ''}`}
                     >
-                      {occupant.name}
+                      <img
+                        src={occupant.portrait || defaultPortrait}
+                        alt={occupant.name}
+                        className={styles.portrait}
+                        onError={e => {
+                          if ((e.currentTarget as HTMLImageElement).src !== defaultPortrait) {
+                            (e.currentTarget as HTMLImageElement).src = defaultPortrait
+                          }
+                        }}
+                      />
+                      <span className={styles.unitName}>{occupant.name}</span>
                     </div>
                   ) : (
-                    'Empty'
+                    <div className={styles.emptySlot}>+</div>
                   )}
                 </div>
               )
@@ -127,7 +138,17 @@ const PreBattleSetup: React.FC = () => {
               onClick={() => setSelectedId(c.id)}
               className={`${styles.unit} ${selectedId === c.id ? styles.unitSelected : ''}`}
             >
-              {c.name}
+              <img
+                src={c.portrait || defaultPortrait}
+                alt={c.name}
+                className={styles.portraitSmall}
+                onError={e => {
+                  if ((e.currentTarget as HTMLImageElement).src !== defaultPortrait) {
+                    (e.currentTarget as HTMLImageElement).src = defaultPortrait
+                  }
+                }}
+              />
+              <span className={styles.unitName}>{c.name}</span>
             </div>
           ))}
         </div>


### PR DESCRIPTION
## Summary
- display character portraits in PreBattleSetup screen
- polish layout and add hover effects

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68436fb361248327a828aec63118be4a