### PR TITLE
Add Party Roster screen

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -3,15 +3,19 @@ import TownHub from './components/TownHub';
 import PreBattleSetup from './components/PreBattleSetup';
 import BattleViewer from './components/BattleViewer';
 import PartySetup from './components/PartySetup';
-import { UnitState } from '../shared/models/UnitState';
-import { MOCK_HEROES, MOCK_ENEMIES } from '../../game/src/logic/mock-data.js';
+import PartyRoster from './components/PartyRoster';
+import { UnitState } from '@shared/models/UnitState';
+import { MOCK_HEROES, MOCK_ENEMIES } from '@shared/mock-data';
 import { simulateBattle } from '../../game/src/logic/battleSimulator.js';
 
 function App() {
-  const [activeScreen, setActiveScreen] = useState<'town' | 'party-setup' | 'pre-battle' | 'battle'>('town');
+  const [activeScreen, setActiveScreen] = useState<'town' | 'party-setup' | 'pre-battle' | 'battle' | 'party-roster'>('town');
   const [activeExpeditionParty, setActiveExpeditionParty] = useState<UnitState[]>([]);
   const [savedParty, setSavedParty] = useState<UnitState[]>([MOCK_HEROES.RANGER, MOCK_HEROES.BARD]); // Start with mock data
   const [battleLog, setBattleLog] = useState<any[]>([]);
+
+  const navigateToTown = () => setActiveScreen('town');
+  const navigateToPartyRoster = () => setActiveScreen('party-roster');
 
   // Navigate to Party Setup from the town hub
   const navigateToPartySetup = () => {
@@ -49,10 +53,18 @@ function App() {
       case 'battle':
         // The BattleViewer will be mostly empty until the simulator is integrated
         return <BattleViewer log={battleLog} />;
+      case 'party-roster':
+        return <PartyRoster onBackToTown={navigateToTown} />;
       case 'town':
       default:
         // Pass the navigation function to the TownHub
-        return <TownHub onStartSkirmish={navigateToPreBattle} onEnterDungeon={navigateToPartySetup} />;
+        return (
+          <TownHub
+            onStartSkirmish={navigateToPreBattle}
+            onEnterDungeon={navigateToPartySetup}
+            onNavigateToParty={navigateToPartyRoster}
+          />
+        );
     }
   };
 

--- a/client/src/components/PartyRoster.tsx
+++ b/client/src/components/PartyRoster.tsx
@@ -1,0 +1,44 @@
+import React from 'react';
+import { MOCK_HEROES } from '@shared/mock-data';
+
+interface PartyRosterProps {
+  onBackToTown: () => void;
+}
+
+const PartyRoster: React.FC<PartyRosterProps> = ({ onBackToTown }) => {
+  const allHeroes = Object.values(MOCK_HEROES);
+
+  return (
+    <div className="min-h-screen flex flex-col items-center p-8 bg-gray-900 text-white">
+      <h1 className="text-4xl font-bold mb-8">Your Roster of Heroes</h1>
+      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6 w-full max-w-6xl">
+        {allHeroes.map(hero => (
+          <div key={hero.id} className="p-4 border-2 border-gray-700 rounded-lg bg-gray-800">
+            <div className="flex justify-between items-center mb-2">
+              <h2 className="text-2xl font-bold">{hero.name}</h2>
+              <span className={`px-2 py-1 text-xs font-bold rounded-full bg-red-500 text-white`}>{hero.archetype}</span>
+            </div>
+            <div className="text-sm opacity-80">
+              <p>HP: {hero.maxHp}</p>
+              <p>Speed: {hero.speed}</p>
+            </div>
+            <div className="mt-4">
+              <p className="font-bold text-sm mb-1">Base Cards:</p>
+              <ul className="list-disc list-inside text-xs">
+                {hero.cardPool.map(card => <li key={card.id}>{card.name}</li>)}
+              </ul>
+            </div>
+          </div>
+        ))}
+      </div>
+      <button
+        onClick={onBackToTown}
+        className="mt-12 px-8 py-3 bg-blue-600 hover:bg-blue-700 rounded-lg text-xl font-bold transition-colors"
+      >
+        Back to Town
+      </button>
+    </div>
+  );
+};
+
+export default PartyRoster;

--- a/client/src/components/TownHub.tsx
+++ b/client/src/components/TownHub.tsx
@@ -13,9 +13,10 @@ import { playerParty, enemyParty } from "../../../game/src/logic/sampleBattleDat
 interface TownHubProps {
   onStartSkirmish: () => void;
   onEnterDungeon: () => void;
+  onNavigateToParty: () => void;
 }
 
-const TownHub: React.FC<TownHubProps> = ({ onStartSkirmish, onEnterDungeon }) => {
+const TownHub: React.FC<TownHubProps> = ({ onStartSkirmish, onEnterDungeon, onNavigateToParty }) => {
   const party = useGameState((s) => s.party);
   const [battleSteps, setBattleSteps] = useState(null);
 
@@ -60,7 +61,7 @@ const TownHub: React.FC<TownHubProps> = ({ onStartSkirmish, onEnterDungeon }) =>
       <div className={styles.grid}>
         <button
           className={styles.card}
-          onClick={() => {}}
+          onClick={onNavigateToParty}
           aria-label="Manage Party"
         >
           <span className={styles.icon}>⚔️</span>

--- a/jest.config.js
+++ b/jest.config.js
@@ -10,6 +10,7 @@ export default {
   moduleNameMapper: {
     '\\.(css)$': '<rootDir>/client/src/__mocks__/styleMock.js',
     '\\.(png|jpg|jpeg|gif|svg)$': '<rootDir>/client/src/__mocks__/fileMock.js',
+    '^@shared/(.*)$': '<rootDir>/shared/$1',
   },
   testMatch: [
     '**/game/src/**/__tests__/**/*.test.js',

--- a/shared/mock-data.ts
+++ b/shared/mock-data.ts
@@ -1,0 +1,75 @@
+import { Card } from './models/Card';
+import { UnitState } from './models/UnitState';
+
+export const MOCK_CARDS: Record<string, Card> = {
+  ARROW_SHOT: {
+    id: 'ARROW_SHOT',
+    name: 'Arrow Shot',
+    cost: 1,
+    description: 'Shoot an arrow dealing 3 damage.',
+    targetType: 'any',
+  },
+  EAGLE_EYE: {
+    id: 'EAGLE_EYE',
+    name: 'Eagle Eye',
+    cost: 1,
+    description: 'Increase critical hit chance by 25% for 2 turns.'
+  },
+  ENTANGLING_TRAP: {
+    id: 'ENTANGLING_TRAP',
+    name: 'Entangling Trap',
+    cost: 2,
+    description: 'Root an enemy, preventing movement or actions for 1 turn.'
+  },
+  INSPIRE: { id: 'INSPIRE', name: 'Inspire', cost: 1, description: 'Grant +2 ATK to an ally for 2 turns.' },
+  LULLABY: { id: 'LULLABY', name: 'Lullaby', cost: 2, description: 'Put an enemy to sleep for 1 turn.' },
+  MOTIVATIONAL_TUNE: { id: 'MOTIVATIONAL_TUNE', name: 'Motivational Tune', cost: 1, description: 'Restore 1 energy to all allies.' },
+};
+
+export const MOCK_HEROES: Record<string, UnitState> = {
+  RANGER: {
+    id: 'RANGER_1',
+    name: 'Ranger',
+    class: 'Ranger',
+    hp: 75,
+    maxHp: 75,
+    energy: 0,
+    speed: 30,
+    position: null,
+    cardsInHand: [],
+    battleDeck: [],
+    cardPool: [MOCK_CARDS.ARROW_SHOT, MOCK_CARDS.EAGLE_EYE, MOCK_CARDS.ENTANGLING_TRAP],
+    archetype: 'DPS',
+  },
+  BARD: {
+    id: 'BARD_1',
+    name: 'Bard',
+    class: 'Bard',
+    hp: 90,
+    maxHp: 90,
+    energy: 0,
+    speed: 25,
+    position: null,
+    cardsInHand: [],
+    battleDeck: [],
+    cardPool: [MOCK_CARDS.INSPIRE, MOCK_CARDS.LULLABY, MOCK_CARDS.MOTIVATIONAL_TUNE],
+    archetype: 'Support',
+  },
+};
+
+export const MOCK_ENEMIES: Record<string, UnitState> = {
+  GOBLIN: {
+    id: 'GOBLIN_1',
+    name: 'Goblin Grunt',
+    class: 'Goblin',
+    hp: 20,
+    maxHp: 20,
+    energy: 0,
+    speed: 15,
+    position: null,
+    cardsInHand: [],
+    battleDeck: [{ id: 'PUNCH', name: 'Punch', cost: 1, description: 'Deal 2 damage.' }],
+    cardPool: [{ id: 'PUNCH', name: 'Punch', cost: 1, description: 'Deal 2 damage.' }],
+    archetype: 'DPS',
+  }
+};


### PR DESCRIPTION
## Summary
- add PartyRoster component
- create shared mock data module for heroes/enemies
- wire up PartyRoster navigation in App
- allow TownHub to navigate to the new screen
- map `@shared/*` alias in Jest config

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68476b1f1b4c8327b71445faefda4e36