### PR TITLE
Improve battle card UI

### DIFF
--- a/client/src/components/BattleScene.module.css
+++ b/client/src/components/BattleScene.module.css
@@ -3,26 +3,34 @@
   display: flex;
   flex-direction: column;
   align-items: center;
+  background: radial-gradient(circle at center, #2b2b39 0%, #141418 80%);
+  min-height: 100vh;
+  color: #fff;
+}
+
+h2 {
+  margin-bottom: 1rem;
+  font-size: 2rem;
+  text-shadow: 0 0 8px #3557ff;
 }
 .grid {
   display: grid;
   grid-template-columns: repeat(2, 1fr);
   gap: 1rem;
   width: 100%;
-  max-width: 600px;
+  max-width: 800px;
 }
 .side {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(100px, 1fr));
-  gap: 0.5rem;
-  justify-items: center;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
 }
 .controls {
   margin-top: 1rem;
 }
 .log {
   margin-top: 1rem;
-  background: #222;
+  background: rgba(0, 0, 0, 0.5);
   color: #fff;
   padding: 0.5rem;
   max-height: 150px;

--- a/client/src/components/BattleScene.tsx
+++ b/client/src/components/BattleScene.tsx
@@ -4,18 +4,20 @@ import UnitCard from './UnitCard'
 import styles from './BattleScene.module.css'
 import { loadPartyState } from '../utils/partyStorage'
 import { classes as allClasses } from '../../../shared/models/classes.js'
+import defaultPortrait from '../../../shared/images/default-portrait.png'
 
 interface Unit {
   id: string
   name: string
   hp: number
   maxHp: number
+  portrait?: string
   status?: string
 }
 
 const enemyData: Unit[] = [
-  { id: 'goblin', name: 'Goblin', hp: 15, maxHp: 15 },
-  { id: 'orc', name: 'Orc', hp: 20, maxHp: 20 },
+  { id: 'goblin', name: 'Goblin', hp: 15, maxHp: 15, portrait: defaultPortrait },
+  { id: 'orc', name: 'Orc', hp: 20, maxHp: 20, portrait: defaultPortrait },
 ]
 
 export default function BattleScene() {
@@ -33,6 +35,7 @@ export default function BattleScene() {
         name: c.name,
         hp: c.stats.hp,
         maxHp: c.stats.hp,
+        portrait: c.portrait || defaultPortrait,
       }))
       setPlayers(chars)
       const firstAlive = chars.find(c => c.hp > 0)
@@ -44,7 +47,13 @@ export default function BattleScene() {
           const cls = allClasses.find(c => c.id === m.class)
           const name = cls ? cls.name : m.class
           const id = `${m.class}-${i}`
-          return { id, name, hp: 30, maxHp: 30 }
+          return {
+            id,
+            name,
+            hp: 30,
+            maxHp: 30,
+            portrait: cls?.portrait || defaultPortrait,
+          }
         })
         setPlayers(chars)
         if (chars.length) setActiveId(chars[0].id)
