### PR TITLE
Prevent removing last party member

### DIFF
--- a/client/src/components/PartyBuilder.jsx
+++ b/client/src/components/PartyBuilder.jsx
@@ -20,7 +20,11 @@ function PartyBuilder() {
   }
 
   function removeCharacter(id) {
-    setParty(party.filter((c) => c.id !== id))
+    if (party.length > 1) {
+      setParty(party.filter((c) => c.id !== id))
+    } else {
+      alert('Your party must have at least one member.')
+    }
   }
 
   function addCard(index) {
@@ -92,7 +96,12 @@ function PartyBuilder() {
           {party.map((char, idx) => (
             <li key={char.id}>
               <strong>{char.name}</strong>{' '}
-              <button onClick={() => removeCharacter(char.id)}>Remove</button>
+              <button
+                onClick={() => removeCharacter(char.id)}
+                disabled={party.length === 1}
+              >
+                Remove
+              </button>
               <ul>
                 {char.cards.map((cid) => {
                   const card = sampleCards.find((c) => c.id === cid)

--- a/client/src/components/PartySetup.tsx
+++ b/client/src/components/PartySetup.tsx
@@ -166,9 +166,13 @@ const PartySetup: React.FC = () => {
   };
 
   const handleClassRemove = (characterId: string) => {
-    const newParty = selectedCharacters.filter(c => c.id !== characterId);
-    setSelectedCharacters(newParty);
-    rerollAvailableClasses(newParty);
+    if (selectedCharacters.length > 1) {
+      const newParty = selectedCharacters.filter(c => c.id !== characterId);
+      setSelectedCharacters(newParty);
+      rerollAvailableClasses(newParty);
+    } else {
+      notify('Your party must have at least one member.', 'error');
+    }
   };
 
   const handleCardAssign = (characterId: string, card: Card) => {
@@ -312,7 +316,13 @@ const PartySetup: React.FC = () => {
             <div key={pc.id} className={styles.selectedCharacterPanel}> {/* Apply .selectedCharacterPanel */}
               <div className={styles.characterPanelHeader}> {/* Apply .characterPanelHeader */}
                 <h3>{pc.name} (Class: {clsDef ? clsDef.name : 'Unknown'})</h3>
-                <button onClick={() => handleClassRemove(pc.id)} className={styles.removeButton}>Remove Class</button>
+                <button
+                  onClick={() => handleClassRemove(pc.id)}
+                  disabled={selectedCharacters.length === 1}
+                  className={styles.removeButton}
+                >
+                  Remove Class
+                </button>
               </div>
               <CardAssignmentPanel
                 character={pc}

--- a/client/src/components/PartySummary.tsx
+++ b/client/src/components/PartySummary.tsx
@@ -142,6 +142,7 @@ const PartySummary: React.FC<PartySummaryProps> = ({
                 className={styles.actionButton}
                 aria-label={`Remove ${character.name}`}
                 onClick={() => onRemoveCharacter?.(character.id)}
+                disabled={selectedCharacters.length === 1}
               >
                 ❌
               </button>


### PR DESCRIPTION
## Summary
- prevent party member removal if only one member left
- warn user when trying to remove the final member
- disable "Remove" buttons when only one party member remains

## Testing
- `npm run lint -w client`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68437e99dc1c832787f0293908914a08