### PR TITLE
Add party cards container style

### DIFF
--- a/client/src/routes/TownHub.css
+++ b/client/src/routes/TownHub.css
@@ -1,0 +1,6 @@
+.town-hub__party-cards {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+  gap: 1rem;
+  margin: 1rem 0 2rem;
+}


### PR DESCRIPTION
## Summary
- add TownHub CSS for party cards container layout

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68439413ea348327940a4ae84c63477c