### PR TITLE
Implement dungeon state grid and tests

### DIFF
--- a/shared/dungeonState.js
+++ b/shared/dungeonState.js
@@ -1,32 +1,66 @@
 // shared/dungeonState.js
 
-let dungeon = null
+/**
+ * Current dungeon data. The grid is stored both as a flat `rooms` array and a
+ * two-dimensional `grid` for convenience. Each room tracks its coordinates,
+ * a simple `type` string, and whether the player has visited it.
+ */
+export let dungeon = {
+  width: 5,
+  height: 5,
+  rooms: [],
+  grid: [],
+  start: { x: 0, y: 0 },
+  end: { x: 4, y: 4 },
+  current: { x: 0, y: 0 },
+}
 
-export function generateDungeon(width = 5, height = 5) {
-  const rooms = []
-  for (let y = 0; y < height; y++) {
-    for (let x = 0; x < width; x++) {
-      rooms.push({ x, y, visited: false })
-    }
-  }
+/**
+ * Create a new dungeon layout. A minimal straight path from the start to the
+ * end will exist, but the algorithm simply fills every cell for now.
+ *
+ * @param {number} w - width of the dungeon grid
+ * @param {number} h - height of the dungeon grid
+ */
+export function generateDungeon(w = 5, h = 5) {
   dungeon = {
-    width,
-    height,
-    rooms,
+    width: w,
+    height: h,
+    rooms: [],
+    grid: [],
+    start: { x: 0, y: 0 },
+    end: { x: w - 1, y: h - 1 },
     current: { x: 0, y: 0 },
   }
-  dungeon.rooms[0].visited = true
+
+  for (let y = 0; y < h; y++) {
+    const row = []
+    for (let x = 0; x < w; x++) {
+      const room = { x, y, type: 'empty', visited: false }
+      dungeon.rooms.push(room)
+      row.push(room)
+    }
+    dungeon.grid.push(row)
+  }
+
+  // mark the starting room as visited
+  dungeon.grid[0][0].visited = true
 }
 
-export function getDungeon() {
-  return dungeon
-}
-
+/**
+ * Update the current position and mark the destination room as visited.
+ *
+ * @param {number} x
+ * @param {number} y
+ */
 export function moveTo(x, y) {
-  if (!dungeon) return
   const room = dungeon.rooms.find((r) => r.x === x && r.y === y)
   if (room) {
     dungeon.current = { x, y }
     room.visited = true
   }
+}
+
+export function getDungeon() {
+  return dungeon
 }

--- a/shared/dungeonState.test.js
+++ b/shared/dungeonState.test.js
@@ -1,0 +1,24 @@
+import { test } from 'node:test'
+import assert from 'assert'
+import { generateDungeon, getDungeon, moveTo } from './dungeonState.js'
+
+test('generateDungeon initializes grid, rooms and start/end', () => {
+  generateDungeon(3, 3)
+  const d = getDungeon()
+  assert.strictEqual(d.width, 3)
+  assert.strictEqual(d.height, 3)
+  assert.deepStrictEqual(d.start, { x: 0, y: 0 })
+  assert.deepStrictEqual(d.end, { x: 2, y: 2 })
+  assert.strictEqual(d.rooms.length, 9)
+  assert.ok(Array.isArray(d.grid) && d.grid.length === 3)
+  assert.ok(d.grid[0][0].visited)
+})
+
+test('moveTo updates current and marks visited', () => {
+  generateDungeon(2, 2)
+  moveTo(1, 1)
+  const d = getDungeon()
+  assert.deepStrictEqual(d.current, { x: 1, y: 1 })
+  const room = d.rooms.find(r => r.x === 1 && r.y === 1)
+  assert.ok(room.visited)
+})


### PR DESCRIPTION
## Summary
- expand dungeon state to track start and end
- keep rooms in both array and grid form
- add tests for dungeon generation and movement

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68439a7bc1208327991a60ab97e69cb5