### PR TITLE
Add README and technical documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,47 @@
+# Auto-Battler Card RPG
+
+This repository contains a simple browser-based card RPG prototype with accompanying design documents. It can serve as a starting point for building an auto-battler or turn-based combat system.
+
+## Repository Structure
+
+- **card_rpg_mvp/** – Minimal playable prototype containing HTML, CSS, JavaScript and PHP for a basic card RPG.
+- **docs/** – Game design documents describing classes, cards, items, mechanics and other systems.
+
+## Running the Prototype
+
+The MVP is a static web application with a lightweight PHP API for saving/loading data. To run it locally:
+
+1. Install PHP (7.4+ recommended).
+2. From the repository root, start the built-in PHP server:
+   ```bash
+   php -S localhost:8000 -t card_rpg_mvp/public
+   ```
+3. Open `http://localhost:8000` in your browser.
+
+## Development Notes
+
+- The main client logic lives in `card_rpg_mvp/public/app.js`.
+- Basic styles are in `card_rpg_mvp/public/style.css`.
+- API endpoints are under `card_rpg_mvp/public/api` and are written in PHP.
+
+## Design Documents
+
+The `docs/` folder contains markdown files with additional design details:
+
+- `gdd.md` – overall game design document
+- `class_card_gdd.md`, `armor_gdd.md`, `weapons_gdd.md` – details on cards and equipment
+- `mechanics_gdd.md`, `game_modes_gdd.md` – status effects, PvP and other systems
+
+These documents are intended to guide future feature development.
+
+## Contribution Guidelines
+
+1. Fork the repository and create a new branch for your feature or bugfix.
+2. Follow the existing coding style in JavaScript and PHP files.
+3. Update or add tests if applicable.
+4. Open a pull request with a clear description of your changes.
+
+## License
+
+This project is licensed under the MIT License. See [LICENSE](LICENSE) for details.
+

--- a/docs/technical_overview.md
+++ b/docs/technical_overview.md
@@ -1,0 +1,49 @@
+# Technical Overview
+
+This document explains the structure of the MVP code in `card_rpg_mvp/public` and how the pieces fit together. It is intended for developers who want to extend the prototype or integrate AI generated features.
+
+## Folder Layout
+
+```
+card_rpg_mvp/public/
+├── api/            # PHP endpoints for saving/loading data
+├── app.js          # Main client-side logic
+├── index.html      # Entry point for the browser game
+├── style.css       # Basic styling
+└── includes/       # Shared PHP includes
+```
+
+### API Endpoints
+
+The `api/` directory contains simple PHP scripts used for data persistence:
+
+- `save.php` – saves a JSON payload to `data.json` on the server
+- `load.php` – returns the contents of `data.json`
+
+These scripts are intentionally minimal and can be replaced with a real backend.
+
+### Client Logic
+
+`app.js` manages the user interface and communicates with the PHP API via `fetch`. Key features include:
+
+- Dynamic creation of character and card elements
+- Simple turn-based battle loop
+- Logging of battle events for replay
+
+The code is organized by scene (setup, battle, tournament). Each scene has helper functions for rendering and user interactions.
+
+## Suggested Improvements
+
+- Replace the PHP API with a more robust backend (Node.js, Python, etc.) and a real database if persistent storage is required.
+- Split `app.js` into modules or components to improve maintainability.
+- Add tests for combat logic and API functions.
+- Consider using a JavaScript framework (React/Vue) for complex UI flows.
+
+## Related Design Docs
+
+For gameplay and balancing details, consult the other documents in this folder:
+
+- [gdd.md](gdd.md)
+- [mechanics_gdd.md](mechanics_gdd.md)
+- [game_modes_gdd.md](game_modes_gdd.md)
+


### PR DESCRIPTION
## Summary
- add high level README with project overview and running instructions
- document folder layout and code internals in `docs/technical_overview.md`

## Testing
- `php -l` on all PHP files

------
https://chatgpt.com/codex/tasks/task_e_6848b405302c83279665a30d5bd4c703