### PR TITLE
Fix state reload on client-side navigation

### DIFF
--- a/client/src/components/InventoryScreen.tsx
+++ b/client/src/components/InventoryScreen.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect } from 'react'
+import { useLocation } from 'react-router-dom'
 import { useNotification } from './NotificationManager.jsx'
 import { getInventory, loadInventory } from 'shared/inventoryState'
 import cardArt from '../assets/placeholder-card-art.svg'
@@ -27,11 +28,12 @@ export default function InventoryScreen() {
   const [filter, setFilter] = useState('All')
   const [items, setItems] = useState<InventoryItem[]>([])
   const { notify } = useNotification()
+  const location = useLocation()
 
   useEffect(() => {
     loadInventory()
     setItems(fetchItems())
-  }, [])
+  }, [location.pathname])
 
   const filtered = items.filter(i => filter === 'All' || i.type === filter)
 

--- a/client/src/components/PartySetup.tsx
+++ b/client/src/components/PartySetup.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate, useLocation } from 'react-router-dom';
 import { useGameStore } from '../store/gameStore';
 // Import data models. Adjust paths if necessary.
 import type { Character } from '../../../shared/models/Character';
@@ -67,6 +67,7 @@ const PartySetup: React.FC = () => {
   }
 
   const navigate = useNavigate();
+  const location = useLocation();
   const setParty = useGameStore(state => state.setParty);
   const updateGameState = useGameStore(state => state.updateGameState);
   const save = useGameStore(state => state.save);
@@ -77,7 +78,7 @@ const PartySetup: React.FC = () => {
   // reload from storage whenever this component mounts
   useEffect(() => {
     loadSharedPartyState();
-  }, []);
+  }, [location.pathname]);
 
   // Reset limits when starting a new setup session
   useEffect(() => {

--- a/client/src/components/TownView.tsx
+++ b/client/src/components/TownView.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect } from "react";
-import { useNavigate, Link } from "react-router-dom";
+import { useNavigate, Link, useLocation } from "react-router-dom";
 import { useGameState } from "../GameStateProvider.jsx";
 import CharacterCard from "./CharacterCard.tsx";
 import styles from "./TownView.module.css";
@@ -10,11 +10,12 @@ import {
 
 export default function TownView() {
   const navigate = useNavigate();
+  const location = useLocation();
   const party = useGameState((s) => s.party);
 
   useEffect(() => {
     loadPartyState();
-  }, []);
+  }, [location.pathname]);
 
   return (
     <div className={styles.container}>

--- a/client/src/routes/Battle.tsx
+++ b/client/src/routes/Battle.tsx
@@ -1,13 +1,15 @@
 import React, { useRef, useEffect } from 'react';
+import { useLocation } from 'react-router-dom';
 import { loadPartyState } from 'shared/partyState';
 import { loadGameState } from 'game/state';
 
 export default function Battle() {
+  const location = useLocation();
   // On mount reload both party and game state from localStorage
   useEffect(() => {
     loadPartyState();
     loadGameState();
-  }, []);
+  }, [location.pathname]);
 
   const phaserRef = useRef<HTMLDivElement | null>(null);
   // Placeholder for Phaser embed


### PR DESCRIPTION
## Summary
- reload page data when navigating client-side by watching `location.pathname`

## Testing
- `npm test`
- `npx prettier --write client/src/components/TownView.tsx client/src/components/InventoryScreen.tsx client/src/components/PartySetup.tsx client/src/routes/Battle.tsx --single-quote`

------
https://chatgpt.com/codex/tasks/task_e_6843b29f3f5883278a7b44b4b18c752e