### PR TITLE
Add reveal state to dungeon tiles

### DIFF
--- a/client/src/routes/Dungeon.css
+++ b/client/src/routes/Dungeon.css
@@ -17,6 +17,12 @@
   background: #1f2230;
   border: 2px solid #2e3042;
   border-radius: 4px;
+  opacity: 0.2; /* default hidden */
+  cursor: default;
+}
+
+.dungeon-tile.revealed {
+  opacity: 1;
   cursor: pointer;
 }
 

--- a/client/src/routes/Dungeon.jsx
+++ b/client/src/routes/Dungeon.jsx
@@ -23,10 +23,12 @@ export default function Dungeon() {
         {d.rooms.map((r, i) => (
           <div
             key={i}
-            className={`dungeon-tile ${r.visited ? 'visited' : ''} ${
+            className={`dungeon-tile ${r.revealed ? 'revealed' : ''} ${
+              r.visited ? 'visited' : ''
+            } ${
               r.x === d.current.x && r.y === d.current.y ? 'current' : ''
             }`}
-            onClick={() => handleClick(r.x, r.y)}
+            onClick={() => r.revealed && handleClick(r.x, r.y)}
           />
         ))}
       </div>

--- a/shared/dungeonState.js
+++ b/shared/dungeonState.js
@@ -2,11 +2,28 @@
 
 let dungeon = null
 
+function reveal(x, y) {
+  if (!dungeon) return
+  const dirs = [
+    [0, 0],
+    [1, 0],
+    [-1, 0],
+    [0, 1],
+    [0, -1],
+  ]
+  dirs.forEach(([dx, dy]) => {
+    const nx = x + dx
+    const ny = y + dy
+    const room = dungeon.rooms.find((r) => r.x === nx && r.y === ny)
+    if (room) room.revealed = true
+  })
+}
+
 export function generateDungeon(width = 5, height = 5) {
   const rooms = []
   for (let y = 0; y < height; y++) {
     for (let x = 0; x < width; x++) {
-      rooms.push({ x, y, visited: false })
+      rooms.push({ x, y, visited: false, revealed: false })
     }
   }
   dungeon = {
@@ -16,6 +33,7 @@ export function generateDungeon(width = 5, height = 5) {
     current: { x: 0, y: 0 },
   }
   dungeon.rooms[0].visited = true
+  reveal(0, 0)
 }
 
 export function getDungeon() {
@@ -28,5 +46,6 @@ export function moveTo(x, y) {
   if (room) {
     dungeon.current = { x, y }
     room.visited = true
+    reveal(x, y)
   }
 }


### PR DESCRIPTION
## Summary
- introduce `revealed` property in dungeon state
- reveal starting room and neighbors when generating the dungeon
- reveal the current room when moving
- update React dungeon map to display `revealed` tiles and block clicks otherwise
- style hidden vs revealed tiles in `Dungeon.css`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684399bc588883279b7aa6ec283c3fd4