### PR TITLE
Implement dedicated PHP API endpoints

### DIFF
--- a/card_rpg_mvp/public/api/battle_simulate.php
+++ b/card_rpg_mvp/public/api/battle_simulate.php
@@ -1,0 +1,96 @@
+<?php
+// public/api/battle_simulate.php
+
+// Adjust path based on your server's directory structure
+require_once __DIR__ . '/../../includes/db.php';
+require_once __DIR__ . '/../../includes/utils.php';
+require_once __DIR__ . '/../../includes/BattleSimulator.php'; // Requires all its dependencies too
+
+header('Content-Type: application/json');
+
+$database = new Database();
+$db = $database->getConnection();
+
+if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
+    sendError("Invalid request method. Only POST is allowed.", 405);
+}
+
+try {
+    // Load player's current session data
+    $stmt = $db->query("SELECT psd.champion_id, c.name as champion_name, c.role, c.starting_hp, c.speed, psd.deck_card_ids, psd.current_hp, psd.current_energy, psd.current_speed, psd.wins, psd.losses, psd.current_xp, psd.current_level
+                                   FROM player_session_data psd
+                                   JOIN champions c ON psd.champion_id = c.id
+                                   LIMIT 1");
+    $playerSessionData = $stmt->fetch(PDO::FETCH_ASSOC);
+    
+    if (!$playerSessionData) {
+        sendError("Player not set up for battle. Please complete character setup first.", 400);
+    }
+
+    // Pick a random AI Monster opponent (from GDD)
+    $allMonstersStmt = $db->query("SELECT id, name, role, starting_hp, speed FROM monsters ORDER BY RAND() LIMIT 1");
+    $aiMonsterData = $allMonstersStmt->fetch(PDO::FETCH_ASSOC);
+
+    if (!$aiMonsterData) {
+        sendError("No monsters available for AI opponent.", 500);
+    }
+    
+    $battleSimulator = new BattleSimulator();
+    $simulationResult = $battleSimulator->simulateBattle($playerSessionData, $aiMonsterData['id']);
+
+    // Update player's session data after battle (HP, XP, wins/losses, etc.)
+    if ($simulationResult['result'] === 'win') {
+        $playerSessionData['wins']++;
+        $playerSessionData['current_xp'] += $simulationResult['xp_awarded'];
+    } else { // loss or draw
+        $playerSessionData['losses']++; // For MVP, draw also counts as a loss for elimination purposes
+        $playerSessionData['current_xp'] += $simulationResult['xp_awarded'];
+    }
+    $playerSessionData['current_hp'] = $simulationResult['player_final_hp'];
+    $playerSessionData['current_energy'] = 1; // Reset energy after battle
+    $playerSessionData['current_speed'] = $playerSessionData['speed']; // Reset speed after battle (base speed)
+
+    // Check for level up
+    $xpTable = [
+        1 => 60, 2 => 70, 3 => 80, 4 => 90, 5 => 100,
+        6 => 110, 7 => 120, 8 => 130, 9 => 140, 10 => 99999 // Max level, very high XP
+    ];
+    
+    // Check if player leveled up
+    $levelUpOccurred = false;
+    $currentLevelXpRequired = $xpTable[$playerSessionData['current_level']] ?? 0;
+    while ($playerSessionData['current_xp'] >= $currentLevelXpRequired && $playerSessionData['current_level'] < 10) {
+        $playerSessionData['current_level']++;
+        $playerSessionData['current_hp'] += 2; // +2 HP per level
+        $playerSessionData['starting_hp'] = $playerSessionData['current_hp']; // Update max HP for reference
+        $playerSessionData['current_energy'] = min($playerSessionData['current_energy'] + 1, 4); // Max energy increases
+        // GDD: Speed updates are conditional (+1 speed every 3 levels or so for agile types)
+        // For MVP, we'll keep it simple for now and rely on base speed + potential card buffs.
+        $levelUpOccurred = true;
+        $currentLevelXpRequired = $xpTable[$playerSessionData['current_level']] ?? 0;
+    }
+
+
+    $updateStmt = $db->prepare("UPDATE player_session_data SET current_hp = :current_hp, current_energy = :current_energy, current_speed = :current_speed, wins = :wins, losses = :losses, current_xp = :current_xp, current_level = :current_level LIMIT 1");
+    $updateStmt->bindParam(':current_hp', $playerSessionData['current_hp']);
+    $updateStmt->bindParam(':current_energy', $playerSessionData['current_energy']);
+    $updateStmt->bindParam(':current_speed', $playerSessionData['current_speed']);
+    $updateStmt->bindParam(':wins', $playerSessionData['wins']);
+    $updateStmt->bindParam(':losses', $playerSessionData['losses']);
+    $updateStmt->bindParam(':current_xp', $playerSessionData['current_xp']);
+    $updateStmt->bindParam(':current_level', $playerSessionData['current_level']);
+    $updateStmt->execute();
+
+    // Add opponent data to the response for frontend display
+    $simulationResult['opponent_monster_name'] = $aiMonsterData['name'];
+    $simulationResult['opponent_start_hp'] = $aiMonsterData['starting_hp'];
+    $simulationResult['player_start_hp'] = $playerSessionData['starting_hp']; // Pass initial HP for UI bar calcs
+    
+    sendResponse($simulationResult);
+
+} catch (PDOException $e) {
+    sendError("Database error during battle simulation: " . $e->getMessage(), 500);
+} catch (Exception $e) {
+    sendError("Error during battle simulation: " . $e->getMessage(), 500);
+}
+?>

--- a/card_rpg_mvp/public/api/cards_common_by_type.php
+++ b/card_rpg_mvp/public/api/cards_common_by_type.php
@@ -1,0 +1,51 @@
+<?php
+// public/api/cards_common_by_type.php
+
+// Adjust path based on your server's directory structure
+require_once __DIR__ . '/../../includes/db.php';
+require_once __DIR__ . '/../../includes/utils.php';
+
+header('Content-Type: application/json');
+
+$database = new Database();
+$db = $database->getConnection();
+
+$cardType = $_GET['type'] ?? '';
+$classAffinity = $_GET['class'] ?? '';
+
+if (empty($cardType)) {
+    sendError("Card type is required.", 400);
+}
+
+try {
+    $query = "SELECT id, name, energy_cost, description, damage_type, armor_type, effect_details, flavor_text
+              FROM cards
+              WHERE rarity = 'Common' AND card_type = :card_type";
+
+    if (!empty($classAffinity)) {
+        // This handles affinities like 'Warrior', 'Warrior,Paladin', 'Paladin,Warrior,Ranger'
+        $query .= " AND (class_affinity = :class_affinity_exact OR class_affinity LIKE :class_affinity_start OR class_affinity LIKE :class_affinity_middle OR class_affinity LIKE :class_affinity_end OR class_affinity IS NULL)";
+    }
+
+    $stmt = $db->prepare($query);
+    $stmt->bindParam(':card_type', $cardType);
+    if (!empty($classAffinity)) {
+         $stmt->bindValue(':class_affinity_exact', $classAffinity);
+         $stmt->bindValue(':class_affinity_start', $classAffinity . ',%');
+         $stmt->bindValue(':class_affinity_middle', '%,' . $classAffinity . ',%');
+         $stmt->bindValue(':class_affinity_end', '%,' . $classAffinity);
+    }
+    $stmt->execute();
+    $cards = $stmt->fetchAll(PDO::FETCH_ASSOC);
+
+    foreach ($cards as &$card) {
+        if ($card['effect_details']) {
+            $card['effect_details'] = json_decode($card['effect_details'], true);
+        }
+    }
+    sendResponse($cards);
+
+} catch (PDOException $e) {
+    sendError("Database error fetching cards: " . $e->getMessage(), 500);
+}
+?>

--- a/card_rpg_mvp/public/api/champions.php
+++ b/card_rpg_mvp/public/api/champions.php
@@ -1,0 +1,20 @@
+<?php
+// public/api/champions.php
+
+// Adjust path based on your server's directory structure
+require_once __DIR__ . '/../../includes/db.php';
+require_once __DIR__ . '/../../includes/utils.php';
+
+header('Content-Type: application/json'); // Always ensure JSON header for API responses
+
+$database = new Database();
+$db = $database->getConnection();
+
+try {
+    $stmt = $db->query("SELECT id, name, role, starting_hp, speed FROM champions");
+    $champions = $stmt->fetchAll(PDO::FETCH_ASSOC);
+    sendResponse($champions);
+} catch (PDOException $e) {
+    sendError("Database error fetching champions: " . $e->getMessage(), 500);
+}
+?>

--- a/card_rpg_mvp/public/api/player_current_setup.php
+++ b/card_rpg_mvp/public/api/player_current_setup.php
@@ -1,0 +1,29 @@
+<?php
+// public/api/player_current_setup.php
+
+// Adjust path based on your server's directory structure
+require_once __DIR__ . '/../../includes/db.php';
+require_once __DIR__ . '/../../includes/utils.php';
+
+header('Content-Type: application/json');
+
+$database = new Database();
+$db = $database->getConnection();
+
+try {
+    $stmt = $db->query("SELECT psd.champion_id, c.name as champion_name, c.role, c.starting_hp, c.speed, psd.deck_card_ids, psd.current_hp, psd.current_energy, psd.current_speed, psd.wins, psd.losses, psd.current_xp, psd.current_level
+                                   FROM player_session_data psd
+                                   JOIN champions c ON psd.champion_id = c.id
+                                   LIMIT 1");
+    $playerData = $stmt->fetch(PDO::FETCH_ASSOC);
+
+    if ($playerData) {
+        $playerData['deck_card_ids'] = json_decode($playerData['deck_card_ids'], true);
+        sendResponse($playerData);
+    } else {
+        sendError("No player setup found. Please go through setup first.", 404);
+    }
+} catch (PDOException $e) {
+    sendError("Database error fetching current player setup: " . $e->getMessage(), 500);
+}
+?>

--- a/card_rpg_mvp/public/api/player_setup.php
+++ b/card_rpg_mvp/public/api/player_setup.php
@@ -1,0 +1,83 @@
+<?php
+// public/api/player_setup.php
+
+// Adjust path based on your server's directory structure
+require_once __DIR__ . '/../../includes/db.php';
+require_once __DIR__ . '/../../includes/utils.php';
+
+header('Content-Type: application/json');
+
+$database = new Database();
+$db = $database->getConnection();
+
+if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
+    sendError("Invalid request method. Only POST is allowed.", 405);
+}
+
+$input = json_decode(file_get_contents('php://input'), true);
+$championId = $input['champion_id'] ?? null;
+$cardIds = $input['card_ids'] ?? [];
+
+if (empty($championId) || count($cardIds) !== 3) {
+    sendError("Invalid setup data provided. Requires champion_id and 3 card_ids.", 400);
+}
+
+try {
+    // Check if champion_id exists
+    $stmt = $db->prepare("SELECT name, starting_hp, speed FROM champions WHERE id = :champion_id");
+    $stmt->bindParam(':champion_id', $championId, PDO::PARAM_INT);
+    $stmt->execute();
+    $championData = $stmt->fetch(PDO::FETCH_ASSOC);
+    if (!$championData) {
+        sendError("Champion ID not found.", 404);
+    }
+    $championName = $championData['name'];
+
+    // Check if all card_ids exist and are valid common cards usable by the champion
+    $cardIdsPlaceholder = implode(',', array_fill(0, count($cardIds), '?'));
+    $stmt = $db->prepare("SELECT id, name, card_type, class_affinity FROM cards WHERE id IN ($cardIdsPlaceholder) AND rarity = 'Common'");
+    $stmt->execute($cardIds);
+    $fetchedCards = $stmt->fetchAll(PDO::FETCH_ASSOC);
+
+    if (count($fetchedCards) !== 3) {
+        sendError("One or more card IDs are invalid or not common cards.", 400);
+    }
+
+    foreach ($fetchedCards as $card) {
+        if ($card['card_type'] === 'ability' || $card['card_type'] === 'armor' || $card['card_type'] === 'weapon') {
+            if ($card['class_affinity'] !== NULL) { // Allow NULL for generic items
+                $affinities = explode(',', $card['class_affinity']);
+                if (!in_array($championName, $affinities)) {
+                     sendError("Card '{$card['name']}' is not usable by {$championName}.", 400);
+                }
+            }
+        }
+    }
+
+    // Clear any old player session data before inserting new (for MVP simplicity)
+    $db->exec("DELETE FROM player_session_data");
+    
+    // Store player's selected champion and deck for the current tournament run
+    $stmt = $db->prepare("INSERT INTO player_session_data (champion_id, deck_card_ids, current_hp, current_energy, current_speed, current_xp, current_level, wins, losses) VALUES (:champion_id, :deck_card_ids, :current_hp, :current_energy, :current_speed, :current_xp, :current_level, :wins, :losses)");
+    $deckJson = json_encode($cardIds);
+
+    $stmt->bindParam(':champion_id', $championId);
+    $stmt->bindParam(':deck_card_ids', $deckJson);
+    $stmt->bindParam(':current_hp', $championData['starting_hp']);
+    $stmt->bindValue(':current_energy', 1); // Start with 1 energy
+    $stmt->bindParam(':current_speed', $championData['speed']);
+    $stmt->bindValue(':current_xp', 0);
+    $stmt->bindValue(':current_level', 1);
+    $stmt->bindValue(':wins', 0);
+    $stmt->bindValue(':losses', 0);
+
+    $stmt->execute();
+
+    sendResponse(["message" => "Player setup complete.", "champion_id" => $championId, "card_ids" => $cardIds]);
+
+} catch (PDOException $e) {
+    sendError("Database error during player setup: " . $e->getMessage(), 500);
+} catch (Exception $e) {
+    sendError("Error during player setup: " . $e->getMessage(), 500);
+}
+?>

--- a/card_rpg_mvp/public/api/tournament_reset.php
+++ b/card_rpg_mvp/public/api/tournament_reset.php
@@ -1,0 +1,23 @@
+<?php
+// public/api/tournament_reset.php
+
+// Adjust path based on your server's directory structure
+require_once __DIR__ . '/../../includes/db.php';
+require_once __DIR__ . '/../../includes/utils.php';
+
+header('Content-Type: application/json');
+
+$database = new Database();
+$db = $database->getConnection();
+
+if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
+    sendError("Invalid request method. Only POST is allowed.", 405);
+}
+
+try {
+    $db->exec("TRUNCATE TABLE player_session_data"); // Reset player progress
+    sendResponse(["message" => "Tournament and player progress reset."]);
+} catch (PDOException $e) {
+    sendError("Database error during tournament reset: " . $e->getMessage(), 500);
+}
+?>

