### PR TITLE
Update card collection grid

### DIFF
--- a/client/src/components/CardCollection.module.css
+++ b/client/src/components/CardCollection.module.css
@@ -30,11 +30,28 @@
 }
 .grid {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
-  gap: 1.5rem;
+  grid-template-columns: repeat(5, 1fr);
+  gap: 2rem;
+  margin: 2rem 0;
+}
+
+@media (max-width: 1200px) {
+  .grid {
+    grid-template-columns: repeat(3, 1fr);
+  }
+}
+
+@media (max-width: 700px) {
+  .grid {
+    grid-template-columns: 1fr;
+  }
 }
 .cardWrapper {
   position: relative;
+  min-width: 180px;
+  min-height: 240px;
+  display: flex;
+  justify-content: center;
 }
 .checkbox {
   position: absolute;

--- a/client/src/components/CardDisplay.module.css
+++ b/client/src/components/CardDisplay.module.css
@@ -1,7 +1,8 @@
 .card {
   position: relative;
-  width: 140px;
-  max-width: 180px;
+  width: 100%;
+  min-width: 180px;
+  min-height: 240px;
   border-radius: 12px;
   overflow: hidden;
   box-shadow: 0 2px 6px rgba(0, 0, 0, 0.3);
@@ -136,7 +137,7 @@
 
 @media (max-width: 600px) {
   .card {
-    width: 110px;
+    width: 100%;
   }
 }
 

--- a/client/src/components/CardDisplay.tsx
+++ b/client/src/components/CardDisplay.tsx
@@ -2,6 +2,9 @@ import React from 'react'
 import type { Card } from '../../../shared/models/Card'
 import placeholderArt from '../assets/placeholder-card-art.svg'
 
+// Use uploaded art as fallback when available
+const uploadedArtPath = '/mnt/data/0896d875-b93b-46e8-9f89-2ff6101dea82.png'
+
 const abilityImages = import.meta.glob('../../../shared/images/ability_*.png', {
   eager: true,
   import: 'default',
@@ -10,7 +13,12 @@ const abilityImages = import.meta.glob('../../../shared/images/ability_*.png', {
 const getAbilityImage = (cardName: string): string => {
   const key = cardName.toLowerCase().replace(/ /g, '_')
   const path = `../../../shared/images/ability_${key}.png`
-  return abilityImages[path] || abilityImages['../../../shared/images/ability_default.png'] || placeholderArt
+  return (
+    abilityImages[path] ||
+    abilityImages['../../../shared/images/ability_default.png'] ||
+    uploadedArtPath ||
+    placeholderArt
+  )
 }
 import styles from './CardDisplay.module.css'
 


### PR DESCRIPTION
## Summary
- switch CardCollection grid to fixed column layout for desktop, tablet and mobile
- ensure card elements have consistent dimensions
- reference uploaded art path as placeholder in `CardDisplay`

## Testing
- `npm test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_684380f9647c8327b6fb082c99faf9cc