### PR TITLE
Add inventory state module

### DIFF
--- a/shared/index.js
+++ b/shared/index.js
@@ -2,3 +2,4 @@
 export * from './models/index.js'
 export * from './systems/index.js'
 export * from './initiativeQueue.js'
+export * from './inventoryState.js'

--- a/shared/inventoryState.js
+++ b/shared/inventoryState.js
@@ -1,0 +1,37 @@
+// shared/inventoryState.js
+
+// In-memory cache
+export let inventory = []
+
+// Load from localStorage (call on app start)
+export function loadInventory() {
+  try {
+    const saved = localStorage.getItem('playerInventory')
+    inventory = saved ? JSON.parse(saved) : []
+  } catch (e) {
+    inventory = []
+  }
+}
+
+// Persist to localStorage
+export function saveInventory() {
+  localStorage.setItem('playerInventory', JSON.stringify(inventory))
+}
+
+// Add a card (avoid duplicates if desired)
+export function addCardToInventory(card) {
+  inventory.push(card)
+  saveInventory()
+}
+
+// Optionally remove a card
+export function removeCardFromInventory(cardId) {
+  inventory = inventory.filter((c) => c.id !== cardId)
+  saveInventory()
+}
+
+// Export for consumption
+export function getInventory() {
+  return inventory
+}
+

--- a/shared/inventoryState.test.js
+++ b/shared/inventoryState.test.js
@@ -1,0 +1,41 @@
+import { test } from 'node:test'
+import assert from 'assert'
+import {
+  loadInventory,
+  addCardToInventory,
+  removeCardFromInventory,
+  getInventory,
+} from './inventoryState.js'
+
+function createMockStorage(initial = '[]') {
+  let store = initial
+  return {
+    getItem: () => store,
+    setItem: (_k, v) => {
+      store = v
+    },
+    get value() {
+      return store
+    },
+  }
+}
+
+test('loadInventory reads from storage', () => {
+  const storage = createMockStorage(JSON.stringify([{ id: 'c1' }]))
+  global.localStorage = storage
+  loadInventory()
+  assert.deepStrictEqual(getInventory(), [{ id: 'c1' }])
+})
+
+test('add and remove card updates storage', () => {
+  const storage = createMockStorage('[]')
+  global.localStorage = storage
+  loadInventory()
+  addCardToInventory({ id: 'x' })
+  assert.deepStrictEqual(getInventory(), [{ id: 'x' }])
+  assert.strictEqual(storage.value, JSON.stringify([{ id: 'x' }]))
+  removeCardFromInventory('x')
+  assert.deepStrictEqual(getInventory(), [])
+  assert.strictEqual(storage.value, JSON.stringify([]))
+})
+


### PR DESCRIPTION
## Summary
- create `shared/inventoryState.js` for shared inventory persistence
- export the new module from `shared/index.js`
- add tests for inventory state logic

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68439184feec832785f05b481c59a7e5