### PR TITLE
Fix include paths for moved includes

### DIFF
--- a/card_rpg_mvp/public/api/battle_simulate.php
+++ b/card_rpg_mvp/public/api/battle_simulate.php
@@ -2,9 +2,9 @@
 // public/api/battle_simulate.php
 
 // Adjust path based on your server's directory structure
-require_once __DIR__ . '/../../includes/db.php';
-require_once __DIR__ . '/../../includes/utils.php';
-require_once __DIR__ . '/../../includes/BattleSimulator.php'; // Requires all its dependencies too
+require_once __DIR__ . '/../includes/db.php';
+require_once __DIR__ . '/../includes/utils.php';
+require_once __DIR__ . '/../includes/BattleSimulator.php'; // Requires all its dependencies too
 
 header('Content-Type: application/json');
 

--- a/card_rpg_mvp/public/api/cards_common_by_type.php
+++ b/card_rpg_mvp/public/api/cards_common_by_type.php
@@ -2,8 +2,8 @@
 // public/api/cards_common_by_type.php
 
 // Adjust path based on your server's directory structure
-require_once __DIR__ . '/../../includes/db.php';
-require_once __DIR__ . '/../../includes/utils.php';
+require_once __DIR__ . '/../includes/db.php';
+require_once __DIR__ . '/../includes/utils.php';
 
 header('Content-Type: application/json');
 

--- a/card_rpg_mvp/public/api/champions.php
+++ b/card_rpg_mvp/public/api/champions.php
@@ -2,8 +2,8 @@
 // public/api/champions.php
 
 // Adjust path based on your server's directory structure
-require_once __DIR__ . '/../../includes/db.php';
-require_once __DIR__ . '/../../includes/utils.php';
+require_once __DIR__ . '/../includes/db.php';
+require_once __DIR__ . '/../includes/utils.php';
 
 header('Content-Type: application/json'); // Always ensure JSON header for API responses
 

--- a/card_rpg_mvp/public/api/player_current_setup.php
+++ b/card_rpg_mvp/public/api/player_current_setup.php
@@ -2,8 +2,8 @@
 // public/api/player_current_setup.php
 
 // Adjust path based on your server's directory structure
-require_once __DIR__ . '/../../includes/db.php';
-require_once __DIR__ . '/../../includes/utils.php';
+require_once __DIR__ . '/../includes/db.php';
+require_once __DIR__ . '/../includes/utils.php';
 
 header('Content-Type: application/json');
 

--- a/card_rpg_mvp/public/api/player_setup.php
+++ b/card_rpg_mvp/public/api/player_setup.php
@@ -2,8 +2,8 @@
 // public/api/player_setup.php
 
 // Adjust path based on your server's directory structure
-require_once __DIR__ . '/../../includes/db.php';
-require_once __DIR__ . '/../../includes/utils.php';
+require_once __DIR__ . '/../includes/db.php';
+require_once __DIR__ . '/../includes/utils.php';
 
 header('Content-Type: application/json');
 

--- a/card_rpg_mvp/public/api/tournament_reset.php
+++ b/card_rpg_mvp/public/api/tournament_reset.php
@@ -2,8 +2,8 @@
 // public/api/tournament_reset.php
 
 // Adjust path based on your server's directory structure
-require_once __DIR__ . '/../../includes/db.php';
-require_once __DIR__ . '/../../includes/utils.php';
+require_once __DIR__ . '/../includes/db.php';
+require_once __DIR__ . '/../includes/utils.php';
 
 header('Content-Type: application/json');
 

--- a/card_rpg_mvp/public/api/tournament_status.php
+++ b/card_rpg_mvp/public/api/tournament_status.php
@@ -2,8 +2,8 @@
 // public/api/tournament_status.php
 
 // Adjust path based on your server's directory structure
