### PR TITLE
Add attack stats to GameEntity and update constructors

### DIFF
--- a/card_rpg_mvp/public/includes/Champion.php
+++ b/card_rpg_mvp/public/includes/Champion.php
@@ -14,7 +14,8 @@ class Champion extends GameEntity {
             $data['champion_name'],
             $data['starting_hp'],
             $data['speed'],
-            $data['role'] // Assuming role is passed from champions table
+            $data['role'],
+            $data['base_attack'] ?? 1
         );
         $this->champion_id = $data['champion_id'];
         $this->level = $data['current_level'] ?? 1;

--- a/card_rpg_mvp/public/includes/GameEntity.php
+++ b/card_rpg_mvp/public/includes/GameEntity.php
@@ -12,6 +12,8 @@ class GameEntity {
     public $current_energy;
     public $current_evasion; // temporary evasion from buffs/debuffs
     public $current_defense_reduction; // temporary defense reduction from buffs/debuffs
+    public $base_attack; // baseline attack value
+    public $current_attack; // attack after buffs/debuffs
     public $buffs = []; // Array of active StatusEffect objects
     public $debuffs = []; // Array of active StatusEffect objects
     public $deck = []; // Array of Card objects (the full deck)
@@ -20,7 +22,7 @@ class GameEntity {
     public $team; // Reference to the team this entity belongs to (PlayerTeam or AITeam)
     public $role; // Tank, DPS, Support etc.
 
-    public function __construct($id, $name, $hp, $speed, $role = 'unknown') {
+    public function __construct($id, $name, $hp, $speed, $role = 'unknown', $base_attack = 1) {
         $this->id = $id;
         $this->name = $name;
         $this->max_hp = $hp;
@@ -31,6 +33,8 @@ class GameEntity {
         $this->current_evasion = 0;
         $this->current_defense_reduction = 0;
         $this->role = $role;
+        $this->base_attack = $base_attack;
+        $this->current_attack = $base_attack;
     }
 
     public function takeDamage($amount, $damage_type = NULL) {
@@ -111,7 +115,7 @@ class GameEntity {
 
     // Placeholder for getting actual damage dealt by entity (needs card logic)
     public function getAttackPower() {
-        return 1; // Very basic placeholder
+        return $this->current_attack;
     }
 }
 ?>

--- a/card_rpg_mvp/public/includes/Monster.php
+++ b/card_rpg_mvp/public/includes/Monster.php
@@ -13,7 +13,8 @@ class Monster extends GameEntity {
             $data['name'],
             $data['starting_hp'],
             $data['speed'],
-            $data['role'] ?? 'unknown' // Role might not be in base monsters table
+            $data['role'] ?? 'unknown',
+            $data['base_attack'] ?? 1
         );
         $this->monster_id = $data['id'];
         // Monsters might have special properties like taking 2 team slots (from GDD)


### PR DESCRIPTION
## Summary
- add `base_attack` and `current_attack` properties to `GameEntity`
- initialise attack stats via constructor and expose via `getAttackPower`
- update `Champion` and `Monster` constructors to pass `base_attack`

## Testing
- `curl -s -X POST http://game.strahde.com/public/api/battle_simulate.php | head -n 5` *(fails: Warning: Undefined array key "class_affinity")*
- `php -l card_rpg_mvp/public/includes/GameEntity.php` *(fails: php command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6848b23ace688327990d980fb9eae3c0