### PR TITLE
Fix auto battle logging

### DIFF
--- a/client/src/phaser/BattleScene.ts
+++ b/client/src/phaser/BattleScene.ts
@@ -99,7 +99,9 @@ export default class BattleScene extends Phaser.Scene {
     if (!attacker || !target) return
     const card = attacker.data.deck?.[0]
     this.current = attacker
-    this.performCardAction(card, target)
+    if (card) {
+      this.resolveCard(card, attacker, target)
+    }
   }
 
   constructor() {


### PR DESCRIPTION
## Summary
- route initiative queue actions through `resolveCard` to capture card names in the log

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684390a42da4832784a9782a64e76bc1