@@ -109,6 +118,7 @@ export default function BattleScene() {
               key={p.id}
               id={p.id}
               name={p.name}
+              portrait={p.portrait}
               hp={p.hp}
               maxHp={p.maxHp}
               status={p.hp <= 0 ? 'KO' : p.status}
@@ -124,6 +134,7 @@ export default function BattleScene() {
               key={e.id}
               id={e.id}
               name={e.name}
+              portrait={e.portrait}
               hp={e.hp}
               maxHp={e.maxHp}
               status={e.hp <= 0 ? 'KO' : e.status}

--- a/client/src/components/UnitCard.module.css
+++ b/client/src/components/UnitCard.module.css
@@ -1,76 +1,97 @@
-.card {
-  background: #232429;
-  color: #fff;
-  border-radius: 8px;
-  padding: 0.5rem;
-  width: 100%;
-  max-width: 120px;
-  text-align: center;
-  position: relative;
+.battleCard {
+  background: #fffdf6;
+  border-radius: 18px;
+  box-shadow: 0 4px 18px rgba(0, 0, 0, 0.13);
+  border: 2px solid #3557ff50;
+  padding: 1rem;
+  width: 180px;
+  margin: 1rem auto;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
   transition: box-shadow 0.2s, transform 0.2s;
   cursor: pointer;
 }
-.card:hover {
-  transform: translateY(-2px);
+
+.battleCard:hover {
+  transform: translateY(-3px);
 }
-.card.active {
-  box-shadow: 0 0 8px #646cff;
-  border: 2px solid #646cff;
+
+.battleCard.active {
+  box-shadow: 0 0 24px #3557ff, 0 2px 16px rgba(0, 0, 0, 0.18);
+  border-color: #3557ff;
+  transform: scale(1.03);
 }
-.card.disabled {
+
+.battleCard.disabled {
   opacity: 0.4;
   cursor: not-allowed;
 }
+
+.battleCard img {
+  width: 64px;
+  height: 64px;
+  border-radius: 50%;
+  object-fit: cover;
+  margin-bottom: 0.5rem;
+}
+
 .name {
+  font-size: 1.2rem;
   font-weight: bold;
+  margin-bottom: 0.3rem;
+  text-align: center;
 }
-.healthBar {
-  background: #555;
-  border-radius: 4px;
-  height: 6px;
-  margin-top: 4px;
+
+.hpBar {
+  width: 100%;
+  height: 16px;
+  background: #222;
+  border-radius: 8px;
+  margin: 0.3rem 0;
   overflow: hidden;
+  position: relative;
 }
-.health {
-  display: block;
-  background: #4caf50;
+
+.hpBarInner {
   height: 100%;
-  width: var(--hp, 100%);
+  background: linear-gradient(90deg, #2ecc40, #f7e81d, #ff4848);
+  transition: width 0.4s;
 }
+
 .hpText {
-  font-size: 0.75rem;
-  margin-top: 2px;
-}
-.status {
-  font-size: 0.75rem;
-  margin-top: 0.25rem;
-}
-.statusRow {
-  margin-top: 2px;
-  display: flex;
-  justify-content: center;
-  gap: 2px;
-  font-size: 0.9rem;
-}
-.statusIcon {
-  transition: transform 0.2s;
-}
-.actions {
-  margin-top: 0.5rem;
-  display: flex;
-  gap: 4px;
-  justify-content: center;
-}
-.actions button {
-  background: #646cff;
-  border: none;
+  position: absolute;
+  width: 100%;
+  text-align: center;
+  font-size: 0.95rem;
   color: #fff;
-  padding: 2px 6px;
-  border-radius: 4px;
-  font-size: 0.7rem;
-  cursor: pointer;
+  top: 0;
+  left: 0;
 }
-.actions button:hover,
-.actions button:focus-visible {
-  background: #767aff;
+
+.status {
+  margin-top: 0.25rem;
+  font-size: 0.75rem;
+}
+
+.actions {
+  display: flex;
+  gap: 0.6rem;
+  margin-top: 0.5rem;
+}
+
+.actionBtn {
+  border: none;
+  border-radius: 999px;
+  background: #3557ff;
+  color: #fff;
+  padding: 0.5rem 1rem;
+  font-weight: bold;
+  cursor: pointer;
+  transition: background 0.2s, transform 0.2s;
+}
+
+.actionBtn:hover {
+  background: #233b91;
+  transform: translateY(-3px) scale(1.07);
 }

--- a/client/src/components/UnitCard.tsx
+++ b/client/src/components/UnitCard.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import styles from './UnitCard.module.css'
+import defaultPortrait from '../../shared/images/default-portrait.png'
 
 const STATUS_ICONS: Record<string, { icon: string; color: string }> = {
   poison: { icon: '☠', color: '#88ff88' },
@@ -19,6 +20,7 @@ interface UnitCardProps {
   name: string
   hp: number
   maxHp: number
+  portrait?: string
   status?: string
   statuses?: { type: string; value?: number }[]
   actions?: Action[]
@@ -31,6 +33,7 @@ const UnitCard: React.FC<UnitCardProps> = ({
   name,
   hp,
   maxHp,
+  portrait,
   status,
   statuses = [],
   actions = [],
@@ -55,7 +58,7 @@ const UnitCard: React.FC<UnitCardProps> = ({
 
   return (
     <div
-      className={`${styles.card} ${isActive ? styles.active : ''} ${
+      className={`${styles.battleCard} ${isActive ? styles.active : ''} ${
         isDisabled ? styles.disabled : ''
       }`}
       onClick={handleClick}
@@ -66,12 +69,23 @@ const UnitCard: React.FC<UnitCardProps> = ({
       aria-disabled={isDisabled}
       aria-label={`${name} HP ${hp}`}
     >
+      <img
+        src={portrait || defaultPortrait}
+        alt={name}
+        onError={e => {
+          const img = e.currentTarget as HTMLImageElement
+          if (img.src !== defaultPortrait) img.src = defaultPortrait
+        }}
+      />
       <div className={styles.name}>{name}</div>
-      <div className={styles.healthBar} aria-hidden="true">
-        <span className={styles.health} style={{ width: `${percent}%` }} />
-      </div>
-      <div className={styles.hpText}>
-        {hp} / {maxHp}
+      <div className={styles.hpBar} aria-hidden="true">
+        <div
+          className={styles.hpBarInner}
+          style={{ width: `${percent}%` }}
+        />
+        <div className={styles.hpText}>
+          {hp} / {maxHp}
+        </div>
       </div>
       <div className={styles.status}>{status}</div>
       {statuses.length > 0 && (
@@ -100,6 +114,7 @@ const UnitCard: React.FC<UnitCardProps> = ({
                 e.stopPropagation()
                 if (!isDisabled) a.onClick()
               }}
+              className={styles.actionBtn}
             >
               {a.label}
             </button>


### PR DESCRIPTION
## Summary
- redesign battle cards with portrait, gradient health bar and action buttons
- show portraits for players and enemies in battle
- apply arena styling to battle scene background

## Testing
- `npm test`
- `npm --workspace client run lint`

------
https://chatgpt.com/codex/tasks/task_e_684380eefdb48327a01a1f11d23e96a3