### PR TITLE
Ensure final battle UI reflects completed state

### DIFF
--- a/card_rpg_mvp/public/api/battle_simulate.php
+++ b/card_rpg_mvp/public/api/battle_simulate.php
@@ -163,6 +163,33 @@ try {
     $simulationResult['player_start_hp_1'] = $playerTeam->entities[0]->max_hp;
     $simulationResult['player_start_hp_2'] = $playerTeam->entities[1]->max_hp;
 
+    // Include final energy and active effects for UI update
+    $simulationResult['player_energy_1'] = $playerTeam->entities[0]->current_energy;
+    $simulationResult['player_energy_2'] = $playerTeam->entities[1]->current_energy;
+    $simulationResult['opponent_energy_1'] = $opponentTeam->entities[0]->current_energy;
+    $simulationResult['opponent_energy_2'] = $opponentTeam->entities[1]->current_energy;
+
+    $simulationResult['player_1_active_effects'] = array_map(fn($e) => [
+        'type' => $e->type,
+        'duration' => $e->duration,
+        'is_debuff' => $e->is_debuff
+    ], array_merge($playerTeam->entities[0]->buffs, $playerTeam->entities[0]->debuffs));
+    $simulationResult['player_2_active_effects'] = array_map(fn($e) => [
+        'type' => $e->type,
+        'duration' => $e->duration,
+        'is_debuff' => $e->is_debuff
+    ], array_merge($playerTeam->entities[1]->buffs, $playerTeam->entities[1]->debuffs));
+    $simulationResult['opponent_1_active_effects'] = array_map(fn($e) => [
+        'type' => $e->type,
+        'duration' => $e->duration,
+        'is_debuff' => $e->is_debuff
+    ], array_merge($opponentTeam->entities[0]->buffs, $opponentTeam->entities[0]->debuffs));
+    $simulationResult['opponent_2_active_effects'] = array_map(fn($e) => [
+        'type' => $e->type,
+        'duration' => $e->duration,
+        'is_debuff' => $e->is_debuff
+    ], array_merge($opponentTeam->entities[1]->buffs, $opponentTeam->entities[1]->debuffs));
+
     sendResponse($simulationResult);
 
 } catch (PDOException $e) {

--- a/card_rpg_mvp/public/app.js
+++ b/card_rpg_mvp/public/app.js
@@ -449,6 +449,37 @@ async function renderBattleScene() {
             logIndex++;
         } else {
             clearInterval(playbackInterval);
+
+            // --- Ensure final UI reflects end-of-battle state ---
+            updateCombatantUI(
+                'player-1',
+                battleResult.player_final_hp_1,
+                initialPlayerHp1,
+                battleResult.player_energy_1 ?? initialPlayerState.champion_energy_1,
+                battleResult.player_1_active_effects ?? []
+            );
+            updateCombatantUI(
+                'player-2',
+                battleResult.player_final_hp_2,
+                initialPlayerHp2,
+                battleResult.player_energy_2 ?? initialPlayerState.champion_energy_2,
+                battleResult.player_2_active_effects ?? []
+            );
+            updateCombatantUI(
+                'opponent-1',
+                battleResult.opponent_final_hp_1,
+                battleResult.opponent_start_hp_1,
+                battleResult.opponent_energy_1 ?? 1,
+                battleResult.opponent_1_active_effects ?? []
+            );
+            updateCombatantUI(
+                'opponent-2',
+                battleResult.opponent_final_hp_2,
+                battleResult.opponent_start_hp_2,
+                battleResult.opponent_energy_2 ?? 1,
+                battleResult.opponent_2_active_effects ?? []
+            );
+
             const battleEndP = document.createElement('p');
             battleEndP.innerHTML = `<strong>Battle Concluded! Winner: ${battleResult.winner}</strong><br>You ${battleResult.result} this battle. Gained ${battleResult.xp_awarded} XP.`;
             logEntriesDiv.prepend(battleEndP);

--- a/card_rpg_mvp/public/includes/BattleSimulator.php
+++ b/card_rpg_mvp/public/includes/BattleSimulator.php
@@ -160,7 +160,33 @@ class BattleSimulator {
             "winner" => $winner,
             "result" => $result,
             "xp_awarded" => $xp_awarded,
-            "log" => $this->battleLog
+            "log" => $this->battleLog,
+            // Final energy values for each combatant
+            "player_energy_1" => $this->playerTeam->entities[0]->current_energy,
+            "player_energy_2" => $this->playerTeam->entities[1]->current_energy,
+            "opponent_energy_1" => $this->opponentTeam->entities[0]->current_energy,
+            "opponent_energy_2" => $this->opponentTeam->entities[1]->current_energy,
+            // Serialize active buffs and debuffs for final UI state
+            "player_1_active_effects" => array_map(fn($e) => [
+                'type' => $e->type,
+                'duration' => $e->duration,
+                'is_debuff' => $e->is_debuff
+            ], array_merge($this->playerTeam->entities[0]->buffs, $this->playerTeam->entities[0]->debuffs)),
+            "player_2_active_effects" => array_map(fn($e) => [
+                'type' => $e->type,
+                'duration' => $e->duration,
+                'is_debuff' => $e->is_debuff
+            ], array_merge($this->playerTeam->entities[1]->buffs, $this->playerTeam->entities[1]->debuffs)),
+            "opponent_1_active_effects" => array_map(fn($e) => [
+                'type' => $e->type,
+                'duration' => $e->duration,
+                'is_debuff' => $e->is_debuff
+            ], array_merge($this->opponentTeam->entities[0]->buffs, $this->opponentTeam->entities[0]->debuffs)),
+            "opponent_2_active_effects" => array_map(fn($e) => [
+                'type' => $e->type,
+                'duration' => $e->duration,
+                'is_debuff' => $e->is_debuff
+            ], array_merge($this->opponentTeam->entities[1]->buffs, $this->opponentTeam->entities[1]->debuffs))
         ];
     }
 


### PR DESCRIPTION
## Summary
- update BattleSimulator to include final energy and active effects in results
- expose these new fields in `battle_simulate.php`
- refresh combatant UI after playback ends to show last HP/energy/effects

## Testing
- `npm test` *(fails: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6849ba644fc88327b5a20c16e0e39a16