### PR TITLE
Fix API debug visibility and log formatting

### DIFF
--- a/card_rpg_mvp/public/api/battle_simulate.php
+++ b/card_rpg_mvp/public/api/battle_simulate.php
@@ -1,6 +1,9 @@
 <?php
 // public/api/battle_simulate.php
 
+ini_set('display_errors', 1);
+error_reporting(E_ALL);
+
 require_once __DIR__ . '/../includes/db.php';
 require_once __DIR__ . '/../includes/utils.php';
 require_once __DIR__ . '/../includes/GameEntity.php';

--- a/card_rpg_mvp/public/api/player_current_setup.php
+++ b/card_rpg_mvp/public/api/player_current_setup.php
@@ -1,6 +1,9 @@
 <?php
 // public/api/player_current_setup.php
 
+ini_set('display_errors', 1);
+error_reporting(E_ALL);
+
 // Adjust path based on your server's directory structure
 require_once __DIR__ . '/../includes/db.php';
 require_once __DIR__ . '/../includes/utils.php';

--- a/card_rpg_mvp/public/includes/BattleSimulator.php
+++ b/card_rpg_mvp/public/includes/BattleSimulator.php
@@ -28,6 +28,14 @@ class BattleSimulator {
         $this->battleLog[] = createBattleLogEntry($turn, $actorName, $actionType, $details);
     }
 
+    private function safeFormat(string $template, array $args): string {
+        $expected = preg_match_all('/%[sd]/', $template, $matches);
+        if ($expected > count($args)) {
+            $args = array_pad($args, $expected, '');
+        }
+        return @vsprintf($template, $args) ?: $template;
+    }
+
     public function simulateBattle(Team $playerTeam, Team $opponentTeam, AIPlayer $aiPlayer) {
         $this->playerTeam = $playerTeam;
         $this->opponentTeam = $opponentTeam;
@@ -216,7 +224,7 @@ class BattleSimulator {
                     break;
                 case 'Plays Card':
                     $template = $entry['log_template'] ?? '%s plays "%s" on %s.';
-                    $formatted[] = sprintf($template, $entry['actor'], $entry['card_name'], $entry['target']);
+                    $formatted[] = $this->safeFormat($template, [$entry['actor'], $entry['card_name'], $entry['target']]);
                     break;
                 case 'Passes Turn':
                     $formatted[] = "{$entry['actor']} passes turn ({$entry['reason']}).";


### PR DESCRIPTION
## Summary
- show PHP errors during debugging in `battle_simulate.php` and `player_current_setup.php`
- guard against broken log templates with new `safeFormat` helper in `BattleSimulator`
- use `safeFormat` when generating battle log messages

## Testing
- `php -l card_rpg_mvp/public/api/battle_simulate.php`
- `php -l card_rpg_mvp/public/api/player_current_setup.php`
- `php -l card_rpg_mvp/public/includes/BattleSimulator.php`
- `find card_rpg_mvp/public -name '*.php' -print0 | xargs -0 -n1 php -l`

------
https://chatgpt.com/codex/tasks/task_e_6849f4ab02d88327ae81a2bc9a9ba86c