### PR TITLE
Fix missing icons on TownHub

### DIFF
--- a/client/src/components/TownHub.tsx
+++ b/client/src/components/TownHub.tsx
@@ -18,7 +18,7 @@ export const TownHub: React.FC<TownHubProps> = ({
           <span className="hub-label">Party</span>
         </button>
         <button className="hub-icon" aria-label="Inventory">
-          <i className="fa-solid fa-backpack" />
+          <i className="fa-solid fa-bag-shopping" />
           <span className="hub-label">Inventory</span>
         </button>
         <button className="hub-icon" aria-label="Cards">
@@ -36,7 +36,7 @@ export const TownHub: React.FC<TownHubProps> = ({
           <span className="hub-label">Shop</span>
         </button>
         <button className="hub-icon" onClick={onStartSkirmish} aria-label="Battle">
-          <i className="fa-solid fa-swords" />
+          <i className="fa-solid fa-user-ninja" />
           <span className="hub-label">Battle</span>
         </button>
       </div>


### PR DESCRIPTION
## Summary
- replace missing FontAwesome icons on TownHub with free equivalents

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684842b7f0088327809d26813b6bdb52