### PR TITLE
Implement core classes for battle simulation

### DIFF
--- a/card_rpg_mvp/includes/AIPlayer.php
+++ b/card_rpg_mvp/includes/AIPlayer.php
@@ -1,0 +1,119 @@
+<?php
+// includes/AIPlayer.php
+
+require_once INCLUDES_PATH . '/Card.php';
+require_once INCLUDES_PATH . '/GameEntity.php';
+require_once INCLUDES_PATH . '/db.php'; // To fetch persona data
+
+class AIPlayer {
+    private $persona; // AI Persona object (from db)
+    private $db_conn;
+
+    public function __construct($personaId) {
+        $database = new Database();
+        $this->db_conn = $database->getConnection();
+        $this->loadPersona($personaId);
+    }
+
+    private function loadPersona($personaId) {
+        $stmt = $this->db_conn->prepare("SELECT priorities FROM ai_personas WHERE id = :id");
+        $stmt->bindParam(':id', $personaId, PDO::PARAM_INT);
+        $stmt->execute();
+        $personaData = $stmt->fetch(PDO::FETCH_ASSOC);
+        if ($personaData) {
+            $this->persona = json_decode($personaData['priorities'], true);
+        } else {
+            // Default to Aggressive if persona not found
+            $this->persona = json_decode('{"card_priority": ["damage", "direct_damage", "aoe_damage"], "target_priority": "lowest_hp", "buff_use_threshold": 0.2, "item_use_priority": ["offense"] }', true);
+            error_log("AI Persona ID {$personaId} not found. Defaulting to Aggressive.");
+        }
+    }
+
+    /**
+     * Decides which card an AI entity should play and on whom.
+     * @param GameEntity $aiEntity The AI-controlled entity.
+     * @param GameEntity $playerEntity The human player's entity.
+     * @param Card[] $availableCards The cards currently in the AI entity's hand/deck.
+     * @return array|null Returns ['card' => Card object, 'target' => GameEntity object] or null if no action.
+     */
+    public function decideAction(GameEntity $aiEntity, GameEntity $playerEntity, array $availableCards) {
+        $chosenCard = null;
+        $chosenTarget = null;
+        $bestScore = -1;
+
+        $targetPriorities = $this->persona['target_priority'];
+        $cardPriorities = $this->persona['card_priority'];
+
+        // Filter for affordable cards
+        $affordableCards = array_filter($availableCards, function($card) use ($aiEntity) {
+            return $aiEntity->current_energy >= $card->energy_cost;
+        });
+
+        if (empty($affordableCards)) {
+            return null; // Cannot afford any cards
+        }
+
+        foreach ($cardPriorities as $priorityType) {
+            foreach ($affordableCards as $card) {
+                $score = 0;
+
+                // Score cards based on persona's card priorities
+                if ($priorityType === 'damage' && ($card->card_type === 'ability' || $card->card_type === 'weapon')) {
+                    // Placeholder: Check effect_details for damage type
+                    if (isset($card->effect_details['type']) && (strpos($card->effect_details['type'], 'damage') !== false)) {
+                         $score += 10; // High score for damage cards
+                         if (isset($card->effect_details['aoe_damage'])) $score += 5; // Bonus for AOE
+                    }
+                } elseif ($priorityType === 'defense' && $card->card_type === 'armor') {
+                    if (isset($card->effect_details['type']) && (strpos($card->effect_details['type'], 'reduction') !== false || strpos($card->effect_details['type'], 'block') !== false || strpos($card->effect_details['type'], 'immunity') !== false)) {
+                        $score += 8; // High score for defense cards
+                    }
+                } elseif ($priorityType === 'heal' && $card->card_type === 'item') {
+                     if (isset($card->effect_details['type']) && (strpos($card->effect_details['type'], 'heal') !== false)) {
+                        $score += 7;
+                        if ($aiEntity->current_hp / $aiEntity->max_hp < ($this->persona['buff_use_threshold'] ?? 0.5)) { // Use threshold for buffs/healing
+                            $score += 5; // Bonus if low HP
+                        }
+                     }
+                }
+                // ... more complex scoring based on GDD details for other card types/effects
+
+                // Target selection (simplistic for MVP)
+                $targetCandidate = null;
+                if ($card->card_type === 'ability' || $card->card_type === 'weapon' || $card->card_type === 'item') {
+                    if (strpos($card->effect_details['type'] ?? '', 'damage') !== false) {
+                         // Damaging cards target based on target_priority (lowest_hp for aggressive)
+                         if ($targetPriorities === 'lowest_hp') {
+                            $targetCandidate = ($playerEntity->current_hp <= $aiEntity->current_hp) ? $playerEntity : $aiEntity; // Simple low HP check
+                         } else {
+                            $targetCandidate = $playerEntity; // Default to player
+                         }
+                    } elseif (strpos($card->effect_details['type'] ?? '', 'heal') !== false || strpos($card->effect_details['type'] ?? '', 'buff') !== false) {
+                        // Healing/buffing cards target based on persona (self_lowest_hp for defensive)
+                        if ($targetPriorities === 'self_lowest_hp') {
+                            $targetCandidate = ($aiEntity->current_hp < $aiEntity->max_hp) ? $aiEntity : null; // Only heal if not full HP
+                        } else {
+                            $targetCandidate = $aiEntity; // Default to self
+                        }
+                    }
+                }
+                
+                // Ensure chosen target is valid and alive
+                if ($targetCandidate && $targetCandidate->current_hp > 0) {
+                    if ($score > $bestScore) {
+                        $bestScore = $score;
+                        $chosenCard = $card;
+                        $chosenTarget = $targetCandidate;
+                    }
+                }
+            }
+        }
+        
+        if ($chosenCard) {
+            return ['card' => $chosenCard, 'target' => $chosenTarget];
+        }
+
+        return null; // No suitable action found
+    }
+}
+?>

