### PR TITLE
Add persistent dungeon generation

### DIFF
--- a/shared/dungeonState.js
+++ b/shared/dungeonState.js
@@ -45,6 +45,7 @@ export function generateDungeon(width = 5, height = 5) {
     end: { x: width - 1, y: height - 1 },
     current: { x: 0, y: 0 },
   }
+  saveDungeon()
 }
 
 export function loadDungeon() {

--- a/shared/dungeonState.test.js
+++ b/shared/dungeonState.test.js
@@ -2,6 +2,13 @@ import { test } from 'node:test'
 import assert from 'assert'
 import { generateDungeon, getDungeon } from './dungeonState.js'
 
+const storageMock = {
+  getItem: () => null,
+  setItem: () => {},
+}
+
+global.localStorage = storageMock
+
 function neighbors(room, rooms) {
   const dirs = [
     { x: 1, y: 0 },


### PR DESCRIPTION
## Summary
- save newly generated dungeon immediately
- mock `localStorage` in dungeon state test

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68439e406458832786080c96194ec9a0