### PR TITLE
Implement global back navigation

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -9,11 +9,12 @@ import { MOCK_HEROES, MOCK_ENEMIES } from '@shared/mock-data';
 import { simulateBattle } from '../../game/src/logic/battleSimulator.js';
 
 function App() {
-  const [activeScreen, setActiveScreen] = useState<'town' | 'party-setup' | 'pre-battle' | 'battle' | 'party-roster'>('town');
+  const [activeScreen, setActiveScreen] = useState<'town' | 'pre-battle' | 'battle' | 'party-setup' | 'party-roster'>('town');
   const [activeExpeditionParty, setActiveExpeditionParty] = useState<UnitState[]>([]);
   const [savedParty, setSavedParty] = useState<UnitState[]>([MOCK_HEROES.RANGER, MOCK_HEROES.BARD]); // Start with mock data
   const [battleLog, setBattleLog] = useState<any[]>([]);
 
+  // Universal navigation helper to return to town
   const navigateToTown = () => setActiveScreen('town');
   const navigateToPartyRoster = () => setActiveScreen('party-roster');
 
@@ -47,12 +48,25 @@ function App() {
   const renderScreen = () => {
     switch (activeScreen) {
       case 'party-setup':
-        return <PartySetup onPartySaved={handlePartySaved} />;
+        return (
+          <PartySetup
+            onPartySaved={handlePartySaved}
+            onCancelSetup={navigateToTown}
+          />
+        );
       case 'pre-battle':
-        return <PreBattleSetup initialParty={savedParty} onStartBattle={startBattle} />;
+        return (
+          <PreBattleSetup
+            initialParty={savedParty}
+            onStartBattle={startBattle}
+            onBackToTown={navigateToTown}
+          />
+        );
       case 'battle':
         // The BattleViewer will be mostly empty until the simulator is integrated
-        return <BattleViewer log={battleLog} />;
+        return (
+          <BattleViewer steps={battleLog} onReturnToTown={navigateToTown} />
+        );
       case 'party-roster':
         return <PartyRoster onBackToTown={navigateToTown} />;
       case 'town':

--- a/client/src/components/BattleViewer.tsx
+++ b/client/src/components/BattleViewer.tsx
@@ -5,9 +5,10 @@ import CharacterPanel from './CharacterPanel'
 interface Props {
   steps: BattleStep[]
   initialStep?: number
+  onReturnToTown: () => void
 }
 
-export default function BattleViewer({ steps, initialStep = 0 }: Props) {
+export default function BattleViewer({ steps, initialStep = 0, onReturnToTown }: Props) {
   const [currentStep, setCurrentStep] = useState(initialStep)
   const [isPlaying, setIsPlaying] = useState(false)
 
@@ -91,6 +92,12 @@ export default function BattleViewer({ steps, initialStep = 0 }: Props) {
           {step.details.result === 'victory' ? 'Victory!' : 'Defeat'}
         </div>
       )}
+      <button
+        onClick={onReturnToTown}
+        className="mt-8 px-8 py-3 bg-blue-600 hover:bg-blue-700 rounded-lg text-xl font-bold"
+      >
+        Return to Town
+      </button>
     </div>
   )
 }

--- a/client/src/components/ClassDraft.tsx
+++ b/client/src/components/ClassDraft.tsx
@@ -4,11 +4,12 @@ import { MOCK_HEROES } from '../../../game/src/logic/mock-data.js';
 
 interface Props {
   onComplete: (party: UnitState[]) => void;
+  onBack: () => void;
 }
 
 const availableHeroes: UnitState[] = Object.values(MOCK_HEROES).map(h => ({ ...h }));
 
-const ClassDraft: React.FC<Props> = ({ onComplete }) => {
+const ClassDraft: React.FC<Props> = ({ onComplete, onBack }) => {
   const [selected, setSelected] = useState<UnitState[]>([]);
 
   const toggleHero = (hero: UnitState) => {
@@ -29,7 +30,10 @@ const ClassDraft: React.FC<Props> = ({ onComplete }) => {
           </button>
         ))}
       </div>
-      <button onClick={() => onComplete(selected)}>Confirm Party</button>
+      <div style={{ marginTop: '1rem', display: 'flex', gap: '1rem' }}>
+        <button onClick={onBack}>Back</button>
+        <button onClick={() => onComplete(selected)}>Confirm Party</button>
+      </div>
     </div>
   );
 };

--- a/client/src/components/DeckBuilder.tsx
+++ b/client/src/components/DeckBuilder.tsx
@@ -5,9 +5,10 @@ import { Card } from '../../shared/models/Card';
 interface Props {
   unit: UnitState;
   onComplete: (unit: UnitState) => void;
+  onBack: () => void;
 }
 
-const DeckBuilder: React.FC<Props> = ({ unit, onComplete }) => {
+const DeckBuilder: React.FC<Props> = ({ unit, onComplete, onBack }) => {
   const [selected, setSelected] = useState<Card[]>(unit.battleDeck || []);
 
   const toggleCard = (card: Card) => {
@@ -36,7 +37,10 @@ const DeckBuilder: React.FC<Props> = ({ unit, onComplete }) => {
           </button>
         ))}
       </div>
-      <button onClick={handleConfirm}>Finish Deck</button>
+      <div style={{ marginTop: '1rem', display: 'flex', gap: '1rem' }}>
+        <button onClick={onBack}>Back</button>
+        <button onClick={handleConfirm}>Finish Deck</button>
+      </div>
     </div>
   );
 };

--- a/client/src/components/PartySetup.tsx
+++ b/client/src/components/PartySetup.tsx
@@ -6,14 +6,36 @@ import PartySummary from './PartySummary';
 
 export interface PartySetupProps {
   onPartySaved: (finalParty: UnitState[]) => void;
+  onCancelSetup: () => void;
 }
 
 type Step = 'DRAFTING' | 'DECK_BUILDING' | 'SUMMARY';
 
-const PartySetup: React.FC<PartySetupProps> = ({ onPartySaved }) => {
+const PartySetup: React.FC<PartySetupProps> = ({ onPartySaved, onCancelSetup }) => {
   const [step, setStep] = useState<Step>('DRAFTING');
   const [draftedParty, setDraftedParty] = useState<UnitState[]>([]);
   const [deckIndex, setDeckIndex] = useState(0);
+
+  // Handler for backward navigation between steps
+  const handleBack = () => {
+    switch (step) {
+      case 'SUMMARY':
+        setStep('DECK_BUILDING');
+        setDeckIndex(draftedParty.length - 1);
+        break;
+      case 'DECK_BUILDING':
+        if (deckIndex > 0) {
+          setDeckIndex(deckIndex - 1);
+        } else {
+          setStep('DRAFTING');
+        }
+        break;
+      case 'DRAFTING':
+      default:
+        onCancelSetup();
+        break;
+    }
+  };
 
   const handleDraftComplete = (party: UnitState[]) => {
     setDraftedParty(party);
@@ -38,15 +60,23 @@ const PartySetup: React.FC<PartySetupProps> = ({ onPartySaved }) => {
   };
 
   if (step === 'DRAFTING') {
-    return <ClassDraft onComplete={handleDraftComplete} />;
+    return <ClassDraft onComplete={handleDraftComplete} onBack={handleBack} />;
   }
 
   if (step === 'DECK_BUILDING') {
     const unit = draftedParty[deckIndex];
-    return <DeckBuilder unit={unit} onComplete={handleDeckBuilt} />;
+    return (
+      <DeckBuilder unit={unit} onComplete={handleDeckBuilt} onBack={handleBack} />
+    );
   }
 
-  return <PartySummary party={draftedParty} onConfirm={handlePartySave} />;
+  return (
+    <PartySummary
+      party={draftedParty}
+      onConfirm={handlePartySave}
+      onBack={handleBack}
+    />
+  );
 };
 
 export default PartySetup;

--- a/client/src/components/PartySummary.tsx
+++ b/client/src/components/PartySummary.tsx
@@ -4,9 +4,10 @@ import { UnitState } from '../../shared/models/UnitState';
 interface Props {
   party: UnitState[];
   onConfirm: () => void;
+  onBack: () => void;
 }
 
-const PartySummary: React.FC<Props> = ({ party, onConfirm }) => {
+const PartySummary: React.FC<Props> = ({ party, onConfirm, onBack }) => {
   return (
     <div>
       <h2>Party Summary</h2>
@@ -17,7 +18,10 @@ const PartySummary: React.FC<Props> = ({ party, onConfirm }) => {
           </li>
         ))}
       </ul>
-      <button onClick={onConfirm}>Save Party</button>
+      <div style={{ marginTop: '1rem', display: 'flex', gap: '1rem' }}>
+        <button onClick={onBack}>Back</button>
+        <button onClick={onConfirm}>Save Party</button>
+      </div>
     </div>
   );
 };

--- a/client/src/components/PreBattleSetup.tsx
+++ b/client/src/components/PreBattleSetup.tsx
@@ -4,9 +4,10 @@ import { UnitState } from '../../shared/models/UnitState';
 interface PreBattleSetupProps {
   initialParty: UnitState[];
   onStartBattle: (positionedParty: UnitState[]) => void;
+  onBackToTown: () => void;
 }
 
-const PreBattleSetup: React.FC<PreBattleSetupProps> = ({ initialParty, onStartBattle }) => {
+const PreBattleSetup: React.FC<PreBattleSetupProps> = ({ initialParty, onStartBattle, onBackToTown }) => {
   const [gridSlots, setGridSlots] = useState<(UnitState | null)[]>(new Array(9).fill(null));
   const [roster, setRoster] = useState<UnitState[]>(initialParty);
 
@@ -45,12 +46,22 @@ const PreBattleSetup: React.FC<PreBattleSetupProps> = ({ initialParty, onStartBa
           </div>
         ))}
       </div>
-      <button
-        onClick={() => onStartBattle(gridSlots.filter(u => u !== null) as UnitState[])}
-        className="mt-8 px-6 py-3 bg-green-600 hover:bg-green-700 rounded-lg text-xl font-bold"
-      >
-        Start Battle
-      </button>
+      <div className="flex gap-4 mt-8">
+        <button
+          onClick={onBackToTown}
+          className="px-10 py-4 bg-gray-600 hover:bg-gray-700 rounded-lg text-xl font-bold transition-colors shadow-lg"
+        >
+          Back to Town
+        </button>
+        <button
+          onClick={() =>
+            onStartBattle(gridSlots.filter(u => u !== null) as UnitState[])
+          }
+          className="px-10 py-4 bg-green-600 hover:bg-green-700 rounded-lg text-xl font-bold transition-colors shadow-lg"
+        >
+          Start Battle
+        </button>
+      </div>
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- make `App` pass a universal back-to-town callback
- add a back button on the pre-battle setup screen
- add a return button to `BattleViewer`
- integrate back navigation inside party setup and its child screens

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684771130d248327a1679f2a5f55a6c7