### PR TITLE
Center town hub icons and add labels

### DIFF
--- a/client/src/components/TownHub.css
+++ b/client/src/components/TownHub.css
@@ -4,35 +4,53 @@
   height: 100vh;
 }
 
-.hub-icons {
+.hub-icon-group {
   position: absolute;
+  top: 50%;
+  transform: translateY(-50%);
   display: flex;
   flex-direction: column;
-  gap: 40px;
+  gap: 48px;
+  justify-content: center;
   z-index: 2;
 }
 .hub-left {
-  left: 80px;
-  top: 200px;
+  left: calc(50% - 260px);
 }
 .hub-right {
-  right: 80px;
-  top: 200px;
+  right: calc(50% - 260px);
 }
-.hub-icons a i {
-  color: #fff;
-  font-size: 64px;
-  filter: drop-shadow(0 0 8px #222);
-  transition: transform 0.12s, color 0.12s;
+
+.hub-icon {
+  background: none;
+  border: none;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
   cursor: pointer;
 }
-.hub-icons a:hover i,
-.hub-icons a:focus i {
+.hub-icon i {
+  color: #fff;
+  font-size: 64px;
+  margin-bottom: 12px;
+  filter: drop-shadow(0 1px 7px #2227);
+  transition: transform 0.12s, color 0.12s;
+}
+.hub-icon:hover i,
+.hub-icon:focus i {
   color: #84e6fa;
   transform: scale(1.13);
 }
+
+.hub-label {
+  font-size: 20px;
+  color: #f4e9c2;
+  font-weight: 600;
+  text-shadow: 0 2px 10px #2227;
+}
 @media (max-width: 600px) {
-  .hub-icons a i {
+  .hub-icon i {
     font-size: 48px;
   }
 }

--- a/client/src/components/TownHub.tsx
+++ b/client/src/components/TownHub.tsx
@@ -6,18 +6,39 @@ interface TownHubProps {
   onStartSkirmish: () => void;
 }
 
-export const TownHub: React.FC<TownHubProps> = ({ onNavigateToParty, onStartSkirmish }) => {
+export const TownHub: React.FC<TownHubProps> = ({
+  onNavigateToParty,
+  onStartSkirmish,
+}) => {
   return (
     <div className="town-hub">
-      <div className="hub-icons hub-left">
-        <a href="#" onClick={onNavigateToParty} aria-label="Party"><i className="fa-solid fa-shield-halved"></i></a>
-        <a href="#" aria-label="Inventory"><i className="fa-solid fa-backpack"></i></a>
-        <a href="#" aria-label="Cards"><i className="fa-solid fa-clone"></i></a>
+      <div className="hub-icon-group hub-left">
+        <button className="hub-icon" onClick={onNavigateToParty} aria-label="Party">
+          <i className="fa-solid fa-shield-halved" />
+          <span className="hub-label">Party</span>
+        </button>
+        <button className="hub-icon" aria-label="Inventory">
+          <i className="fa-solid fa-backpack" />
+          <span className="hub-label">Inventory</span>
+        </button>
+        <button className="hub-icon" aria-label="Cards">
+          <i className="fa-solid fa-clone" />
+          <span className="hub-label">Cards</span>
+        </button>
       </div>
-      <div className="hub-icons hub-right">
-        <a href="#" aria-label="Crafting"><i className="fa-solid fa-flask"></i></a>
-        <a href="#" aria-label="Shop"><i className="fa-solid fa-store"></i></a>
-        <a href="#" onClick={onStartSkirmish} aria-label="Battle"><i className="fa-solid fa-swords"></i></a>
+      <div className="hub-icon-group hub-right">
+        <button className="hub-icon" aria-label="Crafting">
+          <i className="fa-solid fa-flask" />
+          <span className="hub-label">Crafting</span>
+        </button>
+        <button className="hub-icon" aria-label="Shop">
+          <i className="fa-solid fa-store" />
+          <span className="hub-label">Shop</span>
+        </button>
+        <button className="hub-icon" onClick={onStartSkirmish} aria-label="Battle">
+          <i className="fa-solid fa-swords" />
+          <span className="hub-label">Battle</span>
+        </button>
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- center icon groups on town hub screen
- evenly space icons and add labels

## Testing
- `npm test`
- `npm run lint -w client`


------
https://chatgpt.com/codex/tasks/task_e_68478c1f0d608327a3fd289049b11d92