### PR TITLE
feat: Implement Event-Driven Battle Animation & Log System

### DIFF
--- a/card_rpg_mvp/public/app.js
+++ b/card_rpg_mvp/public/app.js
@@ -18,9 +18,9 @@ const ANIMATION_TIMING_MAP = {
     CARD_PLAYED: { actor: 'lunge-animation', delay: 400 },
     DAMAGE_DEALT: { actor: 'lunge-animation', target: 'shake-animation', delay: 400 },
     HEAL_APPLIED: { target: 'heal-flash-animation', delay: 300 },
-    STATUS_EFFECT_APPLIED: { target: 'turn-highlight-animation', delay: 500 },
+    STATUS_EFFECT_APPLIED: { target: 'status-tint-animation', delay: 500 }, // Updated
     ACTION_FAILED: { actor: 'wobble-animation', delay: 300 },
-    EFFECT_APPLYING: { actor: 'pulse-animation', target: 'pulse-animation', delay: 300 },
+    EFFECT_APPLYING: { actor: 'effect-applying-pulse-animation', target: 'effect-applying-pulse-animation', delay: 300 }, // Updated
     TURN_SKIPPED: { actor: 'dim-animation', delay: 300 },
     TURN_PASSED: { actor: 'dim-animation', delay: 300 },
     TURN_END: { delay: 200 },
@@ -534,8 +534,8 @@ async function renderBattleScene() {
     initialOpponentHp2 = battleResult.opponent_start_hp_2;
     currentBattleResult = battleResult;
 
-    const logEntriesDiv = document.getElementById('log-entries');
-    logEntriesDiv.innerHTML = '';
+    // const logEntriesDiv = document.getElementById('log-entries'); // Redundant: Cleared in startBattlePlayback
+    // logEntriesDiv.innerHTML = ''; // Redundant: Cleared in startBattlePlayback
     startBattlePlayback(battleLog);
 }
 
@@ -595,36 +595,97 @@ function updateCombatantUI(elementIdPrefix, currentHp, maxHp, currentEnergy, act
     }
 }
 
