### PR TITLE
Implement persistent dungeon state

### DIFF
--- a/shared/dungeonState.js
+++ b/shared/dungeonState.js
@@ -2,11 +2,29 @@
 
 let dungeon = null
 
+function saveDungeon() {
+  localStorage.setItem('dungeonData', JSON.stringify(dungeon))
+}
+
+export function loadDungeon(width = 5, height = 5) {
+  try {
+    const saved = localStorage.getItem('dungeonData')
+    dungeon = saved ? JSON.parse(saved) : null
+  } catch (e) {
+    dungeon = null
+  }
+  if (!dungeon) {
+    generateDungeon(width, height)
+  }
+}
+
 export function generateDungeon(width = 5, height = 5) {
   const rooms = []
   for (let y = 0; y < height; y++) {
     for (let x = 0; x < width; x++) {
-      rooms.push({ x, y, visited: false })
+      const typeIdx = Math.floor(Math.random() * 3)
+      const type = ['combat', 'shop', 'event'][typeIdx]
+      rooms.push({ x, y, visited: false, type })
     }
   }
   dungeon = {
@@ -16,6 +34,7 @@ export function generateDungeon(width = 5, height = 5) {
     current: { x: 0, y: 0 },
   }
   dungeon.rooms[0].visited = true
+  saveDungeon()
 }
 
 export function getDungeon() {
@@ -28,5 +47,6 @@ export function moveTo(x, y) {
   if (room) {
     dungeon.current = { x, y }
     room.visited = true
+    saveDungeon()
   }
 }

--- a/shared/dungeonState.test.js
+++ b/shared/dungeonState.test.js
@@ -1,0 +1,56 @@
+import { test } from 'node:test'
+import assert from 'assert'
+import {
+  loadDungeon,
+  generateDungeon,
+  getDungeon,
+  moveTo,
+} from './dungeonState.js'
+
+function createMockStorage(initial = '') {
+  let store = initial
+  return {
+    getItem: () => store,
+    setItem: (_k, v) => {
+      store = v
+    },
+    get value() {
+      return store
+    },
+  }
+}
+
+test('generateDungeon assigns room types and persists', () => {
+  const storage = createMockStorage('')
+  global.localStorage = storage
+  generateDungeon(2, 1)
+  const d = getDungeon()
+  assert.strictEqual(d.rooms.length, 2)
+  for (const r of d.rooms) {
+    assert.ok(['combat', 'shop', 'event'].includes(r.type))
+  }
+  assert.strictEqual(storage.value, JSON.stringify(d))
+})
+
+test('loadDungeon loads from storage', () => {
+  const existing = {
+    width: 1,
+    height: 1,
+    rooms: [{ x: 0, y: 0, visited: true, type: 'shop' }],
+    current: { x: 0, y: 0 },
+  }
+  const storage = createMockStorage(JSON.stringify(existing))
+  global.localStorage = storage
+  loadDungeon()
+  assert.deepStrictEqual(getDungeon(), existing)
+})
+
+test('moveTo saves updated position', () => {
+  const storage = createMockStorage('')
+  global.localStorage = storage
+  generateDungeon(1, 2)
+  moveTo(0, 1)
+  const saved = JSON.parse(storage.value)
+  assert.strictEqual(saved.current.y, 1)
+  assert.strictEqual(saved.rooms[1].visited, true)
+})


### PR DESCRIPTION
## Summary
- make dungeon generation include room types
- persist dungeon data in localStorage
- add loadDungeon helper and update moveTo persistence
- test dungeon state persistence

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68439ac248cc8327a705c8a43848269e