### PR TITLE
Fix guild credit reward probability

### DIFF
--- a/shared/systems/postBattle.js
+++ b/shared/systems/postBattle.js
@@ -41,7 +41,8 @@ export function generateLoot(encounter) {
  */
 export function generateCurrencyReward(encounter) {
   const gold = Math.floor(encounter.difficulty * 5)
-  const guildCredit = Math.random() < 0.1 * encounter.difficulty ? 1 : 0
+  const chance = Math.min(1, 0.1 * encounter.difficulty)
+  const guildCredit = Math.random() < chance ? 1 : 0
   return { Gold: gold, GuildCredit: guildCredit }
 }
 

--- a/shared/systems/postBattle.test.js
+++ b/shared/systems/postBattle.test.js
@@ -14,3 +14,11 @@ test('generateCurrencyReward returns numbers', () => {
   assert.ok(reward.Gold >= 0)
 })
 
+test('generateCurrencyReward caps guild credit chance at 100%', () => {
+  const origRand = Math.random
+  Math.random = () => 0
+  const reward = generateCurrencyReward({ difficulty: 20 })
+  Math.random = origRand
+  assert.strictEqual(reward.GuildCredit, 1)
+})
+


### PR DESCRIPTION
## Summary
- cap guild credit drop chance so it never exceeds 100%
- add regression test for reward probability

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68438cf5a14c8327953ec32a64b6c991