+// Helper functions for formatting log entries
+function getSafeActorName(actor) {
+    if (typeof actor === 'string') {
+        return actor;
+    }
+    if (actor && typeof actor === 'object' && actor.displayName) {
+        return actor.displayName;
+    }
+    // Fallback for system messages or undefined actors in log
+    if (actor && typeof actor === 'object' && !actor.displayName && actor.turn !== undefined) { // Heuristic for system actor
+         return 'System';
+    }
+    return 'Unknown Entity';
+}
+
+function getSafeActorRole(actor) {
+    if (actor && typeof actor === 'object' && actor.role) {
+        return actor.role.toLowerCase();
+    }
+    return '';
+}
+
 // Translate backend events to styled HTML snippets
 function formatLogEntry(event) {
-    switch (event.eventType) {
-        case 'BATTLE_START': {
-            const pNames = event.payload.player_team_names.join(' & ');
-            const oNames = event.payload.opponent_team_names.join(' & ');
-            return `<p>The battle begins! <strong>${pNames}</strong> vs <strong>${oNames}</strong>.</p>`;
-        }
+    const { eventType, payload } = event;
+
+    switch (eventType) {
+        case 'BATTLE_START':
+            return `<p class="log-entry log-battle-start">Battle Begins! <strong>${payload.player_team_names.join(' & ')}</strong> vs <strong>${payload.opponent_team_names.join(' & ')}</strong>.</p>`;
+
         case 'TURN_START':
-            return `<p class="turn-start">--- Turn ${event.payload.turn} Begins ---</p>`;
+            return `<p class="log-entry log-turn-start">--- Turn ${payload.turn} (Actor: ${getSafeActorName(payload.actor)}) ---</p>`;
+
         case 'CARD_PLAYED': {
-            const { caster, card, target } = event.payload;
-            return `<p><span class="actor ${caster.role.toLowerCase()}">${caster.displayName}</span> uses <strong class="card-name">${card.name}</strong> on <span class="target">${target}</span>.</p>`;
+            const targetName = (typeof payload.target === 'string') ? payload.target : getSafeActorName(payload.target);
+            const targetRoleClass = (typeof payload.target === 'string') ? '' : getSafeActorRole(payload.target);
+            return `<p class="log-entry log-card-played"><span class="actor-name ${getSafeActorRole(payload.caster)}">${getSafeActorName(payload.caster)}</span> plays <strong class="card-name">${payload.card.name}</strong> on <span class="target-name ${targetRoleClass}">${targetName}</span>.</p>`;
         }
         case 'DAMAGE_DEALT': {
-            const { caster, target, card, result } = event.payload;
-            return `<p><span class="actor ${caster.role.toLowerCase()}">${caster.displayName}</span> deals <span class="damage-value">${result.damageDealt}</span> damage to <span class="target ${target.role.toLowerCase()}">${target.displayName}</span> with <strong class="card-name">${card.name}</strong>.</p>`;
+            const damageType = payload.card && payload.card.damage_type ? payload.card.damage_type : 'unknown';
+            const damageTypeIconName = getDamageTypeIcon(damageType);
+            return `
+                <p class="log-entry log-damage-dealt">
+                    <span class="actor-name ${getSafeActorRole(payload.caster)}">${getSafeActorName(payload.caster)}</span>
+                    deals <span class="damage-value">${payload.result.damageDealt}</span>
+                    <span class="damage-type-icon"><i class="fa-solid fa-${damageTypeIconName}"></i></span>
+                    damage to <span class="target-name ${getSafeActorRole(payload.target)}">${getSafeActorName(payload.target)}</span>
+                    with <strong class="card-name">${payload.card.name}</strong>.
+                </p>
+            `;
         }
-        case 'HEAL_APPLIED': {
-            const { caster, target, card, result } = event.payload;
-            return `<p><span class="actor ${caster.role.toLowerCase()}">${caster.displayName}</span> heals <span class="target ${target.role.toLowerCase()}">${target.displayName}</span> for <span class="heal-value">${result.healed}</span> using <strong class="card-name">${card.name}</strong>.</p>`;
-        }
+        case 'HEAL_APPLIED':
+            return `<p class="log-entry log-heal-applied"><span class="actor-name ${getSafeActorRole(payload.caster)}">${getSafeActorName(payload.caster)}</span> heals <span class="target-name ${getSafeActorRole(payload.target)}">${getSafeActorName(payload.target)}</span> for <span class="heal-value">${payload.result.healed}</span> HP (now ${payload.result.targetHpAfter}) using <strong class="card-name">${payload.card.name}</strong>.</p>`;
+
         case 'STATUS_EFFECT_APPLIED': {
-            const { caster, target, card, effect } = event.payload;
-            return `<p><span class="actor ${caster.role.toLowerCase()}">${caster.displayName}</span> applies <span class="status-effect">${effect.type}</span> to <span class="target ${target.role.toLowerCase()}">${target.displayName}</span> with <strong class="card-name">${card.name}</strong>.</p>`;
+            const effectIconName = getEffectIcon(payload.effect.type);
+            return `<p class="log-entry log-status-effect-applied"><span class="actor-name ${getSafeActorRole(payload.caster)}">${getSafeActorName(payload.caster)}</span> applies <span class="status-effect">${payload.effect.type} <i class="fa-solid fa-${effectIconName}"></i></span> to <span class="target-name ${getSafeActorRole(payload.target)}">${getSafeActorName(payload.target)}</span> with <strong class="card-name">${payload.card.name}</strong>.</p>`;
         }
         case 'BATTLE_END':
-            return `<p><strong>Battle Ends! Winner: ${event.payload.winner}</strong></p>`;
+            return `<p class="log-entry log-battle-end"><strong>Battle Ends! Winner: ${payload.winner}</strong>. Player result: ${payload.result}.</p>`;
+
+        // Added cases
+        case 'TURN_END':
+            return `<p class="log-entry log-turn-end">--- Turn ${payload.turn} Ends (System) ---</p>`;
+
+        case 'TURN_SKIPPED':
+            return `<p class="log-entry log-turn-skipped"><span class="actor-name ${getSafeActorRole(payload.actor)}">${getSafeActorName(payload.actor)}</span> skipped their turn.</p>`;
+
+        case 'TURN_PASSED':
+            return `<p class="log-entry log-turn-passed"><span class="actor-name ${getSafeActorRole(payload.actor)}">${getSafeActorName(payload.actor)}</span> passed their turn.</p>`;
+
+        case 'ENERGY_GAIN':
+            // Amount is not in the schema for this event, so a generic message.
+            return `<p class="log-entry log-energy-gain"><span class="actor-name ${getSafeActorRole(payload.actor)}">${getSafeActorName(payload.actor)}</span> gained energy.</p>`;
+
+        case 'TURN_ACTION':
+            return `<p class="log-entry log-turn-action"><span class="actor-name ${getSafeActorRole(payload.actor)}">${getSafeActorName(payload.actor)}</span> is taking an action.</p>`;
+
+        case 'ACTION_FAILED':
+            if (payload.card && payload.card.name) {
+                return `<p class="log-entry log-action-failed"><span class="actor-name ${getSafeActorRole(payload.actor)}">${getSafeActorName(payload.actor)}</span>'s action with <strong class="card-name">${payload.card.name}</strong> failed.</p>`;
+            }
+            return `<p class="log-entry log-action-failed"><span class="actor-name ${getSafeActorRole(payload.actor)}">${getSafeActorName(payload.actor)}</span>'s action failed.</p>`;
+
+        case 'EFFECT_APPLYING': {
+            const effectIconName = getEffectIcon(payload.effect.type);
+            return `<p class="log-entry log-effect-applying">Effect <span class="status-effect">${payload.effect.type} <i class="fa-solid fa-${effectIconName}"></i></span> from <span class="actor-name ${getSafeActorRole(payload.actor)}">${getSafeActorName(payload.actor)}</span> is applying.</p>`;
+        }
         default:
-            return '';
+            console.warn(`Unknown eventType: ${eventType}`, event);
+            return `<p class="log-entry log-unknown">Unknown Event: ${eventType}</p>`;
     }
 }
 
@@ -633,37 +694,166 @@ function getCombatantElementByName(name) {
     return id ? document.getElementById(id) : null;
 }
 
-function startBattlePlayback(log) {
-    battleEventQueue = Array.from(log);
+function startBattlePlayback(logFromServer) {
+    // 1. Clear any old log entries
+    const logEntriesDiv = document.getElementById('log-entries');
+    if (logEntriesDiv) { // Check if element exists
+        logEntriesDiv.innerHTML = '';
+    } else {
+        console.error("Log entries container 'log-entries' not found.");
+    }
+
+    // 2. Populate our queue with the new events from the server
+    battleEventQueue = Array.from(logFromServer); // Using Array.from() is good practice
+
+    // 3. Kick off the first event
     processNextEvent();
 }
 
 function processNextEvent() {
+    // If the queue is empty, we're done!
     if (battleEventQueue.length === 0) {
+        // The existing finalizeBattlePlayback() handles showing "Proceed" button and final UI updates.
         finalizeBattlePlayback();
         return;
     }
 
+    // Pull the next event from the front of the queue
     const event = battleEventQueue.shift();
-    const animInfo = ANIMATION_TIMING_MAP[event.eventType] || { delay: 300 };
+    const { eventType, payload } = event;
 
-    const actorName = event.payload.caster?.displayName || event.payload.actor;
-    const targetName = event.payload.target?.displayName;
-    const actorEl = getCombatantElementByName(actorName);
-    const targetEl = getCombatantElementByName(targetName);
+    // Default time to wait before showing the log and processing the next event
+    // Use ANIMATION_TIMING_MAP from app.js
+    const animationConfig = ANIMATION_TIMING_MAP[eventType] || { delay: 300 }; // Default delay
+    let animationDelay = animationConfig.delay;
 
-    if (actorEl && animInfo.actor) actorEl.classList.add(animInfo.actor);
-    if (targetEl && animInfo.target) targetEl.classList.add(animInfo.target);
+    // --- Trigger Animations based on Event Type ---
+    let actorElement = null;
+    let targetElement = null;
 
+    // Resolve actor element
+    if (payload.caster) { // Events like DAMAGE_DEALT, HEAL_APPLIED use 'caster'
+        actorElement = getCombatantElementByName(payload.caster.displayName);
+    } else if (payload.actor) { // Events like TURN_ACTION use 'actor'
+        if (typeof payload.actor === 'object' && payload.actor.displayName) {
+            actorElement = getCombatantElementByName(payload.actor.displayName);
+        } else if (typeof payload.actor === 'string') { // System actor for TURN_START etc.
+             // No specific element to animate for "System" usually, but allows config
+            actorElement = getCombatantElementByName(payload.actor);
+        }
+    }
+
+    // Resolve target element
+    if (payload.target) {
+        const targetDisplayName = (typeof payload.target === 'string') ? payload.target : payload.target.displayName;
+        if (targetDisplayName) {
+            targetElement = getCombatantElementByName(targetDisplayName);
+        }
+    }
+
+    // Apply animations
+    if (actorElement && animationConfig.actor) {
+        actorElement.classList.add(animationConfig.actor);
+    }
+    if (targetElement && animationConfig.target) {
+        targetElement.classList.add(animationConfig.target);
+    }
+
+    // Special case for BATTLE_START to animate both teams
+    if (eventType === 'BATTLE_START') {
+        document.querySelectorAll('.player-side .combatant').forEach(el => el.classList.add('slide-in-left'));
+        document.querySelectorAll('.opponent-side .combatant').forEach(el => el.classList.add('slide-in-right'));
+    }
+
+    // Use setTimeout to create a pause for the animation
     setTimeout(() => {
-        if (actorEl && animInfo.actor) actorEl.classList.remove(animInfo.actor);
-        if (targetEl && animInfo.target) targetEl.classList.remove(animInfo.target);
+        // --- After the pause ---
 
+        // 1. Remove any temporary animation classes
+        document.querySelectorAll('.combatant').forEach(el => {
+            for (const key in ANIMATION_TIMING_MAP) {
+                if (ANIMATION_TIMING_MAP[key].actor) el.classList.remove(ANIMATION_TIMING_MAP[key].actor);
+                if (ANIMATION_TIMING_MAP[key].target) el.classList.remove(ANIMATION_TIMING_MAP[key].target);
+            }
+            el.classList.remove('slide-in-left', 'slide-in-right');
+        });
+
+        // 2. Update the UI with the outcome (e.g., HP bars)
+        // For DAMAGE_DEALT and HEAL_APPLIED, payload.target should be the updated entity.
+        if (eventType === 'DAMAGE_DEALT' && payload.target && typeof payload.target === 'object') {
+            const combatantIdPrefix = combatantIdMap[payload.target.displayName];
+            if (combatantIdPrefix) {
+                updateCombatantUI(
+                    combatantIdPrefix,
+                    payload.target.currentHp, // MODIFIED: Assumes payload.target.currentHp is post-damage state
+                    payload.target.maxHp,
+                    payload.target.currentEnergy,
+                    payload.target.active_effects || []
+                );
+            } else {
+                console.warn('Could not find combatantIdPrefix for target:', payload.target.displayName);
+            }
+        } else if (eventType === 'HEAL_APPLIED' && payload.target && typeof payload.target === 'object') {
+            // HEAL_APPLIED correctly uses payload.result.targetHpAfter as per schema
+            const combatantIdPrefix = combatantIdMap[payload.target.displayName];
+            if (combatantIdPrefix) {
+                 updateCombatantUI(
+                    combatantIdPrefix,
+                    payload.result.targetHpAfter, // Correct for HEAL_APPLIED
+                    payload.target.maxHp,
+                    payload.target.currentEnergy,
+                    payload.target.active_effects || []
+                );
+            } else {
+                console.warn('Could not find combatantIdPrefix for target:', payload.target.displayName);
+            }
+        }
+
+        // Update energy for ENERGY_GAIN event
+        // payload.actor should be the updated entity
+        if (eventType === 'ENERGY_GAIN' && payload.actor && typeof payload.actor === 'object') {
+            const combatantIdPrefix = combatantIdMap[payload.actor.displayName];
+            if (combatantIdPrefix) {
+                 updateCombatantUI(
+                    combatantIdPrefix,
+                    payload.actor.currentHp,
+                    payload.actor.maxHp,
+                    payload.actor.currentEnergy, // Key update
+                    payload.actor.active_effects || []
+                );
+            }
+        }
+
+        // Update for STATUS_EFFECT_APPLIED
+        // payload.target should be the updated entity
+        if (eventType === 'STATUS_EFFECT_APPLIED' && payload.target && typeof payload.target === 'object') {
+            const combatantIdPrefix = combatantIdMap[payload.target.displayName];
+             if (combatantIdPrefix) {
+                 updateCombatantUI(
+                    combatantIdPrefix,
+                    payload.target.currentHp,
+                    payload.target.maxHp,
+                    payload.target.currentEnergy,
+                    payload.target.active_effects || [] // Key update: new set of effects
+                );
+             }
+        }
+
+        // 3. Render the formatted log text
+        const logHtml = formatLogEntry(event);
         const logEntriesDiv = document.getElementById('log-entries');
-        if (logEntriesDiv) logEntriesDiv.insertAdjacentHTML('afterbegin', formatLogEntry(event));
+        if (logEntriesDiv && logHtml) {
+            const tempDiv = document.createElement('div');
+            tempDiv.innerHTML = logHtml.trim();
+            if (tempDiv.firstChild) {
+                 logEntriesDiv.prepend(tempDiv.firstChild);
+            }
+        }
 
+        // 4. Call this function again to process the *next* event in the queue
         processNextEvent();
-    }, animInfo.delay);
+
+    }, animationDelay);
 }
 
 function finalizeBattlePlayback() {

--- a/card_rpg_mvp/public/style.css
+++ b/card_rpg_mvp/public/style.css
@@ -577,8 +577,9 @@ h2, h3, h4 {
 }
 
 @keyframes shake {
-    0%,100% { transform: translateX(0); }
+    0%,100% { transform: translateX(0); box-shadow: none; }
     25% { transform: translateX(-5px); }
+    50% { box-shadow: 0 0 10px 5px rgba(255,0,0,0.7); }
     75% { transform: translateX(5px); }
 }
 
@@ -622,3 +623,19 @@ h2, h3, h4 {
 .dim-animation { animation: dim 0.3s ease-out; }
 .fade-turn-animation { animation: fade-turn 0.2s ease-out; }
 .winner-glow-animation { animation: winner-glow 0.8s ease-out forwards; }
+
+/* Added for STATUS_EFFECT_APPLIED */
+@keyframes status-tint-animation {
+  0%, 100% { filter: brightness(1); }
+  50% { filter: brightness(1.2) saturate(1.5); } /* Example tint effect */
+}
+.status-tint-animation {
+  animation: status-tint-animation 0.5s ease-in-out;
+}
+
+/* Added for EFFECT_APPLYING to use pulse keyframes with different duration */
+.effect-applying-pulse-animation {
+  animation-name: pulse; /* Use existing pulse keyframes */
+  animation-duration: 0.3s; /* Specific duration from map */
+  animation-timing-function: ease-out;
+}


### PR DESCRIPTION
Replaces the old battle log system with a new dynamic Playback Manager. This manager consumes structured Event Objects from the battle simulation API. It triggers corresponding CSS animations on combatant cards and renders a synchronized battle log with detailed HTML entries.

Key changes:
- Added new CSS animations and updated existing ones in style.css based on the Animation & Timing Map.
- Implemented `formatLogEntry` to convert Event Objects into styled HTML.
- Implemented `startBattlePlayback` to initialize the playback sequence.
- Implemented `processNextEvent` as the core playback loop, handling event- Mapped event types to animations and timings.
  - Updates UI (HP bars, status effects, energy) based on event payloads.
  - Removes old setInterval-based playback logic.
- Ensures log entries appear after their corresponding animations.

Fix:
- Corrected HP update logic for `DAMAGE_DEALT` events in `processNextEvent`. The system now uses `payload.target.currentHp` instead of `payload.result.targetHpAfter`, as the latter is not provided in the `DAMAGE_DEALT` event schema. This assumes `payload.target` reflects the post-event state.