### PR TITLE
Update dungeon generation and persistence

### DIFF
--- a/shared/dungeonState.js
+++ b/shared/dungeonState.js
@@ -6,16 +6,43 @@ export function generateDungeon(width = 5, height = 5) {
   const rooms = []
   for (let y = 0; y < height; y++) {
     for (let x = 0; x < width; x++) {
-      rooms.push({ x, y, visited: false })
+      rooms.push({ x, y })
     }
   }
   dungeon = {
     width,
     height,
     rooms,
+    start: { x: 0, y: 0 },
+    end: { x: width - 1, y: height - 1 },
     current: { x: 0, y: 0 },
   }
-  dungeon.rooms[0].visited = true
+  // After carving a path, assign room types
+  dungeon.rooms = dungeon.rooms.map((r, idx) => ({
+    ...r,
+    type:
+      idx === 0
+        ? 'start'
+        : idx === dungeon.rooms.length - 1
+        ? 'end'
+        : Math.random() < 0.1
+        ? 'shop'
+        : Math.random() < 0.2
+        ? 'event'
+        : 'combat',
+    visited: idx === 0,
+  }))
+}
+
+export function loadDungeon() {
+  try {
+    const saved = localStorage.getItem('dungeonState')
+    if (saved) {
+      dungeon = JSON.parse(saved)
+    }
+  } catch {
+    /* ignore */
+  }
 }
 
 export function getDungeon() {
@@ -28,5 +55,10 @@ export function moveTo(x, y) {
   if (room) {
     dungeon.current = { x, y }
     room.visited = true
+    saveDungeon()
   }
+}
+
+export function saveDungeon() {
+  localStorage.setItem('dungeonState', JSON.stringify(dungeon))
 }


### PR DESCRIPTION
## Summary
- enhance `shared/dungeonState.js` to assign room types on generation
- add persistence helpers for dungeon state with `loadDungeon` and `saveDungeon`
- update movement to save progress

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684399acd7a48327b94f87ea7689b952