### PR TITLE
Implement defensive mechanics and AI targeting

### DIFF
--- a/card_rpg_mvp/public/includes/BattleSimulator.php
+++ b/card_rpg_mvp/public/includes/BattleSimulator.php
@@ -302,28 +302,28 @@ class BattleSimulator {
                     $this->logAction($this->battleLog[count($this->battleLog)-1]['turn'], $caster->display_name, "Applies Debuff", ["target"=>$actualTarget->display_name, "stat"=>$effectDetails['debuff_stat'], "amount"=>$effectDetails['debuff_amount'], "duration"=>$effectDetails['debuff_duration']]);
                     break;
 
-                case 'damage_reduction':
+                case 'damage_reduction': // For armor cards like Leather Padding, Studded Vest, Iron Plate
                     $reductionEffect = new StatusEffect('Defense Boost', $effectDetails['amount'], $effectDetails['duration'], false, 'defense_reduction');
                     $actualTarget->addStatusEffect($reductionEffect);
-                    $this->logAction($this->battleLog[count($this->battleLog)-1]['turn'], $caster->display_name, "Gains Defense", ["target"=>$actualTarget->display_name, "amount"=>$effectDetails['amount'], "duration"=>$effectDetails['duration']]);
+                    $this->logAction($this->battleLog[count($this->battleLog)-1]['turn'], $caster->display_name, "Gains Defense", ["target" => $actualTarget->display_name, "amount" => $effectDetails['amount'], "duration" => $effectDetails['duration']]);
                     break;
 
-                case 'magic_damage_reduction':
+                case 'magic_damage_reduction': // For Mystic Robes, Runed Cloak
                     $reductionEffect = new StatusEffect('Magic Defense Boost', $effectDetails['amount'], $effectDetails['duration'], false, 'magic_defense_reduction');
                     $actualTarget->addStatusEffect($reductionEffect);
-                    $this->logAction($this->battleLog[count($this->battleLog)-1]['turn'], $caster->display_name, "Gains Magic Defense", ["target"=>$actualTarget->display_name, "amount"=>$effectDetails['amount'], "duration"=>$effectDetails['duration']]);
+                    $this->logAction($this->battleLog[count($this->battleLog)-1]['turn'], $caster->display_name, "Gains Magic Defense", ["target" => $actualTarget->display_name, "amount" => $effectDetails['amount'], "duration" => $effectDetails['duration']]);
                     break;
 
-                case 'block':
-                    $blockEffect = new StatusEffect('Block', $effectDetails['amount'] ?? 999, 1, false, 'block_incoming');
+                case 'block': // For Righteous Shield, Parry
+                    $blockEffect = new StatusEffect('Block', $effectDetails['amount'], 1, false, 'block_incoming');
                     $actualTarget->addStatusEffect($blockEffect);
-                    $this->logAction($this->battleLog[count($this->battleLog)-1]['turn'], $caster->display_name, "Applies Block", ["target"=>$actualTarget->display_name, "amount"=>$effectDetails['amount'] ?? 999]);
+                    $this->logAction($this->battleLog[count($this->battleLog)-1]['turn'], $caster->display_name, "Applies Block", ["target" => $actualTarget->display_name, "amount" => $effectDetails['amount']]);
                     break;
 
-                case 'block_magic':
-                    $blockEffect = new StatusEffect('Block Magic', $effectDetails['amount'] ?? 999, 1, false, 'block_magic_incoming');
+                case 'block_magic': // For Arcane Ward, Magic Barrier
+                    $blockEffect = new StatusEffect('Block Magic', $effectDetails['amount'], 1, false, 'block_magic_incoming');
                     $actualTarget->addStatusEffect($blockEffect);
-                    $this->logAction($this->battleLog[count($this->battleLog)-1]['turn'], $caster->display_name, "Applies Magic Block", ["target"=>$actualTarget->display_name, "amount"=>$effectDetails['amount'] ?? 999]);
+                    $this->logAction($this->battleLog[count($this->battleLog)-1]['turn'], $caster->display_name, "Applies Magic Block", ["target" => $actualTarget->display_name, "amount" => $effectDetails['amount']]);
                     break;
 
                 case 'stun':

--- a/card_rpg_mvp/public/includes/BuffManager.php
+++ b/card_rpg_mvp/public/includes/BuffManager.php
@@ -45,9 +45,9 @@ class BuffManager {
         $entity->current_speed = $entity->base_speed;
         $entity->current_evasion = 0;
         $entity->current_defense_reduction = 0;
-        $entity->current_magic_defense_reduction = 0;
-        $entity->current_block_charges = 0;
-        $entity->current_magic_block_charges = 0;
+        $entity->current_magic_defense_reduction = 0; // NEW: reset magic defense
+        $entity->current_block_charges = 0; // NEW: reset block charges
+        $entity->current_magic_block_charges = 0; // NEW: reset magic block charges
         // Add current_attack to GameEntity, initialize to base_attack
         $entity->current_attack = $entity->base_attack ?? 1; // Assuming base attack of 1 if not set
 


### PR DESCRIPTION
## Summary
- refine AI targeting for self-buffs
- handle new defensive statuses in BattleSimulator
- factor in new block and defense stats in GameEntity
- reset new stat fields in BuffManager

## Testing
- `php -l card_rpg_mvp/public/includes/AIPlayer.php`
- `php -l card_rpg_mvp/public/includes/BattleSimulator.php`
- `php -l card_rpg_mvp/public/includes/GameEntity.php`
- `php -l card_rpg_mvp/public/includes/BuffManager.php`


------
https://chatgpt.com/codex/tasks/task_e_6848d58b08148327b3873c67da13ed91