### PR TITLE
Implement tactical positioning in battle simulator

### DIFF
--- a/game/src/logic/mock-data.js
+++ b/game/src/logic/mock-data.js
@@ -1,6 +1,6 @@
 export const MOCK_CARDS = {
   // Ranger Cards
-  ARROW_SHOT: { id: 'ARROW_SHOT', name: 'Arrow Shot', cost: 1, description: 'Shoot an arrow dealing 3 damage.' },
+  ARROW_SHOT: { id: 'ARROW_SHOT', name: 'Arrow Shot', cost: 1, description: 'Shoot an arrow dealing 3 damage.', targetType: 'any' },
   EAGLE_EYE: { id: 'EAGLE_EYE', name: 'Eagle Eye', cost: 1, description: 'Increase critical hit chance by 25% for 2 turns.' },
   ENTANGLING_TRAP: { id: 'ENTANGLING_TRAP', name: 'Entangling Trap', cost: 2, description: 'Root an enemy, preventing movement or actions for 1 turn.' },
 


### PR DESCRIPTION
This commit introduces a tactical positioning system to the battle simulator, making unit positions from the Pre-Battle Setup screen mechanically affect combat targeting.

Key changes:
- Added an `isTargetable` helper function to determine valid targets based on a "Front Row Taunt" system. Units in the front row (row 0) must be targeted before units in back rows.
- Updated the AI action selection logic to use `isTargetable`. The AI now targets the lowest HP enemy among valid targets. If no valid targets exist, the unit's action is skipped, and energy is refunded.
- Implemented a card-specific targeting override. Cards with `targetType: 'any'` (e.g., `ARROW_SHOT`) can bypass the default positioning rules.
- Updated mock data for `ARROW_SHOT` to include `targetType: 'any'`.
- Modified the temporary test to include unit positions and allow manual verification of the new targeting logic. Enemy units are now distinguished by ID and name (e.g., "Goblin Front", "Goblin Back") for clearer log inspection.