--- a/card_rpg_mvp/includes/BattleSimulator.php
+++ b/card_rpg_mvp/includes/BattleSimulator.php
@@ -1,0 +1,284 @@
+<?php
+// includes/BattleSimulator.php
+
+require_once INCLUDES_PATH . '/db.php';
+require_once INCLUDES_PATH . '/GameEntity.php';
+require_once INCLUDES_PATH . '/Champion.php';
+require_once INCLUDES_PATH . '/Monster.php';
+require_once INCLUDES_PATH . '/Card.php';
+require_once INCLUDES_PATH . '/StatusEffect.php';
+require_once INCLUDES_PATH . '/BuffManager.php';
+require_once INCLUDES_PATH . '/AIPlayer.php';
+require_once INCLUDES_PATH . '/utils.php'; // For logging functions
+
+class BattleSimulator {
+    private $db_conn;
+    private $battleLog = [];
+    private $player; // Champion object
+    private $opponent; // Monster object
+    private $aiPlayer; // AIPlayer object for opponent
+
+    public function __construct() {
+        $database = new Database();
+        $this->db_conn = $database->getConnection();
+    }
+
+    private function logAction($turn, $actorName, $actionType, $details = []) {
+        $this->battleLog[] = createBattleLogEntry($turn, $actorName, $actionType, $details);
+    }
+
+    public function simulateBattle($playerChampionData, $opponentMonsterId) {
+        // 1. Initialize Player Champion
+        $this->player = new Champion($playerChampionData);
+        // Load full card data for player's deck
+        $playerFullDeckCards = [];
+        if (!empty($playerChampionData['deck_card_ids'])) {
+            $cardIdsPlaceholder = implode(',', array_fill(0, count($playerChampionData['deck_card_ids']), '?'));
+            $stmt = $this->db_conn->prepare("SELECT id, name, card_type, rarity, energy_cost, description, damage_type, armor_type, class_affinity, effect_details, flavor_text FROM cards WHERE id IN ($cardIdsPlaceholder)");
+            $stmt->execute($playerChampionData['deck_card_ids']);
+            $playerDeckData = $stmt->fetchAll(PDO::FETCH_ASSOC);
+            foreach ($playerDeckData as $cardData) {
+                $playerFullDeckCards[] = new Card(array_merge($cardData, ['effect_details' => json_decode($cardData['effect_details'], true)]));
+            }
+        }
+        $this->player->deck = $playerFullDeckCards;
+        $this->player->hand = $playerFullDeckCards; // For MVP, entire deck is hand
+
+        // 2. Initialize Opponent Monster & AI
+        $stmt = $this->db_conn->prepare("SELECT id, name, role, starting_hp, speed FROM monsters WHERE id = :id");
+        $stmt->bindParam(':id', $opponentMonsterId, PDO::PARAM_INT);
+        $stmt->execute();
+        $aiMonsterData = $stmt->fetch(PDO::FETCH_ASSOC);
+        if (!$aiMonsterData) {
+            sendError("Opponent monster not found.", 500); // Should not happen if data is good
+        }
+        $this->opponent = new Monster($aiMonsterData);
+        // Assign a random AI persona (for MVP, let's pick aggressive by default or random from DB)
+        $randomPersonaStmt = $this->db_conn->query("SELECT id FROM ai_personas ORDER BY RAND() LIMIT 1");
+        $personaId = $randomPersonaStmt->fetchColumn();
+        $this->aiPlayer = new AIPlayer($personaId);
+
+        // Load AI Monster's cards (random 3 common ability cards for MVP)
+        $aiCardsStmt = $this->db_conn->prepare("SELECT id, name, card_type, rarity, energy_cost, description, damage_type, armor_type, effect_details, flavor_text FROM cards WHERE card_type = 'ability' AND rarity = 'Common' ORDER BY RAND() LIMIT 3");
+        $aiCardsStmt->execute();
+        $aiDeckData = $aiCardsStmt->fetchAll(PDO::FETCH_ASSOC);
+        $aiFullDeckCards = [];
+        foreach ($aiDeckData as $cardData) {
+            $aiFullDeckCards[] = new Card(array_merge($cardData, ['effect_details' => json_decode($cardData['effect_details'], true)]));
+        }
+        $this->opponent->deck = $aiFullDeckCards;
+        $this->opponent->hand = $aiFullDeckCards; // For MVP, entire deck is hand
+
+
+        $turn = 0;
+        $maxTurns = 20; // Max turns to prevent infinite loops
+
+        $this->logAction(0, "System", "Battle Start", [
+            "player" => ["name" => $this->player->name, "hp" => $this->player->current_hp, "speed" => $this->player->current_speed],
+            "opponent" => ["name" => $this->opponent->name, "hp" => $this->opponent->current_hp, "speed" => $this->opponent->current_speed]
+        ]);
+
+        while ($this->player->current_hp > 0 && $this->opponent->current_hp > 0 && $turn < $maxTurns) {
+            $turn++;
+            $this->logAction($turn, "System", "Turn Start");
+
+            // 1. Reset temporary stats and apply active buffs/debuffs
+            $this->player->resetTemporaryStats();
+            $this->opponent->resetTemporaryStats();
+            BuffManager::updateEntityStats($this->player);
+            BuffManager::updateEntityStats($this->opponent);
+
+            // 2. Initiative Phase: Determine turn order
+            $turnOrder = $this->determineInitiative($this->player, $this->opponent);
+            
+            foreach ($turnOrder as $activeEntity) {
+                if ($activeEntity->current_hp <= 0) { // Check if entity is still alive
+                    $this->logAction($turn, $activeEntity->name, "Skipped Turn", ["reason" => "Defeated"]);
+                    continue;
+                }
+                // Check for Stun effect (GDD: Stun - Effect: Target skips their next action.)
+                $isStunned = false;
+                foreach($activeEntity->debuffs as $effect) {
+                    if ($effect->type === 'Stun') {
+                        $this->logAction($turn, $activeEntity->name, "Skipped Turn", ["reason" => "Stunned"]);
+                        $isStunned = true;
+                        break;
+                    }
+                }
+                if ($isStunned) continue;
+
+                $this->logAction($turn, $activeEntity->name, "Turn Action", ["energy_before" => $activeEntity->current_energy]);
+
+                // 3. Energy Gain Phase
+                $activeEntity->current_energy = min($activeEntity->current_energy + 1, 4); // Capped at 4 as per GDD progression
+                $this->logAction($turn, $activeEntity->name, "Energy Gain", ["energy_gained" => 1, "energy_after" => $activeEntity->current_energy]);
+
+                // 4. Action Phase (Play Cards)
+                $chosenAction = null;
+                if ($activeEntity->id === $this->player->id) {
+                    // Player's turn (since auto-battle, player AI is simple)
+                    $chosenAction = $this->aiPlayer->decideAction($this->player, $this->opponent, $this->player->hand);
+                } else {
+                    // Opponent's turn
+                    $chosenAction = $this->aiPlayer->decideAction($this->opponent, $this->player, $this->opponent->hand);
+                }
+
+                if ($chosenAction && $activeEntity->current_energy >= $chosenAction['card']->energy_cost) {
+                    $card = $chosenAction['card'];
+                    $target = $chosenAction['target'];
+                    $activeEntity->current_energy -= $card->energy_cost;
+
+                    $this->logAction($turn, $activeEntity->name, "Plays Card", ["card_name" => $card->name, "energy_spent" => $card->energy_cost, "target" => $target->name]);
+
+                    // Apply card effect (this is where BuffManager will shine)
+                    // This is a placeholder for complex card effect application based on effect_details JSON
+                    // The BuffManager::applyEffect needs to be greatly expanded to handle all GDD card types
+                    if ($card->effect_details) {
+                        $this->applyCardEffect($activeEntity, $target, $card); // New helper method
+                    }
+
+                } else {
+                    $this->logAction($turn, $activeEntity->name, "Passes Turn", ["reason" => "No affordable cards or valid action"]);
+                }
+
+                // Check for immediate defeat after action
+                if ($this->player->current_hp <= 0 || $this->opponent->current_hp <= 0) {
+                    break;
+                }
+            }
+            
+            // 5. Resolution Phase (End of Turn Effects, DOTs, Decrement Durations)
+            BuffManager::decrementDurations($this->player); // This will also apply DOTs
+            BuffManager::decrementDurations($this->opponent);
+            
+            // Re-check defeat after DOTs
+            if ($this->player->current_hp <= 0 || $this->opponent->current_hp <= 0) {
+                break;
+            }
+            
+            $this->logAction($turn, "System", "Turn End", [
+                "player_hp_after_turn" => $this->player->current_hp,
+                "opponent_hp_after_turn" => $this->opponent->current_hp
+            ]);
+        }
+
+        // 6. Determine Winner
+        $winner = null;
+        $result = 'draw';
+        if ($this->player->current_hp <= 0 && $this->opponent->current_hp > 0) {
+            $winner = $this->opponent->name;
+            $result = 'loss';
+        } elseif ($this->opponent->current_hp <= 0 && $this->player->current_hp > 0) {
+            $winner = $this->player->name;
+            $result = 'win';
+        } elseif ($this->player->current_hp <= 0 && $this->opponent->current_hp <= 0) {
+            $winner = 'None (Double KO)'; // Or specific tie-breaker
+            $result = 'loss'; // For MVP, double KO means player loss
+        } else {
+             $winner = 'None (Max Turns)'; // Max turns reached, still a draw
+             $result = 'draw'; // Could be 'loss' for player in a competitive context
+        }
+
+        $xp_awarded = ($result === 'win' ? 60 : 30); // From GDD: Game Modes - 1.2. XP Rewards Per Match
+
+        $this->logAction($turn, "System", "Battle End", ["winner" => $winner, "result" => $result]);
+
+        return [
+            "message" => "Battle simulated.",
+            "player_final_hp" => $this->player->current_hp,
+            "opponent_final_hp" => $this->opponent->current_hp,
+            "winner" => $winner,
+            "result" => $result,
+            "xp_awarded" => $xp_awarded,
+            "log" => $this->battleLog
+        ];
+    }
+
+    // Helper to determine initiative based on speed
+    private function determineInitiative(GameEntity $entity1, GameEntity $entity2) {
+        // GDD: Battle System - 5. Initiative System: Determines turn order based on agility or dice rolls.
+        // For MVP, simple speed comparison. No dice yet.
+        if ($entity1->current_speed > $entity2->current_speed) {
+            return [$entity1, $entity2];
+        } elseif ($entity2->current_speed > $entity1->current_speed) {
+            return [$entity2, $entity1];
+        } else {
+            // Tie-breaker (e.g., random, or player advantage)
+            return [$entity1, $entity2]; // Player first in case of tie for MVP
+        }
+    }
+
+    // This method needs significant expansion to correctly parse and apply all card effects
+    private function applyCardEffect(GameEntity $caster, GameEntity $target, Card $card) {
+        $effectDetails = $card->effect_details;
+        if (!$effectDetails) return;
+
+        // Determine actual target based on card effect (self, single_enemy, all_allies, etc.)
+        $actualTarget = $target; // Default to single enemy for most offensive cards
+        $actualCaster = $caster; // Default to caster for self-buffs
+
+        if (isset($effectDetails['target'])) {
+            if ($effectDetails['target'] === 'self') {
+                $actualTarget = $caster;
+            } elseif ($effectDetails['target'] === 'single_ally') {
+                // In 1v1, single_ally would mean caster itself.
+                // In party, you'd need logic to pick an ally.
+                $actualTarget = $caster; // For MVP 1v1 simplified
+            } elseif ($effectDetails['target'] === 'all_allies') {
+                // In 1v1, all_allies means caster itself.
+                // In party, you'd iterate through team members.
+                // For MVP, this might still affect just self for now.
+                // For logging, let's treat it as affecting the caster.
+                $actualTarget = $caster;
+            } elseif ($effectDetails['target'] === 'all_enemies') {
+                // For AOE, need to affect all opposing entities.
+                // In MVP 1v1, this means the single opponent.
+                $actualTarget = $target; // Still applies to the one opponent
+            }
+        }
+        
+        // This is a simplified mapping of GDD effect types to actions.
+        // This needs to be expanded extensively to handle all card types and effect_details.
+        switch ($effectDetails['type']) {
+            case 'damage':
+                $damageDealt = calculateDamage($effectDetails['damage'], $card->damage_type, $actualTarget->armor_type ?? NULL);
+                $actualTarget->takeDamage($damageDealt);
+                $this->logAction($this->battleLog[count($this->battleLog)-1]['turn'], $caster->name, "Deals Damage", ["target" => $actualTarget->name, "amount" => $damageDealt, "target_hp_after" => $actualTarget->current_hp]);
+                break;
+            case 'heal':
+                $actualTarget->heal($effectDetails['amount']);
+                $this->logAction($this->battleLog[count($this->battleLog)-1]['turn'], $caster->name, "Heals", ["target" => $actualTarget->name, "amount" => $effectDetails['amount'], "target_hp_after" => $actualTarget->current_hp]);
+                break;
+            case 'buff':
+                BuffManager::applyEffect($actualTarget, $card, $effectDetails);
+                $this->logAction($this->battleLog[count($this->battleLog)-1]['turn'], $caster->name, "Applies Buff", ["target" => $actualTarget->name, "stat" => $effectDetails['stat'], "amount" => $effectDetails['amount'], "duration" => $effectDetails['duration']]);
+                break;
+            case 'debuff':
+                BuffManager::applyEffect($actualTarget, $card, $effectDetails);
+                $this->logAction($this->battleLog[count($this->battleLog)-1]['turn'], $caster->name, "Applies Debuff", ["target" => $actualTarget->name, "stat" => $effectDetails['stat'], "amount" => $effectDetails['amount'], "duration" => $effectDetails['duration']]);
+                break;
+            case 'status_effect': // Stun, Root, Confuse, Shock
+                BuffManager::applyEffect($actualTarget, $card, $effectDetails);
+                 $this->logAction($this->battleLog[count($this->battleLog)-1]['turn'], $caster->name, "Applies Status", ["target" => $actualTarget->name, "effect" => $effectDetails['effect'], "duration" => $effectDetails['duration']]);
+                break;
+            case 'damage_dot':
+                $damageDealt = calculateDamage($effectDetails['damage'], $card->damage_type, $actualTarget->armor_type ?? NULL);
+                $actualTarget->takeDamage($damageDealt);
+                $this->logAction($this->battleLog[count($this->battleLog)-1]['turn'], $caster->name, "Deals Damage", ["target" => $actualTarget->name, "amount" => $damageDealt, "target_hp_after" => $actualTarget->current_hp]);
+                BuffManager::applyEffect($actualTarget, $card, $effectDetails); // Apply DOT as a status effect
+                $this->logAction($this->battleLog[count($this->battleLog)-1]['turn'], $caster->name, "Applies DOT", ["target" => $actualTarget->name, "type" => $effectDetails['dot_type'], "amount" => $effectDetails['dot_amount'], "duration" => $effectDetails['dot_duration']]);
+                break;
+            case 'aoe_damage': // For MVP 1v1, this just hits the single opponent
+                $damageDealt = calculateDamage($effectDetails['damage'], $card->damage_type, $actualTarget->armor_type ?? NULL);
+                $actualTarget->takeDamage($damageDealt);
+                 $this->logAction($this->battleLog[count($this->battleLog)-1]['turn'], $caster->name, "Deals AOE Damage", ["target" => $actualTarget->name, "amount" => $damageDealt, "target_hp_after" => $actualTarget->current_hp]);
+                break;
+            // Add other effect types based on your card data's effect_details
+            // Example: 'damage_self_debuff', 'aoe_damage_self_damage', 'prevent_defeat', etc.
+            default:
+                $this->logAction($this->battleLog[count($this->battleLog)-1]['turn'], $caster->name, "Unhandled Effect", ["card_name" => $card->name, "effect_type" => $effectDetails['type']]);
+                break;
+        }
+    }
+}
+?>

