### PR TITLE
Improve dungeon exploration visuals

### DIFF
--- a/client/src/components/DungeonMap.tsx
+++ b/client/src/components/DungeonMap.tsx
@@ -151,7 +151,7 @@ export default function DungeonMap() {
         width: 40,
         height: 40,
         background: isExplored ? roomColors[room.type] : '#000',
-        opacity: isExplored ? 1 : 0.2,
+        opacity: 1,
         border: room.type === 'boss' || room.type === 'exit' ? '2px solid gold' : '1px solid #444',
         position: 'relative',
         cursor: isReachable && isExplored ? 'pointer' : 'default',

--- a/client/src/components/MiniMap.tsx
+++ b/client/src/components/MiniMap.tsx
@@ -28,7 +28,7 @@ export default function MiniMap({ dungeon, explored, current }: MiniMapProps) {
         height: 20,
         border: '1px solid #444',
         background: isExplored ? colors[room.type] : '#000',
-        opacity: isExplored ? 1 : 0.2,
+        opacity: 1,
       }
       if (id === current) {
         style.outline = '2px solid white'

--- a/client/src/routes/Dungeon.css
+++ b/client/src/routes/Dungeon.css
@@ -27,4 +27,20 @@
 .dungeon-tile.current {
   background: #50fa7b;
   box-shadow: 0 0 8px #50fa7b;
+  animation: pulse 1s infinite;
+}
+
+@keyframes pulse {
+  0% {
+    transform: scale(1);
+    opacity: 1;
+  }
+  50% {
+    transform: scale(1.1);
+    opacity: 0.7;
+  }
+  100% {
+    transform: scale(1);
+    opacity: 1;
+  }
 }

--- a/client/src/routes/Dungeon.jsx
+++ b/client/src/routes/Dungeon.jsx
@@ -12,7 +12,18 @@ export default function Dungeon() {
 
   const handleClick = (x, y) => {
     moveTo(x, y)
-    setD({ ...getDungeon() })
+    const dungeon = getDungeon()
+    const neighbors = [
+      [x + 1, y],
+      [x - 1, y],
+      [x, y + 1],
+      [x, y - 1],
+    ]
+    neighbors.forEach(([nx, ny]) => {
+      const room = dungeon.rooms.find((r) => r.x === nx && r.y === ny)
+      if (room) room.visited = true
+    })
+    setD({ ...dungeon })
   }
 
   if (!d) return null


### PR DESCRIPTION
## Summary
- explore adjacent rooms when clicking a tile
- keep minimap and dungeon map tiles fully dark until explored
- highlight current tile with pulsing effect

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68439ac45c4083278ef0308f3b318af0