### PR TITLE
Improve inventory visuals

### DIFF
--- a/client/src/components/InventoryScreen.module.css
+++ b/client/src/components/InventoryScreen.module.css
@@ -1,45 +1,131 @@
 .container {
-  padding: 20px;
+  padding: 1.5rem;
+  background: linear-gradient(#3b3b3b, #2c2c2c);
+  border-radius: 12px;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.4);
 }
+
 .title {
-  margin-bottom: 20px;
+  margin-bottom: 1rem;
+  font-size: 2rem;
+  text-align: center;
+  text-shadow: 0 0 6px rgba(255, 255, 255, 0.4);
+  border-bottom: 2px solid #777;
+  padding-bottom: 0.25rem;
 }
+
 .filterRow {
-  margin-bottom: 15px;
-}
-.select {
-  margin-left: 8px;
-}
-.grid {
+  margin-bottom: 1rem;
   display: flex;
-  flex-wrap: wrap;
-  gap: 10px;
+  justify-content: flex-end;
+  align-items: center;
+  gap: 0.5rem;
 }
-.item {
-  border: 1px solid #ccc;
+
+.select {
+  padding: 0.25rem 0.5rem;
   border-radius: 6px;
-  padding: 10px;
-  width: 150px;
-  background: #fff;
+}
+
+.grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  gap: 1rem;
+}
+
+.item {
+  background: #f5f0e6;
+  border-radius: 10px;
+  padding: 0.75rem;
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.25);
   display: flex;
   flex-direction: column;
   align-items: center;
+  animation: fadeIn 0.3s ease;
 }
+
+@keyframes fadeIn {
+  from { opacity: 0; transform: scale(0.95); }
+  to { opacity: 1; transform: scale(1); }
+}
+
+.icon {
+  width: 80px;
+  height: 48px;
+  margin-bottom: 0.5rem;
+}
+
+.name {
+  font-weight: bold;
+  margin-bottom: 0.25rem;
+}
+
 .desc {
-  font-size: 0.8em;
-  color: #555;
+  font-size: 0.9em;
+  color: #333;
   text-align: center;
-  margin: 4px 0;
+  margin: 0.5rem 0;
 }
+
 .meta {
   font-size: 0.8em;
-  color: #666;
+  color: #555;
 }
+
 .actions {
-  margin-top: 8px;
+  margin-top: auto;
   display: flex;
-  gap: 4px;
+  gap: 0.25rem;
 }
+
 .actions button {
   flex: 1 1 auto;
+  border-radius: 20px;
+  font-size: 0.8em;
+  padding: 0.3rem 0.6rem;
+  transition: background-color 0.2s;
+}
+
+.use {
+  background: #3a7a32;
+  color: #fff;
+}
+.use:hover {
+  background: #44933b;
+}
+
+.equip {
+  background: #2b6cb0;
+  color: #fff;
+}
+.equip:hover {
+  background: #377fd1;
+}
+
+.sell {
+  background: #a83232;
+  color: #fff;
+}
+.sell:hover {
+  background: #c23c3c;
+}
+
+.common {
+  border: 2px solid #a0a0a0;
+}
+
+.uncommon {
+  border: 2px solid #2f855a;
+}
+
+.rare {
+  border: 2px solid #3182ce;
+}
+
+.epic {
+  border: 2px solid #805ad5;
+}
+
+.legendary {
+  border: 2px solid #d69e2e;
 }

--- a/client/src/components/InventoryScreen.tsx
+++ b/client/src/components/InventoryScreen.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react'
 import { useNotification } from './NotificationManager.jsx'
 import { sampleCards } from '../../../shared/models/cards.js'
+import cardArt from '../assets/placeholder-card-art.svg'
 import styles from './InventoryScreen.module.css'
 
 interface InventoryItem {
@@ -27,6 +28,14 @@ export default function InventoryScreen() {
 
   const uniqueTypes = Array.from(new Set(allItems.map(i => i.type)))
 
+  const rarityClass: Record<string, string> = {
+    Common: styles.common,
+    Uncommon: styles.uncommon,
+    Rare: styles.rare,
+    Epic: styles.epic,
+    Legendary: styles.legendary,
+  }
+
   return (
     <div className={styles.container}>
       <h1 className={styles.title}>Inventory</h1>
@@ -48,17 +57,18 @@ export default function InventoryScreen() {
         {items.map(item => (
           <div
             key={item.id}
-            className={styles.item}
+            className={`${styles.item} ${rarityClass[item.rarity] || styles.common}`}
             tabIndex={0}
             aria-label={`${item.name} ${item.rarity} ${item.type}. ${item.description}`}
           >
-            <strong>{item.name}</strong>
+            <img src={cardArt} alt="" className={styles.icon} />
+            <strong className={styles.name}>{item.name}</strong>
             <span className={styles.meta}>{item.rarity}</span>
             <p className={styles.desc}>{item.description}</p>
             <div className={styles.actions}>
-              <button onClick={() => notify(`Used ${item.name}`, 'success')}>Use</button>
-              <button onClick={() => notify(`Equipped ${item.name}`, 'success')}>Equip</button>
-              <button onClick={() => notify(`Sold ${item.name}`, 'success')}>Sell</button>
+              <button className={styles.use} onClick={() => notify(`Used ${item.name}`, 'success')}>Use</button>
+              <button className={styles.equip} onClick={() => notify(`Equipped ${item.name}`, 'success')}>Equip</button>
+              <button className={styles.sell} onClick={() => notify(`Sold ${item.name}`, 'success')}>Sell</button>
             </div>
           </div>
         ))}


### PR DESCRIPTION
## Summary
- style InventoryScreen cards like collectible cards
- color buttons by action
- adjust layout to a responsive grid

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6843720a0fc48327b96d7a07f6c23f2f