### PR TITLE
Add random opponent AI personas

### DIFF
--- a/card_rpg_mvp/public/app.js
+++ b/card_rpg_mvp/public/app.js
@@ -391,7 +391,7 @@ async function renderBattleScene() {
         return;
     }
 
-    const battleResult = await callApi('battle_simulate.php', 'POST', { persona_id: selectedPersonaId });
+    const battleResult = await callApi('battle_simulate.php', 'POST', { player_persona_id: selectedPersonaId });
     if (!battleResult) {
         alert('Failed to simulate battle.');
         return;

--- a/card_rpg_mvp/public/includes/BattleSimulator.php
+++ b/card_rpg_mvp/public/includes/BattleSimulator.php
@@ -17,7 +17,8 @@ class BattleSimulator {
     private $battleLog = [];
     private $playerTeam;
     private $opponentTeam;
-    private $aiPlayer;
+    private $playerAi;
+    private $opponentAi;
 
     public function __construct() {
         $database = new Database();
@@ -36,10 +37,11 @@ class BattleSimulator {
         return @vsprintf($template, $args) ?: $template;
     }
 
-    public function simulateBattle(Team $playerTeam, Team $opponentTeam, AIPlayer $aiPlayer) {
+    public function simulateBattle(Team $playerTeam, Team $opponentTeam, AIPlayer $playerAi, AIPlayer $opponentAi) {
         $this->playerTeam = $playerTeam;
         $this->opponentTeam = $opponentTeam;
-        $this->aiPlayer = $aiPlayer;
+        $this->playerAi = $playerAi;
+        $this->opponentAi = $opponentAi;
 
         $turn = 0;
         $maxTurns = 50;
@@ -95,7 +97,8 @@ class BattleSimulator {
 
                 $actingTeam = $actor->team;
                 $opposingTeam = ($actingTeam === $this->playerTeam) ? $this->opponentTeam : $this->playerTeam;
-                $chosen = $this->aiPlayer->decideAction($actor, $actingTeam, $opposingTeam, $actor->hand);
+                $ai = ($actingTeam === $this->playerTeam) ? $this->playerAi : $this->opponentAi;
+                $chosen = $ai->decideAction($actor, $actingTeam, $opposingTeam, $actor->hand);
 
                 $statusFail = null;
                 foreach ($actor->debuffs as $effect) {
@@ -202,8 +205,8 @@ class BattleSimulator {
             "opponent_display_name_1_short" => explode(' ', $this->opponentTeam->entities[0]->display_name)[1] ?? $this->opponentTeam->entities[0]->display_name,
             "opponent_class_name_2" => $this->opponentTeam->entities[1]->name,
             "opponent_display_name_2_short" => explode(' ', $this->opponentTeam->entities[1]->display_name)[1] ?? $this->opponentTeam->entities[1]->display_name,
-            "player_team_persona_name" => $this->aiPlayer->getPersonaName(),
-            "opponent_team_persona_name" => $this->aiPlayer->getPersonaName()
+            "player_team_persona_name" => $this->playerAi->getPersonaName(),
+            "opponent_team_persona_name" => $this->opponentAi->getPersonaName()
         ];
     }
 


### PR DESCRIPTION
## Summary
- update battle simulator to support separate AI personas for each team
- randomly choose an opponent persona in `battle_simulate.php`
- send player's persona id using new `player_persona_id` field in the JS client

## Testing
- `php -l card_rpg_mvp/public/api/battle_simulate.php`
- `php -l card_rpg_mvp/public/includes/BattleSimulator.php`


------
https://chatgpt.com/codex/tasks/task_e_6849fde2d3a48327944c5d47b11e8a22