### PR TITLE
Implement replay-based battle simulator

### DIFF
--- a/client/src/components/BattleHUD.jsx
+++ b/client/src/components/BattleHUD.jsx
@@ -51,6 +51,32 @@ export default function BattleHUD() {
         `${combatantsRef.current[actorId]?.name || actorId} played ${cardId} on ${combatantsRef.current[targetId]?.name || targetId}`,
       ].slice(-20))
     }
+    const onDamage = ({ targetId, amount }) => {
+      setCombatants(c => {
+        const updated = {
+          ...c,
+          [targetId]: {
+            ...c[targetId],
+            currentHp: Math.max(0, (c[targetId]?.currentHp || 0) - amount),
+          },
+        }
+        combatantsRef.current = updated
+        return updated
+      })
+    }
+    const onHeal = ({ actorId, amount }) => {
+      setCombatants(c => {
+        const updated = {
+          ...c,
+          [actorId]: {
+            ...c[actorId],
+            currentHp: Math.min(c[actorId]?.maxHp || 0, (c[actorId]?.currentHp || 0) + amount),
+          },
+        }
+        combatantsRef.current = updated
+        return updated
+      })
+    }
     const onTurnSkipped = ({ actorId }) => {
       setLog(l => [...l, `${combatantsRef.current[actorId]?.name || actorId} skipped turn`].slice(-20))
     }
@@ -59,17 +85,19 @@ export default function BattleHUD() {
     scene.events.on('initial-state', onInitialState)
     scene.events.on('turn-start', onTurnStart)
     scene.events.on('card-played', onCardPlayed)
+    scene.events.on('damage', onDamage)
+    scene.events.on('heal', onHeal)
     scene.events.on('turn-skipped', onTurnSkipped)
     scene.events.on('battle-end', onBattleEnd)
 
-    scene.events.emit('request-state')
-
     return () => {
       scene.events.off('initial-state', onInitialState)
-      scene.events.off('turn-start', onTurnStart)
-      scene.events.off('card-played', onCardPlayed)
-      scene.events.off('turn-skipped', onTurnSkipped)
-      scene.events.off('battle-end', onBattleEnd)
+      scene.events.off('turn-start',    onTurnStart)
+      scene.events.off('card-played',   onCardPlayed)
+      scene.events.off('damage',        onDamage)
+      scene.events.off('heal',          onHeal)
+      scene.events.off('turn-skipped',  onTurnSkipped)
+      scene.events.off('battle-end',    onBattleEnd)
     }
   }, [scene])
 

--- a/game/src/logic/__tests__/battleSimulator.test.js
+++ b/game/src/logic/__tests__/battleSimulator.test.js
@@ -1,0 +1,13 @@
+import { simulateBattle } from '../battleSimulator.js'
+
+describe('simulateBattle()', () => {
+  it('produces a valid event sequence and ends with battle-end', () => {
+    const party = [{ id:'p1', name:'P', stats:{hp:5,mana:1}, deck:[{id:'c1',cost:1, effect:{type:'damage', magnitude:5}}] }]
+    const enemy = [{ id:'e1', name:'E', stats:{hp:5,mana:1}, deck:[{id:'d1',cost:1, effect:{type:'damage', magnitude:5}}] }]
+    const events = simulateBattle(party, enemy)
+    expect(events.length).toBeGreaterThan(0)
+    const last = events[events.length-1]
+    expect(last.type).toBe('battle-end')
+    expect(['victory','defeat','draw']).toContain(last.result)
+  })
+})

