### PR TITLE
Persist card assignments in party state

### DIFF
--- a/client/src/utils/partyStorage.ts
+++ b/client/src/utils/partyStorage.ts
@@ -1,5 +1,10 @@
+export interface PartyMember {
+  class: string
+  cards: string[]
+}
+
 export interface PartyState {
-  members: { class: string; cards: string[] }[];
+  members: PartyMember[]
 }
 
 const KEY = 'partyState';
@@ -13,11 +18,39 @@ export function savePartyState(state: PartyState) {
 }
 
 export function loadPartyState(): PartyState | null {
-  const raw = localStorage.getItem(KEY);
-  if (!raw) return null;
+  const raw = localStorage.getItem(KEY)
+  if (!raw) return null
   try {
-    return JSON.parse(raw) as PartyState;
+    const data = JSON.parse(raw)
+
+    // Old format: array of class strings
+    if (Array.isArray(data)) {
+      return {
+        members: data.map((c: any) => ({ class: String(c), cards: [] })),
+      }
+    }
+
+    let members: PartyMember[] = []
+    if (Array.isArray(data.members)) {
+      members = data.members.map((m: any) =>
+        typeof m === 'string'
+          ? { class: m, cards: [] }
+          : { class: m.class, cards: Array.isArray(m.cards) ? m.cards : [] },
+      )
+    } else if (Array.isArray(data.characters)) {
+      members = data.characters.map((m: any) =>
+        typeof m === 'string'
+          ? { class: m, cards: [] }
+          : { class: m.class || m.id || '', cards: Array.isArray(m.cards) ? m.cards : [] },
+      )
+    }
+
+    if (members.length > 0) {
+      return { members }
+    }
+
+    return data as PartyState
   } catch {
-    return null;
+    return null
   }
 }

--- a/game/src/shared/partyState.js
+++ b/game/src/shared/partyState.js
@@ -8,7 +8,27 @@ export function loadPartyState() {
   if (!raw) return
   try {
     const data = JSON.parse(raw)
-    partyState.members = data.members || data.characters || []
+
+    let members = []
+    if (Array.isArray(data)) {
+      members = data.map((c) => ({ class: String(c), cards: [] }))
+    } else if (Array.isArray(data.members)) {
+      members = data.members.map((m) =>
+        typeof m === 'string'
+          ? { class: m, cards: [] }
+          : { class: m.class, cards: Array.isArray(m.cards) ? m.cards : [] },
+      )
+    } else if (Array.isArray(data.characters)) {
+      members = data.characters.map((m) =>
+        typeof m === 'string'
+          ? { class: m, cards: [] }
+          : { class: m.class || m.id || '', cards: Array.isArray(m.cards) ? m.cards : [] },
+      )
+    }
+    if (members.length > 0) {
+      partyState.members = members
+    }
+
     partyState.formation = data.formation || 'default'
   } catch (e) {
     console.error('Failed to parse party state', e)

--- a/shared/systems/partyState.test.js
+++ b/shared/systems/partyState.test.js
@@ -1,0 +1,29 @@
+import { test } from 'node:test'
+import assert from 'assert'
+import { partyState, loadPartyState } from '../../game/src/shared/partyState.js'
+
+function mockStorage(value) {
+  return {
+    getItem: () => value,
+    setItem: () => {},
+  }
+}
+
+test('loadPartyState upgrades string array saves', () => {
+  global.localStorage = mockStorage(JSON.stringify(['cleric', 'warrior']))
+  loadPartyState()
+  assert.deepStrictEqual(partyState.members, [
+    { class: 'cleric', cards: [] },
+    { class: 'warrior', cards: [] },
+  ])
+})
+
+test('loadPartyState loads card assignments', () => {
+  global.localStorage = mockStorage(
+    JSON.stringify({ members: [{ class: 'bard', cards: ['inspire'] }] }),
+  )
+  loadPartyState()
+  assert.deepStrictEqual(partyState.members, [
+    { class: 'bard', cards: ['inspire'] },
+  ])
+})


### PR DESCRIPTION
## Summary
- extend `partyStorage` utilities to handle legacy saves and persist cards
- update Phaser party loader for new format
- add unit tests for party persistence upgrade

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68438147c42c8327a7905f1e7357f261