--- a/card_rpg_mvp/includes/BuffManager.php
+++ b/card_rpg_mvp/includes/BuffManager.php
@@ -1,0 +1,110 @@
+<?php
+// includes/BuffManager.php
+// Manages application and removal of buffs/debuffs on a GameEntity
+
+class BuffManager {
+    public static function applyEffect(GameEntity $target, Card $sourceCard, array $effectDetails) {
+        // This is a placeholder for the full GDD status effects logic.
+        // It will be crucial to map JSON effect_details to actual StatusEffect objects.
+
+        switch ($effectDetails['type']) {
+            case 'buff':
+                $effect = new StatusEffect($effectDetails['stat'], $effectDetails['amount'], $effectDetails['duration'], false, $effectDetails['stat'], $sourceCard->id);
+                $target->addStatusEffect($effect);
+                // Apply immediate stat change
+                if ($effectDetails['stat'] === 'attack') $target->current_attack += $effectDetails['amount']; // Requires current_attack on GameEntity
+                // ... handle other stats like evasion, speed, defense_reduction
+                break;
+            case 'damage_debuff':
+                // For debuffs, first apply damage then the debuff
+                $target->takeDamage($effectDetails['damage'], $sourceCard->damage_type);
+                $effect = new StatusEffect($effectDetails['debuff_stat'], $effectDetails['debuff_amount'], $effectDetails['debuff_duration'], true, $effectDetails['debuff_stat'], $sourceCard->id);
+                $target->addStatusEffect($effect);
+                // Apply immediate stat change for debuffs like attack down
+                if ($effectDetails['debuff_stat'] === 'attack') $target->current_attack -= $effectDetails['debuff_amount'];
+                // ... handle other debuffs
+                break;
+            case 'heal':
+                $target->heal($effectDetails['amount']);
+                break;
+            case 'status_effect': // For Stun, Root, Confuse, Shock
+                $isDebuff = true; // Most direct status effects are debuffs
+                $effect = new StatusEffect($effectDetails['effect'], null, $effectDetails['duration'], $isDebuff, null, $sourceCard->id);
+                $target->addStatusEffect($effect);
+                break;
+            // ... implement logic for all other effect types defined in GDD (damage_dot, etc.)
+        }
+    }
+
+    public static function updateEntityStats(GameEntity $entity) {
+        // This function should be called at the start of each turn to re-calculate
+        // current_speed, current_evasion, current_defense_reduction, current_attack, etc.
+        // based on ALL active buffs and debuffs.
+
+        // Reset to base stats first
+        $entity->current_speed = $entity->base_speed;
+        $entity->current_evasion = 0;
+        $entity->current_defense_reduction = 0;
+        // Add current_attack to GameEntity, initialize to base_attack
+        $entity->current_attack = $entity->base_attack ?? 1; // Assuming base attack of 1 if not set
+
+        // Apply buffs
+        foreach ($entity->buffs as $effect) {
+            switch ($effect->stat_affected) {
+                case 'attack':
+                    $entity->current_attack += $effect->amount;
+                    break;
+                case 'defense':
+                    $entity->current_defense_reduction += $effect->amount;
+                    break;
+                case 'evasion':
+                    $entity->current_evasion += $effect->amount;
+                    break;
+                case 'speed':
+                    $entity->current_speed += $effect->amount;
+                    break;
+                // ... handle other stats
+            }
+        }
+
+        // Apply debuffs
+        foreach ($entity->debuffs as $effect) {
+            switch ($effect->stat_affected) {
+                case 'attack':
+                    $entity->current_attack -= $effect->amount;
+                    break;
+                case 'defense':
+                    $entity->current_defense_reduction -= $effect->amount;
+                    break;
+                case 'speed':
+                    $entity->current_speed -= $effect->amount;
+                    break;
+                // ... handle other stats
+            }
+        }
+    }
+    
+    public static function decrementDurations(GameEntity $entity) {
+        // Decrement durations and remove expired effects
+        foreach ($entity->buffs as $key => $effect) {
+            $effect->duration--;
+            if ($effect->duration <= 0) {
+                unset($entity->buffs[$key]);
+            }
+        }
+        foreach ($entity->debuffs as $key => $effect) {
+            // Apply DOT damage before decrementing duration if it's a DOT
+            if (in_array($effect->type, ['Poison', 'Bleed', 'Burn'])) {
+                $entity->takeDamage($effect->amount); // Damage applied directly
+                // Log this DOT damage as part of turn actions
+            }
+            $effect->duration--;
+            if ($effect->duration <= 0) {
+                unset($entity->debuffs[$key]);
+            }
+        }
+        $entity->buffs = array_values($entity->buffs);
+        $entity->debuffs = array_values($entity->debuffs);
+    }
+}
+?>