--- a/game/src/logic/battleSimulator.js
+++ b/game/src/logic/battleSimulator.js
@@ -1,0 +1,95 @@
+import _ from 'lodash';
+import { applyCardEffects, chooseTarget, shuffleArray } from './battleUtils.js';
+
+/**
+ * @typedef {Object} BattleEvent
+ * @property {number} time
+ * @property {'turn-start'|'card-played'|'turn-skipped'|'damage'|'heal'|'battle-end'} type
+ * @property {string} actorId
+ * @property {string} [targetId]
+ * @property {string} [cardId]
+ * @property {number} [amount]
+ * @property {string} [result]
+ */
+
+/**
+ * Simulate a full battle between two sides.
+ * @param {Object[]} partyData
+ * @param {Object[]} enemyData
+ * @returns {BattleEvent[]}
+ */
+export function simulateBattle(partyData, enemyData) {
+  const parties = _.cloneDeep(partyData).map(d => ({ ...d, currentHp: d.stats.hp, currentEnergy: 0, deck: [...(d.deck || [])], hand: [] }));
+  const enemies = _.cloneDeep(enemyData).map(d => ({ ...d, currentHp: d.stats.hp, currentEnergy: 0, deck: [...(d.deck || [])], hand: [] }));
+
+  const turnOrder = [...parties, ...enemies];
+
+  /** @type {BattleEvent[]} */
+  const events = [];
+  let step = 0;
+  const record = (type, payload) => {
+    events.push({ time: step++, type, ...payload });
+  };
+
+  const gainEnergy = (unit) => {
+    const max = unit.stats.mana ?? unit.stats.energy ?? unit.stats.maxMana ?? 0;
+    unit.currentEnergy = Math.min(max, (unit.currentEnergy || 0) + 1);
+  };
+
+  const drawCard = (unit) => {
+    if (unit.deck.length === 0) {
+      unit.deck = shuffleArray(unit.hand.splice(0));
+    }
+    if (unit.deck.length) {
+      const card = unit.deck.shift();
+      unit.hand.push(card);
+    }
+  };
+
+  let aliveParties = true;
+  let aliveEnemies = true;
+  while (aliveParties && aliveEnemies) {
+    for (const unit of turnOrder) {
+      if (unit.currentHp <= 0) continue;
+      gainEnergy(unit);
+      drawCard(unit);
+      record('turn-start', { actorId: unit.id });
+      const playable = unit.hand.filter(c => (c.energyCost ?? c.cost ?? 0) <= unit.currentEnergy);
+      if (playable.length === 0) {
+        record('turn-skipped', { actorId: unit.id });
+      } else {
+        const card = playable[0];
+        const cost = card.energyCost ?? card.cost ?? 0;
+        unit.currentEnergy = Math.max(0, unit.currentEnergy - cost);
+        const defenders = parties.includes(unit) ? enemies : parties;
+        const target = chooseTarget(defenders);
+        if (!target) continue;
+        record('card-played', { actorId: unit.id, cardId: card.id, targetId: target.id });
+        const { damage, heal } = applyCardEffects(unit, target, card);
+        if (damage) {
+          target.currentHp = Math.max(0, target.currentHp - damage);
+          record('damage', { actorId: unit.id, targetId: target.id, amount: damage });
+        }
+        if (heal) {
+          unit.currentHp = Math.min(unit.stats.hp, unit.currentHp + heal);
+          record('heal', { actorId: unit.id, amount: heal });
+        }
+      }
+      aliveParties = parties.some(u => u.currentHp > 0);
+      aliveEnemies = enemies.some(u => u.currentHp > 0);
+      if (!aliveParties && !aliveEnemies) {
+        record('battle-end', { actorId: unit.id, result: 'draw' });
+        return events;
+      }
+      if (!aliveEnemies) {
+        record('battle-end', { actorId: unit.id, result: 'victory' });
+        return events;
+      }
+      if (!aliveParties) {
+        record('battle-end', { actorId: unit.id, result: 'defeat' });
+        return events;
+      }
+    }
+  }
+  return events;
+}

--- a/game/src/logic/battleUtils.js
+++ b/game/src/logic/battleUtils.js
@@ -1,0 +1,21 @@
+export function chooseTarget(units) {
+  const alive = units.filter(u => u.currentHp > 0);
+  if (alive.length === 0) return null;
+  return alive[Math.floor(Math.random() * alive.length)];
+}
+
+export function applyCardEffects(attacker, defender, card) {
+  const effects = [];
+  if (card.effect) effects.push(card.effect);
+  if (Array.isArray(card.effects)) effects.push(...card.effects);
+  let damage = 0;
+  let heal = 0;
+  for (const eff of effects) {
+    const amount = eff.magnitude ?? eff.value ?? 0;
+    if (eff.type === 'damage') damage += amount;
+    if (eff.type === 'heal') heal += amount;
+  }
+  return { damage, heal };
+}
+
+export { shuffleArray } from '../utils/shuffleArray.js';


### PR DESCRIPTION
## Summary
- add pure `simulateBattle` in game logic and helpers in `battleUtils`
- update Phaser `BattleScene` to replay precomputed events
- bind combat animations to new events
- sync React `BattleHUD` with damage/heal events
- test the simulator

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684604bc2e148327a7a503c5519b9ab4