### PR TITLE
Add room icons to dungeon tiles

### DIFF
--- a/client/src/routes/Dungeon.css
+++ b/client/src/routes/Dungeon.css
@@ -12,6 +12,7 @@
 }
 
 .dungeon-tile {
+  position: relative;
   width: 48px;
   height: 48px;
   background: #1f2230;
@@ -33,4 +34,12 @@
 .dungeon-tile.current {
   background: #50fa7b;
   box-shadow: 0 0 8px #50fa7b;
+}
+
+.dungeon-icon {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  font-size: 1rem;
 }

--- a/client/src/routes/Dungeon.jsx
+++ b/client/src/routes/Dungeon.jsx
@@ -38,14 +38,34 @@ export default function Dungeon() {
           const dx = Math.abs(r.x - d.current.x)
           const dy = Math.abs(r.y - d.current.y)
           const revealed = r.visited || dx + dy === 1
+          let icon = ''
+          switch (r.type) {
+            case 'shop':
+              icon = '🛒'
+              break
+            case 'event':
+              icon = '❓'
+              break
+            case 'combat':
+              icon = '⚔️'
+              break
+            case 'start':
+              icon = '🏠'
+              break
+            case 'end':
+              icon = '🚪'
+              break
+          }
           return (
             <div
               key={i}
-              className={`dungeon-tile ${r.visited ? 'visited' : ''} ${
-                revealed ? 'revealed' : ''
-              } ${r.x === d.current.x && r.y === d.current.y ? 'current' : ''}`}
+              className={`dungeon-tile ${revealed ? 'revealed' : ''} ${
+                r.visited ? 'visited' : ''
+              } ${r.type}`}
               onClick={() => revealed && handleClick(r.x, r.y)}
-            />
+            >
+              <span className="dungeon-icon">{icon}</span>
+            </div>
           )
         })}
       </div>


### PR DESCRIPTION
## Summary
- overlay icons for each room type on the dungeon grid
- add positioning styles for the icons

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6843a1846eb483279e3e6a3bb7260ad0