### PR TITLE
Improve HP bar display and death visuals

### DIFF
--- a/client/src/components/UnitCard.module.css
+++ b/client/src/components/UnitCard.module.css
@@ -28,6 +28,24 @@
   cursor: not-allowed;
 }
 
+.battleCard.dead {
+  filter: grayscale(0.9) brightness(0.6);
+  opacity: 0.5;
+  position: relative;
+}
+
+.battleCard.dead::after {
+  content: '';
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: rgba(80, 0, 20, 0.4);
+  border-radius: 18px;
+  pointer-events: none;
+}
+
 .battleCard img {
   width: 64px;
   height: 64px;
@@ -51,7 +69,7 @@
   height: 14px;
   background: #23243a;
   border-radius: 8px;
-  margin: 0.5rem auto 0.2rem auto;
+  margin: 0.5rem auto 0.6rem auto;
   overflow: hidden;
   position: relative;
 }

--- a/client/src/components/UnitCard.tsx
+++ b/client/src/components/UnitCard.tsx
@@ -42,6 +42,11 @@ const UnitCard: React.FC<UnitCardProps> = ({
   onSelect,
 }) => {
   const percent = Math.max(0, Math.min(100, (hp / maxHp) * 100))
+  const hpRatio = hp / maxHp
+  let barColor = '#38d46b'
+  if (hpRatio <= 0.6 && hpRatio > 0.3) barColor = '#f7d839'
+  if (hpRatio <= 0.3 && hpRatio > 0) barColor = '#ea4646'
+  if (hp === 0) barColor = '#800019'
 
   const handleClick = () => {
     if (!isDisabled) {
@@ -60,7 +65,7 @@ const UnitCard: React.FC<UnitCardProps> = ({
     <div
       className={`${styles.battleCard} ${isActive ? styles.active : ''} ${
         isDisabled ? styles.disabled : ''
-      }`}
+      } ${hp === 0 ? styles.dead : ''}`}
       onClick={handleClick}
       onKeyDown={handleKeyDown}
       tabIndex={isDisabled ? -1 : 0}
@@ -81,7 +86,11 @@ const UnitCard: React.FC<UnitCardProps> = ({
       <div className={styles.hpBar} aria-hidden="true">
         <div
           className={styles.hpBarInner}
-          style={{ width: `${percent}%` }}
+          style={{
+            width: `${percent}%`,
+            background: barColor,
+            transition: 'width 0.4s, background 0.2s',
+          }}
         />
         <div className={styles.hpText}>
           {hp} / {maxHp}


### PR DESCRIPTION
## Summary
- pad bottom of HP bar so text doesn't clip
- add dynamic HP bar colors based on health
- fade card when a unit dies

## Testing
- `npm run lint --silent --workspace=client`
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6843872eccb08327982c552eaa1786d6