### PR TITLE
Ensure page state loads on navigation

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -1,6 +1,5 @@
 import "./App.css";
 import { Routes, Route, useLocation } from "react-router-dom";
-import { CSSTransition, TransitionGroup } from "react-transition-group";
 import MainMenu from "./components/MainMenu.jsx";
 import PartySetup from "./components/PartySetup.tsx";
 import PreBattleSetup from "./components/PreBattleSetup.tsx";
@@ -15,25 +14,21 @@ import DeckManager from "./components/DeckManager.jsx";
 import BattleScene from "./components/BattleScene.tsx";
 
 export default function App() {
-  const loc = useLocation();
+  const location = useLocation();
   return (
-    <TransitionGroup>
-      <CSSTransition key={loc.pathname} classNames="page" timeout={300}>
-        <Routes location={loc} key={loc.pathname}>
-          <Route path="/" element={<MainMenu />} />
-          <Route path="/party-setup" element={<PartySetup />} />
-          <Route path="/dungeon" element={<DungeonMap />} />
-          <Route path="/town" element={<TownView />} />
-          <Route path="/inventory" element={<InventoryPage />} />
-          <Route path="/cards" element={<CollectionPage />} />
-          <Route path="/crafting" element={<CraftingPage />} />
-          <Route path="/shop" element={<Shop />} />
-          <Route path="/pre-battle" element={<PreBattleSetup />} />
-          <Route path="/battle" element={<BattleScene />} />
-          <Route path="/event" element={<Event />} />
-          <Route path="/decks" element={<DeckManager />} />
-        </Routes>
-      </CSSTransition>
-    </TransitionGroup>
+    <Routes key={location.pathname} location={location}>
+      <Route path="/" element={<MainMenu />} />
+      <Route path="/party-setup" element={<PartySetup />} />
+      <Route path="/dungeon" element={<DungeonMap />} />
+      <Route path="/town" element={<TownView />} />
+      <Route path="/inventory" element={<InventoryPage />} />
+      <Route path="/cards" element={<CollectionPage />} />
+      <Route path="/crafting" element={<CraftingPage />} />
+      <Route path="/shop" element={<Shop />} />
+      <Route path="/pre-battle" element={<PreBattleSetup />} />
+      <Route path="/battle" element={<BattleScene />} />
+      <Route path="/event" element={<Event />} />
+      <Route path="/decks" element={<DeckManager />} />
+    </Routes>
   );
 }

--- a/client/src/components/InventoryScreen.tsx
+++ b/client/src/components/InventoryScreen.tsx
@@ -33,7 +33,8 @@ export default function InventoryScreen() {
   useEffect(() => {
     loadInventory()
     setItems(fetchItems())
-  }, [location.pathname])
+    console.log('InventoryScreen mounted - inventory loaded')
+  }, [])
 
   const filtered = items.filter(i => filter === 'All' || i.type === filter)
 

--- a/client/src/components/PartySetup.tsx
+++ b/client/src/components/PartySetup.tsx
@@ -78,7 +78,8 @@ const PartySetup: React.FC = () => {
   // reload from storage whenever this component mounts
   useEffect(() => {
     loadSharedPartyState();
-  }, [location.pathname]);
+    console.log('PartySetup mounted - party state loaded');
+  }, []);
 
   // Reset limits when starting a new setup session
   useEffect(() => {

--- a/client/src/components/TownView.tsx
+++ b/client/src/components/TownView.tsx
@@ -15,7 +15,8 @@ export default function TownView() {
 
   useEffect(() => {
     loadPartyState();
-  }, [location.pathname]);
+    console.log('TownView mounted - party state loaded');
+  }, []);
 
   return (
     <div className={styles.container}>

--- a/client/src/main.jsx
+++ b/client/src/main.jsx
@@ -7,13 +7,6 @@ import { useGameStore } from './store/gameStore'
 import { GameStateProvider } from './GameStateProvider.jsx'
 import { ModalProvider } from './components/ModalManager.jsx'
 import { NotificationProvider } from './components/NotificationManager.jsx'
-import { loadInventory } from 'shared/inventoryState'
-import { loadDungeon } from 'shared/dungeonState'
-
-// Load persisted inventory before rendering
-loadInventory()
-// Load persisted dungeon (so we resume in the right room)
-loadDungeon()
 
 // Load any saved state before the app renders
 useGameStore.getState().load()

--- a/client/src/routes/Battle.tsx
+++ b/client/src/routes/Battle.tsx
@@ -9,7 +9,8 @@ export default function Battle() {
   useEffect(() => {
     loadPartyState();
     loadGameState();
-  }, [location.pathname]);
+    console.log('Battle mounted - party and game state loaded');
+  }, []);
 
   const phaserRef = useRef<HTMLDivElement | null>(null);
   // Placeholder for Phaser embed


### PR DESCRIPTION
## Summary
- force a full remount on route changes by keying `<Routes>`
- remove global state loading from `main.jsx`
- load party and inventory state in their respective pages
- add console logging on mount for debugging

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6843c56d0ea88327abae233bb16572c2