### PR TITLE
Revamp battle UI

### DIFF
--- a/client/src/components/BattleScene.module.css
+++ b/client/src/components/BattleScene.module.css
@@ -1,29 +1,42 @@
 .container {
-  padding: 1rem;
+  padding: 2rem;
   display: flex;
   flex-direction: column;
   align-items: center;
-  background: radial-gradient(circle at center, #2b2b39 0%, #141418 80%);
-  min-height: 100vh;
-  color: #fff;
+  background: rgba(35, 40, 60, 0.85);
+  backdrop-filter: blur(6px);
+  border-radius: 1rem;
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.45);
+  max-width: 960px;
+  margin: 2rem auto;
+  color: #f0f6ff;
 }
 
 h2 {
   margin-bottom: 1rem;
-  font-size: 2rem;
-  text-shadow: 0 0 8px #3557ff;
+  font-size: 2.2rem;
+  text-shadow: 0 0 8px #3557ff77;
 }
-.grid {
-  display: grid;
-  grid-template-columns: repeat(2, 1fr);
-  gap: 1rem;
+
+h3 {
+  margin: 0.2rem 0 0.6rem 0;
+  font-size: 1.2rem;
+  color: #f0f6ff;
+  text-shadow: 0 0 6px #0006;
+}
+.teams {
+  display: flex;
+  gap: 3rem;
   width: 100%;
-  max-width: 800px;
+  justify-content: space-between;
+  margin-bottom: 1rem;
 }
-.side {
+.team {
   display: flex;
   flex-direction: column;
   align-items: center;
+  flex: 1;
+  gap: 0.6rem;
 }
 .controls {
   margin-top: 1rem;
@@ -41,7 +54,8 @@ h2 {
 }
 
 @media (max-width: 500px) {
-  .grid {
-    grid-template-columns: 1fr;
+  .teams {
+    flex-direction: column;
+    gap: 2rem;
   }
 }

--- a/client/src/components/BattleScene.tsx
+++ b/client/src/components/BattleScene.tsx
@@ -111,8 +111,9 @@ export default function BattleScene() {
   return (
     <div className={styles.container}>
       <h2>Battle</h2>
-      <div className={styles.grid}>
-        <div className={styles.side}>
+      <div className={styles.teams}>
+        <div className={styles.team}>
+          <h3>Allies</h3>
           {players.map(p => (
             <UnitCard
               key={p.id}
@@ -128,7 +129,8 @@ export default function BattleScene() {
             />
           ))}
         </div>
-        <div className={styles.side}>
+        <div className={styles.team}>
+          <h3>Enemies</h3>
           {enemies.map(e => (
             <UnitCard
               key={e.id}

--- a/client/src/components/UnitCard.module.css
+++ b/client/src/components/UnitCard.module.css
@@ -1,15 +1,15 @@
 .battleCard {
-  background: #fffdf6;
+  background: linear-gradient(145deg, #23283c 80%, #181c26 100%);
   border-radius: 18px;
-  box-shadow: 0 4px 18px rgba(0, 0, 0, 0.13);
-  border: 2px solid #3557ff50;
+  box-shadow: 0 6px 32px rgba(0, 0, 0, 0.19);
+  border: 2px solid transparent;
   padding: 1rem;
   width: 180px;
   margin: 1rem auto;
   display: flex;
   flex-direction: column;
   align-items: center;
-  transition: box-shadow 0.2s, transform 0.2s;
+  transition: box-shadow 0.3s, border 0.2s, background 0.3s;
   cursor: pointer;
 }
 
@@ -18,8 +18,8 @@
 }
 
 .battleCard.active {
-  box-shadow: 0 0 24px #3557ff, 0 2px 16px rgba(0, 0, 0, 0.18);
-  border-color: #3557ff;
+  border: 2.5px solid #5580ff;
+  box-shadow: 0 0 24px #3557ff;
   transform: scale(1.03);
 }
 
@@ -33,7 +33,9 @@
   height: 64px;
   border-radius: 50%;
   object-fit: cover;
-  margin-bottom: 0.5rem;
+  border: 2px solid #222c;
+  box-shadow: 0 2px 8px #0008;
+  margin-bottom: 0.4rem;
 }
 
 .name {
@@ -41,29 +43,30 @@
   font-weight: bold;
   margin-bottom: 0.3rem;
   text-align: center;
+  color: #f0f0fa;
 }
 
 .hpBar {
-  width: 100%;
-  height: 16px;
-  background: #222;
+  width: 90%;
+  height: 14px;
+  background: #23243a;
   border-radius: 8px;
-  margin: 0.3rem 0;
+  margin: 0.5rem auto 0.2rem auto;
   overflow: hidden;
   position: relative;
 }
 
 .hpBarInner {
   height: 100%;
-  background: linear-gradient(90deg, #2ecc40, #f7e81d, #ff4848);
-  transition: width 0.4s;
+  background: linear-gradient(90deg, #36c163 70%, #eeb42e 90%, #ea4646 100%);
+  transition: width 0.3s;
 }
 
 .hpText {
   position: absolute;
   width: 100%;
   text-align: center;
-  font-size: 0.95rem;
+  font-size: 0.9rem;
   color: #fff;
   top: 0;
   left: 0;
@@ -83,15 +86,28 @@
 .actionBtn {
   border: none;
   border-radius: 999px;
-  background: #3557ff;
-  color: #fff;
-  padding: 0.5rem 1rem;
+  background: #23283c;
+  color: #8cbaff;
+  border: 1.5px solid #3557ff;
+  padding: 0.4rem 1.2rem;
   font-weight: bold;
   cursor: pointer;
-  transition: background 0.2s, transform 0.2s;
+  box-shadow: 0 1px 6px #0003;
+  transition: background 0.2s, color 0.2s;
 }
 
 .actionBtn:hover {
-  background: #233b91;
-  transform: translateY(-3px) scale(1.07);
+  background: #3557ff;
+  color: #fff;
+}
+
+.statusRow {
+  display: flex;
+  gap: 0.25rem;
+  margin-top: 0.25rem;
+}
+
+.statusIcon {
+  font-size: 0.9rem;
+  text-shadow: 0 1px 2px #000a;
 }

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -28,6 +28,7 @@ body {
   place-items: center;
   min-width: 320px;
   min-height: 100vh;
+  background: radial-gradient(ellipse at 60% 40%, #23283c 60%, #13141e 100%);
 }
 
 h1 {


### PR DESCRIPTION
## Summary
- restyle UnitCard with darker gradients and modern buttons
- redesign BattleScene layout with semi-transparent panel and team headers
- apply radial gradient background to body

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6843852799b48327b26d904c70c86f39