### PR TITLE
Advance dungeon floor on reaching exit

### DIFF
--- a/client/src/routes/Dungeon.jsx
+++ b/client/src/routes/Dungeon.jsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from 'react'
 import { useNavigate } from 'react-router-dom'
-import { generateDungeon, getDungeon, moveTo } from 'shared/dungeonState'
+import { generateDungeon, getDungeon, moveTo, nextFloor, loadDungeon } from 'shared/dungeonState'
 import './Dungeon.css'
 
 export default function Dungeon() {
@@ -8,7 +8,10 @@ export default function Dungeon() {
   const navigate = useNavigate()
 
   useEffect(() => {
-    generateDungeon(5, 5)
+    loadDungeon()
+    if (!getDungeon()) {
+      generateDungeon(5, 5)
+    }
     setD({ ...getDungeon() })
   }, [])
 
@@ -30,6 +33,11 @@ export default function Dungeon() {
     setD({ ...dungeon })
 
     const room = dungeon.rooms.find((r) => r.x === x && r.y === y)
+    if (room.type === 'end') {
+      nextFloor()
+      setD({ ...getDungeon() })
+      return
+    }
     switch (room?.type) {
       case 'combat':
         return navigate('/battle')
@@ -45,7 +53,7 @@ export default function Dungeon() {
   if (!d) return null
   return (
     <div className="dungeon-container">
-      <h1>Dungeon – Floor 1</h1>
+      <h1>Dungeon – Floor {d.floor}</h1>
       <div className="dungeon-grid">
         {d.rooms.map((r, i) => {
           // determine if tile is revealed

--- a/shared/dungeonState.js
+++ b/shared/dungeonState.js
@@ -18,7 +18,7 @@ function randomPath(width, height) {
   return path
 }
 
-export function generateDungeon(width = 5, height = 5) {
+export function generateDungeon(width = 5, height = 5, floor = 1) {
   const rooms = []
   const path = randomPath(width, height)
   for (let y = 0; y < height; y++) {
@@ -40,6 +40,7 @@ export function generateDungeon(width = 5, height = 5) {
   dungeon = {
     width,
     height,
+    floor,
     rooms,
     start: { x: 0, y: 0 },
     end: { x: width - 1, y: height - 1 },
@@ -75,4 +76,11 @@ export function moveTo(x, y) {
 
 export function saveDungeon() {
   localStorage.setItem('dungeonState', JSON.stringify(dungeon))
+}
+
+export function nextFloor() {
+  if (!dungeon) return
+  const { width, height } = dungeon
+  const floor = (dungeon.floor || 1) + 1
+  generateDungeon(width, height, floor)
 }

--- a/shared/dungeonState.test.js
+++ b/shared/dungeonState.test.js
@@ -1,6 +1,6 @@
 import { test } from 'node:test'
 import assert from 'assert'
-import { generateDungeon, getDungeon } from './dungeonState.js'
+import { generateDungeon, getDungeon, nextFloor } from './dungeonState.js'
 
 const storageMock = {
   getItem: () => null,
@@ -48,4 +48,12 @@ test('generated dungeon has a path from start to end', () => {
     }
   }
   assert.ok(found, 'end room reachable from start')
+})
+
+test('nextFloor increments the floor counter', () => {
+  generateDungeon(3, 3)
+  const firstFloor = getDungeon().floor
+  nextFloor()
+  const second = getDungeon()
+  assert.equal(second.floor, firstFloor + 1)
 })


### PR DESCRIPTION
## Summary
- persist dungeon state between reloads
- regenerate a new floor when clicking the end room
- expose `nextFloor` in dungeon state
- test floor advancement logic

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6843a29d6bbc8327a5d79a70478aefc1