### PR TITLE
Implement random dungeon path generation

### DIFF
--- a/shared/dungeonState.js
+++ b/shared/dungeonState.js
@@ -2,11 +2,39 @@
 
 let dungeon = null
 
+function randomPath(width, height) {
+  const path = [{ x: 0, y: 0 }]
+  let x = 0
+  let y = 0
+  while (x !== width - 1 || y !== height - 1) {
+    const options = []
+    if (x < width - 1) options.push({ x: x + 1, y })
+    if (y < height - 1) options.push({ x, y: y + 1 })
+    const next = options[Math.floor(Math.random() * options.length)]
+    x = next.x
+    y = next.y
+    path.push({ x, y })
+  }
+  return path
+}
+
 export function generateDungeon(width = 5, height = 5) {
   const rooms = []
+  const path = randomPath(width, height)
   for (let y = 0; y < height; y++) {
     for (let x = 0; x < width; x++) {
-      rooms.push({ x, y })
+      const inPath = path.some((p) => p.x === x && p.y === y)
+      const idx = path.findIndex((p) => p.x === x && p.y === y)
+      let type = 'empty'
+      if (idx === 0) {
+        type = 'start'
+      } else if (idx === path.length - 1) {
+        type = 'end'
+      } else if (inPath) {
+        const roll = Math.random()
+        type = roll < 0.1 ? 'shop' : roll < 0.3 ? 'event' : 'combat'
+      }
+      rooms.push({ x, y, type, visited: idx === 0 })
     }
   }
   dungeon = {
@@ -17,21 +45,6 @@ export function generateDungeon(width = 5, height = 5) {
     end: { x: width - 1, y: height - 1 },
     current: { x: 0, y: 0 },
   }
-  // After carving a path, assign room types
-  dungeon.rooms = dungeon.rooms.map((r, idx) => ({
-    ...r,
-    type:
-      idx === 0
-        ? 'start'
-        : idx === dungeon.rooms.length - 1
-        ? 'end'
-        : Math.random() < 0.1
-        ? 'shop'
-        : Math.random() < 0.2
-        ? 'event'
-        : 'combat',
-    visited: idx === 0,
-  }))
 }
 
 export function loadDungeon() {

--- a/shared/dungeonState.test.js
+++ b/shared/dungeonState.test.js
@@ -1,0 +1,44 @@
+import { test } from 'node:test'
+import assert from 'assert'
+import { generateDungeon, getDungeon } from './dungeonState.js'
+
+function neighbors(room, rooms) {
+  const dirs = [
+    { x: 1, y: 0 },
+    { x: -1, y: 0 },
+    { x: 0, y: 1 },
+    { x: 0, y: -1 }
+  ]
+  const out = []
+  for (const d of dirs) {
+    const nx = room.x + d.x
+    const ny = room.y + d.y
+    const r = rooms.find((rr) => rr.x === nx && rr.y === ny)
+    if (r && r.type !== 'empty') out.push(r)
+  }
+  return out
+}
+
+test('generated dungeon has a path from start to end', () => {
+  generateDungeon(5, 5)
+  const { rooms, start, end } = getDungeon()
+  const startRoom = rooms.find((r) => r.x === start.x && r.y === start.y)
+  const endRoom = rooms.find((r) => r.x === end.x && r.y === end.y)
+  const stack = [startRoom]
+  const visited = new Set()
+  let found = false
+  while (stack.length) {
+    const current = stack.pop()
+    if (current.x === endRoom.x && current.y === endRoom.y) {
+      found = true
+      break
+    }
+    const key = current.x + ',' + current.y
+    if (visited.has(key)) continue
+    visited.add(key)
+    for (const n of neighbors(current, rooms)) {
+      stack.push(n)
+    }
+  }
+  assert.ok(found, 'end room reachable from start')
+})


### PR DESCRIPTION
## Summary
- create a randomPath helper for generating a route from start to end
- populate room types based on the carved path
- add `shared/dungeonState.test.js` verifying that a path exists

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68439d353dc0832790ff6c1188e12c89