--- a/card_rpg_mvp/includes/Card.php
+++ b/card_rpg_mvp/includes/Card.php
@@ -1,0 +1,40 @@
+<?php
+// includes/Card.php
+
+class Card {
+    public $id;
+    public $name;
+    public $card_type; // ability, armor, weapon, item
+    public $rarity;
+    public $energy_cost;
+    public $description;
+    public $damage_type;
+    public $armor_type; // For armor cards
+    public $class_affinity; // Comma-separated string
+    public $flavor_text;
+    public $effect_details; // Decoded JSON object
+
+    public function __construct($data) {
+        $this->id = $data['id'];
+        $this->name = $data['name'];
+        $this->card_type = $data['card_type'];
+        $this->rarity = $data['rarity'];
+        $this->energy_cost = $data['energy_cost'];
+        $this->description = $data['description'];
+        $this->damage_type = $data['damage_type'];
+        $this->armor_type = $data['armor_type'];
+        $this->class_affinity = $data['class_affinity'];
+        $this->flavor_text = $data['flavor_text'];
+        $this->effect_details = $data['effect_details']; // Already decoded JSON
+    }
+
+    // Method to check if card is usable by a specific class
+    public function isUsableByClass($championName) {
+        if ($this->class_affinity === NULL) { // Items have NULL affinity
+            return true;
+        }
+        $affinities = explode(',', $this->class_affinity);
+        return in_array($championName, $affinities);
+    }
+}
+?>

