### PR TITLE
Fix import paths for ClassDraft component

### DIFF
--- a/client/src/components/ClassDraft.tsx
+++ b/client/src/components/ClassDraft.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
-import { UnitState } from '../../shared/models/UnitState';
-import { MOCK_HEROES } from '../../game/src/logic/mock-data';
+import { UnitState } from '../../../shared/models/UnitState';
+import { MOCK_HEROES } from '../../../game/src/logic/mock-data';
 
 interface Props {
   onComplete: (party: UnitState[]) => void;


### PR DESCRIPTION
## Summary
- correct relative paths for `ClassDraft` imports

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6847570322388327a1db3c86410c77eb