### PR TITLE
Expand dungeon exploration

### DIFF
--- a/client/src/components/DungeonMap.tsx
+++ b/client/src/components/DungeonMap.tsx
@@ -151,7 +151,7 @@ export default function DungeonMap() {
         width: 40,
         height: 40,
         background: isExplored ? roomColors[room.type] : '#000',
-        opacity: isExplored ? 1 : 0.2,
+        opacity: isExplored ? 1 : 1,
         border: room.type === 'boss' || room.type === 'exit' ? '2px solid gold' : '1px solid #444',
         position: 'relative',
         cursor: isReachable && isExplored ? 'pointer' : 'default',

--- a/client/src/components/MiniMap.tsx
+++ b/client/src/components/MiniMap.tsx
@@ -28,7 +28,7 @@ export default function MiniMap({ dungeon, explored, current }: MiniMapProps) {
         height: 20,
         border: '1px solid #444',
         background: isExplored ? colors[room.type] : '#000',
-        opacity: isExplored ? 1 : 0.2,
+        opacity: isExplored ? 1 : 1,
       }
       if (id === current) {
         style.outline = '2px solid white'

--- a/client/src/routes/Dungeon.css
+++ b/client/src/routes/Dungeon.css
@@ -33,4 +33,20 @@
 .dungeon-tile.current {
   background: #50fa7b;
   box-shadow: 0 0 8px #50fa7b;
+  animation: pulse 1s ease-in-out infinite;
+}
+
+@keyframes pulse {
+  0% {
+    transform: scale(1);
+    opacity: 1;
+  }
+  50% {
+    transform: scale(1.1);
+    opacity: 0.8;
+  }
+  100% {
+    transform: scale(1);
+    opacity: 1;
+  }
 }

--- a/client/src/routes/Dungeon.jsx
+++ b/client/src/routes/Dungeon.jsx
@@ -13,9 +13,23 @@ export default function Dungeon() {
   }, [])
 
   const handleClick = (x, y) => {
+    // move the player and mark the selected room as visited
     moveTo(x, y)
-    setD({ ...getDungeon() })
-    const room = getDungeon().rooms.find((r) => r.x === x && r.y === y)
+
+    // also mark the four neighboring rooms as visited
+    const dungeon = getDungeon()
+    const markVisited = (mx, my) => {
+      const neighbor = dungeon.rooms.find((r) => r.x === mx && r.y === my)
+      if (neighbor) neighbor.visited = true
+    }
+    markVisited(x + 1, y)
+    markVisited(x - 1, y)
+    markVisited(x, y + 1)
+    markVisited(x, y - 1)
+
+    setD({ ...dungeon })
+
+    const room = dungeon.rooms.find((r) => r.x === x && r.y === y)
     switch (room?.type) {
       case 'combat':
         return navigate('/battle')


### PR DESCRIPTION
## Summary
- expose neighbors when moving in the simple React dungeon demo
- darken unexplored tiles on maps
- pulse the current tile

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6843a1228da88327a32c3f57439223da