### PR TITLE
UI polish with reusable components

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -82,7 +82,11 @@ function App() {
     }
   };
 
-  return <div>{renderScreen()}</div>;
+  return (
+    <div className="min-h-screen flex flex-col items-center justify-center">
+      {renderScreen()}
+    </div>
+  );
 }
 
 export default App;

--- a/client/src/components/ClassDraft.tsx
+++ b/client/src/components/ClassDraft.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
-import { UnitState } from '../../../shared/models/UnitState';
-import { MOCK_HEROES } from '../../../game/src/logic/mock-data.js';
+import { UnitState } from '@shared/models/UnitState';
+import { MOCK_HEROES } from '@shared/mock-data';
+import HeroCard from './HeroCard';
 
 interface Props {
   onComplete: (party: UnitState[]) => void;
@@ -20,19 +21,35 @@ const ClassDraft: React.FC<Props> = ({ onComplete, onBack }) => {
     );
   };
 
+  const isSelected = (hero: UnitState) => selected.find(h => h.id === hero.id);
+
   return (
-    <div>
-      <h2>Class Draft</h2>
-      <div style={{ display: 'flex', gap: '1rem', marginBottom: '1rem' }}>
+    <div className="w-full max-w-4xl mx-auto text-center p-8">
+      <h2 className="text-4xl font-bold mb-6">Class Draft</h2>
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-4 mb-6">
         {availableHeroes.map(hero => (
-          <button key={hero.id} onClick={() => toggleHero(hero)}>
-            {selected.find(h => h.id === hero.id) ? 'Remove' : 'Add'} {hero.name}
-          </button>
+          <div
+            key={hero.id}
+            onClick={() => toggleHero(hero)}
+            className={`cursor-pointer ${isSelected(hero) ? 'ring-2 ring-blue-500' : ''}`}
+          >
+            <HeroCard hero={hero} />
+          </div>
         ))}
       </div>
-      <div style={{ marginTop: '1rem', display: 'flex', gap: '1rem' }}>
-        <button onClick={onBack}>Back</button>
-        <button onClick={() => onComplete(selected)}>Confirm Party</button>
+      <div className="flex justify-center gap-4">
+        <button
+          onClick={onBack}
+          className="px-6 py-2 bg-gray-600 hover:bg-gray-700 rounded-lg font-semibold"
+        >
+          Back
+        </button>
+        <button
+          onClick={() => onComplete(selected)}
+          className="px-6 py-2 bg-blue-600 hover:bg-blue-700 rounded-lg font-semibold"
+        >
+          Confirm Party
+        </button>
       </div>
     </div>
   );