--- a/card_rpg_mvp/public/api/tournament_status.php
+++ b/card_rpg_mvp/public/api/tournament_status.php
@@ -1,0 +1,43 @@
+<?php
+// public/api/tournament_status.php
+
+// Adjust path based on your server's directory structure
+require_once __DIR__ . '/../../includes/db.php';
+require_once __DIR__ . '/../../includes/utils.php';
+
+header('Content-Type: application/json');
+
+$database = new Database();
+$db = $database->getConnection();
+
+try {
+    $stmt = $db->query("SELECT psd.wins, psd.losses, psd.current_level, psd.current_xp, c.name as champion_name
+                                   FROM player_session_data psd
+                                   JOIN champions c ON psd.champion_id = c.id
+                                   LIMIT 1");
+    $playerTournamentStatus = $stmt->fetch(PDO::FETCH_ASSOC);
+
+    if ($playerTournamentStatus) {
+        $gameOver = ($playerTournamentStatus['losses'] >= 2); // GDD: 2 losses = elimination
+
+        $nextOpponentName = "N/A"; 
+        if (!$gameOver) {
+             // In a real tournament, this would be determined by bracket logic.
+             // For MVP, just randomly select a monster for the next potential fight display.
+             $randomMonsterStmt = $db->query("SELECT name FROM monsters ORDER BY RAND() LIMIT 1");
+             $nextOpponentName = $randomMonsterStmt->fetchColumn() . " (AI)";
+        }
+        
+        sendResponse([
+            "player_status" => $playerTournamentStatus,
+            "game_over" => $gameOver,
+            "next_opponent" => $nextOpponentName,
+            "message" => $gameOver ? "You have been eliminated from the tournament." : "Ready for the next round!"
+        ]);
+    } else {
+        sendError("Tournament status not found. Please setup player first.", 404);
+    }
+} catch (PDOException $e) {
+    sendError("Database error fetching tournament status: " . $e->getMessage(), 500);
+}
+?>

--- a/card_rpg_mvp/public/app.js
+++ b/card_rpg_mvp/public/app.js
@@ -114,7 +114,7 @@ document.addEventListener('DOMContentLoaded', () => {
 });
 
 async function loadGame() {
-    const response = await callApi('player/current_setup');
+    const response = await callApi('player_current_setup.php');
     if (response && response.champion_id) {
         playerData = response;
         // If player already set up, maybe jump to tournament view or next battle
@@ -136,7 +136,7 @@ let selectedCards = {
 
 async function renderCharacterSetup() {
     // 1. Fetch 4 random champions
-    const championsResponse = await callApi('champions');
+    const championsResponse = await callApi('champions.php');
     if (!championsResponse || championsResponse.length === 0) {
         appDiv.innerHTML = '<p>Error: No champions found. Please check database population.</p>';
         return;
@@ -202,7 +202,7 @@ async function selectChampion(championId, championData) {
 }
 
 async function fetchDraftCards(cardType, championName) {
-    const cardsResponse = await callApi(`cards/common_by_type?type=${cardType}&class=${championName}`);
+    const cardsResponse = await callApi(`cards_common_by_type.php?type=${cardType}&class=${championName}`);
     if (!cardsResponse || cardsResponse.length === 0) {
         document.getElementById(`${cardType}-cards`).innerHTML = `<p>No ${cardType} cards found for ${championName}.</p>`;
         return;
@@ -256,7 +256,7 @@ async function confirmSetup() {
         selectedCards.weapon.id
     ];
 
-    const response = await callApi('player/setup', 'POST', {
+    const response = await callApi('player_setup.php', 'POST', {
         champion_id: selectedChampionId,
         card_ids: cardIds
     });
@@ -310,7 +310,7 @@ async function renderBattleScene() {
 }
 
 async function startBattleSimulation() {
-    const battleResult = await callApi('battle/simulate', 'POST', {}); // Empty POST body to trigger simulation
+    const battleResult = await callApi('battle_simulate.php', 'POST', {}); // Empty POST body to trigger simulation
     if (!battleResult) {
         alert('Failed to simulate battle.');
         return;
@@ -406,7 +406,7 @@ function formatLogEntry(entry) {
 
 // --- Scene 3: Tournament View ---
 async function renderTournamentView() {
-    const statusResponse = await callApi('tournament/status');
+    const statusResponse = await callApi('tournament_status.php');
     if (!statusResponse || !statusResponse.player_status) {
         appDiv.innerHTML = '<p>Error: Could not retrieve tournament status.</p>';
         return;
@@ -446,7 +446,7 @@ async function renderTournamentView() {
 async function resetTournament() {
     const confirmReset = confirm("Are you sure you want to start a new tournament? Your current progress will be lost.");
     if (confirmReset) {
-        const response = await callApi('tournament/reset', 'POST');
+        const response = await callApi('tournament_reset.php', 'POST');
         if (response && response.message === "Tournament and player progress reset.") {
             alert('Tournament reset. Starting new game...');
             // Clear client-side player data too

--- a/card_rpg_mvp/public/index.php
+++ b/card_rpg_mvp/public/index.php
@@ -1,41 +1,14 @@
 <?php
 // public/index.php
 
-// Define basic paths for our project
-define('ROOT_PATH', dirname(__DIR__));
-define('PUBLIC_PATH', __DIR__);
-define('INCLUDES_PATH', ROOT_PATH . '/includes');
-
-// Basic error reporting for development
+// Basic error reporting for development (keep this)
 ini_set('display_errors', 1);
 ini_set('display_startup_errors', 1);
 error_reporting(E_ALL);
 
-// Set content type for JSON responses
-header('Content-Type: application/json');
+// Set content type for HTML responses for the main page
+header('Content-Type: text/html');
 
-// Simple routing based on URL path
-$requestUri = parse_url($_SERVER['REQUEST_URI'], PHP_URL_PATH);
-$pathSegments = explode('/', trim($requestUri, '/'));
-
-// Define the API base path if necessary, adjust for your GoDaddy domain/subfolder
-// For example, if your app is at example.com/mygame/, then $apiBase = 'mygame/api';
-$apiBase = 'api'; // Assuming your APIs will be under /api/
-
-if (!empty($pathSegments) && $pathSegments[0] === $apiBase) {
-    array_shift($pathSegments); // Remove 'api' segment
-    $endpoint = $pathSegments[0] ?? ''; // Get the main endpoint (e.g., 'champions', 'player', 'battle')
-    $action = $pathSegments[1] ?? ''; // Get action (e.g., 'setup', 'simulate', 'status')
-
-    // Include the API handler
-    require_once INCLUDES_PATH . '/api_handler.php';
-    handleApiRequest($endpoint, $action);
-
-} else {
-    // For non-API requests, serve the main HTML file (frontend will handle routing)
-    // For MVP, this might just be an empty HTML file that loads our JS
-    header('Content-Type: text/html');
-    echo file_get_contents(PUBLIC_PATH . '/index.html');
-}
-
+// Serve the main HTML file for the frontend application
+echo file_get_contents(__DIR__ . '/index.html');
 ?>


### PR DESCRIPTION
## Summary
- simplify `public/index.php` to just serve HTML
- add dedicated PHP API endpoint files
- update JS to use new `.php` endpoints

## Testing
- `php` was not available so syntax checks could not be run

------
https://chatgpt.com/codex/tasks/task_e_68489ce3d48c8327a26bd00cb9e665f4