### PR TITLE
Add responsive draft card grid

### DIFF
--- a/client/src/components/CardAssignmentPanel.tsx
+++ b/client/src/components/CardAssignmentPanel.tsx
@@ -101,7 +101,8 @@ const CardAssignmentPanel: React.FC<CardAssignmentPanelProps> = ({ character, av
   };
 
   const availableCardsListStyle: React.CSSProperties = {
-    ...cardListStyle, // Reuse common styles
+    gap: '10px', // Spacing between cards
+    marginBottom: '15px',
     maxHeight: '220px', // Slightly increased height
     overflowY: 'auto',
     padding: '5px',
@@ -146,7 +147,11 @@ const CardAssignmentPanel: React.FC<CardAssignmentPanelProps> = ({ character, av
       {canAssignMoreCards && (
         <>
           <h5 style={subSectionTitleStyle}>Draft a Card</h5>
-          <div style={availableCardsListStyle} className={styles.fade} key={draftKey}>
+          <div
+            style={availableCardsListStyle}
+            className={`${styles.fade} ${styles.draftCardsGrid}`}
+            key={draftKey}
+          >
             {draftCards.map((card) => (
               <CardDisplay
                 key={card.id}

--- a/client/src/components/PartySetup.module.css
+++ b/client/src/components/PartySetup.module.css
@@ -249,3 +249,28 @@
     box-shadow: none;
   }
 }
+
+/* Grid layout for draftable cards */
+.draftCardsGrid {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 1rem;
+}
+
+@media (max-width: 1024px) {
+  .draftCardsGrid {
+    grid-template-columns: repeat(3, 1fr);
+  }
+}
+
+@media (max-width: 768px) {
+  .draftCardsGrid {
+    grid-template-columns: repeat(2, 1fr);
+  }
+}
+
+@media (max-width: 480px) {
+  .draftCardsGrid {
+    grid-template-columns: 1fr;
+  }
+}


### PR DESCRIPTION
## Summary
- switch draft card container to use CSS grid
- define `draftCardsGrid` class with responsive columns

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684389d51fd4832785580e70e3fec583