### PR TITLE
Add end room floor progression

### DIFF
--- a/client/src/routes/Dungeon.jsx
+++ b/client/src/routes/Dungeon.jsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from 'react'
 import { useNavigate } from 'react-router-dom'
-import { generateDungeon, getDungeon, moveTo } from 'shared/dungeonState'
+import { generateDungeon, getDungeon, moveTo, nextFloor } from 'shared/dungeonState'
 import './Dungeon.css'
 import Minimap from '../components/Minimap'
 
@@ -9,7 +9,10 @@ export default function Dungeon() {
   const navigate = useNavigate()
 
   useEffect(() => {
-    generateDungeon(5, 5)
+    const existing = getDungeon()
+    if (!existing.rooms || existing.rooms.length === 0) {
+      generateDungeon(5, 5)
+    }
     setD({ ...getDungeon() })
   }, [])
 
@@ -31,6 +34,11 @@ export default function Dungeon() {
     setD({ ...dungeon })
 
     const room = dungeon.rooms.find((r) => r.x === x && r.y === y)
+    if (room?.type === 'end') {
+      nextFloor()
+      setD({ ...getDungeon() })
+      return
+    }
     switch (room?.type) {
       case 'combat':
         return navigate('/battle')
@@ -46,7 +54,7 @@ export default function Dungeon() {
   if (!d) return null
   return (
     <div className="dungeon-container">
-      <h1>Dungeon – Floor 1</h1>
+      <h1>Dungeon – Floor {d.floor}</h1>
       <Minimap />
       <div className="dungeon-grid">
         {d.rooms.map((r, i) => {


### PR DESCRIPTION
## Summary
- only generate dungeon if no saved state exists
- progress to the next floor when stepping on the end tile
- display current floor number in the dungeon UI

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6843a41bc418832780a221598dc2db02