### PR TITLE
Add alias for shared and update import

### DIFF
--- a/client/src/components/ClassDraft.tsx
+++ b/client/src/components/ClassDraft.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import { UnitState } from '../../../shared/models/UnitState';
-import { MOCK_HEROES } from '../../../game/src/logic/mock-data';
+import { MOCK_HEROES } from '@shared/mock-data';
 
 interface Props {
   onComplete: (party: UnitState[]) => void;

--- a/client/vite.config.js
+++ b/client/vite.config.js
@@ -1,6 +1,9 @@
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
 import path from 'path'
+import { fileURLToPath } from 'url'
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
 
 // https://vite.dev/config/
 export default defineConfig({

--- a/client/vite.config.js
+++ b/client/vite.config.js
@@ -1,7 +1,13 @@
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
+import path from 'path'
 
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [react()],
+  resolve: {
+    alias: {
+      '@shared': path.resolve(__dirname, '../shared'),
+    },
+  },
 })


### PR DESCRIPTION
## Summary
- simplify client imports by adding `@shared` alias in vite config
- use new alias for `MOCK_HEROES` import in `ClassDraft`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6847597b70f48327a4c43f22cb9409a7