### PR TITLE
Fix lint and jest config

### DIFF
--- a/client/src/__mocks__/fileMock.js
+++ b/client/src/__mocks__/fileMock.js
@@ -1,0 +1,1 @@
+export default '';

--- a/client/src/__mocks__/styleMock.js
+++ b/client/src/__mocks__/styleMock.js
@@ -1,0 +1,1 @@
+export default {};

--- a/client/src/components/__tests__/BattleHUD.test.cjs
+++ b/client/src/components/__tests__/BattleHUD.test.cjs
@@ -1,9 +1,9 @@
-/* global jest, describe, it, expect */
-import React from 'react';
-import { render, screen } from '@testing-library/react';
-import BattleHUD from '../BattleHUD';
-import { createEventEmitterMock } from '../__mocks__/phaserSceneMock';
-import { usePhaserScene } from '../../hooks/usePhaserScene';
+/* global jest, describe, it, expect, beforeEach */
+const React = require('react');
+const { render, screen } = require('@testing-library/react');
+const BattleHUD = require('../BattleHUD').default;
+const { createEventEmitterMock } = require('../__mocks__/phaserSceneMock');
+const { usePhaserScene } = require('../../hooks/usePhaserScene');
 jest.mock('../../hooks/usePhaserScene');
 
 let scene;

--- a/jest.config.js
+++ b/jest.config.js
@@ -4,7 +4,11 @@ export default {
     global: { branches: 0, functions: 0, lines: 0, statements: 0 },
   },
   transform: {
-    '^.+\\.jsx$': ['babel-jest', { presets: ['@babel/preset-react'], configFile: false }],
+    '^.+\\.jsx?$': ['babel-jest', { presets: ['@babel/preset-env', '@babel/preset-react'], configFile: false }],
+  },
+  moduleNameMapper: {
+    '\\.(css)$': '<rootDir>/client/src/__mocks__/styleMock.js',
+    '\\.(png|jpg|jpeg|gif|svg)$': '<rootDir>/client/src/__mocks__/fileMock.js',
   },
   testMatch: [
     '**/game/src/**/__tests__/**/*.test.js',

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   },
   "type": "module",
   "devDependencies": {
+    "@babel/preset-env": "^7.23.3",
     "@babel/preset-react": "^7.24.5",
     "@testing-library/jest-dom": "^6.6.3",
     "@testing-library/react": "^14.2.2",


### PR DESCRIPTION
## Summary
- fix lint issues in BattleHUD test by defining `beforeEach`
- support Jest with Babel for React code in JS/JSX
- mock CSS and image imports during tests
- run BattleHUD test with CommonJS

## Testing
- `npm test`
- `npm --workspace client run lint`


------
https://chatgpt.com/codex/tasks/task_e_6844f48b75408327aaadac134dfb3581