### PR TITLE
Fix import path for default portrait

### DIFF
--- a/client/src/components/UnitCard.tsx
+++ b/client/src/components/UnitCard.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import styles from './UnitCard.module.css'
-import defaultPortrait from '../../shared/images/default-portrait.png'
+import defaultPortrait from '../../../shared/images/default-portrait.png'
 
 const STATUS_ICONS: Record<string, { icon: string; color: string }> = {
   poison: { icon: '☠', color: '#88ff88' },


### PR DESCRIPTION
## Summary
- fix default portrait path in UnitCard component

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684382b70a748327ba7debe2e64a5cb6