### PR TITLE
Fix HP bar spacing

### DIFF
--- a/client/src/components/UnitCard.module.css
+++ b/client/src/components/UnitCard.module.css
@@ -69,7 +69,7 @@
   height: 14px;
   background: #23243a;
   border-radius: 8px;
-  margin: 0.5rem auto 0.6rem auto;
+  margin: 0.5rem auto 0.8rem auto;
   overflow: hidden;
   position: relative;
 }


### PR DESCRIPTION
## Summary
- add bottom margin to the HP bar in `UnitCard.module.css`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68438ce5c98083279bc6c045ac4c5f8c