### PR TITLE
Implement auto attack on battle start

### DIFF
--- a/client/src/components/BattleScene.tsx
+++ b/client/src/components/BattleScene.tsx
@@ -103,6 +103,16 @@ export default function BattleScene() {
     }
   }, [turn, players])
 
+  useEffect(() => {
+    if (turn === 'player') {
+      const attacker = players.find(p => p.hp > 0)
+      const target = enemies.find(e => e.hp > 0)
+      if (attacker && target) {
+        attack(target.id)
+      }
+    }
+  }, [turn, players, enemies])
+
   const battleOver =
     players.every(p => p.hp <= 0) || enemies.every(e => e.hp <= 0)
 


### PR DESCRIPTION
## Summary
- auto pick first available enemy target when the battle page loads

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68438a85167883279fdc79f934d5ecc5