--- a/card_rpg_mvp/includes/Champion.php
+++ b/card_rpg_mvp/includes/Champion.php
@@ -1,0 +1,28 @@
+<?php
+// includes/Champion.php
+
+require_once INCLUDES_PATH . '/GameEntity.php';
+
+class Champion extends GameEntity {
+    public $champion_id; // FK to champions table
+    public $level;
+    public $xp;
+
+    public function __construct($data) {
+        parent::__construct(
+            $data['champion_id'], // Use champion_id as entity ID
+            $data['champion_name'],
+            $data['starting_hp'],
+            $data['speed'],
+            $data['role'] // Assuming role is passed from champions table
+        );
+        $this->champion_id = $data['champion_id'];
+        $this->level = $data['current_level'] ?? 1;
+        $this->xp = $data['current_xp'] ?? 0;
+        // Load actual cards for the deck
+        // This is handled in the BattleSimulator for MVP
+    }
+    
+    // Champion specific methods (e.g., levelUp, equipCard)
+}
+?>

--- a/card_rpg_mvp/includes/GameEntity.php
+++ b/card_rpg_mvp/includes/GameEntity.php
@@ -1,0 +1,117 @@
+<?php
+// includes/GameEntity.php
+// Base class for anything that participates in battle (Champion, Monster, Minion)
+
+class GameEntity {
+    public $id;
+    public $name;
+    public $max_hp;
+    public $current_hp;
+    public $base_speed;
+    public $current_speed;
+    public $current_energy;
+    public $current_evasion; // temporary evasion from buffs/debuffs
+    public $current_defense_reduction; // temporary defense reduction from buffs/debuffs
+    public $buffs = []; // Array of active StatusEffect objects
+    public $debuffs = []; // Array of active StatusEffect objects
+    public $deck = []; // Array of Card objects (the full deck)
+    public $hand = []; // Array of Card objects currently in hand (for MVP, maybe just 'available cards')
+    public $discard = []; // Array of Card objects in discard
+    public $team; // Reference to the team this entity belongs to (PlayerTeam or AITeam)
+    public $role; // Tank, DPS, Support etc.
+
+    public function __construct($id, $name, $hp, $speed, $role = 'unknown') {
+        $this->id = $id;
+        $this->name = $name;
+        $this->max_hp = $hp;
+        $this->current_hp = $hp;
+        $this->base_speed = $speed;
+        $this->current_speed = $speed; // Speed can be modified by buffs/debuffs
+        $this->current_energy = 1; // All start with 1 energy at Level 1, as per GDD
+        $this->current_evasion = 0;
+        $this->current_defense_reduction = 0;
+        $this->role = $role;
+    }
+
+    public function takeDamage($amount, $damage_type = NULL) {
+        // Apply defense reduction based on active buffs/debuffs and armor
+        $effectiveDamage = $amount - $this->current_defense_reduction;
+        // Further apply armor reduction based on GDD (Weapon GDD - 4.)
+        // This is a placeholder for actual armor calculation
+        // For MVP, just simple reduction
+        if ($this->current_defense_reduction > 0) {
+            $effectiveDamage = max(0, $effectiveDamage); // Damage cannot go below 0 due to reduction
+        }
+        
+        $this->current_hp -= $effectiveDamage;
+        if ($this->current_hp < 0) {
+            $this->current_hp = 0;
+        }
+        return $effectiveDamage; // Return actual damage taken
+    }
+
+    public function heal($amount) {
+        $this->current_hp = min($this->current_hp + $amount, $this->max_hp);
+    }
+
+    public function addStatusEffect(StatusEffect $effect) {
+        if ($effect->is_debuff) {
+            $this->debuffs[] = $effect;
+        } else {
+            $this->buffs[] = $effect;
+        }
+    }
+
+    public function applyTurnEffects() {
+        // Apply DOTs (Poison, Bleed, Burn)
+        foreach ($this->debuffs as $key => $effect) {
+            if (in_array($effect->type, ['Poison', 'Bleed', 'Burn'])) {
+                $damage = $effect->amount;
+                $this->takeDamage($damage); // Apply damage directly
+                // Log this DOT damage
+            }
+        }
+
+        // Decrement durations
+        foreach ($this->buffs as $key => $effect) {
+            $effect->duration--;
+            if ($effect->duration <= 0) {
+                // Remove buff and revert stats
+                unset($this->buffs[$key]);
+            }
+        }
+        foreach ($this->debuffs as $key => $effect) {
+            $effect->duration--;
+            if ($effect->duration <= 0) {
+                // Remove debuff and revert stats
+                unset($this->debuffs[$key]);
+            }
+        }
+        // Re-index arrays after unsetting
+        $this->buffs = array_values($this->buffs);
+        $this->debuffs = array_values($this->debuffs);
+    }
+
+    public function resetTemporaryStats() {
+        // Reset speed, evasion, defense modifications from 1-turn effects
+        $this->current_speed = $this->base_speed;
+        $this->current_evasion = 0;
+        $this->current_defense_reduction = 0;
+
+        // Re-apply buffs/debuffs that last multiple turns
+        $this->applyActiveStatModifiers(); // This function will be called here
+    }
+
+    public function applyActiveStatModifiers() {
+        // Recalculate current_speed, current_evasion, current_defense_reduction
+        // based on active buffs and debuffs for the current turn.
+        // This would iterate through $this->buffs and $this->debuffs
+        // and apply their stat changes. (Detailed implementation later)
+    }
+
+    // Placeholder for getting actual damage dealt by entity (needs card logic)
+    public function getAttackPower() {
+        return 1; // Very basic placeholder
+    }
+}
+?>

