### PR TITLE
Fix HP bar clipping in battle card

### DIFF
--- a/client/src/components/UnitCard.module.css
+++ b/client/src/components/UnitCard.module.css
@@ -3,7 +3,7 @@
   border-radius: 18px;
   box-shadow: 0 6px 32px rgba(0, 0, 0, 0.19);
   border: 2px solid transparent;
-  padding: 1rem;
+  padding: 1.5rem 1rem 2rem;
   width: 180px;
   margin: 1rem auto;
   display: flex;


### PR DESCRIPTION
## Summary
- increase bottom padding in `UnitCard` so child elements don't get clipped

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68438960fe0083278e1627452c796c89