### PR TITLE
Implement dungeon run setup flow

### DIFF
--- a/client/src/components/TownHub.tsx
+++ b/client/src/components/TownHub.tsx
@@ -114,7 +114,7 @@ const TownHub: React.FC<TownHubProps> = ({ onStartSkirmish, onEnterDungeon }) =>
         </button>
         <button
           className={`${styles.card} ${!party ? styles.disabled : ""}`}
-          onClick={() => party && onEnterDungeon()}
+          onClick={onEnterDungeon}
           aria-label="Enter Dungeon"
         >
           <span className={styles.icon}>🏰</span>


### PR DESCRIPTION
## Summary
- wire up TownHub to call the dungeon setup flow directly
- add simple party drafting UI components

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684755236f488327ae78aef4e2646583