### PR TITLE
Finalize React Battle HUD

### DIFF
--- a/client/src/components/BattleHUD.jsx
+++ b/client/src/components/BattleHUD.jsx
@@ -49,10 +49,10 @@ export default function BattleHUD() {
       setLog(l => [
         ...l,
         `${combatantsRef.current[actorId]?.name || actorId} played ${cardId} on ${combatantsRef.current[targetId]?.name || targetId}`,
-      ])
+      ].slice(-20))
     }
     const onTurnSkipped = ({ actorId }) => {
-      setLog(l => [...l, `${combatantsRef.current[actorId]?.name || actorId} skipped turn`])
+      setLog(l => [...l, `${combatantsRef.current[actorId]?.name || actorId} skipped turn`].slice(-20))
     }
     const onBattleEnd = ({ result }) => setResult(result)
 

--- a/client/src/components/CombatantCard.jsx
+++ b/client/src/components/CombatantCard.jsx
@@ -7,7 +7,7 @@ export default function CombatantCard({ name, portraitUrl, currentHp, maxHp, cur
   return (
     <div
       role="group"
-      aria-label={`${name} ${isActive ? 'active turn' : ''}`}
+      aria-label={`${name}${isActive ? ' (active)' : ''}`}
       tabIndex={0}
       className={`combatant-card${isActive ? ' active' : ''}`}
     >

--- a/docs/BATTLE_UI.md
+++ b/docs/BATTLE_UI.md
@@ -1,11 +1,12 @@
 # React-Driven Battle HUD
 
 ## Event Schema
-- `initial-state`  
-- `turn-start`  
-- `card-played`  
-- `turn-skipped`  
-- `battle-end`  
+- `initial-state`
+- `request-state`
+- `turn-start`
+- `card-played`
+- `turn-skipped`
+- `battle-end`
 
 ## Component Architecture
 - `Battle.tsx` – embeds Phaser canvas & `<BattleHUD />`  
@@ -19,5 +20,12 @@
 - Color tokens, font sizes, grid gaps  
 
 ## Accessibility
-- ARIA roles on combatant cards and log  
-- Keyboard navigable focus styles  
+- ARIA roles on combatant cards and log
+- Keyboard navigable focus styles
+
+## Summary
+
+- Emit `initial-state` once per battle so React can hydrate.
+- React HUD receives updates via `turn-start`, `card-played`, and `turn-skipped`.
+- Phaser no longer draws rectangles/text; only logic and event emissions remain.
+- UI elements highlight the active combatant and keep the log to the last 20 lines.


### PR DESCRIPTION
## Summary
- tweak Combatant card aria label
- clamp battle log to last 20 entries
- document request-state event and HUD summary

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68451fc6f1fc8327b010c84d454d4f60