### PR TITLE
Fix battle simulate deck id handling

### DIFF
--- a/card_rpg_mvp/public/api/battle_simulate.php
+++ b/card_rpg_mvp/public/api/battle_simulate.php
@@ -22,6 +22,16 @@ try {
                                    JOIN champions c ON psd.champion_id = c.id
                                    LIMIT 1");
     $playerSessionData = $stmt->fetch(PDO::FETCH_ASSOC);
+
+    if ($playerSessionData && !empty($playerSessionData['deck_card_ids'])) {
+        $decoded = json_decode($playerSessionData['deck_card_ids'], true);
+        if (json_last_error() === JSON_ERROR_NONE) {
+            $playerSessionData['deck_card_ids'] = $decoded;
+        } else {
+            // If decoding fails, treat as empty to avoid SQL errors later
+            $playerSessionData['deck_card_ids'] = [];
+        }
+    }
     
     if (!$playerSessionData) {
         sendError("Player not set up for battle. Please complete character setup first.", 400);


### PR DESCRIPTION
## Summary
- decode `deck_card_ids` before using them in `battle_simulate.php`

## Testing
- `git diff --cached --stat`


------
https://chatgpt.com/codex/tasks/task_e_6848a77533f08327b898876e54ed918c