--- a/card_rpg_mvp/includes/Monster.php
+++ b/card_rpg_mvp/includes/Monster.php
@@ -1,0 +1,25 @@
+<?php
+// includes/Monster.php
+
+require_once INCLUDES_PATH . '/GameEntity.php';
+
+class Monster extends GameEntity {
+    public $monster_id; // FK to monsters table
+    public $is_player_monster = false; // Flag if this is a player-controlled monster (for future)
+
+    public function __construct($data) {
+        parent::__construct(
+            $data['id'], // Use monster id as entity ID
+            $data['name'],
+            $data['starting_hp'],
+            $data['speed'],
+            $data['role'] ?? 'unknown' // Role might not be in base monsters table
+        );
+        $this->monster_id = $data['id'];
+        // Monsters might have special properties like taking 2 team slots (from GDD)
+        // This would be handled by BattleSimulator or team management logic
+    }
+    
+    // Monster specific methods
+}
+?>

--- a/card_rpg_mvp/includes/StatusEffect.php
+++ b/card_rpg_mvp/includes/StatusEffect.php
@@ -1,0 +1,24 @@
+<?php
+// includes/StatusEffect.php
+// Represents a single active buff or debuff on an entity
+
+class StatusEffect {
+    public $type; // e.g., 'Stun', 'Poison', 'AttackBoost', 'Evasion'
+    public $amount; // Numeric value for buffs/debuffs (e.g., +2 attack, -1 defense, 5 HP heal)
+    public $duration; // Turns remaining
+    public $is_debuff; // true if it's a debuff, false if a buff
+    public $source_card_id; // ID of the card that applied this effect
+    public $stat_affected; // e.g., 'attack', 'defense', 'speed', 'evasion'
+    public $condition_trigger; // e.g., 'on_attacked' for traps
+
+    public function __construct($type, $amount, $duration, $is_debuff, $stat_affected = null, $source_card_id = null, $condition_trigger = null) {
+        $this->type = $type;
+        $this->amount = $amount;
+        $this->duration = $duration;
+        $this->is_debuff = $is_debuff;
+        $this->stat_affected = $stat_affected;
+        $this->source_card_id = $source_card_id;
+        $this->condition_trigger = $condition_trigger;
+    }
+}
+?>

