### PR TITLE
Initialize inventory state on app load

### DIFF
--- a/client/src/main.jsx
+++ b/client/src/main.jsx
@@ -7,9 +7,11 @@ import { useGameStore } from './store/gameStore'
 import { GameStateProvider } from './GameStateProvider.jsx'
 import { ModalProvider } from './components/ModalManager.jsx'
 import { NotificationProvider } from './components/NotificationManager.jsx'
+import { loadInventory } from 'shared/inventoryState'
 
 // Load any saved state before the app renders
 useGameStore.getState().load()
+loadInventory()
 
 createRoot(document.getElementById('root')).render(
   <StrictMode>

--- a/shared/index.js
+++ b/shared/index.js
@@ -2,3 +2,4 @@
 export * from './models/index.js'
 export * from './systems/index.js'
 export * from './initiativeQueue.js'
+export * from './inventoryState.js'

--- a/shared/inventoryState.js
+++ b/shared/inventoryState.js
@@ -1,0 +1,32 @@
+export const inventoryState = {
+  items: []
+}
+
+/**
+ * Load inventory data from localStorage into inventoryState.
+ */
+export function loadInventory() {
+  const raw = localStorage.getItem('inventoryState')
+  if (!raw) return
+  try {
+    const data = JSON.parse(raw)
+    if (Array.isArray(data)) {
+      inventoryState.items = data
+    } else if (Array.isArray(data.items)) {
+      inventoryState.items = data.items
+    }
+  } catch (e) {
+    console.error('Failed to load inventory', e)
+  }
+}
+
+/**
+ * Persist current inventoryState to localStorage.
+ */
+export function saveInventory() {
+  try {
+    localStorage.setItem('inventoryState', JSON.stringify(inventoryState))
+  } catch (e) {
+    console.error('Failed to save inventory', e)
+  }
+}


### PR DESCRIPTION
## Summary
- create `inventoryState` helper with load/save helpers
- export `inventoryState` from shared index
- load persisted inventory before bootstrapping client

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684391969cf083278080efc2fca5bb3e