### PR TITLE
Implement room clearing on battle victory

### DIFF
--- a/game/src/scenes/BattleScene.js
+++ b/game/src/scenes/BattleScene.js
@@ -2,6 +2,7 @@ import Phaser from 'phaser'
 import { applyRolePenalty, getSynergyBonuses } from 'shared/systems/classRole.js'
 import { applyBiomeBonuses, getCurrentBiome } from 'shared/systems/biome.js'
 import { applyEventEffects } from 'shared/systems/floorEvents.js'
+import { markRoomCleared } from 'shared/dungeonState'
 import { chooseEnemyAction, trackEnemyActions, chooseTarget } from 'shared/systems/enemyAI.js'
 import { canUseAbility, applyCooldown, tickCooldowns } from 'shared/systems/abilities.js'
 import { floatingText } from '../effects.js'
@@ -527,8 +528,11 @@ export default class BattleScene extends Phaser.Scene {
     this.add.text(360, 300, text, { fontSize: '32px' }).setOrigin(0.5)
     this.showFloat(text, this.current, text === 'Victory' ? '#44ff44' : '#ff4444')
     if (enemiesAlive === false) {
-      const dungeon = this.scene.get('dungeon')
-      dungeon.rooms[this.roomIndex].cleared = true
+      // mark this room cleared
+      markRoomCleared(
+        this.scene.get('dungeon').rooms[this.roomIndex].x,
+        this.scene.get('dungeon').rooms[this.roomIndex].y
+      )
     }
     this.time.delayedCall(1500, () => {
       this.scene.stop()

--- a/shared/dungeonState.js
+++ b/shared/dungeonState.js
@@ -42,7 +42,7 @@ export function generateDungeon(width = 5, height = 5, floor = 1) {
         const roll = Math.random()
         type = roll < 0.1 ? 'shop' : roll < 0.3 ? 'event' : 'combat'
       }
-      rooms.push({ x, y, type, visited: idx === 0 })
+      rooms.push({ x, y, type, visited: idx === 0, cleared: false })
     }
   }
   dungeon = {
@@ -78,6 +78,15 @@ export function moveTo(x, y) {
   if (room) {
     dungeon.current = { x, y }
     room.visited = true
+    saveDungeon()
+  }
+}
+
+export function markRoomCleared(x, y) {
+  if (!dungeon) return
+  const room = dungeon.rooms.find((r) => r.x === x && r.y === y)
+  if (room) {
+    room.cleared = true
     saveDungeon()
   }
 }


### PR DESCRIPTION
## Summary
- mark cleared rooms in `dungeonState`
- call `markRoomCleared` from `BattleScene` when enemies are defeated

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6843a5460da48327b2bcdfe53ff03900