### PR TITLE
Show party cards on town screen

### DIFF
--- a/client/src/components/TownView.module.css
+++ b/client/src/components/TownView.module.css
@@ -15,6 +15,14 @@
   margin: 0.25rem 0 0.5rem;
 }
 
+.partyCards {
+  display: flex;
+  gap: 1rem;
+  justify-content: center;
+  flex-wrap: wrap;
+  margin-bottom: 1rem;
+}
+
 .mainMenu {
   color: #fff;
   background: #333;

--- a/client/src/components/TownView.tsx
+++ b/client/src/components/TownView.tsx
@@ -1,19 +1,32 @@
 import React from 'react'
 import { useNavigate, Link } from 'react-router-dom'
 import { useGameState } from '../GameStateProvider.jsx'
+import CharacterCard from './CharacterCard.tsx'
 import styles from './TownView.module.css'
 
 export default function TownView() {
   const navigate = useNavigate()
   const party = useGameState(s => s.party)
 
-  const members = party?.characters?.map(c => c.name).join(', ') || 'No party'
-
   return (
     <div className={styles.container}>
       <header className={styles.header}>
         <h2>Town Hub</h2>
-        <p className={styles.summary}>Party: {members}</p>
+        <div className={styles.partyCards}>
+          {party?.characters && party.characters.length > 0 ? (
+            party.characters.map(character => (
+              <CharacterCard
+                key={character.id}
+                character={character}
+                onSelect={() => {}}
+                isSelected={false}
+                isDisabled={false}
+              />
+            ))
+          ) : (
+            <p>No party</p>
+          )}
+        </div>
         <Link to="/" className={styles.mainMenu}>Return to Main Menu</Link>
       </header>
       <div className={styles.grid}>


### PR DESCRIPTION
## Summary
- render `CharacterCard` components on the Town view instead of a plain text list
- add simple layout styling for the party cards

## Testing
- `npm test`
- `npm run lint --workspace=client`


------
https://chatgpt.com/codex/tasks/task_e_684393f4fb9083278a35278969239fee