### PR TITLE
Add shop/event scenes with dungeon transitions

### DIFF
--- a/game/src/index.js
+++ b/game/src/index.js
@@ -3,6 +3,8 @@ import BattleScene from './scenes/BattleScene'
 import DungeonScene from './scenes/DungeonScene'
 import DecisionScene from './scenes/DecisionScene'
 import TownScene from './scenes/TownScene'
+import ShopScene from './scenes/ShopScene'
+import EventScene from './scenes/EventScene'
 import { loadPartyState } from './shared/partyState.js'
 
 const config = {
@@ -10,7 +12,7 @@ const config = {
   width: 800,
   height: 600,
   parent: 'game-container',
-  scene: [TownScene, DungeonScene, BattleScene, DecisionScene],
+  scene: [TownScene, DungeonScene, BattleScene, DecisionScene, ShopScene, EventScene],
 }
 
 loadPartyState()

--- a/game/src/scenes/EventScene.js
+++ b/game/src/scenes/EventScene.js
@@ -1,0 +1,23 @@
+import Phaser from 'phaser'
+
+export default class EventScene extends Phaser.Scene {
+  constructor() {
+    super('event')
+  }
+
+  create(data) {
+    this.cameras.main.fadeIn(250)
+    const text = data && data.message ? data.message : 'Event - press SPACE to return'
+    this.add.text(400, 300, text, { fontSize: '20px' }).setOrigin(0.5)
+
+    this.input.keyboard.once('keydown-SPACE', () => {
+      this.cameras.main.once(Phaser.Cameras.Scene2D.Events.FADE_OUT_COMPLETE, () => {
+        this.scene.stop()
+        const dungeon = this.scene.get('dungeon')
+        dungeon.cameras.main.fadeIn(250)
+        this.scene.wake('dungeon')
+      })
+      this.cameras.main.fadeOut(250)
+    })
+  }
+}

--- a/game/src/scenes/ShopScene.js
+++ b/game/src/scenes/ShopScene.js
@@ -1,0 +1,24 @@
+import Phaser from 'phaser'
+
+export default class ShopScene extends Phaser.Scene {
+  constructor() {
+    super('shop')
+  }
+
+  create() {
+    this.cameras.main.fadeIn(250)
+    this.add
+      .text(400, 300, 'Shop - press SPACE to return', { fontSize: '20px' })
+      .setOrigin(0.5)
+
+    this.input.keyboard.once('keydown-SPACE', () => {
+      this.cameras.main.once(Phaser.Cameras.Scene2D.Events.FADE_OUT_COMPLETE, () => {
+        this.scene.stop()
+        const dungeon = this.scene.get('dungeon')
+        dungeon.cameras.main.fadeIn(250)
+        this.scene.wake('dungeon')
+      })
+      this.cameras.main.fadeOut(250)
+    })
+  }
+}


### PR DESCRIPTION
## Summary
- add `ShopScene` and `EventScene` Phaser scenes
- switch `DungeonScene` to check room `type` and transition with fades
- register new scenes in the game configuration

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68439ac3c5688327bf9553c63e3a36f3