### PR TITLE
Implement aggressive AI and expanded card effects

### DIFF
--- a/card_rpg_mvp/public/includes/AIPlayer.php
+++ b/card_rpg_mvp/public/includes/AIPlayer.php
@@ -4,10 +4,10 @@
 require_once __DIR__ . '/Card.php';
 require_once __DIR__ . '/GameEntity.php';
 require_once __DIR__ . '/db.php';
-require_once __DIR__ . '/Team.php'; // Ensure Team.php is included
+require_once __DIR__ . '/Team.php';
 
 class AIPlayer {
-    private $persona; // AI Persona object (from db)
+    private $persona;
     private $db_conn;
 
     public function __construct($personaId) {
@@ -24,133 +24,127 @@ class AIPlayer {
         if ($personaData) {
             $this->persona = json_decode($personaData['priorities'], true);
         } else {
-            // Default to Aggressive if persona not found
-            $this->persona = json_decode('{"card_priority": ["damage", "direct_damage", "aoe_damage"], "target_priority": "lowest_hp", "buff_use_threshold": 0.2, "item_use_priority": ["offense"] }', true);
+            // fallback aggressive persona
+            $this->persona = json_decode('{"card_priority":["damage","heal","defense","utility"],"target_priority":"lowest_hp_enemy","damage_card_score_multiplier":1,"aoe_damage_bonus_score":5,"lethal_damage_bonus_score":10,"heal_use_threshold":0.5,"defense_use_threshold":0.5}', true);
             error_log("AI Persona ID {$personaId} not found. Defaulting to Aggressive.");
         }
     }
 
-    /**
-     * Decides which card an AI entity should play and on whom.
-     * @param GameEntity $aiEntity The AI-controlled entity.
-     * @param Team $actingTeam The team the entity belongs to.
-     * @param Team $opposingTeam The enemy team.
-     * @param Card[] $availableCards The cards currently in the AI entity's hand/deck.
-     * @return array|null Returns ['card' => Card object, 'target' => GameEntity object] or null if no action.
-     */
     public function decideAction(GameEntity $activeEntity, Team $actingTeam, Team $opposingTeam, array $availableCards) {
-        $bestAction = null;
-        $bestScore = -1;
-
-        $targetPriorityType = $this->persona["target_priority"];
-        $cardPriorities = $this->persona["card_priority"];
-
-        $affordableCards = array_filter($availableCards, function($card) use ($activeEntity) {
-            return $activeEntity->current_energy >= $card->energy_cost;
+        $affordableCards = array_filter($availableCards, function($c) use ($activeEntity) {
+            return $activeEntity->current_energy >= $c->energy_cost;
         });
-
         if (empty($affordableCards)) {
             return null;
         }
 
-        foreach ($cardPriorities as $currentPriorityType) {
-            usort($affordableCards, function($a, $b) use ($currentPriorityType) {
-                return $this->scoreCard($b, $currentPriorityType) <=> $this->scoreCard($a, $currentPriorityType);
+        $priorities = $this->persona['card_priority'] ?? ['damage','heal','defense','utility'];
+        $targetPref = $this->persona['target_priority'] ?? 'lowest_hp_enemy';
+
+        foreach ($priorities as $priorityType) {
+            usort($affordableCards, function($a, $b) use ($priorityType, $activeEntity, $opposingTeam) {
+                $sa = $this->scoreCard($a, $priorityType, $activeEntity, $opposingTeam);
+                $sb = $this->scoreCard($b, $priorityType, $activeEntity, $opposingTeam);
+                return $sb <=> $sa;
             });
 
             foreach ($affordableCards as $card) {
-                $potentialTargets = $this->getPotentialTargets($activeEntity, $card, $actingTeam, $opposingTeam);
-                $potentialTargets = array_filter($potentialTargets, fn($t) => $t instanceof GameEntity && $t->current_hp > 0);
-                if (empty($potentialTargets)) {
+                $targets = $this->getPotentialTargets($activeEntity, $card, $actingTeam, $opposingTeam);
+                $targets = array_filter($targets, fn($t) => $t instanceof GameEntity && $t->current_hp > 0);
+                if (empty($targets)) {
                     continue;
                 }
-                $chosenTargetEntity = $this->selectBestTarget($activeEntity, $potentialTargets, $targetPriorityType);
-                if ($chosenTargetEntity) {
-                    return ["card" => $card, "target_entity" => $chosenTargetEntity];
+                $chosen = $this->selectBestTarget($activeEntity, $targets, $targetPref);
+                if ($chosen) {
+                    return ['card' => $card, 'target_entity' => $chosen];
                 }
             }
         }
         return null;
     }
 
-    private function scoreCard(Card $card, string $priorityType): float {
+    private function scoreCard(Card $card, string $priorityType, GameEntity $caster, Team $opposingTeam): float {
+        $type = $card->effect_details['type'] ?? '';
         $score = 0;
-        $effectType = $card->effect_details["type"] ?? "";
-        $damageMultiplier = $this->persona["damage_card_score_multiplier"] ?? 1;
-        $aoeBonus = $this->persona["aoe_damage_bonus_score"] ?? 0;
-        $lethalBonus = $this->persona["lethal_damage_bonus_score"] ?? 0;
-        $healThreshold = $this->persona["heal_use_threshold"] ?? 0.5;
-        $defenseThreshold = $this->persona["defense_use_threshold"] ?? 0.5;
 
         switch ($priorityType) {
-            case "damage":
-                if (strpos($effectType, "damage") !== false) {
-                    $baseDamage = $card->effect_details["damage"] ?? 0;
-                    $score += $baseDamage * $damageMultiplier;
-                    if (strpos($effectType, "aoe") !== false) $score += $aoeBonus;
+            case 'damage':
+                if (strpos($type, 'damage') !== false) {
+                    $dmg = $card->effect_details['damage'] ?? 0;
+                    $score += $dmg * ($this->persona['damage_card_score_multiplier'] ?? 1);
+                    if (strpos($type, 'aoe') !== false) {
+                        $score += $this->persona['aoe_damage_bonus_score'] ?? 0;
+                    }
+                    $lowest = $opposingTeam->getLowestHpActiveEntity();
+                    if ($lowest && $dmg >= $lowest->current_hp) {
+                        $score += $this->persona['lethal_damage_bonus_score'] ?? 0;
+                    }
                 }
                 break;
-            case "heal":
-                if (strpos($effectType, "heal") !== false) {
-                    $baseHeal = $card->effect_details["amount"] ?? 0;
-                    $score += $baseHeal * 5;
+
+            case 'heal':
+                if (strpos($type, 'heal') !== false) {
+                    $amount = $card->effect_details['amount'] ?? ($card->effect_details['heal'] ?? 0);
+                    $ratio = $caster->current_hp / $caster->max_hp;
+                    if ($ratio < ($this->persona['heal_use_threshold'] ?? 0.5)) {
+                        $score += $amount * 5;
+                    }
                 }
                 break;
-            case "defense":
-                if (strpos($effectType, "reduction") !== false || strpos($effectType, "block") !== false || strpos($effectType, "immunity") !== false) {
+
+            case 'defense':
+                if (strpos($type, 'reduction') !== false || strpos($type, 'block') !== false || strpos($type, 'immunity') !== false) {
                     $score += 10;
                 }
                 break;
-            case "utility":
-                $score += 2;
+
+            case 'utility':
+                $score += 1;
                 break;
         }
         return $score;
     }
 
-    private function selectBestTarget(GameEntity $activeEntity, array $potentialTargets, string $targetPriorityType): ?GameEntity {
-        if (empty($potentialTargets)) {
-            return null;
-        }
-        if ($targetPriorityType === "lowest_hp_enemy") {
-            $enemies = array_filter($potentialTargets, fn($t) => $t->team !== $activeEntity->team);
-            if (!empty($enemies)) {
+    private function selectBestTarget(GameEntity $activeEntity, array $targets, string $priorityType): ?GameEntity {
+        if (empty($targets)) return null;
+        if ($priorityType === 'lowest_hp_enemy') {
+            $enemies = array_filter($targets, fn($t) => $t->team !== $activeEntity->team);
+            if ($enemies) {
                 usort($enemies, fn($a, $b) => $a->current_hp <=> $b->current_hp);
                 return $enemies[0];
             }
-        } elseif ($targetPriorityType === "lowest_hp_ally") {
-            $allies = array_filter($potentialTargets, fn($t) => $t->team === $activeEntity->team);
-            if (!empty($allies)) {
+        } elseif ($priorityType === 'lowest_hp_ally') {
+            $allies = array_filter($targets, fn($t) => $t->team === $activeEntity->team);
+            if ($allies) {
                 usort($allies, fn($a, $b) => $a->current_hp <=> $b->current_hp);
                 return $allies[0];
             }
         }
-        return $potentialTargets[array_rand($potentialTargets)];
+        return $targets[array_rand($targets)];
     }
 
     private function getPotentialTargets(GameEntity $caster, Card $card, Team $actingTeam, Team $opposingTeam): array {
         $effectDetails = $card->effect_details;
-        $targets = [];
-        $cardTargetType = $effectDetails["target"] ?? null;
-        switch ($cardTargetType) {
-            case "self": $targets = [$caster]; break;
-            case "single_ally": $targets = $actingTeam->getActiveEntities(); break;
-            case "all_allies": $targets = $actingTeam->getActiveEntities(); break;
-            case "single_enemy": $targets = $opposingTeam->getActiveEntities(); break;
-            case "random_enemy": $targets = $opposingTeam->getActiveEntities(); break;
-            case "all_enemies": $targets = $opposingTeam->getActiveEntities(); break;
+        $tType = $effectDetails['target'] ?? null;
+        switch ($tType) {
+            case 'self':
+                return [$caster];
+            case 'single_ally':
+            case 'all_allies':
+                return $actingTeam->getActiveEntities();
+            case 'single_enemy':
+            case 'random_enemy':
+            case 'all_enemies':
+                return $opposingTeam->getActiveEntities();
             default:
-                if ($card->card_type === "armor" || (strpos($effectDetails["type"] ?? "", "buff") !== false && !strpos($effectDetails["type"] ?? "", "damage") !== false)) {
-                    $targets = [$caster];
-                } elseif ($card->card_type === "weapon" || strpos($effectDetails["type"] ?? "", "damage") !== false) {
-                    $targets = $opposingTeam->getActiveEntities();
-                } else {
-                    $targets = [$caster];
+                if ($card->card_type === 'armor' || (strpos($effectDetails['type'] ?? '', 'buff') !== false && strpos($effectDetails['type'] ?? '', 'damage') === false)) {
+                    return [$caster];
                 }
-                break;
+                if ($card->card_type === 'weapon' || strpos($effectDetails['type'] ?? '', 'damage') !== false) {
+                    return $opposingTeam->getActiveEntities();
+                }
+                return [$caster];
         }
-        return $targets;
     }
-
 }
 ?>

--- a/card_rpg_mvp/public/includes/BattleSimulator.php
+++ b/card_rpg_mvp/public/includes/BattleSimulator.php
@@ -173,21 +173,28 @@ class BattleSimulator {
         if (!$effectDetails) return;
 
         $targets = [];
-
         if ($explicitTarget) {
             $targets = [$explicitTarget];
         } elseif (isset($effectDetails['target'])) {
             switch ($effectDetails['target']) {
-                case 'self': $targets = [$caster]; break;
-                case 'single_ally': $targets = $actingTeam->getActiveEntities(); break;
-                case 'all_allies': $targets = $actingTeam->getActiveEntities(); break;
-                case 'single_enemy': $targets = $opposingTeam->getActiveEntities(); break;
-                case 'random_enemy': $targets = $opposingTeam->getActiveEntities(); break;
-                case 'all_enemies': $targets = $opposingTeam->getActiveEntities(); break;
-                default: $targets = [$caster]; break;
+                case 'self':
+                    $targets = [$caster];
+                    break;
+                case 'single_ally':
+                case 'all_allies':
+                    $targets = $actingTeam->getActiveEntities();
+                    break;
+                case 'single_enemy':
+                case 'random_enemy':
+                case 'all_enemies':
+                    $targets = $opposingTeam->getActiveEntities();
+                    break;
+                default:
+                    $targets = [$caster];
+                    break;
             }
         } else {
-            if ($card->card_type === 'armor' || (strpos($effectDetails['type'] ?? '', 'buff') !== false && !strpos($effectDetails['type'] ?? '', 'damage') !== false)) {
+            if ($card->card_type === 'armor' || (strpos($effectDetails['type'] ?? '', 'buff') !== false && strpos($effectDetails['type'] ?? '', 'damage') === false)) {
                 $targets = [$caster];
             } elseif ($card->card_type === 'weapon' || strpos($effectDetails['type'] ?? '', 'damage') !== false) {
                 $targets = $opposingTeam->getActiveEntities();
@@ -197,67 +204,66 @@ class BattleSimulator {
         }
 
         $targets = array_filter($targets, fn($t) => $t instanceof GameEntity && $t->current_hp > 0);
-
         if (empty($targets)) {
-             $this->logAction($this->battleLog[count($this->battleLog)-1]['turn'], $caster->display_name, "Action Failed", ["card_name" => $card->name, "reason" => "No active or valid targets for card effect."]);
-             return;
+            $this->logAction($this->battleLog[count($this->battleLog)-1]['turn'], $caster->display_name, 'Action Failed', ['card_name' => $card->name, 'reason' => 'No active or valid targets for card effect.']);
+            return;
         }
 
         foreach ($targets as $actualTarget) {
-            $this->logAction($this->battleLog[count($this->battleLog)-1]['turn'], $caster->display_name, "Applying Effect", ["card_name" => $card->name, "effect_type" => $effectDetails['type'], "target" => $actualTarget->display_name]);
+            $this->logAction($this->battleLog[count($this->battleLog)-1]['turn'], $caster->display_name, 'Applying Effect', ['card_name' => $card->name, 'effect_type' => $effectDetails['type'], 'target' => $actualTarget->display_name]);
 
             switch ($effectDetails['type']) {
                 case 'damage':
                 case 'aoe_damage':
                 case 'damage_heal':
                     $damageDealt = calculateDamage($effectDetails['damage'], $card->damage_type, $actualTarget->armor_type ?? NULL);
-                    $actualTarget->takeDamage($damageDealt);
-                    $this->logAction($this->battleLog[count($this->battleLog)-1]['turn'], $caster->display_name, "Deals Damage", ["target"=>$actualTarget->display_name, "amount"=>$damageDealt, "target_hp_after"=>$actualTarget->current_hp]);
+                    $actualTarget->takeDamage($damageDealt, $card->damage_type);
+                    $this->logAction($this->battleLog[count($this->battleLog)-1]['turn'], $caster->display_name, 'Deals Damage', ['target' => $actualTarget->display_name, 'amount' => $damageDealt, 'target_hp_after' => $actualTarget->current_hp]);
                     if ($effectDetails['type'] === 'damage_heal') {
                         $caster->heal($effectDetails['heal']);
-                        $this->logAction($this->battleLog[count($this->battleLog)-1]['turn'], $caster->display_name, "Heals Self", ["amount"=>$effectDetails['heal'], "target_hp_after"=>$caster->current_hp]);
+                        $this->logAction($this->battleLog[count($this->battleLog)-1]['turn'], $caster->display_name, 'Heals Self', ['amount' => $effectDetails['heal'], 'target_hp_after' => $caster->current_hp]);
                     }
                     break;
 
                 case 'heal':
                     $actualTarget->heal($effectDetails['amount']);
-                    $this->logAction($this->battleLog[count($this->battleLog)-1]['turn'], $caster->display_name, "Heals", ["target"=>$actualTarget->display_name, "amount"=>$effectDetails['amount'], "target_hp_after"=>$actualTarget->current_hp]);
+                    $this->logAction($this->battleLog[count($this->battleLog)-1]['turn'], $caster->display_name, 'Heals', ['target' => $actualTarget->display_name, 'amount' => $effectDetails['amount'], 'target_hp_after' => $actualTarget->current_hp]);
                     break;
 
                 case 'buff':
                     BuffManager::applyEffect($actualTarget, $card, $effectDetails);
-                    $this->logAction($this->battleLog[count($this->battleLog)-1]['turn'], $caster->display_name, "Applies Buff", ["target"=>$actualTarget->display_name, "stat"=>$effectDetails['stat'], "amount"=>$effectDetails['amount'], "duration"=>$effectDetails['duration']]);
+                    $this->logAction($this->battleLog[count($this->battleLog)-1]['turn'], $caster->display_name, 'Applies Buff', ['target' => $actualTarget->display_name, 'stat' => $effectDetails['stat'], 'amount' => $effectDetails['amount'], 'duration' => $effectDetails['duration']]);
                     break;
 
                 case 'debuff':
                     BuffManager::applyEffect($actualTarget, $card, $effectDetails);
-                    $this->logAction($this->battleLog[count($this->battleLog)-1]['turn'], $caster->display_name, "Applies Debuff", ["target"=>$actualTarget->display_name, "stat"=>$effectDetails['stat'], "amount"=>$effectDetails['amount'], "duration"=>$effectDetails['duration']]);
+                    $this->logAction($this->battleLog[count($this->battleLog)-1]['turn'], $caster->display_name, 'Applies Debuff', ['target' => $actualTarget->display_name, 'stat' => $effectDetails['stat'], 'amount' => $effectDetails['amount'], 'duration' => $effectDetails['duration']]);
                     break;
 
                 case 'status_effect':
                     BuffManager::applyEffect($actualTarget, $card, $effectDetails);
-                    $this->logAction($this->battleLog[count($this->battleLog)-1]['turn'], $caster->display_name, "Applies Status", ["target"=>$actualTarget->display_name, "effect"=>$effectDetails['effect'], "duration"=>$effectDetails['duration']]);
+                    $this->logAction($this->battleLog[count($this->battleLog)-1]['turn'], $caster->display_name, 'Applies Status', ['target' => $actualTarget->display_name, 'effect' => $effectDetails['effect'], 'duration' => $effectDetails['duration']]);
                     break;
 
                 case 'damage_dot':
                     $damageDealt = calculateDamage($effectDetails['damage'], $card->damage_type, $actualTarget->armor_type ?? NULL);
-                    $actualTarget->takeDamage($damageDealt);
-                    $this->logAction($this->battleLog[count($this->battleLog)-1]['turn'], $caster->display_name, "Deals Damage", ["target"=>$actualTarget->display_name, "amount"=>$damageDealt, "target_hp_after"=>$actualTarget->current_hp]);
+                    $actualTarget->takeDamage($damageDealt, $card->damage_type);
+                    $this->logAction($this->battleLog[count($this->battleLog)-1]['turn'], $caster->display_name, 'Deals Damage', ['target' => $actualTarget->display_name, 'amount' => $damageDealt, 'target_hp_after' => $actualTarget->current_hp]);
                     $dotEffect = new StatusEffect($effectDetails['dot_type'], $effectDetails['dot_amount'], $effectDetails['dot_duration'], true, 'dot_damage');
                     $actualTarget->addStatusEffect($dotEffect);
-                    $this->logAction($this->battleLog[count($this->battleLog)-1]['turn'], $caster->display_name, "Applies DOT", ["target"=>$actualTarget->display_name, "type"=>$effectDetails['dot_type'], "amount"=>$effectDetails['dot_amount'], "duration"=>$effectDetails['dot_duration']]);
+                    $this->logAction($this->battleLog[count($this->battleLog)-1]['turn'], $caster->display_name, 'Applies DOT', ['target' => $actualTarget->display_name, 'type' => $effectDetails['dot_type'], 'amount' => $effectDetails['dot_amount'], 'duration' => $effectDetails['dot_duration']]);
                     break;
 
                 case 'heal_over_time':
                     $hotEffect = new StatusEffect('HoT', $effectDetails['amount_per_turn'], $effectDetails['duration'], false, 'hp_over_time');
                     $actualTarget->addStatusEffect($hotEffect);
-                    $this->logAction($this->battleLog[count($this->battleLog)-1]['turn'], $caster->display_name, "Applies HoT", ["target"=>$actualTarget->display_name, "amount"=>$effectDetails['amount_per_turn'], "duration"=>$effectDetails['duration']]);
+                    $this->logAction($this->battleLog[count($this->battleLog)-1]['turn'], $caster->display_name, 'Applies HoT', ['target' => $actualTarget->display_name, 'amount' => $effectDetails['amount_per_turn'], 'duration' => $effectDetails['duration']]);
                     break;
 
                 case 'damage_bypass_defense':
                     $damageDealt = $effectDetails['damage'];
                     $actualTarget->current_hp -= $damageDealt;
-                    $this->logAction($this->battleLog[count($this->battleLog)-1]['turn'], $caster->display_name, "Deals Bypass Damage", ["target"=>$actualTarget->display_name, "amount"=>$damageDealt, "target_hp_after"=>$actualTarget->current_hp]);
+                    $this->logAction($this->battleLog[count($this->battleLog)-1]['turn'], $caster->display_name, 'Deals Bypass Damage', ['target' => $actualTarget->display_name, 'amount' => $damageDealt, 'target_hp_after' => $actualTarget->current_hp]);
                     break;
 
                 case 'damage_random_element':
@@ -266,259 +272,261 @@ class BattleSimulator {
                     $chosenElement = $elements[array_rand($elements)];
                     $damageDealt = calculateDamage($effectDetails['damage'], $chosenElement, $actualTarget->armor_type ?? NULL);
                     $actualTarget->takeDamage($damageDealt, $chosenElement);
-                    $this->logAction($this->battleLog[count($this->battleLog)-1]['turn'], $caster->display_name, "Deals Random Elemental Damage", ["target"=>$actualTarget->display_name, "amount"=>$damageDealt, "element"=>$chosenElement, "target_hp_after"=>$actualTarget->current_hp]);
+                    $this->logAction($this->battleLog[count($this->battleLog)-1]['turn'], $caster->display_name, 'Deals Random Elemental Damage', ['target' => $actualTarget->display_name, 'amount' => $damageDealt, 'element' => $chosenElement, 'target_hp_after' => $actualTarget->current_hp]);
                     if ($effectDetails['type'] === 'damage_random_debuff') {
-                         $debuffs = $effectDetails['debuff_types'];
-                         $chosenDebuff = $debuffs[array_rand($debuffs)];
-                         $debuffEffect = new StatusEffect($chosenDebuff, null, $effectDetails['duration'], true);
-                         $actualTarget->addStatusEffect($debuffEffect);
-                         $this->logAction($this->battleLog[count($this->battleLog)-1]['turn'], $caster->display_name, "Applies Random Debuff", ["target"=>$actualTarget->display_name, "debuff"=>$chosenDebuff, "duration"=>$effectDetails['duration']]);
+                        $debuffs = $effectDetails['debuff_types'];
+                        $chosenDebuff = $debuffs[array_rand($debuffs)];
+                        $debuffEffect = new StatusEffect($chosenDebuff, null, $effectDetails['duration'], true);
+                        $actualTarget->addStatusEffect($debuffEffect);
+                        $this->logAction($this->battleLog[count($this->battleLog)-1]['turn'], $caster->display_name, 'Applies Random Debuff', ['target' => $actualTarget->display_name, 'debuff' => $chosenDebuff, 'duration' => $effectDetails['duration']]);
                     }
                     break;
 
                 case 'damage_self_debuff':
                     $damageDealt = calculateDamage($effectDetails['damage'], $card->damage_type, $actualTarget->armor_type ?? NULL);
-                    $actualTarget->takeDamage($damageDealt);
-                    $this->logAction($this->battleLog[count($this->battleLog)-1]['turn'], $caster->display_name, "Deals Damage", ["target"=>$actualTarget->display_name, "amount"=>$damageDealt, "target_hp_after"=>$actualTarget->current_hp]);
+                    $actualTarget->takeDamage($damageDealt, $card->damage_type);
+                    $this->logAction($this->battleLog[count($this->battleLog)-1]['turn'], $caster->display_name, 'Deals Damage', ['target' => $actualTarget->display_name, 'amount' => $damageDealt, 'target_hp_after' => $actualTarget->current_hp]);
                     BuffManager::applyEffect($caster, $card, $effectDetails);
-                    $this->logAction($this->battleLog[count($this->battleLog)-1]['turn'], $caster->display_name, "Applies Self Debuff", ["stat"=>$effectDetails['debuff_stat'], "amount"=>$effectDetails['debuff_amount'], "duration"=>$effectDetails['debuff_duration']]);
+                    $this->logAction($this->battleLog[count($this->battleLog)-1]['turn'], $caster->display_name, 'Applies Self Debuff', ['stat' => $effectDetails['debuff_stat'], 'amount' => $effectDetails['debuff_amount'], 'duration' => $effectDetails['debuff_duration']]);
                     break;
 
                 case 'damage_conditional':
                     $damageDealt = calculateDamage($effectDetails['damage'], $card->damage_type, $actualTarget->armor_type ?? NULL);
                     $actualTarget->takeDamage($damageDealt, $card->damage_type);
-                    $this->logAction($this->battleLog[count($this->battleLog)-1]['turn'], $caster->display_name, "Deals Conditional Damage", ["target"=>$actualTarget->display_name, "amount"=>$damageDealt, "target_hp_after"=>$actualTarget->current_hp]);
+                    $this->logAction($this->battleLog[count($this->battleLog)-1]['turn'], $caster->display_name, 'Deals Conditional Damage', ['target' => $actualTarget->display_name, 'amount' => $damageDealt, 'target_hp_after' => $actualTarget->current_hp]);
                     break;
 
                 case 'energy_gain':
                     $actualTarget->current_energy = min($actualTarget->current_energy + $effectDetails['amount'], 4);
-                    $this->logAction($this->battleLog[count($this->battleLog)-1]['turn'], $caster->display_name, "Gains Energy", ["target"=>$actualTarget->display_name, "amount"=>$effectDetails['amount'], "energy_after"=>$actualTarget->current_energy]);
+                    $this->logAction($this->battleLog[count($this->battleLog)-1]['turn'], $caster->display_name, 'Gains Energy', ['target' => $actualTarget->display_name, 'amount' => $effectDetails['amount'], 'energy_after' => $actualTarget->current_energy]);
                     break;
 
                 case 'extra_action':
-                    $this->logAction($this->battleLog[count($this->battleLog)-1]['turn'], $caster->display_name, "Gains Extra Action", ["target"=>$actualTarget->display_name]);
+                    $this->logAction($this->battleLog[count($this->battleLog)-1]['turn'], $caster->display_name, 'Gains Extra Action', ['target' => $actualTarget->display_name]);
                     break;
 
                 case 'damage_draw':
                     $damageDealt = calculateDamage($effectDetails['damage'], $card->damage_type, $actualTarget->armor_type ?? NULL);
-                    $actualTarget->takeDamage($damageDealt);
-                    $this->logAction($this->battleLog[count($this->battleLog)-1]['turn'], $caster->display_name, "Deals Damage", ["target"=>$actualTarget->display_name, "amount"=>$damageDealt, "target_hp_after"=>$actualTarget->current_hp]);
-                    $this->logAction($this->battleLog[count($this->battleLog)-1]['turn'], $caster->display_name, "Draws Card", ["amount"=>$effectDetails['draw_count']]);
+                    $actualTarget->takeDamage($damageDealt, $card->damage_type);
+                    $this->logAction($this->battleLog[count($this->battleLog)-1]['turn'], $caster->display_name, 'Deals Damage', ['target' => $actualTarget->display_name, 'amount' => $damageDealt, 'target_hp_after' => $actualTarget->current_hp]);
+                    $this->logAction($this->battleLog[count($this->battleLog)-1]['turn'], $caster->display_name, 'Draws Card', ['amount' => $effectDetails['draw_count']]);
                     break;
 
                 case 'damage_energy_steal':
                     $damageDealt = calculateDamage($effectDetails['damage'], $card->damage_type, $actualTarget->armor_type ?? NULL);
-                    $actualTarget->takeDamage($damageDealt);
+                    $actualTarget->takeDamage($damageDealt, $card->damage_type);
                     $caster->current_energy = min($caster->current_energy + $effectDetails['energy_amount'], 4);
                     $actualTarget->current_energy = max(0, $actualTarget->current_energy - $effectDetails['energy_amount']);
-                    $this->logAction($this->battleLog[count($this->battleLog)-1]['turn'], $caster->display_name, "Steals Energy", ["target"=>$actualTarget->display_name, "amount"=>$effectDetails['energy_amount'], "caster_energy"=>$caster->current_energy, "target_energy"=>$actualTarget->current_energy]);
+                    $this->logAction($this->battleLog[count($this->battleLog)-1]['turn'], $caster->display_name, 'Steals Energy', ['target' => $actualTarget->display_name, 'amount' => $effectDetails['energy_amount'], 'caster_energy' => $caster->current_energy, 'target_energy' => $actualTarget->current_energy]);
                     break;
 
                 case 'damage_debuff':
                     $damageDealt = calculateDamage($effectDetails['damage'], $card->damage_type, $actualTarget->armor_type ?? NULL);
-                    $actualTarget->takeDamage($damageDealt);
-                    $this->logAction($this->battleLog[count($this->battleLog)-1]['turn'], $caster->display_name, "Deals Damage", ["target"=>$actualTarget->display_name, "amount"=>$damageDealt, "target_hp_after"=>$actualTarget->current_hp]);
+                    $actualTarget->takeDamage($damageDealt, $card->damage_type);
+                    $this->logAction($this->battleLog[count($this->battleLog)-1]['turn'], $caster->display_name, 'Deals Damage', ['target' => $actualTarget->display_name, 'amount' => $damageDealt, 'target_hp_after' => $actualTarget->current_hp]);
                     $debuffEffect = new StatusEffect($effectDetails['debuff_stat'], $effectDetails['debuff_amount'], $effectDetails['debuff_duration'], true, $effectDetails['debuff_stat']);
                     $actualTarget->addStatusEffect($debuffEffect);
-                    $this->logAction($this->battleLog[count($this->battleLog)-1]['turn'], $caster->display_name, "Applies Debuff", ["target"=>$actualTarget->display_name, "stat"=>$effectDetails['debuff_stat'], "amount"=>$effectDetails['debuff_amount'], "duration"=>$effectDetails['debuff_duration']]);
+                    $this->logAction($this->battleLog[count($this->battleLog)-1]['turn'], $caster->display_name, 'Applies Debuff', ['target' => $actualTarget->display_name, 'stat' => $effectDetails['debuff_stat'], 'amount' => $effectDetails['debuff_amount'], 'duration' => $effectDetails['debuff_duration']]);
                     break;
 
-                case 'damage_reduction': // For armor cards like Leather Padding, Studded Vest, Iron Plate
+                case 'damage_reduction':
                     $reductionEffect = new StatusEffect('Defense Boost', $effectDetails['amount'], $effectDetails['duration'], false, 'defense_reduction');
                     $actualTarget->addStatusEffect($reductionEffect);
-                    $this->logAction($this->battleLog[count($this->battleLog)-1]['turn'], $caster->display_name, "Gains Defense", ["target" => $actualTarget->display_name, "amount" => $effectDetails['amount'], "duration" => $effectDetails['duration']]);
+                    $this->logAction($this->battleLog[count($this->battleLog)-1]['turn'], $caster->display_name, 'Gains Defense', ['target' => $actualTarget->display_name, 'amount' => $effectDetails['amount'], 'duration' => $effectDetails['duration']]);
                     break;
 
-                case 'magic_damage_reduction': // For Mystic Robes, Runed Cloak
+                case 'magic_damage_reduction':
                     $reductionEffect = new StatusEffect('Magic Defense Boost', $effectDetails['amount'], $effectDetails['duration'], false, 'magic_defense_reduction');
                     $actualTarget->addStatusEffect($reductionEffect);
-                    $this->logAction($this->battleLog[count($this->battleLog)-1]['turn'], $caster->display_name, "Gains Magic Defense", ["target" => $actualTarget->display_name, "amount" => $effectDetails['amount'], "duration" => $effectDetails['duration']]);
+                    $this->logAction($this->battleLog[count($this->battleLog)-1]['turn'], $caster->display_name, 'Gains Magic Defense', ['target' => $actualTarget->display_name, 'amount' => $effectDetails['amount'], 'duration' => $effectDetails['duration']]);
                     break;
 
-                case 'block': // For Righteous Shield, Parry
+                case 'block':
                     $blockEffect = new StatusEffect('Block', $effectDetails['amount'], 1, false, 'block_incoming');
                     $actualTarget->addStatusEffect($blockEffect);
-                    $this->logAction($this->battleLog[count($this->battleLog)-1]['turn'], $caster->display_name, "Applies Block", ["target" => $actualTarget->display_name, "amount" => $effectDetails['amount']]);
+                    $this->logAction($this->battleLog[count($this->battleLog)-1]['turn'], $caster->display_name, 'Applies Block', ['target' => $actualTarget->display_name, 'amount' => $effectDetails['amount']]);
                     break;
 
-                case 'block_magic': // For Arcane Ward, Magic Barrier
+                case 'block_magic':
                     $blockEffect = new StatusEffect('Block Magic', $effectDetails['amount'], 1, false, 'block_magic_incoming');
                     $actualTarget->addStatusEffect($blockEffect);
-                    $this->logAction($this->battleLog[count($this->battleLog)-1]['turn'], $caster->display_name, "Applies Magic Block", ["target" => $actualTarget->display_name, "amount" => $effectDetails['amount']]);
+                    $this->logAction($this->battleLog[count($this->battleLog)-1]['turn'], $caster->display_name, 'Applies Magic Block', ['target' => $actualTarget->display_name, 'amount' => $effectDetails['amount']]);
                     break;
 
                 case 'stun':
                     $stunEffect = new StatusEffect('Stun', null, $effectDetails['duration'] ?? 1, true);
                     $actualTarget->addStatusEffect($stunEffect);
-                    $this->logAction($this->battleLog[count($this->battleLog)-1]['turn'], $caster->display_name, "Applies Stun", ["target"=>$actualTarget->display_name, "duration"=>$effectDetails['duration'] ?? 1]);
+                    $this->logAction($this->battleLog[count($this->battleLog)-1]['turn'], $caster->display_name, 'Applies Stun', ['target' => $actualTarget->display_name, 'duration' => $effectDetails['duration'] ?? 1]);
                     break;
 
                 case 'root':
                     $rootEffect = new StatusEffect('Root', null, $effectDetails['duration'] ?? 1, true);
                     $actualTarget->addStatusEffect($rootEffect);
-                    $this->logAction($this->battleLog[count($this->battleLog)-1]['turn'], $caster->display_name, "Applies Root", ["target"=>$actualTarget->display_name, "duration"=>$effectDetails['duration'] ?? 1]);
+                    $this->logAction($this->battleLog[count($this->battleLog)-1]['turn'], $caster->display_name, 'Applies Root', ['target' => $actualTarget->display_name, 'duration' => $effectDetails['duration'] ?? 1]);
                     break;
 
                 case 'slow':
                     $slowEffect = new StatusEffect('Slow', $effectDetails['amount'] ?? 1, $effectDetails['duration'] ?? 1, true, 'speed');
                     $actualTarget->addStatusEffect($slowEffect);
-                    $this->logAction($this->battleLog[count($this->battleLog)-1]['turn'], $caster->display_name, "Applies Status", ["target"=>$actualTarget->display_name, "effect"=>'Slow', "duration"=>$effectDetails['duration'] ?? 1]);
+                    $this->logAction($this->battleLog[count($this->battleLog)-1]['turn'], $caster->display_name, 'Applies Status', ['target' => $actualTarget->display_name, 'effect' => 'Slow', 'duration' => $effectDetails['duration'] ?? 1]);
                     break;
 
                 case 'confuse':
                     $confEffect = new StatusEffect('Confuse', null, $effectDetails['duration'] ?? 1, true);
                     $actualTarget->addStatusEffect($confEffect);
-                    $this->logAction($this->battleLog[count($this->battleLog)-1]['turn'], $caster->display_name, "Applies Status", ["target"=>$actualTarget->display_name, "effect"=>'Confuse', "duration"=>$effectDetails['duration'] ?? 1]);
+                    $this->logAction($this->battleLog[count($this->battleLog)-1]['turn'], $caster->display_name, 'Applies Status', ['target' => $actualTarget->display_name, 'effect' => 'Confuse', 'duration' => $effectDetails['duration'] ?? 1]);
                     break;
 
                 case 'shock':
                     $shockEffect = new StatusEffect('Shock', null, $effectDetails['duration'] ?? 1, true);
                     $actualTarget->addStatusEffect($shockEffect);
-                    $this->logAction($this->battleLog[count($this->battleLog)-1]['turn'], $caster->display_name, "Applies Status", ["target"=>$actualTarget->display_name, "effect"=>'Shock', "duration"=>$effectDetails['duration'] ?? 1]);
+                    $this->logAction($this->battleLog[count($this->battleLog)-1]['turn'], $caster->display_name, 'Applies Status', ['target' => $actualTarget->display_name, 'effect' => 'Shock', 'duration' => $effectDetails['duration'] ?? 1]);
                     break;
 
                 case 'fear':
                     $fearEffect = new StatusEffect('Fear', $effectDetails['amount'] ?? 1, $effectDetails['duration'] ?? 1, true, 'attack');
                     $actualTarget->addStatusEffect($fearEffect);
-                    $this->logAction($this->battleLog[count($this->battleLog)-1]['turn'], $caster->display_name, "Applies Status", ["target"=>$actualTarget->display_name, "effect"=>'Fear', "duration"=>$effectDetails['duration'] ?? 1]);
+                    $this->logAction($this->battleLog[count($this->battleLog)-1]['turn'], $caster->display_name, 'Applies Status', ['target' => $actualTarget->display_name, 'effect' => 'Fear', 'duration' => $effectDetails['duration'] ?? 1]);
                     break;
 
                 case 'attack_down':
                     $atkDebuff = new StatusEffect('Attack Down', $effectDetails['amount'], $effectDetails['duration'], true, 'attack');
                     $actualTarget->addStatusEffect($atkDebuff);
-                    $this->logAction($this->battleLog[count($this->battleLog)-1]['turn'], $caster->display_name, "Applies Debuff", ["target"=>$actualTarget->display_name, "stat"=>'attack', "amount"=>$effectDetails['amount'], "duration"=>$effectDetails['duration']]);
+                    $this->logAction($this->battleLog[count($this->battleLog)-1]['turn'], $caster->display_name, 'Applies Debuff', ['target' => $actualTarget->display_name, 'stat' => 'attack', 'amount' => $effectDetails['amount'], 'duration' => $effectDetails['duration']]);
                     break;
 
                 case 'defense_down':
                     $defDebuff = new StatusEffect('Defense Down', $effectDetails['amount'], $effectDetails['duration'], true, 'defense');
                     $actualTarget->addStatusEffect($defDebuff);
-                    $this->logAction($this->battleLog[count($this->battleLog)-1]['turn'], $caster->display_name, "Applies Debuff", ["target"=>$actualTarget->display_name, "stat"=>'defense', "amount"=>$effectDetails['amount'], "duration"=>$effectDetails['duration']]);
+                    $this->logAction($this->battleLog[count($this->battleLog)-1]['turn'], $caster->display_name, 'Applies Debuff', ['target' => $actualTarget->display_name, 'stat' => 'defense', 'amount' => $effectDetails['amount'], 'duration' => $effectDetails['duration']]);
                     break;
 
                 case 'vulnerable':
-                    $vulnDebuff = new StatusEffect('Vulnerable', $effectDetails['amount'], $effectDetails['duration'], true, 'defense');
-                    $actualTarget->addStatusEffect($vulnDebuff);
-                    $this->logAction($this->battleLog[count($this->battleLog)-1]['turn'], $caster->display_name, "Applies Vulnerable", ["target"=>$actualTarget->display_name, "amount"=>$effectDetails['amount'], "duration"=>$effectDetails['duration']]);
+                    $vuln = new StatusEffect('Vulnerable', $effectDetails['amount'], $effectDetails['duration'], true, 'vulnerable');
+                    $actualTarget->addStatusEffect($vuln);
+                    $this->logAction($this->battleLog[count($this->battleLog)-1]['turn'], $caster->display_name, 'Applies Vulnerable', ['target' => $actualTarget->display_name, 'amount' => $effectDetails['amount'], 'duration' => $effectDetails['duration']]);
                     break;
 
                 case 'evasion_buff':
-                    $buff = new StatusEffect('Evasion', $effectDetails['amount'], $effectDetails['duration'], false, 'evasion');
-                    $actualTarget->addStatusEffect($buff);
-                    $this->logAction($this->battleLog[count($this->battleLog)-1]['turn'], $caster->display_name, "Applies Buff", ["target"=>$actualTarget->display_name, "stat"=>'evasion', "amount"=>$effectDetails['amount'], "duration"=>$effectDetails['duration']]);
+                    $evasionBuff = new StatusEffect('Evasion Buff', $effectDetails['amount'], $effectDetails['duration'], false, 'evasion');
+                    $actualTarget->addStatusEffect($evasionBuff);
+                    $this->logAction($this->battleLog[count($this->battleLog)-1]['turn'], $caster->display_name, 'Applies Evasion', ['target' => $actualTarget->display_name, 'amount' => $effectDetails['amount'], 'duration' => $effectDetails['duration']]);
                     break;
 
                 case 'speed_buff':
-                    $buff = new StatusEffect('Speed', $effectDetails['amount'], $effectDetails['duration'], false, 'speed');
-                    $actualTarget->addStatusEffect($buff);
-                    $this->logAction($this->battleLog[count($this->battleLog)-1]['turn'], $caster->display_name, "Applies Buff", ["target"=>$actualTarget->display_name, "stat"=>'speed', "amount"=>$effectDetails['amount'], "duration"=>$effectDetails['duration']]);
+                    $speedBuff = new StatusEffect('Speed Buff', $effectDetails['amount'], $effectDetails['duration'], false, 'speed');
+                    $actualTarget->addStatusEffect($speedBuff);
+                    $this->logAction($this->battleLog[count($this->battleLog)-1]['turn'], $caster->display_name, 'Applies Speed', ['target' => $actualTarget->display_name, 'amount' => $effectDetails['amount'], 'duration' => $effectDetails['duration']]);
                     break;
 
                 case 'crit_chance_buff':
-                    $buff = new StatusEffect('Crit Chance', $effectDetails['amount'], $effectDetails['duration'], false, 'crit_chance');
-                    $actualTarget->addStatusEffect($buff);
-                    $this->logAction($this->battleLog[count($this->battleLog)-1]['turn'], $caster->display_name, "Applies Buff", ["target"=>$actualTarget->display_name, "stat"=>'crit_chance', "amount"=>$effectDetails['amount'], "duration"=>$effectDetails['duration']]);
+                    $critBuff = new StatusEffect('Crit Chance', $effectDetails['amount'], $effectDetails['duration'], false, 'crit_chance');
+                    $actualTarget->addStatusEffect($critBuff);
+                    $this->logAction($this->battleLog[count($this->battleLog)-1]['turn'], $caster->display_name, 'Applies Crit Chance', ['target' => $actualTarget->display_name, 'amount' => $effectDetails['amount'], 'duration' => $effectDetails['duration']]);
                     break;
 
                 case 'total_immunity':
-                    $buff = new StatusEffect('Total Immunity', null, $effectDetails['duration'] ?? 1, false, 'total_immunity');
-                    $actualTarget->addStatusEffect($buff);
-                    $this->logAction($this->battleLog[count($this->battleLog)-1]['turn'], $caster->display_name, "Applies Total Immunity", ["target"=>$actualTarget->display_name, "duration"=>$effectDetails['duration'] ?? 1]);
+                    $immunity = new StatusEffect('Total Immunity', null, $effectDetails['duration'], false, 'total_immunity');
+                    $actualTarget->addStatusEffect($immunity);
+                    $this->logAction($this->battleLog[count($this->battleLog)-1]['turn'], $caster->display_name, 'Applies Immunity', ['target' => $actualTarget->display_name, 'duration' => $effectDetails['duration']]);
                     break;
 
                 case 'aoe_damage_debuff':
                     $damageDealt = calculateDamage($effectDetails['damage'], $card->damage_type, $actualTarget->armor_type ?? NULL);
-                    $actualTarget->takeDamage($damageDealt);
-                    $this->logAction($this->battleLog[count($this->battleLog)-1]['turn'], $caster->display_name, "Deals Damage", ["target"=>$actualTarget->display_name, "amount"=>$damageDealt, "target_hp_after"=>$actualTarget->current_hp]);
-                    $debuffEffect = new StatusEffect($effectDetails['debuff_stat'], $effectDetails['debuff_amount'], $effectDetails['debuff_duration'], true, $effectDetails['debuff_stat']);
-                    $actualTarget->addStatusEffect($debuffEffect);
-                    $this->logAction($this->battleLog[count($this->battleLog)-1]['turn'], $caster->display_name, "Applies Debuff", ["target"=>$actualTarget->display_name, "stat"=>$effectDetails['debuff_stat'], "amount"=>$effectDetails['debuff_amount'], "duration"=>$effectDetails['debuff_duration']]);
+                    $actualTarget->takeDamage($damageDealt, $card->damage_type);
+                    $this->logAction($this->battleLog[count($this->battleLog)-1]['turn'], $caster->display_name, 'Deals Damage', ['target' => $actualTarget->display_name, 'amount' => $damageDealt, 'target_hp_after' => $actualTarget->current_hp]);
+                    $debuff = new StatusEffect($effectDetails['debuff_stat'], $effectDetails['debuff_amount'], $effectDetails['debuff_duration'], true, $effectDetails['debuff_stat']);
+                    $actualTarget->addStatusEffect($debuff);
+                    $this->logAction($this->battleLog[count($this->battleLog)-1]['turn'], $caster->display_name, 'Applies Debuff', ['target' => $actualTarget->display_name, 'stat' => $effectDetails['debuff_stat'], 'amount' => $effectDetails['debuff_amount'], 'duration' => $effectDetails['debuff_duration']]);
                     break;
 
                 case 'aoe_damage_dot':
                     $damageDealt = calculateDamage($effectDetails['damage'], $card->damage_type, $actualTarget->armor_type ?? NULL);
-                    $actualTarget->takeDamage($damageDealt);
-                    $this->logAction($this->battleLog[count($this->battleLog)-1]['turn'], $caster->display_name, "Deals AOE Damage", ["target"=>$actualTarget->display_name, "amount"=>$damageDealt, "target_hp_after"=>$actualTarget->current_hp]);
-                    $dotEffect = new StatusEffect($effectDetails['dot_type'], $effectDetails['dot_amount'], $effectDetails['dot_duration'], true, 'dot_damage');
-                    $actualTarget->addStatusEffect($dotEffect);
-                    $this->logAction($this->battleLog[count($this->battleLog)-1]['turn'], $caster->display_name, "Applies DOT", ["target"=>$actualTarget->display_name, "type"=>$effectDetails['dot_type'], "amount"=>$effectDetails['dot_amount'], "duration"=>$effectDetails['dot_duration']]);
+                    $actualTarget->takeDamage($damageDealt, $card->damage_type);
+                    $this->logAction($this->battleLog[count($this->battleLog)-1]['turn'], $caster->display_name, 'Deals Damage', ['target' => $actualTarget->display_name, 'amount' => $damageDealt, 'target_hp_after' => $actualTarget->current_hp]);
+                    $dot = new StatusEffect($effectDetails['dot_type'], $effectDetails['dot_amount'], $effectDetails['dot_duration'], true, 'dot_damage');
+                    $actualTarget->addStatusEffect($dot);
+                    $this->logAction($this->battleLog[count($this->battleLog)-1]['turn'], $caster->display_name, 'Applies DOT', ['target' => $actualTarget->display_name, 'type' => $effectDetails['dot_type'], 'amount' => $effectDetails['dot_amount'], 'duration' => $effectDetails['dot_duration']]);
                     break;
 
                 case 'extra_actions_next_turn':
-                    $this->logAction($this->battleLog[count($this->battleLog)-1]['turn'], $caster->display_name, "Gains Extra Actions Next Turn", ["target"=>$actualTarget->display_name, "amount"=>$effectDetails['amount'] ?? 1]);
+                    $extra = new StatusEffect('Extra Actions', $effectDetails['amount'] ?? 1, 1, false, 'extra_actions_next_turn');
+                    $actualTarget->addStatusEffect($extra);
+                    $this->logAction($this->battleLog[count($this->battleLog)-1]['turn'], $caster->display_name, 'Gains Extra Actions Next Turn', ['target' => $actualTarget->display_name, 'amount' => $effectDetails['amount'] ?? 1]);
                     break;
 
                 case 'buff_extra_action_immunity':
                     $buff = new StatusEffect('Extra Action Immunity', null, $effectDetails['duration'] ?? 1, false, 'extra_action_immunity');
                     $actualTarget->addStatusEffect($buff);
-                    $this->logAction($this->battleLog[count($this->battleLog)-1]['turn'], $caster->display_name, "Applies Buff", ["target"=>$actualTarget->display_name, "stat"=>'extra_action_immunity', "duration"=>$effectDetails['duration'] ?? 1]);
+                    $this->logAction($this->battleLog[count($this->battleLog)-1]['turn'], $caster->display_name, 'Applies Buff', ['target' => $actualTarget->display_name, 'stat' => 'extra_action_immunity', 'duration' => $effectDetails['duration'] ?? 1]);
                     break;
 
                 case 'taunt_buff':
                     $taunt = new StatusEffect('Taunt', null, $effectDetails['duration'] ?? 1, false, 'taunt');
                     $actualTarget->addStatusEffect($taunt);
-                    $this->logAction($this->battleLog[count($this->battleLog)-1]['turn'], $caster->display_name, "Applies Taunt", ["target"=>$actualTarget->display_name, "duration"=>$effectDetails['duration'] ?? 1]);
+                    $this->logAction($this->battleLog[count($this->battleLog)-1]['turn'], $caster->display_name, 'Applies Taunt', ['target' => $actualTarget->display_name, 'duration' => $effectDetails['duration'] ?? 1]);
                     break;
 
                 case 'summon':
-                    $this->logAction($this->battleLog[count($this->battleLog)-1]['turn'], $caster->display_name, "Summons Ally", ["target"=>$actualTarget->display_name, "summon"=>$effectDetails['summon_name'] ?? 'unknown']);
+                    $this->logAction($this->battleLog[count($this->battleLog)-1]['turn'], $caster->display_name, 'Summons Ally', ['target' => $actualTarget->display_name, 'summon' => $effectDetails['summon_name'] ?? 'unknown']);
                     break;
 
                 case 'prevent_defeat':
                     $effect = new StatusEffect('Prevent Defeat', null, $effectDetails['duration'] ?? 1, false, 'prevent_defeat');
                     $actualTarget->addStatusEffect($effect);
-                    $this->logAction($this->battleLog[count($this->battleLog)-1]['turn'], $caster->display_name, "Prevents Defeat", ["target"=>$actualTarget->display_name, "duration"=>$effectDetails['duration'] ?? 1]);
+                    $this->logAction($this->battleLog[count($this->battleLog)-1]['turn'], $caster->display_name, 'Prevents Defeat', ['target' => $actualTarget->display_name, 'duration' => $effectDetails['duration'] ?? 1]);
                     break;
 
                 case 'full_heal':
                     $healAmount = $actualTarget->max_hp - $actualTarget->current_hp;
                     $actualTarget->heal($healAmount);
-                    $this->logAction($this->battleLog[count($this->battleLog)-1]['turn'], $caster->display_name, "Heals", ["target"=>$actualTarget->display_name, "amount"=>$healAmount, "target_hp_after"=>$actualTarget->current_hp]);
+                    $this->logAction($this->battleLog[count($this->battleLog)-1]['turn'], $caster->display_name, 'Heals', ['target' => $actualTarget->display_name, 'amount' => $healAmount, 'target_hp_after' => $actualTarget->current_hp]);
                     break;
 
                 case 'revive':
                     if ($actualTarget->current_hp <= 0) {
                         $reviveAmount = $effectDetails['amount'] ?? $actualTarget->max_hp;
                         $actualTarget->current_hp = min($reviveAmount, $actualTarget->max_hp);
-                        $this->logAction($this->battleLog[count($this->battleLog)-1]['turn'], $caster->display_name, "Revives", ["target"=>$actualTarget->display_name, "amount"=>$actualTarget->current_hp]);
+                        $this->logAction($this->battleLog[count($this->battleLog)-1]['turn'], $caster->display_name, 'Revives', ['target' => $actualTarget->display_name, 'amount' => $actualTarget->current_hp]);
                     }
                     break;
 
                 case 'aoe_heal_cleanse':
                     $actualTarget->heal($effectDetails['heal']);
-                    $this->logAction($this->battleLog[count($this->battleLog)-1]['turn'], $caster->display_name, "Heals", ["target"=>$actualTarget->display_name, "amount"=>$effectDetails['heal'], "target_hp_after"=>$actualTarget->current_hp]);
-                    $this->logAction($this->battleLog[count($this->battleLog)-1]['turn'], $caster->display_name, "Cleanses Debuffs", ["target"=>$actualTarget->display_name]);
+                    $this->logAction($this->battleLog[count($this->battleLog)-1]['turn'], $caster->display_name, 'Heals', ['target' => $actualTarget->display_name, 'amount' => $effectDetails['heal'], 'target_hp_after' => $actualTarget->current_hp]);
+                    $this->logAction($this->battleLog[count($this->battleLog)-1]['turn'], $caster->display_name, 'Cleanses Debuffs', ['target' => $actualTarget->display_name]);
                     break;
 
                 case 'aoe_heal_buff':
                     $actualTarget->heal($effectDetails['heal']);
-                    $this->logAction($this->battleLog[count($this->battleLog)-1]['turn'], $caster->display_name, "Heals", ["target"=>$actualTarget->display_name, "amount"=>$effectDetails['heal'], "target_hp_after"=>$actualTarget->current_hp]);
+                    $this->logAction($this->battleLog[count($this->battleLog)-1]['turn'], $caster->display_name, 'Heals', ['target' => $actualTarget->display_name, 'amount' => $effectDetails['heal'], 'target_hp_after' => $actualTarget->current_hp]);
                     BuffManager::applyEffect($actualTarget, $card, $effectDetails);
-                    $this->logAction($this->battleLog[count($this->battleLog)-1]['turn'], $caster->display_name, "Applies Buff", ["target"=>$actualTarget->display_name, "stat"=>$effectDetails['buff_stat'], "amount"=>$effectDetails['buff_amount'], "duration"=>$effectDetails['duration']]);
+                    $this->logAction($this->battleLog[count($this->battleLog)-1]['turn'], $caster->display_name, 'Applies Buff', ['target' => $actualTarget->display_name, 'stat' => $effectDetails['buff_stat'], 'amount' => $effectDetails['buff_amount'], 'duration' => $effectDetails['duration']]);
                     break;
 
                 case 'initiative_manipulation':
-                    $this->logAction($this->battleLog[count($this->battleLog)-1]['turn'], $caster->display_name, "Manipulates Initiative", ["target"=>$actualTarget->display_name]);
+                    $this->logAction($this->battleLog[count($this->battleLog)-1]['turn'], $caster->display_name, 'Manipulates Initiative', ['target' => $actualTarget->display_name]);
                     break;
 
                 case 'untargetable':
                 case 'untargetable_buff':
                     $statusEffect = new StatusEffect('Untargetable', null, $effectDetails['duration'], false, 'untargetable');
                     $actualTarget->addStatusEffect($statusEffect);
-                    $this->logAction($this->battleLog[count($this->battleLog)-1]['turn'], $caster->display_name, "Becomes Untargetable", ["target"=>$actualTarget->display_name, "duration"=>$effectDetails['duration']]);
+                    $this->logAction($this->battleLog[count($this->battleLog)-1]['turn'], $caster->display_name, 'Becomes Untargetable', ['target' => $actualTarget->display_name, 'duration' => $effectDetails['duration']]);
                     break;
 
                 case 'mind_control':
-                    $this->logAction($this->battleLog[count($this->battleLog)-1]['turn'], $caster->display_name, "Mind Controls", ["target"=>$actualTarget->display_name, "duration"=>$effectDetails['duration']]);
+                    $this->logAction($this->battleLog[count($this->battleLog)-1]['turn'], $caster->display_name, 'Mind Controls', ['target' => $actualTarget->display_name, 'duration' => $effectDetails['duration']]);
                     break;
 
                 case 'conditional_damage_modifier':
                     $buffEffect = new StatusEffect('Damage Modifier', $effectDetails['modifier_type'], $effectDetails['duration'], false, 'damage_modifier');
                     $caster->addStatusEffect($buffEffect);
-                    $this->logAction($this->battleLog[count($this->battleLog)-1]['turn'], $caster->display_name, "Gains Conditional Damage Boost", ["target"=>$caster->display_name, "modifier"=>$effectDetails['modifier_type'], "duration"=>$effectDetails['duration']]);
+                    $this->logAction($this->battleLog[count($this->battleLog)-1]['turn'], $caster->display_name, 'Gains Conditional Damage Boost', ['target' => $caster->display_name, 'modifier' => $effectDetails['modifier_type'], 'duration' => $effectDetails['duration']]);
                     break;
 
                 default:
-                    $this->logAction($this->battleLog[count($this->battleLog)-1]['turn'], $caster->display_name, "Unhandled Effect", ["card_name"=>$card->name, "effect_type"=>$effectDetails['type']]);
+                    $this->logAction($this->battleLog[count($this->battleLog)-1]['turn'], $caster->display_name, 'Unhandled Effect', ['card_name' => $card->name, 'effect_type' => $effectDetails['type']]);
                     break;
             }
         }


### PR DESCRIPTION
## Summary
- implement improved aggressive AI player logic
- expand card effect application logic in battle simulator

## Testing
- `php -l card_rpg_mvp/public/includes/AIPlayer.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6848ed1f8a5c8327b94afb57d235dfc1