### PR TITLE
Update inventory route to use player inventory

### DIFF
--- a/client/src/components/InventoryScreen.tsx
+++ b/client/src/components/InventoryScreen.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react'
 import { useNotification } from './NotificationManager.jsx'
-import { sampleCards } from '../../../shared/models/cards.js'
+import { getInventory } from '../../../shared/inventoryState.js'
 import cardArt from '../assets/placeholder-card-art.svg'
 import styles from './InventoryScreen.module.css'
 
@@ -12,7 +12,7 @@ interface InventoryItem {
   description: string
 }
 
-const allItems: InventoryItem[] = sampleCards.map(c => ({
+const allItems: InventoryItem[] = getInventory().map(c => ({
   id: c.id,
   name: c.name,
   type: c.category || c.type || 'Unknown',

--- a/shared/inventoryState.js
+++ b/shared/inventoryState.js
@@ -1,0 +1,39 @@
+export const inventoryState = {
+  cards: [],
+};
+
+export function loadInventoryState() {
+  const raw = typeof localStorage !== 'undefined' ? localStorage.getItem('inventoryState') : null;
+  if (!raw) return;
+  try {
+    const data = JSON.parse(raw);
+    if (Array.isArray(data)) {
+      inventoryState.cards = data;
+    } else if (Array.isArray(data.cards)) {
+      inventoryState.cards = data.cards;
+    }
+  } catch (e) {
+    console.error('Failed to parse inventory state', e);
+  }
+}
+
+export function saveInventoryState() {
+  if (typeof localStorage === 'undefined') return;
+  localStorage.setItem('inventoryState', JSON.stringify(inventoryState));
+}
+
+export function getInventory() {
+  return inventoryState.cards;
+}
+
+export function setInventory(cards) {
+  if (Array.isArray(cards)) {
+    inventoryState.cards = cards;
+    saveInventoryState();
+  }
+}
+
+export function addToInventory(card) {
+  inventoryState.cards.push(card);
+  saveInventoryState();
+}


### PR DESCRIPTION
## Summary
- add new `inventoryState` module to manage saved inventory
- update `InventoryScreen` to show collected cards using `getInventory`

## Testing
- `npm test`
- `npm run lint` in `client`

------
https://chatgpt.com/codex/tasks/task_e_684391a69d88832788182564cb5b5913