### PR TITLE
Add client lint step to CI

### DIFF
--- a/.github/workflows/node-test.yml
+++ b/.github/workflows/node-test.yml
@@ -11,4 +11,5 @@ jobs:
         with:
           node-version: 20
       - run: npm install
+      - run: npm --workspace client run lint
       - run: npm test


### PR DESCRIPTION
## Summary
- run lint in the client workspace as part of CI

## Testing
- `npm --workspace client run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68438404f3908327b951826f4bdcb8e5