### PR TITLE
Add dungeon load on bootstrap

### DIFF
--- a/client/src/main.jsx
+++ b/client/src/main.jsx
@@ -8,9 +8,12 @@ import { GameStateProvider } from './GameStateProvider.jsx'
 import { ModalProvider } from './components/ModalManager.jsx'
 import { NotificationProvider } from './components/NotificationManager.jsx'
 import { loadInventory } from 'shared/inventoryState'
+import { loadDungeon } from 'shared/dungeonState'
 
 // Load persisted inventory before rendering
 loadInventory()
+// Load persisted dungeon (so we resume in the right room)
+loadDungeon()
 
 // Load any saved state before the app renders
 useGameStore.getState().load()


### PR DESCRIPTION
## Summary
- load the persisted dungeon in the React client so rooms stay consistent between sessions

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6843a33d622c8327b649b3d735d29945