### PR TITLE
Implement inventory integration for card drafting

### DIFF
--- a/client/src/components/PartySetup.tsx
+++ b/client/src/components/PartySetup.tsx
@@ -19,6 +19,7 @@ import { useModal } from './ModalManager.jsx';
 import { useNotification } from './NotificationManager.jsx';
 import styles from './PartySetup.module.css';
 import { savePartyState, loadPartyState } from '../utils/partyStorage';
+import { addCardToInventory } from 'shared/inventoryState';
 
 // Make sure PartyCharacter is exported
 export interface PartyCharacter extends Character {
@@ -182,6 +183,7 @@ const PartySetup: React.FC = () => {
       }
       return pc;
     }));
+    addCardToInventory(card);
   };
 
   const handleCardRemove = (characterId: string, cardId: string) => {

--- a/shared/index.js
+++ b/shared/index.js
@@ -2,3 +2,4 @@
 export * from './models/index.js'
 export * from './systems/index.js'
 export * from './initiativeQueue.js'
+export * from './inventoryState.js'

--- a/shared/inventoryState.js
+++ b/shared/inventoryState.js
@@ -1,0 +1,27 @@
+let inventory = [];
+
+/** Get a copy of the current inventory */
+export function getInventory() {
+  return [...inventory];
+}
+
+/** Set inventory items directly */
+export function setInventory(items) {
+  inventory = [...items];
+}
+
+/** Add a card or item to the inventory */
+export function addCardToInventory(card) {
+  inventory.push(card);
+}
+
+/** Remove an item from inventory by id */
+export function removeFromInventory(id) {
+  const idx = inventory.findIndex(i => i.id === id);
+  if (idx !== -1) inventory.splice(idx, 1);
+}
+
+/** Clear the inventory */
+export function resetInventory() {
+  inventory = [];
+}


### PR DESCRIPTION
## Summary
- add a simple `shared/inventoryState` helper for managing the player's inventory
- export the inventory helpers from `shared/index.js`
- push newly drafted cards into inventory from the Party Setup screen

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6843919e6b40832789b27ad9e07b9e37