### PR TITLE
Add navigation and fog of war to dungeon

### DIFF
--- a/client/src/routes/Dungeon.css
+++ b/client/src/routes/Dungeon.css
@@ -20,6 +20,12 @@
   cursor: pointer;
 }
 
+.dungeon-tile:not(.revealed) {
+  background: #000;
+  border-color: #000;
+  cursor: default;
+}
+
 .dungeon-tile.visited {
   background: #44475a;
 }

--- a/client/src/routes/Dungeon.jsx
+++ b/client/src/routes/Dungeon.jsx
@@ -1,9 +1,11 @@
 import React, { useEffect, useState } from 'react'
+import { useNavigate } from 'react-router-dom'
 import { generateDungeon, getDungeon, moveTo } from 'shared/dungeonState'
 import './Dungeon.css'
 
 export default function Dungeon() {
   const [d, setD] = useState(null)
+  const navigate = useNavigate()
 
   useEffect(() => {
     generateDungeon(5, 5)
@@ -13,6 +15,17 @@ export default function Dungeon() {
   const handleClick = (x, y) => {
     moveTo(x, y)
     setD({ ...getDungeon() })
+    const room = getDungeon().rooms.find((r) => r.x === x && r.y === y)
+    switch (room?.type) {
+      case 'combat':
+        return navigate('/battle')
+      case 'shop':
+        return navigate('/shop')
+      case 'event':
+        return navigate('/event')
+      default:
+        return
+    }
   }
 
   if (!d) return null
@@ -20,15 +33,21 @@ export default function Dungeon() {
     <div className="dungeon-container">
       <h1>Dungeon – Floor 1</h1>
       <div className="dungeon-grid">
-        {d.rooms.map((r, i) => (
-          <div
-            key={i}
-            className={`dungeon-tile ${r.visited ? 'visited' : ''} ${
-              r.x === d.current.x && r.y === d.current.y ? 'current' : ''
-            }`}
-            onClick={() => handleClick(r.x, r.y)}
-          />
-        ))}
+        {d.rooms.map((r, i) => {
+          // determine if tile is revealed
+          const dx = Math.abs(r.x - d.current.x)
+          const dy = Math.abs(r.y - d.current.y)
+          const revealed = r.visited || dx + dy === 1
+          return (
+            <div
+              key={i}
+              className={`dungeon-tile ${r.visited ? 'visited' : ''} ${
+                revealed ? 'revealed' : ''
+              } ${r.x === d.current.x && r.y === d.current.y ? 'current' : ''}`}
+              onClick={() => revealed && handleClick(r.x, r.y)}
+            />
+          )
+        })}
       </div>
       <p>
         Room{' '}


### PR DESCRIPTION
## Summary
- navigate to new pages when entering certain rooms
- show only visited or adjacent rooms on the dungeon grid

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684399b45ef8832787dbc608ac058e4c