--- a/card_rpg_mvp/includes/utils.php
+++ b/card_rpg_mvp/includes/utils.php
@@ -12,13 +12,50 @@ function sendError($message, $statusCode = 400) {
 }
 
 // Function to calculate damage based on type and armor
-// This is a simplified version; you'll build out the full logic later.
-function calculateDamage($baseDamage, $damageType, $armorType) {
-    // For MVP, just return base damage
-    // Later, you'll consult the Damage Type vs. Armor Effectiveness Matrix from GDD (Weapon GDD - 4.)
-    // Example:
-    // if ($damageType == 'Piercing' && $armorType == 'Light') { return $baseDamage + 1; }
-    // else if ($damageType == 'Slashing' && $armorType == 'Heavy') { return $baseDamage - 2; }
-    return $baseDamage;
+// Reference GDD: Weapon Design Document (Weapon GDD) - 4. Damage Type vs. Armor Effectiveness Matrix
+// This is still simplified; needs full GDD logic.
+function calculateDamage($baseDamage, $damageType, $targetArmorType) {
+    $finalDamage = $baseDamage;
+
+    // MVP simplified damage calculation based on GDD matrix:
+    // This assumes targetArmorType is 'Light', 'Medium', 'Heavy', 'Magic'
+    // You'll need to fetch the target's equipped armor's armor_type to pass here.
+
+    if ($damageType === 'Slashing') {
+        if ($targetArmorType === 'Medium') {
+            $finalDamage -= 1;
+        } elseif ($targetArmorType === 'Heavy') {
+            $finalDamage -= 2;
+        }
+    } elseif ($damageType === 'Piercing') {
+        if ($targetArmorType === 'Light') {
+            $finalDamage += 1;
+        } elseif ($targetArmorType === 'Heavy') {
+            $finalDamage -= 1;
+        }
+    } elseif ($damageType === 'Bludgeoning') {
+        if ($targetArmorType === 'Medium') {
+            $finalDamage += 1;
+        } elseif ($targetArmorType === 'Heavy') {
+            $finalDamage += 2;
+        }
+    } elseif ($damageType === 'Magic') {
+        if ($targetArmorType === 'Magic') {
+            $finalDamage -= 2; // Assuming '-2 damage (if warded)' means reduction
+        }
+    }
+    
+    // Ensure damage is not negative after reductions unless specifically allowed by a card effect
+    return max(0, $finalDamage);
+}
+
+// Helper for battle logging
+function createBattleLogEntry($turn, $actorName, $actionType, $details = []) {
+    return array_merge([
+        "turn" => $turn,
+        "actor" => $actorName,
+        "action_type" => $actionType,
+        "timestamp" => microtime(true) // For precise ordering
+    ], $details);
 }
 ?>


### PR DESCRIPTION
## Summary
- add GameEntity, Champion, Monster, Card and status-related classes
- create BuffManager, AIPlayer and BattleSimulator for fight logic
- expand helper utils
- overhaul API handler to run auto battles

## Testing
- `php` not available so syntax not tested

------
https://chatgpt.com/codex/tasks/task_e_68489466930c83279ccf5e17b2b930e6