-require_once __DIR__ . '/../../../includes/db.php';
-require_once __DIR__ . '/../../../includes/utils.php';
+require_once __DIR__ . '/../includes/db.php';
+require_once __DIR__ . '/../includes/utils.php';
 
 header('Content-Type: application/json');
 

--- a/card_rpg_mvp/public/includes/AIPlayer.php
+++ b/card_rpg_mvp/public/includes/AIPlayer.php
@@ -1,9 +1,9 @@
 <?php
 // includes/AIPlayer.php
 
-require_once INCLUDES_PATH . '/Card.php';
-require_once INCLUDES_PATH . '/GameEntity.php';
-require_once INCLUDES_PATH . '/db.php'; // To fetch persona data
+require_once __DIR__ . '/Card.php';
+require_once __DIR__ . '/GameEntity.php';
+require_once __DIR__ . '/db.php'; // To fetch persona data
 
 class AIPlayer {
     private $persona; // AI Persona object (from db)

--- a/card_rpg_mvp/public/includes/BattleSimulator.php
+++ b/card_rpg_mvp/public/includes/BattleSimulator.php
@@ -1,15 +1,15 @@
 <?php
 // includes/BattleSimulator.php
 
-require_once INCLUDES_PATH . '/db.php';
-require_once INCLUDES_PATH . '/GameEntity.php';
-require_once INCLUDES_PATH . '/Champion.php';
-require_once INCLUDES_PATH . '/Monster.php';
-require_once INCLUDES_PATH . '/Card.php';
-require_once INCLUDES_PATH . '/StatusEffect.php';
-require_once INCLUDES_PATH . '/BuffManager.php';
-require_once INCLUDES_PATH . '/AIPlayer.php';
-require_once INCLUDES_PATH . '/utils.php'; // For logging functions
+require_once __DIR__ . '/db.php';
+require_once __DIR__ . '/GameEntity.php';
+require_once __DIR__ . '/Champion.php';
+require_once __DIR__ . '/Monster.php';
+require_once __DIR__ . '/Card.php';
+require_once __DIR__ . '/StatusEffect.php';
+require_once __DIR__ . '/BuffManager.php';
+require_once __DIR__ . '/AIPlayer.php';
+require_once __DIR__ . '/utils.php'; // For logging functions
 
 class BattleSimulator {
     private $db_conn;

--- a/card_rpg_mvp/public/includes/Champion.php
+++ b/card_rpg_mvp/public/includes/Champion.php
@@ -1,7 +1,7 @@
 <?php
 // includes/Champion.php
 
-require_once INCLUDES_PATH . '/GameEntity.php';
+require_once __DIR__ . '/GameEntity.php';
 
 class Champion extends GameEntity {
     public $champion_id; // FK to champions table

--- a/card_rpg_mvp/public/includes/Monster.php
+++ b/card_rpg_mvp/public/includes/Monster.php
@@ -1,7 +1,7 @@
 <?php
 // includes/Monster.php
 
-require_once INCLUDES_PATH . '/GameEntity.php';
+require_once __DIR__ . '/GameEntity.php';
 
 class Monster extends GameEntity {
     public $monster_id; // FK to monsters table

--- a/card_rpg_mvp/public/includes/api_handler.php
+++ b/card_rpg_mvp/public/includes/api_handler.php
@@ -1,9 +1,9 @@
 <?php
 // includes/api_handler.php
 
-require_once INCLUDES_PATH . '/db.php';
-require_once INCLUDES_PATH . '/utils.php';
-require_once INCLUDES_PATH . '/BattleSimulator.php'; // New include
+require_once __DIR__ . '/db.php';
+require_once __DIR__ . '/utils.php';
+require_once __DIR__ . '/BattleSimulator.php'; // New include
 
 function handleApiRequest($endpoint, $action) {
     $database = new Database();


### PR DESCRIPTION
## Summary
- fix `require_once` paths in PHP API files under `public/api`
- update include file references in `public/includes` to use `__DIR__`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6848a5f066b083278e40e79cf83fa0cd