### PR TITLE
Integrate React HUD for battles

### DIFF
--- a/client/src/components/BattleHUD.jsx
+++ b/client/src/components/BattleHUD.jsx
@@ -1,30 +1,113 @@
 import React, { useEffect, useState } from 'react'
+import { useNavigate } from 'react-router-dom'
 import { usePhaserScene } from '../hooks/usePhaserScene'
+import CombatantCard from './CombatantCard'
+import LogLine from './LogLine'
+import Overlay from './Overlay'
 
 export default function BattleHUD() {
   const scene = usePhaserScene('battle')
+  const navigate = useNavigate()
+  const [turnOrder, setTurnOrder] = useState([])
+  const [combatants, setCombatants] = useState({})
   const [log, setLog] = useState([])
+  const [activeId, setActiveId] = useState(null)
+  const [battleResult, setBattleResult] = useState(null)
 
   useEffect(() => {
-    // ─── Add battle-log listener for rich, card-specific messages ───
-    const logHandler = (entry) => {
-      setLog((l) => {
-        const next = [...l, entry]
-        return next.length > 20 ? next.slice(next.length - 20) : next
+    if (!scene) return
+
+    const updateTurnStart = ({ actorId, newEnergy, hand }) => {
+      setActiveId(actorId)
+      setCombatants(prev => {
+        const next = { ...prev }
+        if (next[actorId]) {
+          next[actorId] = { ...next[actorId], energy: newEnergy, hand }
+        }
+        return next
       })
     }
+
+    const updateCardPlayed = (payload) => {
+      setCombatants(prev => {
+        const next = { ...prev }
+        if (payload.damage && next[payload.targetId]) {
+          const t = next[payload.targetId]
+          next[payload.targetId] = { ...t, hp: Math.max(0, t.hp - payload.damage) }
+        }
+        if (payload.heal && next[payload.actorId]) {
+          const a = next[payload.actorId]
+          next[payload.actorId] = { ...a, hp: Math.min(a.maxHp, a.hp + payload.heal) }
+        }
+        return next
+      })
+    }
+
+    const updateSkip = ({ actorId }) => {
+      setLog(l => [...l, { type: 'skip', actorId }])
+    }
+
+    const updateBattleEnd = ({ result }) => {
+      setBattleResult(result)
+    }
+
+    const logHandler = (entry) => {
+      setLog(l => [...l.slice(-19), { type: 'text', text: entry }])
+    }
+
+    scene.events.on('turn-start', updateTurnStart)
+    scene.events.on('card-played', updateCardPlayed)
+    scene.events.on('turn-skipped', updateSkip)
+    scene.events.on('battle-end', updateBattleEnd)
     scene.events.on('battle-log', logHandler)
 
+    if (scene.turnOrder) {
+      const order = scene.turnOrder.map(c => c.data.id)
+      const map = {}
+      scene.turnOrder.forEach(c => {
+        map[c.data.id] = {
+          id: c.data.id,
+          type: c.type,
+          name: c.data.name,
+          portraitUrl: c.data.portrait,
+          hp: c.hp,
+          maxHp: c.data.stats.hp,
+          energy: c.energy ?? c.data.currentEnergy ?? 0,
+        }
+      })
+      setTurnOrder(order)
+      setCombatants(map)
+    }
+
     return () => {
+      scene.events.off('turn-start', updateTurnStart)
+      scene.events.off('card-played', updateCardPlayed)
+      scene.events.off('turn-skipped', updateSkip)
+      scene.events.off('battle-end', updateBattleEnd)
       scene.events.off('battle-log', logHandler)
     }
   }, [scene])
 
   return (
-    <div className="battle-log">
-      {log.map((line, i) => (
-        <div key={i}>{line}</div>
-      ))}
+    <div className="battle-hud">
+      <div className="combatants allies">
+        {turnOrder.filter(id => combatants[id]?.type === 'player').map(id => (
+          <CombatantCard key={id} data={combatants[id]} isActive={id === activeId} />
+        ))}
+      </div>
+      <div className="battle-log">
+        {log.map((entry, i) => (
+          <LogLine key={i} {...entry} />
+        ))}
+      </div>
+      <div className="combatants enemies">
+        {turnOrder.filter(id => combatants[id]?.type === 'enemy').map(id => (
+          <CombatantCard key={id} data={combatants[id]} isActive={id === activeId} />
+        ))}
+      </div>
+      {battleResult && (
+        <Overlay message={battleResult} onContinue={() => navigate('/town')} />
+      )}
     </div>
   )
 }

--- a/client/src/components/CombatantCard.jsx
+++ b/client/src/components/CombatantCard.jsx
@@ -1,0 +1,18 @@
+import React from 'react'
+import defaultPortrait from '../../../shared/images/default-portrait.png'
+
+export default function CombatantCard({ data, isActive }) {
+  if (!data) return null
+  const { name, portraitUrl, hp, maxHp, energy } = data
+  const ratio = Math.max(0, Math.min(1, hp / maxHp))
+  return (
+    <div className={`combatant-card${isActive ? ' active' : ''}`}>
+      <img src={portraitUrl || defaultPortrait} alt={name} />
+      <div className="name">{name}</div>
+      <div className="hp-bar">
+        <div className="fill" style={{ width: `${ratio * 100}%` }} />
+      </div>
+      <div className="energy">⚡{energy}</div>
+    </div>
+  )
+}

--- a/client/src/components/LogLine.jsx
+++ b/client/src/components/LogLine.jsx
@@ -1,0 +1,9 @@
+import React from 'react'
+
+export default function LogLine(props) {
+  if (props.type === 'text') return <div>{props.text}</div>
+  if (props.type === 'skip') return <div style={{ color: '#888' }}>{props.actorId} skipped</div>
+  if (props.type === 'card') return <div>{props.actorId} used {props.cardId}</div>
+  if (props.type === 'result') return <div>{props.result}</div>
+  return <div>{JSON.stringify(props)}</div>
+}

--- a/client/src/components/Overlay.jsx
+++ b/client/src/components/Overlay.jsx
@@ -1,0 +1,12 @@
+import React from 'react'
+
+export default function Overlay({ message, onContinue }) {
+  return (
+    <div className="overlay">
+      <div className="overlay-inner">
+        <p>{message}</p>
+        <button onClick={onContinue}>Continue</button>
+      </div>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- emit granular battle events from `BattleScene`
- replace Phaser UI with `BattleHUD` React component
- add new subcomponents for combatants, log lines and overlays
- strip old Phaser UI drawing code

## Testing
- `npm test`
- `npm run validate:cards`

------
https://chatgpt.com/codex/tasks/task_e_68446dda98488327a56c2a2d120577fb