### PR TITLE
Add markRoomCleared and use it after combat

### DIFF
--- a/game/src/scenes/BattleScene.js
+++ b/game/src/scenes/BattleScene.js
@@ -10,6 +10,7 @@ import { partyState, loadPartyState } from '../shared/partyState.js'
 import { InitiativeQueue } from '../../shared/initiativeQueue.js'
 import { sampleCharacters } from 'shared/models/characters.js'
 import { sampleCards } from 'shared/models/cards.js'
+import { markRoomCleared } from 'shared/dungeonState.js'
 import {
   STATUS_META,
   addStatusEffect,
@@ -528,7 +529,8 @@ export default class BattleScene extends Phaser.Scene {
     this.showFloat(text, this.current, text === 'Victory' ? '#44ff44' : '#ff4444')
     if (enemiesAlive === false) {
       const dungeon = this.scene.get('dungeon')
-      dungeon.rooms[this.roomIndex].cleared = true
+      const room = dungeon.rooms[this.roomIndex]
+      markRoomCleared(room.x, room.y)
     }
     this.time.delayedCall(1500, () => {
       this.scene.stop()

--- a/shared/dungeonState.js
+++ b/shared/dungeonState.js
@@ -82,6 +82,14 @@ export function moveTo(x, y) {
   }
 }
 
+export function markRoomCleared(x, y) {
+  const room = dungeon.rooms.find((r) => r.x === x && r.y === y)
+  if (room && room.type === 'combat') {
+    room.type = 'cleared'
+    saveDungeon()
+  }
+}
+
 // Called when player reaches end room
 export function nextFloor() {
   const newFloor = dungeon.floor + 1

--- a/shared/dungeonState.test.js
+++ b/shared/dungeonState.test.js
@@ -1,6 +1,6 @@
 import { test } from 'node:test'
 import assert from 'assert'
-import { generateDungeon, getDungeon, nextFloor } from './dungeonState.js'
+import { generateDungeon, getDungeon, nextFloor, markRoomCleared } from './dungeonState.js'
 
 const storageMock = {
   getItem: () => null,
@@ -60,4 +60,16 @@ test('nextFloor increments floor and resets map', () => {
   assert.strictEqual(second.floor, 2)
   assert.notStrictEqual(second.rooms, prevRooms)
   assert.deepStrictEqual(second.current, { x: 0, y: 0 })
+})
+
+test('markRoomCleared sets combat room to cleared', () => {
+  let combatRoom
+  for (let i = 0; i < 10 && !combatRoom; i++) {
+    generateDungeon(3, 3)
+    combatRoom = getDungeon().rooms.find((r) => r.type === 'combat')
+  }
+  assert.ok(combatRoom, 'combat room exists')
+  markRoomCleared(combatRoom.x, combatRoom.y)
+  const updated = getDungeon().rooms.find((r) => r.x === combatRoom.x && r.y === combatRoom.y)
+  assert.strictEqual(updated.type, 'cleared')
 })


### PR DESCRIPTION
## Summary
- save dungeon after moving
- add `markRoomCleared` to update dungeon state
- use `markRoomCleared` when finishing a battle
- test the new `markRoomCleared` helper

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6843a540d3b48327b6cfb6e95d31c3dd