### PR TITLE
Fix dungeon event assignment on floor advance

### DIFF
--- a/shared/systems/progression.js
+++ b/shared/systems/progression.js
@@ -16,7 +16,9 @@ export function handleAdvance(state) {
   // cycle to a random biome when advancing floors
   const next = biomes[Math.floor(Math.random() * biomes.length)]
   state.currentBiome = next.id
-  assignRandomEventToFloor(state, dungeonEvents)
+  const floorView = { biome: state.currentBiome, activeEvent: state.activeEvent }
+  assignRandomEventToFloor(floorView, dungeonEvents)
+  state.activeEvent = floorView.activeEvent
 }
 
 /**

--- a/shared/systems/progression.test.js
+++ b/shared/systems/progression.test.js
@@ -1,0 +1,31 @@
+import { test } from 'node:test'
+import assert from 'assert'
+import { handleAdvance } from './progression.js'
+
+// Ensure deterministic biome and event selection
+const origRandom = Math.random
+
+function mockRandom() { return 0 }
+
+function createState() {
+  return {
+    currentFloor: 1,
+    dungeonDifficulty: 1,
+    playerStatus: { fatigue: 0, hunger: 0, thirst: 0 },
+    location: 'dungeon',
+    currentBiome: 'fungal-depths',
+    inventory: [],
+    activeEvent: null,
+  }
+}
+
+test('handleAdvance assigns an active event', () => {
+  Math.random = mockRandom
+  const state = createState()
+  handleAdvance(state)
+  Math.random = origRandom
+  assert.ok(state.activeEvent, 'Active event should be assigned')
+  if (state.activeEvent.biomeEligibility) {
+    assert.ok(state.activeEvent.biomeEligibility.includes(state.currentBiome))
+  }
+})


### PR DESCRIPTION
## Summary
- ensure `handleAdvance` passes biome to event selector
- test that advancing floors assigns an event

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6843884369d48327a0f66a74082b2e36