### PR TITLE
Implement next floor logic

### DIFF
--- a/shared/dungeonState.js
+++ b/shared/dungeonState.js
@@ -1,6 +1,14 @@
 // shared/dungeonState.js
 
-let dungeon = null
+export let dungeon = {
+  width: 0,
+  height: 0,
+  rooms: [],
+  start: { x: 0, y: 0 },
+  end: { x: 0, y: 0 },
+  current: { x: 0, y: 0 },
+  floor: 1,
+}
 
 function randomPath(width, height) {
   const path = [{ x: 0, y: 0 }]
@@ -18,7 +26,7 @@ function randomPath(width, height) {
   return path
 }
 
-export function generateDungeon(width = 5, height = 5) {
+export function generateDungeon(width = 5, height = 5, floor = 1) {
   const rooms = []
   const path = randomPath(width, height)
   for (let y = 0; y < height; y++) {
@@ -40,6 +48,7 @@ export function generateDungeon(width = 5, height = 5) {
   dungeon = {
     width,
     height,
+    floor,
     rooms,
     start: { x: 0, y: 0 },
     end: { x: width - 1, y: height - 1 },
@@ -71,6 +80,13 @@ export function moveTo(x, y) {
     room.visited = true
     saveDungeon()
   }
+}
+
+// Called when player reaches end room
+export function nextFloor() {
+  const newFloor = dungeon.floor + 1
+  generateDungeon(5, 5, newFloor)
+  saveDungeon()
 }
 
 export function saveDungeon() {

--- a/shared/dungeonState.test.js
+++ b/shared/dungeonState.test.js
@@ -1,6 +1,6 @@
 import { test } from 'node:test'
 import assert from 'assert'
-import { generateDungeon, getDungeon } from './dungeonState.js'
+import { generateDungeon, getDungeon, nextFloor } from './dungeonState.js'
 
 const storageMock = {
   getItem: () => null,
@@ -48,4 +48,16 @@ test('generated dungeon has a path from start to end', () => {
     }
   }
   assert.ok(found, 'end room reachable from start')
+})
+
+test('nextFloor increments floor and resets map', () => {
+  generateDungeon(5, 5)
+  const first = getDungeon()
+  const prevRooms = first.rooms
+  assert.strictEqual(first.floor, 1)
+  nextFloor()
+  const second = getDungeon()
+  assert.strictEqual(second.floor, 2)
+  assert.notStrictEqual(second.rooms, prevRooms)
+  assert.deepStrictEqual(second.current, { x: 0, y: 0 })
 })


### PR DESCRIPTION
## Summary
- add floor state to dungeon data
- generate dungeon with floor parameter
- implement `nextFloor` helper
- test floor progression and map reset

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6843a29529d48327abbe6555527c4a4d