--- a/client/src/components/DeckBuilder.tsx
+++ b/client/src/components/DeckBuilder.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
-import { UnitState } from '../../shared/models/UnitState';
-import { Card } from '../../shared/models/Card';
+import { UnitState } from '@shared/models/UnitState';
+import { Card } from '@shared/models/Card';
+import GameCard from './GameCard';
 
 interface Props {
   unit: UnitState;
@@ -28,18 +29,32 @@ const DeckBuilder: React.FC<Props> = ({ unit, onComplete, onBack }) => {
   };
 
   return (
-    <div>
-      <h2>Build Deck for {unit.name}</h2>
-      <div style={{ display: 'flex', gap: '0.5rem', marginBottom: '1rem' }}>
+    <div className="w-full max-w-4xl mx-auto text-center p-8">
+      <h2 className="text-4xl font-bold mb-6">Build Deck for {unit.name}</h2>
+      <div className="grid grid-cols-2 md:grid-cols-3 gap-4 mb-6">
         {unit.cardPool.map(card => (
-          <button key={card.id} onClick={() => toggleCard(card)}>
-            {selected.find(c => c.id === card.id) ? 'Remove' : 'Add'} {card.name}
-          </button>
+          <div
+            key={card.id}
+            onClick={() => toggleCard(card)}
+            className="flex justify-center"
+          >
+            <GameCard card={card} selected={!!selected.find(c => c.id === card.id)} />
+          </div>
         ))}
       </div>
-      <div style={{ marginTop: '1rem', display: 'flex', gap: '1rem' }}>
-        <button onClick={onBack}>Back</button>
-        <button onClick={handleConfirm}>Finish Deck</button>
+      <div className="flex justify-center gap-4">
+        <button
+          onClick={onBack}
+          className="px-6 py-2 bg-gray-600 hover:bg-gray-700 rounded-lg font-semibold"
+        >
+          Back
+        </button>
+        <button
+          onClick={handleConfirm}
+          className="px-6 py-2 bg-blue-600 hover:bg-blue-700 rounded-lg font-semibold"
+        >
+          Finish Deck
+        </button>
       </div>
     </div>
   );

--- a/client/src/components/GameCard.tsx
+++ b/client/src/components/GameCard.tsx
@@ -1,0 +1,36 @@
+import React from 'react';
+import { Card } from '@shared/models/Card';
+
+interface GameCardProps {
+  card: Card;
+  onSelect?: (card: Card) => void;
+  disabled?: boolean;
+  selected?: boolean;
+}
+
+const GameCard: React.FC<GameCardProps> = ({ card, onSelect, disabled, selected }) => {
+  const handleClick = () => {
+    if (!disabled) {
+      onSelect?.(card);
+    }
+  };
+
+  return (
+    <div
+      onClick={handleClick}
+      className={`relative w-40 h-56 bg-gray-200 rounded-xl flex flex-col overflow-hidden shadow-lg text-gray-900 ${disabled ? 'opacity-50 cursor-not-allowed' : 'cursor-pointer hover:shadow-2xl transition-shadow'} ${selected ? 'ring-2 ring-blue-500' : ''}`}
+    >
+      <div className="absolute top-2 left-2 w-7 h-7 rounded-full bg-gray-800 text-white text-sm font-bold flex items-center justify-center">
+        {card.cost}
+      </div>
+      <div className="bg-gray-800 text-white text-center py-1">
+        <span className="text-sm font-semibold">{card.name}</span>
+      </div>
+      <div className="flex-grow bg-white p-2 text-xs leading-snug">
+        {card.description}
+      </div>
+    </div>
+  );
+};
+
+export default GameCard;

--- a/client/src/components/HeroCard.tsx
+++ b/client/src/components/HeroCard.tsx
@@ -1,28 +1,26 @@
 import React from 'react';
 import { UnitState } from '@shared/models/UnitState';
 
-const HeroCard: React.FC<{ hero: UnitState }> = ({ hero }) => {
-  // Calculate health percentage for the HP bar
-  const healthPercentage = (hero.hp / hero.maxHp) * 100;
+interface HeroCardProps {
+  hero: UnitState;
+}
+
+const HeroCard: React.FC<HeroCardProps> = ({ hero }) => {
+  const hpPercent = (hero.hp / hero.maxHp) * 100;
 
   return (
     <div className="bg-gray-800 border border-gray-700 rounded-lg p-5 flex flex-col hover:border-blue-500 transition-colors duration-200 shadow-lg">
-      {/* --- Name and Class --- */}
       <div>
-        <h2 className="text-3xl font-bold text-white">{hero.name}</h2>
+        <h2 className="text-3xl font-bold">{hero.name}</h2>
         <p className="text-md text-gray-400 -mt-1">{hero.class}</p>
       </div>
-
-      {/* --- Archetype Tag --- */}
       <p className="mt-3 text-sm font-semibold text-gray-300">{hero.archetype}</p>
-
-      {/* --- HP Bar and Text --- */}
       <div className="mt-auto pt-4">
         <div className="w-full bg-gray-900 rounded-full h-4 border border-gray-600">
           <div
             className="bg-green-500 h-full rounded-full"
-            style={{ width: `${healthPercentage}%` }}
-          ></div>
+            style={{ width: `${hpPercent}%` }}
+          />
         </div>
         <p className="text-center text-xs font-semibold text-gray-300 mt-1">
           {hero.hp} / {hero.maxHp} HP

--- a/client/src/components/PartyRoster.tsx
+++ b/client/src/components/PartyRoster.tsx
@@ -7,24 +7,21 @@ interface PartyRosterProps {
 }
 
 const PartyRoster: React.FC<PartyRosterProps> = ({ onBackToTown }) => {
-  const allHeroes = Object.values(MOCK_HEROES);
+  const heroes = Object.values(MOCK_HEROES);
 
   return (
-    <div className="min-h-screen w-full flex flex-col items-center p-8 bg-gray-900 text-white">
-      {/* --- Screen Header (Styled to match guide) --- */}
+    <div className="min-h-screen w-full flex flex-col items-center p-8">
       <div className="text-center mb-12">
-        <h1 className="text-5xl font-bold">Your Roster of Heroes</h1>
-        <p className="text-lg text-gray-400 mt-2">Review your available adventurers and their abilities.</p>
+        <h1 className="text-5xl font-bold">Party Roster</h1>
+        <p className="text-lg text-gray-400 mt-2">
+          Review your available adventurers and their abilities.
+        </p>
       </div>
-
-      {/* --- Responsive 2-Column Grid for Hero Cards --- */}
       <div className="w-full max-w-4xl grid grid-cols-1 md:grid-cols-2 gap-6">
-        {allHeroes.map(hero => (
+        {heroes.map((hero) => (
           <HeroCard key={hero.id} hero={hero} />
         ))}
       </div>
-
-      {/* --- Styled Action Button --- */}
       <button
         onClick={onBackToTown}
         className="mt-12 px-8 py-3 bg-blue-600 hover:bg-blue-700 rounded-lg text-xl font-bold transition-colors shadow-lg"

--- a/client/src/components/PartySummary.tsx
+++ b/client/src/components/PartySummary.tsx
@@ -1,5 +1,7 @@
 import React from 'react';
-import { UnitState } from '../../shared/models/UnitState';
+import { UnitState } from '@shared/models/UnitState';
+import HeroCard from './HeroCard';
+import GameCard from './GameCard';
 
 interface Props {
   party: UnitState[];
@@ -9,18 +11,33 @@ interface Props {
 
 const PartySummary: React.FC<Props> = ({ party, onConfirm, onBack }) => {
   return (
-    <div>
-      <h2>Party Summary</h2>
-      <ul>
-        {party.map(u => (
-          <li key={u.id}>
-            {u.name} - deck: {u.battleDeck.map(c => c.name).join(', ')}
-          </li>
+    <div className="w-full max-w-4xl mx-auto text-center p-8">
+      <h2 className="text-4xl font-bold mb-6">Party Summary</h2>
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-6 mb-6">
+        {party.map((u) => (
+          <div key={u.id} className="flex flex-col items-center">
+            <HeroCard hero={u} />
+            <div className="mt-4 grid grid-cols-2 gap-2">
+              {u.battleDeck.map((c) => (
+                <GameCard key={c.id} card={c} />
+              ))}
+            </div>
+          </div>
         ))}
-      </ul>
-      <div style={{ marginTop: '1rem', display: 'flex', gap: '1rem' }}>
-        <button onClick={onBack}>Back</button>
-        <button onClick={onConfirm}>Save Party</button>
+      </div>
+      <div className="flex justify-center gap-4">
+        <button
+          onClick={onBack}
+          className="px-6 py-2 bg-gray-600 hover:bg-gray-700 rounded-lg font-semibold"
+        >
+          Back
+        </button>
+        <button
+          onClick={onConfirm}
+          className="px-6 py-2 bg-blue-600 hover:bg-blue-700 rounded-lg font-semibold"
+        >
+          Save Party
+        </button>
       </div>
     </div>
   );

--- a/client/src/components/PreBattleSetup.tsx
+++ b/client/src/components/PreBattleSetup.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
-import { UnitState } from '../../shared/models/UnitState';
+import { UnitState } from '@shared/models/UnitState';
+import HeroCard from './HeroCard';
 
 interface PreBattleSetupProps {
   initialParty: UnitState[];
@@ -29,7 +30,7 @@ const PreBattleSetup: React.FC<PreBattleSetupProps> = ({ initialParty, onStartBa
   };
 
   return (
-    <div className="min-h-screen w-full flex flex-col justify-center items-center p-8 bg-gray-900 text-white">
+    <div className="min-h-screen flex flex-col items-center justify-center p-8 w-full max-w-4xl mx-auto text-center">
       <div className="text-center mb-10">
         <h1 className="text-5xl font-bold">Pre-Battle Setup</h1>
         <p className="text-lg text-gray-400 mt-2">Click a hero from your party below to place them on the grid.</p>
@@ -42,12 +43,7 @@ const PreBattleSetup: React.FC<PreBattleSetupProps> = ({ initialParty, onStartBa
             key={index}
             className="w-full h-full bg-gray-800 rounded-lg flex items-center justify-center border-2 border-dashed border-gray-600"
           >
-            {unit && (
-              <div className="text-center p-2 bg-blue-600 rounded-lg shadow-lg">
-                <p className="font-bold text-white">{unit.name}</p>
-                <p className="text-xs opacity-80">{unit.class}</p>
-              </div>
-            )}
+            {unit && <div className="w-32"><HeroCard hero={unit} /></div>}
           </div>
         ))}
       </div>
@@ -57,13 +53,8 @@ const PreBattleSetup: React.FC<PreBattleSetupProps> = ({ initialParty, onStartBa
         <h2 className="text-xl font-bold mb-4 text-center">Your Party</h2>
         <div className="flex justify-center gap-4">
           {roster.map((unit) => (
-            <div
-              key={unit.id}
-              onClick={() => handlePlaceUnit(unit.id)}
-              className="w-24 h-24 bg-gray-700 hover:bg-gray-600 rounded-lg flex flex-col items-center justify-center cursor-pointer p-2 text-center shadow-md transition-transform transform hover:scale-105"
-            >
-              <p className="font-bold">{unit.name}</p>
-              <p className="text-xs opacity-80">{unit.class}</p>
+            <div key={unit.id} onClick={() => handlePlaceUnit(unit.id)} className="cursor-pointer transform hover:scale-105 transition-transform w-32">
+              <HeroCard hero={unit} />
             </div>
           ))}
           {roster.length === 0 && <p className="text-gray-500">All heroes have been placed.</p>}
@@ -72,7 +63,7 @@ const PreBattleSetup: React.FC<PreBattleSetupProps> = ({ initialParty, onStartBa
       <div className="flex gap-4 mt-8">
         <button
           onClick={onBackToTown}
-          className="px-10 py-4 bg-gray-600 hover:bg-gray-700 rounded-lg text-xl font-bold transition-colors shadow-lg"
+          className="px-10 py-4 bg-gray-600 hover:bg-gray-700 rounded-lg font-bold transition-colors shadow-lg"
         >
           Back to Town
         </button>
@@ -80,7 +71,7 @@ const PreBattleSetup: React.FC<PreBattleSetupProps> = ({ initialParty, onStartBa
           onClick={() =>
             onStartBattle(gridSlots.filter(u => u !== null) as UnitState[])
           }
-          className="px-10 py-4 bg-green-600 hover:bg-green-700 rounded-lg text-xl font-bold transition-colors shadow-lg"
+          className="px-10 py-4 bg-blue-600 hover:bg-blue-700 rounded-lg font-bold transition-colors shadow-lg"
         >
           Start Battle
         </button>

--- a/client/src/components/TownHub.tsx
+++ b/client/src/components/TownHub.tsx
@@ -60,7 +60,7 @@ const TownHub: React.FC<TownHubProps> = ({ onStartSkirmish, onEnterDungeon, onNa
       </header>
       <div className={styles.grid}>
         <button
-          className={styles.card}
+          className="p-6 bg-gray-800 hover:bg-gray-700 rounded-lg cursor-pointer text-center"
           onClick={onNavigateToParty}
           aria-label="Manage Party"
         >
@@ -69,7 +69,7 @@ const TownHub: React.FC<TownHubProps> = ({ onStartSkirmish, onEnterDungeon, onNa
           <span className={styles.subtitle}>Manage your heroes</span>
         </button>
         <button
-          className={styles.card}
+          className="p-6 bg-gray-800 rounded-lg text-center opacity-50 cursor-not-allowed"
           onClick={() => {}}
           aria-label="View Inventory"
         >
@@ -78,7 +78,7 @@ const TownHub: React.FC<TownHubProps> = ({ onStartSkirmish, onEnterDungeon, onNa
           <span className={styles.subtitle}>View your items</span>
         </button>
         <button
-          className={styles.card}
+          className="p-6 bg-gray-800 hover:bg-gray-700 rounded-lg cursor-pointer text-center"
           onClick={() => {}}
           aria-label="Browse Cards"
         >
@@ -87,7 +87,7 @@ const TownHub: React.FC<TownHubProps> = ({ onStartSkirmish, onEnterDungeon, onNa
           <span className={styles.subtitle}>Browse your card collection</span>
         </button>
         <button
-          className={styles.card}
+          className="p-6 bg-gray-800 rounded-lg text-center opacity-50 cursor-not-allowed"
           onClick={() => {}}
           aria-label="Craft Items"
         >
@@ -96,7 +96,7 @@ const TownHub: React.FC<TownHubProps> = ({ onStartSkirmish, onEnterDungeon, onNa
           <span className={styles.subtitle}>Prepare for battle</span>
         </button>
         <button
-          className={styles.card}
+          className="p-6 bg-gray-800 rounded-lg text-center opacity-50 cursor-not-allowed"
           onClick={() => {}}
           aria-label="Visit Shop"
         >
@@ -105,8 +105,8 @@ const TownHub: React.FC<TownHubProps> = ({ onStartSkirmish, onEnterDungeon, onNa
           <span className={styles.subtitle}>Browse wares</span>
         </button>
         <button
-          className={styles.card}
-          onClick={onStartSkirmish} // Changed to use onStartSkirmish callback
+          className="p-6 bg-gray-800 hover:bg-gray-700 rounded-lg cursor-pointer text-center"
+          onClick={onStartSkirmish}
           aria-label="Battle"
         >
           <span className={styles.icon}>⚔️</span>
@@ -114,7 +114,7 @@ const TownHub: React.FC<TownHubProps> = ({ onStartSkirmish, onEnterDungeon, onNa
           <span className={styles.subtitle}>Skirmish test</span>
         </button>
         <button
-          className={`${styles.card} ${!party ? styles.disabled : ""}`}
+          className="p-6 bg-purple-700 hover:bg-purple-600 rounded-lg cursor-pointer text-center transform hover:scale-105 transition-transform"
           onClick={onEnterDungeon}
           aria-label="Enter Dungeon"
         >

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -1,84 +1,8 @@
-:root {
-  font-family: system-ui, Avenir, Helvetica, Arial, sans-serif;
-  line-height: 1.5;
-  font-weight: 400;
-
-  color-scheme: light dark;
-  color: rgba(255, 255, 255, 0.87);
-  background-color: #242424;
-
-  font-synthesis: none;
-  text-rendering: optimizeLegibility;
-  -webkit-font-smoothing: antialiased;
-  -moz-osx-font-smoothing: grayscale;
-}
-
-a {
-  font-weight: 500;
-  color: #646cff;
-  text-decoration: inherit;
-}
-a:hover {
-  color: #535bf2;
-}
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
 
 body {
-  margin: 0;
-  display: flex;
-  place-items: center;
-  min-width: 320px;
-  min-height: 100vh;
-  background: radial-gradient(ellipse at 60% 40%, #23283c 60%, #13141e 100%);
-}
-
-h1 {
-  font-size: 3.2em;
-  line-height: 1.1;
-}
-
-button {
-  border-radius: 8px;
-  border: 1px solid transparent;
-  padding: 0.6em 1.2em;
-  font-size: 1em;
-  font-weight: 500;
-  font-family: inherit;
-  background-color: #1a1a1a;
-  cursor: pointer;
-  transition: border-color 0.25s;
-}
-button:hover {
-  border-color: #646cff;
-}
-button:focus,
-button:focus-visible {
-  outline: 4px auto -webkit-focus-ring-color;
-}
-
-@media (prefers-color-scheme: light) {
-  :root {
-    color: #213547;
-    background-color: #ffffff;
-  }
-  a:hover {
-    color: #747bff;
-  }
-  button {
-    background-color: #f9f9f9;
-  }
-}
-
-.page-enter {
-  opacity: 0;
-}
-.page-enter-active {
-  opacity: 1;
-  transition: opacity 300ms;
-}
-.page-exit {
-  opacity: 1;
-}
-.page-exit-active {
-  opacity: 0;
-  transition: opacity 300ms;
+  background-color: #1a202c; /* A dark slate gray */
+  color: #cbd5e0; /* A light gray for text */
 }


### PR DESCRIPTION
## Summary
- establish global styling defaults
- center app content
- style TownHub buttons for clear hierarchy
- rebuild HeroCard and PartyRoster layouts
- add reusable GameCard component
- update setup flows to use shared components

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68477940a9a083279457ea08e331a0e6