### PR TITLE
Implement battle viewer flow

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -5,7 +5,7 @@ import PartySetup from "./components/PartySetup.tsx";
 import PreBattleSetup from "./components/PreBattleSetup.tsx";
 import DungeonMap from "./components/DungeonMap.tsx";
 import Event from "./routes/Event.jsx";
-import TownView from "./components/TownView.tsx";
+import TownHub from "./components/TownHub.tsx";
 import InventoryPage from "./components/InventoryPage.tsx";
 import CollectionPage from "./components/CollectionPage.tsx";
 import CraftingPage from "./components/CraftingPage.tsx";
@@ -17,12 +17,13 @@ import { sampleSteps } from "./sampleBattleSteps";
 
 export default function App() {
   const location = useLocation();
+  const steps = (location.state && (location.state as any).steps) || sampleSteps;
   return (
     <Routes key={location.pathname} location={location}>
       <Route path="/" element={<MainMenu />} />
       <Route path="/party-setup" element={<PartySetup />} />
       <Route path="/dungeon" element={<DungeonMap />} />
-      <Route path="/town" element={<TownView />} />
+      <Route path="/town" element={<TownHub />} />
       <Route path="/inventory" element={<InventoryPage />} />
       <Route path="/cards" element={<CollectionPage />} />
       <Route path="/crafting" element={<CraftingPage />} />
@@ -31,7 +32,7 @@ export default function App() {
       <Route path="/battle" element={<ReplayBattle />} />
       <Route path="/battle-replay" element={<ReplayBattle />} />
       <Route path="/battle-sim" element={<ReplayBattle />} />
-      <Route path="/viewer" element={<BattleViewer steps={sampleSteps} />} />
+      <Route path="/viewer" element={<BattleViewer steps={steps} />} />
       <Route path="/event" element={<Event />} />
       <Route path="/decks" element={<DeckManager />} />
     </Routes>

--- a/client/src/components/BattleViewer.tsx
+++ b/client/src/components/BattleViewer.tsx
@@ -27,6 +27,7 @@ export default function BattleViewer({ steps, initialStep = 0 }: Props) {
   const state = step ? step.postState : []
   const allies = state.filter(u => u.team === 'party')
   const foes = state.filter(u => u.team === 'enemy')
+  const logs = steps.slice(0, currentStep + 1)
 
   return (
     <div>
@@ -53,10 +54,16 @@ export default function BattleViewer({ steps, initialStep = 0 }: Props) {
           ))}
         </div>
       </div>
-      {step && (
-        <div style={{ marginTop: '1rem' }}>
-          <strong style={{ color: '#58a' }}>{step.actionType}</strong>
-          <pre>{step.logMessage}</pre>
+      <div style={{ marginTop: '1rem', minHeight: '120px' }}>
+        {logs.map((s, i) => (
+          <div key={i} style={{ fontSize: '0.85rem' }}>
+            <strong style={{ color: '#58a' }}>{s.actionType}</strong> {s.logMessage}
+          </div>
+        ))}
+      </div>
+      {step?.actionType === 'endBattle' && (
+        <div style={{ marginTop: '1rem', fontSize: '1.5rem', fontWeight: 'bold' }}>
+          {step.details.result === 'victory' ? 'Victory!' : 'Defeat'}
         </div>
       )}
     </div>

--- a/client/src/components/CharacterPanel.tsx
+++ b/client/src/components/CharacterPanel.tsx
@@ -12,6 +12,7 @@ export default function CharacterPanel({ unit }: Props) {
     <div style={{ border: '1px solid #444', padding: '0.5rem', borderRadius: 8, width: 120, opacity: isDead ? 0.5 : 1 }}>
       <div style={{ fontWeight: 'bold' }}>{unit.name || unit.id}</div>
       <div>HP: {unit.hp}</div>
+      <div>Energy: {unit.energy ?? 0}</div>
       {buffList.length > 0 && (
         <div style={{ fontSize: '0.75rem' }}>Buffs: {buffList.join(', ')}</div>
       )}

--- a/client/src/components/TownHub.tsx
+++ b/client/src/components/TownHub.tsx
@@ -1,0 +1,118 @@
+import React, { useEffect } from "react";
+import { useNavigate, Link, useLocation } from "react-router-dom";
+import { useGameState } from "../GameStateProvider.jsx";
+import CharacterCard from "./CharacterCard.tsx";
+import styles from "./TownView.module.css";
+import {
+  loadPartyState,
+} from "../../../game/src/shared/partyState.js";
+import { simulateBattle as battleSimulator } from "../../../game/src/logic/battleSimulator.js";
+import { playerParty, enemyParty } from "../../../game/src/logic/sampleBattleData.js";
+
+export default function TownHub() {
+  const navigate = useNavigate();
+  const location = useLocation();
+  const party = useGameState((s) => s.party);
+
+  useEffect(() => {
+    loadPartyState();
+    console.log('TownHub mounted - party state loaded');
+  }, []);
+
+  const onTestBattle = () => {
+    const steps = battleSimulator(playerParty, enemyParty);
+    navigate('/viewer', { state: { steps } });
+  };
+
+  return (
+    <div className={styles.container}>
+      <header className={styles.header}>
+        <h2>Town Hub</h2>
+        <div className={styles.partyCards}>
+          {party?.characters && party.characters.length > 0 ? (
+            party.characters.map((character) => (
+              <CharacterCard
+                key={character.id}
+                character={character}
+                onSelect={() => {}}
+                isSelected={false}
+                isDisabled={false}
+              />
+            ))
+          ) : (
+            <p>No party</p>
+          )}
+        </div>
+        <button onClick={onTestBattle}>Test Battle</button>
+        <Link to="/" className={styles.mainMenu}>
+          Return to Main Menu
+        </Link>
+      </header>
+      <div className={styles.grid}>
+        <button
+          className={styles.card}
+          onClick={() => navigate("/party-setup")}
+          aria-label="Manage Party"
+        >
+          <span className={styles.icon}>⚔️</span>
+          <span className={styles.title}>Party</span>
+          <span className={styles.subtitle}>Manage your heroes</span>
+        </button>
+        <button
+          className={styles.card}
+          onClick={() => navigate("/inventory")}
+          aria-label="View Inventory"
+        >
+          <span className={styles.icon}>🎒</span>
+          <span className={styles.title}>Inventory</span>
+          <span className={styles.subtitle}>View your items</span>
+        </button>
+        <button
+          className={styles.card}
+          onClick={() => navigate("/cards")}
+          aria-label="Browse Cards"
+        >
+          <span className={styles.icon}>📜</span>
+          <span className={styles.title}>Cards</span>
+          <span className={styles.subtitle}>Browse your card collection</span>
+        </button>
+        <button
+          className={styles.card}
+          onClick={() => navigate("/crafting")}
+          aria-label="Craft Items"
+        >
+          <span className={styles.icon}>🛠️</span>
+          <span className={styles.title}>Crafting</span>
+          <span className={styles.subtitle}>Prepare for battle</span>
+        </button>
+        <button
+          className={styles.card}
+          onClick={() => navigate("/shop")}
+          aria-label="Visit Shop"
+        >
+          <span className={styles.icon}>🛒</span>
+          <span className={styles.title}>Shop</span>
+          <span className={styles.subtitle}>Browse wares</span>
+        </button>
+        <button
+          className={styles.card}
+          onClick={() => navigate("/pre-battle")}
+          aria-label="Battle"
+        >
+          <span className={styles.icon}>⚔️</span>
+          <span className={styles.title}>Battle</span>
+          <span className={styles.subtitle}>Skirmish test</span>
+        </button>
+        <button
+          className={`${styles.card} ${!party ? styles.disabled : ""}`}
+          onClick={() => party && navigate("/dungeon")}
+          aria-label="Enter Dungeon"
+        >
+          <span className={styles.icon}>🏰</span>
+          <span className={styles.title}>Enter Dungeon</span>
+          <span className={styles.subtitle}>Begin an adventure</span>
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/game/src/logic/sampleBattleData.js
+++ b/game/src/logic/sampleBattleData.js
@@ -1,0 +1,37 @@
+export const playerParty = [
+  {
+    id: 'valerius',
+    name: 'Valerius',
+    stats: { hp: 12, mana: 1 },
+    deck: [
+      { id: 'val_strike', energyCost: 1, effect: { type: 'damage', magnitude: 4 } },
+    ],
+  },
+  {
+    id: 'lyra',
+    name: 'Lyra',
+    stats: { hp: 10, mana: 1 },
+    deck: [
+      { id: 'lyra_heal', energyCost: 1, effect: { type: 'heal', magnitude: 3 } },
+    ],
+  },
+];
+
+export const enemyParty = [
+  {
+    id: 'goblin_slinger',
+    name: 'Goblin Slinger',
+    stats: { hp: 8, mana: 1 },
+    deck: [
+      { id: 'stone_throw', energyCost: 1, effect: { type: 'damage', magnitude: 2 } },
+    ],
+  },
+  {
+    id: 'grumpy_slime',
+    name: 'Grumpy Slime',
+    stats: { hp: 9, mana: 1 },
+    deck: [
+      { id: 'slime_slap', energyCost: 1, effect: { type: 'damage', magnitude: 1 } },
+    ],
+  },
+];


### PR DESCRIPTION
## Summary
- create sample party data for quick simulations
- add Test Battle button in new TownHub page
- route `/town` to TownHub
- pass battle steps via location state to BattleViewer
- display logs, energy, and victory banner in BattleViewer

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684718dc5edc832796287cb55763bbe4