### PR TITLE
Fix dungeon generation when no save data

### DIFF
--- a/game/src/scenes/DungeonScene.js
+++ b/game/src/scenes/DungeonScene.js
@@ -15,7 +15,8 @@ export default class DungeonScene extends Phaser.Scene {
   create() {
     this.cameras.main.fadeIn(250);
     loadDungeon();
-    if (!getDungeon()) {
+    const dungeon = getDungeon();
+    if (!dungeon.rooms || dungeon.rooms.length === 0) {
       generateDungeon(5, 5);
       saveDungeon();
     }


### PR DESCRIPTION
## Summary
- ensure DungeonScene generates a dungeon when no rooms exist

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6847689dcfe883279b68e96c304db5db