### PR TITLE
Improve card collection visuals

### DIFF
--- a/client/src/components/CardCollection.module.css
+++ b/client/src/components/CardCollection.module.css
@@ -1,23 +1,49 @@
 .container {
-  padding: 20px;
-}
-.title {
-  margin-bottom: 20px;
+  padding: 1rem;
   text-align: center;
-}
-.controls {
-  margin-bottom: 15px;
-}
-.grid {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 10px;
-}
-.cardWrapper {
   display: flex;
   flex-direction: column;
   align-items: center;
+  background: radial-gradient(circle at top, #494747, #1b1b1b);
+  min-height: 100vh;
+}
+.title {
+  margin: 0 0 1rem;
+  font-size: 2rem;
+  font-weight: bold;
+  text-shadow: 0 0 6px rgba(255, 255, 255, 0.6);
+  animation: glow 3s ease-in-out infinite alternate;
+}
+.controls {
+  margin-bottom: 1rem;
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+.panel {
+  background: rgba(255, 255, 255, 0.05);
+  padding: 1rem;
+  border-radius: 10px;
+  box-shadow: 0 4px 12px rgba(0,0,0,0.4);
+  width: 100%;
+  max-width: 1000px;
+}
+.grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  gap: 1.5rem;
+}
+.cardWrapper {
+  position: relative;
 }
 .checkbox {
-  margin-bottom: 4px;
+  position: absolute;
+  top: -8px;
+  right: -8px;
 }
+
+@keyframes glow {
+  from { text-shadow: 0 0 3px #fff; }
+  to { text-shadow: 0 0 10px #ffd700; }
+}
+

--- a/client/src/components/CardCollection.tsx
+++ b/client/src/components/CardCollection.tsx
@@ -25,24 +25,26 @@ export default function CardCollection() {
           {rarities.map(r => (<option key={r} value={r}>{r}</option>))}
         </select>
       </div>
-      <div className={styles.grid}>
-        {filtered.map(card => (
-          <div key={card.id} className={styles.cardWrapper}>
-            <input
-              type="checkbox"
-              checked={selected.includes(card.id)}
-              onChange={() => toggle(card.id)}
-              className={styles.checkbox}
-              aria-label={`Select ${card.name}`}
-            />
-            <CardDisplay
-              card={card}
-              onSelect={() => toggle(card.id)}
-              isSelected={selected.includes(card.id)}
-              isDisabled={false}
-            />
-          </div>
-        ))}
+      <div className={styles.panel}>
+        <div className={styles.grid}>
+          {filtered.map(card => (
+            <div key={card.id} className={styles.cardWrapper}>
+              <input
+                type="checkbox"
+                checked={selected.includes(card.id)}
+                onChange={() => toggle(card.id)}
+                className={styles.checkbox}
+                aria-label={`Select ${card.name}`}
+              />
+              <CardDisplay
+                card={card}
+                onSelect={() => toggle(card.id)}
+                isSelected={selected.includes(card.id)}
+                isDisabled={false}
+              />
+            </div>
+          ))}
+        </div>
       </div>
     </div>
   )

--- a/client/src/components/CardDisplay.module.css
+++ b/client/src/components/CardDisplay.module.css
@@ -6,16 +6,18 @@
   overflow: hidden;
   box-shadow: 0 2px 6px rgba(0, 0, 0, 0.3);
   background: linear-gradient(180deg, #fefefe 0%, #ececec 100%);
-  transition: transform 0.2s ease, box-shadow 0.2s ease;
+  transition: transform 0.3s ease, box-shadow 0.3s ease;
   display: flex;
   flex-direction: column;
+  animation: popIn 0.4s ease;
 }
 .card:hover {
-  transform: translateY(-4px);
-  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.4);
+  transform: translateY(-6px) scale(1.03);
+  box-shadow: 0 0 8px var(--rarity-color), 0 8px 16px rgba(0, 0, 0, 0.4);
 }
 .selected {
-  box-shadow: 0 0 10px var(--rarity-color);
+  box-shadow: 0 0 10px var(--rarity-color), 0 0 20px var(--rarity-color);
+  transform: translateY(-4px) scale(1.02);
 }
 .disabled {
   opacity: 0.5;
@@ -142,4 +144,9 @@
   .cardTitle {
     font-size: 0.9rem;
   }
+}
+
+@keyframes popIn {
+  from { opacity: 0; transform: scale(0.9); }
+  to { opacity: 1; transform: scale(1); }
 }

--- a/client/src/components/CollectionPage.tsx
+++ b/client/src/components/CollectionPage.tsx
@@ -6,7 +6,7 @@ import styles from './TownFeaturePage.module.css'
 export default function CollectionPage() {
   return (
     <div className={styles.container}>
-      <Link to="/town" className={styles.back}>Back to Town</Link>
+      <Link to="/town" className={styles.back}>🏠 Back to Town</Link>
       <CardCollection />
     </div>
   )

--- a/client/src/components/TownFeaturePage.module.css
+++ b/client/src/components/TownFeaturePage.module.css
@@ -6,12 +6,15 @@
   display: inline-block;
   margin-bottom: 1rem;
   color: #fff;
-  background: #333;
+  background: #3a3f61;
   padding: 0.4rem 0.8rem;
   border-radius: 4px;
   text-decoration: none;
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.4);
+  transition: background 0.2s ease, transform 0.2s ease;
 }
 
 .back:hover {
-  background: #444;
+  background: #4d538e;
+  transform: translateY(-2px);
 }


### PR DESCRIPTION
## Summary
- use a PNG placeholder for card art
- add popping animation and stronger hover/selection styles on cards
- redesign card collection layout with gradient background and glow effects
- style the back button and include an icon
- remove placeholder PNG

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6843724758488327bb3091c3f4e53cb3