### PR TITLE
Implement sequential 2v2 setup UI

### DIFF
--- a/card_rpg_mvp/public/style.css
+++ b/card_rpg_mvp/public/style.css
@@ -165,12 +165,25 @@ h2, h3, h4 {
     display: flex;
     justify-content: space-around;
     align-items: flex-start;
-    gap: 20px;
+    gap: 10px;
     margin-top: 30px;
-    padding: 20px;
+    padding: 10px;
     background-color: #1f1f1f;
     border-radius: 8px;
     min-height: 250px;
+}
+
+.team-container {
+    display: flex;
+    flex-direction: row;
+    gap: 10px;
+    flex: 1;
+    justify-content: center;
+    align-items: flex-start;
+    padding: 10px;
+    border: 1px solid #333;
+    border-radius: 8px;
+    background-color: #222;
 }
 
 .combatant {
@@ -180,7 +193,9 @@ h2, h3, h4 {
     background-color: #2a2a2a;
     border-radius: 8px;
     box-shadow: inset 0 0 5px rgba(0,0,0,0.5);
-    position: relative; /* For HP bar absolute positioning */
+    position: relative;
+    min-width: 150px;
+    max-width: 200px;
 }
 
 .vs-text {


### PR DESCRIPTION
## Summary
- support sequential champion selection and deck drafting for two champions
- update battle view to show two combatants per side
- show team names in tournament view
- update tournament status API for two champions
- tweak styles for new layout

## Testing
- `node --check card_rpg_mvp/public/app.js`
- `php -l card_rpg_mvp/public/api/tournament_status.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6848c6d8e5088327b118db9fe8ff9a62