### PR TITLE
Increase battle log playback speed

### DIFF
--- a/card_rpg_mvp/public/app.js
+++ b/card_rpg_mvp/public/app.js
@@ -408,7 +408,7 @@ async function renderBattleScene() {
             continueButton.onclick = renderTournamentView;
             appDiv.querySelector('.button-container').appendChild(continueButton);
         }
-    }, 250);
+    }, 125);
 }
 
 function updateCombatantUI(elementIdPrefix, currentHp, maxHp) {


### PR DESCRIPTION
## Summary
- speed up the battle log playback

## Testing
- `node --check card_rpg_mvp/public/app.js`


------
https://chatgpt.com/codex/tasks/task_e_6848d59a77e08327825ad9c4822335de