### PR TITLE
Add AI persona choice on champion selection screen

### DIFF
--- a/card_rpg_mvp/public/api/battle_simulate.php
+++ b/card_rpg_mvp/public/api/battle_simulate.php
@@ -23,6 +23,9 @@ if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
     sendError("Invalid request method. Only POST is allowed.", 405);
 }
 
+$input = json_decode(file_get_contents('php://input'), true);
+$providedPersonaId = $input['persona_id'] ?? null;
+
 try {
     $stmt = $db->query("SELECT
         psd.champion_id, c1.name as champion_name_1, c1.role as champion_role_1, c1.starting_hp as champion_max_hp_1, c1.speed as champion_base_speed_1, psd.deck_card_ids, psd.champion_hp_1, psd.champion_energy_1, psd.champion_speed_1,
@@ -81,8 +84,12 @@ try {
         sendError("Not enough champions available for AI opponent team. Need at least 2.", 500);
     }
 
-    $personaStmt = $db->query("SELECT id FROM ai_personas ORDER BY RAND() LIMIT 1");
-    $aiPersonaId = $personaStmt->fetchColumn();
+    if ($providedPersonaId) {
+        $aiPersonaId = (int)$providedPersonaId;
+    } else {
+        $personaStmt = $db->query("SELECT id FROM ai_personas ORDER BY RAND() LIMIT 1");
+        $aiPersonaId = $personaStmt->fetchColumn();
+    }
     $aiPlayer = new AIPlayer($aiPersonaId);
 
     $aiIndex = 0;

--- a/card_rpg_mvp/public/style.css
+++ b/card_rpg_mvp/public/style.css
@@ -375,6 +375,60 @@ h2, h3, h4 {
     border-color: #00bcd4;
     box-shadow: 0 0 0 3px #00bcd4;
 }
+
+.ai-persona-selection-container {
+    margin-bottom: 20px;
+    text-align: center;
+}
+
+.persona-options-grid {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: space-around;
+    gap: 15px;
+    margin-top: 10px;
+}
+
+.persona-card {
+    background-color: #3a3a3a;
+    border: 2px solid #555;
+    border-radius: 8px;
+    padding: 10px;
+    cursor: pointer;
+    transition: all 0.2s ease-in-out;
+    box-shadow: 0 2px 4px rgba(0,0,0,0.3);
+    width: 150px;
+    position: relative;
+    text-align: center;
+}
+.persona-card:hover {
+    border-color: #00bcd4;
+    box-shadow: 0 6px 12px rgba(0,0,0,0.4);
+}
+.persona-card.selected {
+    border-color: #00bcd4;
+    box-shadow: 0 0 0 3px #00bcd4;
+}
+.persona-card.selected::after {
+    content: '\2713';
+    position: absolute;
+    top: 6px;
+    right: 8px;
+    font-size: 1.2em;
+    color: #00bcd4;
+}
+.persona-card .hidden-radio {
+    display: none;
+}
+.persona-name {
+    color: #00bcd4;
+    font-weight: bold;
+    margin-bottom: 4px;
+}
+.persona-description {
+    font-size: 0.8em;
+    color: #ccc;
+}
 .game-button {
     background-color: #00bcd4;
     color: #1a1a1a;


### PR DESCRIPTION
## Summary
- add AI_PERSONAS constant and selection state
- inject AI persona options above champion selection UI
- style persona selection cards with CSS
- send selected persona ID when simulating a battle
- allow battle API to accept optional persona ID

## Testing
- `php -l card_rpg_mvp/public/api/battle_simulate.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849fa8b9d7c83279829f1274fdcb497