### PR TITLE
Add shop and event scenes with dungeon transitions

### DIFF
--- a/game/src/index.js
+++ b/game/src/index.js
@@ -2,6 +2,8 @@ import Phaser from 'phaser'
 import BattleScene from './scenes/BattleScene'
 import DungeonScene from './scenes/DungeonScene'
 import DecisionScene from './scenes/DecisionScene'
+import ShopScene from './scenes/ShopScene'
+import EventScene from './scenes/EventScene'
 import TownScene from './scenes/TownScene'
 import { loadPartyState } from './shared/partyState.js'
 
@@ -10,7 +12,14 @@ const config = {
   width: 800,
   height: 600,
   parent: 'game-container',
-  scene: [TownScene, DungeonScene, BattleScene, DecisionScene],
+  scene: [
+    TownScene,
+    DungeonScene,
+    ShopScene,
+    EventScene,
+    BattleScene,
+    DecisionScene,
+  ],
 }
 
 loadPartyState()

--- a/game/src/scenes/DungeonScene.js
+++ b/game/src/scenes/DungeonScene.js
@@ -7,6 +7,7 @@ export default class DungeonScene extends Phaser.Scene {
   }
 
   create() {
+    this.cameras.main.fadeIn(250)
     loadDungeon()
     if (!getDungeon()) {
       generateDungeon(5, 5)
@@ -28,8 +29,27 @@ export default class DungeonScene extends Phaser.Scene {
         .rectangle(offsetX + r.x * size, offsetY + r.y * size, size - 4, size - 4, color)
         .setInteractive()
       rect.on('pointerdown', () => {
-        moveTo(r.x, r.y)
-        this.scene.restart()
+        this.cameras.main.fadeOut(250)
+        this.cameras.main.once('camerafadeoutcomplete', () => {
+          moveTo(r.x, r.y)
+          const { rooms } = getDungeon()
+          const idx = rooms.findIndex((room) => room.x === r.x && room.y === r.y)
+          const room = rooms[idx]
+          switch (room.type) {
+            case 'combat':
+              this.scene.launch('battle', { roomIndex: idx })
+              this.scene.sleep()
+              break
+            case 'shop':
+              this.scene.start('shop')
+              break
+            case 'event':
+              this.scene.start('event')
+              break
+            default:
+              this.scene.restart()
+          }
+        })
       })
     })
   }

--- a/game/src/scenes/EventScene.js
+++ b/game/src/scenes/EventScene.js
@@ -1,0 +1,26 @@
+import Phaser from 'phaser'
+import { loadGameState } from '../state'
+
+export default class EventScene extends Phaser.Scene {
+  constructor() {
+    super('event')
+  }
+
+  create() {
+    this.cameras.main.fadeIn(250)
+    const state = loadGameState()
+    const e = state.activeEvent || {}
+    const desc = e.description || 'Something happens.'
+    const name = e.name || 'Event'
+    this.add.text(400, 240, name, { fontSize: '24px', align: 'center' }).setOrigin(0.5)
+    this.add
+      .text(400, 300, desc + '\nClick to continue', { fontSize: '16px', align: 'center' })
+      .setOrigin(0.5)
+    this.input.once('pointerdown', () => {
+      this.cameras.main.fadeOut(250)
+      this.cameras.main.once('camerafadeoutcomplete', () => {
+        this.scene.start('dungeon')
+      })
+    })
+  }
+}

--- a/game/src/scenes/ShopScene.js
+++ b/game/src/scenes/ShopScene.js
@@ -1,0 +1,25 @@
+import Phaser from 'phaser'
+import { loadGameState, saveGameState } from '../state'
+
+export default class ShopScene extends Phaser.Scene {
+  constructor() {
+    super('shop')
+  }
+
+  create() {
+    this.cameras.main.fadeIn(250)
+    this.add.text(400, 250, 'Shop', { fontSize: '24px' }).setOrigin(0.5)
+    this.add
+      .text(400, 300, 'Click to return', { fontSize: '16px' })
+      .setOrigin(0.5)
+    this.input.once('pointerdown', () => {
+      const state = loadGameState()
+      state.location = 'dungeon'
+      saveGameState(state)
+      this.cameras.main.fadeOut(250)
+      this.cameras.main.once('camerafadeoutcomplete', () => {
+        this.scene.start('dungeon')
+      })
+    })
+  }
+}


### PR DESCRIPTION
## Summary
- create `ShopScene` and `EventScene`
- swap scenes in dungeon based on room type
- smooth fade transitions between scenes
- register new scenes in Phaser game config

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68439f466b30832792b76cef6b66aa18