### PR TITLE
Add /battle-replay route

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -11,7 +11,8 @@ import CollectionPage from "./components/CollectionPage.tsx";
 import CraftingPage from "./components/CraftingPage.tsx";
 import Shop from "./routes/Shop.jsx";
 import DeckManager from "./components/DeckManager.jsx";
-import BattleScene from "./components/BattleScene.tsx";
+import Battle from "./routes/Battle";
+import ReplayBattle from "./routes/ReplayBattle";
 
 export default function App() {
   const location = useLocation();
@@ -26,7 +27,8 @@ export default function App() {
       <Route path="/crafting" element={<CraftingPage />} />
       <Route path="/shop" element={<Shop />} />
       <Route path="/pre-battle" element={<PreBattleSetup />} />
-      <Route path="/battle" element={<BattleScene />} />
+      <Route path="/battle" element={<Battle />} />
+      <Route path="/battle-replay" element={<ReplayBattle />} />
       <Route path="/event" element={<Event />} />
       <Route path="/decks" element={<DeckManager />} />
     </Routes>

--- a/client/src/routes/ReplayBattle.jsx
+++ b/client/src/routes/ReplayBattle.jsx
@@ -1,0 +1,29 @@
+import React, { useEffect, useRef } from 'react';
+import Phaser from 'phaser';
+import BattleScene from 'game/src/scenes/BattleScene';
+import BattleHUD from '../components/BattleHUD';
+
+export default function ReplayBattle() {
+  const container = useRef(null);
+
+  useEffect(() => {
+    const game = new Phaser.Game({
+      type: Phaser.AUTO,
+      width: 800,
+      height: 600,
+      parent: container.current,
+      scene: [BattleScene],
+    });
+
+    return () => {
+      game.destroy(true);
+    };
+  }, []);
+
+  return (
+    <div className="battle-page">
+      <div ref={container} className="phaser-container" />
+      <BattleHUD />
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- allow navigating to new `/battle-replay` route
- create `ReplayBattle` component using Phaser

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6846089a9a888327ab2534423f40736b