### PR TITLE
Fix SQL column selection

### DIFF
--- a/card_rpg_mvp/public/api/battle_simulate.php
+++ b/card_rpg_mvp/public/api/battle_simulate.php
@@ -218,7 +218,7 @@ function loadCardsFromIds($db_conn, $cardIds) {
     $fullCards = [];
     if (!empty($cardIds)) {
         $placeholder = implode(',', array_fill(0, count($cardIds), '?'));
-        $stmt = $db_conn->prepare("SELECT id, name, card_type, rarity, energy_cost, description, damage_type, armor_type, class_affinity, effect_details, flavor_text, log_template FROM cards WHERE id IN ($placeholder)");
+        $stmt = $db_conn->prepare("SELECT id, name, card_type, rarity, energy_cost, description, damage_type, armor_type, class_affinity, effect_details, flavor_text FROM cards WHERE id IN ($placeholder)");
         $stmt->execute($cardIds);
         $cardsData = $stmt->fetchAll(PDO::FETCH_ASSOC);
         foreach ($cardsData as $c) {
@@ -230,19 +230,19 @@ function loadCardsFromIds($db_conn, $cardIds) {
 
 function loadRandomCommonCards($db_conn, $championName) {
     $cards = [];
-    $stmtA = $db_conn->prepare("SELECT id, name, card_type, rarity, energy_cost, description, damage_type, armor_type, class_affinity, effect_details, flavor_text, log_template FROM cards WHERE card_type = 'ability' AND rarity = 'Common' AND (FIND_IN_SET(:name_ab, class_affinity) > 0 OR class_affinity IS NULL) ORDER BY RAND() LIMIT 1");
+    $stmtA = $db_conn->prepare("SELECT id, name, card_type, rarity, energy_cost, description, damage_type, armor_type, class_affinity, effect_details, flavor_text FROM cards WHERE card_type = 'ability' AND rarity = 'Common' AND (FIND_IN_SET(:name_ab, class_affinity) > 0 OR class_affinity IS NULL) ORDER BY RAND() LIMIT 1");
     $stmtA->bindParam(':name_ab', $championName);
     $stmtA->execute();
     if ($card = $stmtA->fetch(PDO::FETCH_ASSOC)) {
         $cards[] = new Card(array_merge($card, ['effect_details' => json_decode($card['effect_details'], true)]));
     }
-    $stmtAr = $db_conn->prepare("SELECT id, name, card_type, rarity, energy_cost, description, damage_type, armor_type, class_affinity, effect_details, flavor_text, log_template FROM cards WHERE card_type = 'armor' AND rarity = 'Common' AND (FIND_IN_SET(:name_ar, class_affinity) > 0 OR class_affinity IS NULL) ORDER BY RAND() LIMIT 1");
+    $stmtAr = $db_conn->prepare("SELECT id, name, card_type, rarity, energy_cost, description, damage_type, armor_type, class_affinity, effect_details, flavor_text FROM cards WHERE card_type = 'armor' AND rarity = 'Common' AND (FIND_IN_SET(:name_ar, class_affinity) > 0 OR class_affinity IS NULL) ORDER BY RAND() LIMIT 1");
     $stmtAr->bindParam(':name_ar', $championName);
     $stmtAr->execute();
     if ($card = $stmtAr->fetch(PDO::FETCH_ASSOC)) {
         $cards[] = new Card(array_merge($card, ['effect_details' => json_decode($card['effect_details'], true)]));
     }
-    $stmtW = $db_conn->prepare("SELECT id, name, card_type, rarity, energy_cost, description, damage_type, armor_type, class_affinity, effect_details, flavor_text, log_template FROM cards WHERE card_type = 'weapon' AND rarity = 'Common' AND (FIND_IN_SET(:name_we, class_affinity) > 0 OR class_affinity IS NULL) ORDER BY RAND() LIMIT 1");
+    $stmtW = $db_conn->prepare("SELECT id, name, card_type, rarity, energy_cost, description, damage_type, armor_type, class_affinity, effect_details, flavor_text FROM cards WHERE card_type = 'weapon' AND rarity = 'Common' AND (FIND_IN_SET(:name_we, class_affinity) > 0 OR class_affinity IS NULL) ORDER BY RAND() LIMIT 1");
     $stmtW->bindParam(':name_we', $championName);
     $stmtW->execute();
     if ($card = $stmtW->fetch(PDO::FETCH_ASSOC)) {

--- a/card_rpg_mvp/public/api/test_ai_decision.php
+++ b/card_rpg_mvp/public/api/test_ai_decision.php
@@ -126,7 +126,7 @@ function loadCardsFromIds($db_conn, $cardIds) {
     $fullCards = [];
     if (!empty($cardIds)) {
         $placeholder = implode(',', array_fill(0, count($cardIds), '?'));
-        $stmt = $db_conn->prepare("SELECT id, name, card_type, rarity, energy_cost, description, damage_type, armor_type, class_affinity, effect_details, flavor_text, log_template FROM cards WHERE id IN ($placeholder)");
+        $stmt = $db_conn->prepare("SELECT id, name, card_type, rarity, energy_cost, description, damage_type, armor_type, class_affinity, effect_details, flavor_text FROM cards WHERE id IN ($placeholder)");
         $stmt->execute($cardIds);
         $cardsData = $stmt->fetchAll(PDO::FETCH_ASSOC);
         foreach ($cardsData as $cardData) {

--- a/card_rpg_mvp/public/includes/Card.php
+++ b/card_rpg_mvp/public/includes/Card.php
@@ -13,7 +13,6 @@ class Card {
     public $class_affinity; // Comma-separated string
     public $flavor_text;
     public $effect_details; // Decoded JSON object
-    public $log_template; // Template string for condensed battle log
 
     public function __construct($data) {
         $this->id = $data['id'];
@@ -27,7 +26,6 @@ class Card {
         $this->class_affinity = $data['class_affinity'] ?? NULL;
         $this->flavor_text = $data['flavor_text'] ?? NULL;
         $this->effect_details = $data['effect_details']; // Already decoded JSON
-        $this->log_template = $data['log_template'] ?? null;
     }
 
     // Method to check if card is usable by a specific class
@@ -39,7 +37,7 @@ class Card {
         return in_array($championName, $affinities);
     }
 
-    // Return array representation excluding log_template for safe JSON serialization
+    // Return array representation for safe JSON serialization
     public function toArray() {
         return [
             'id' => $this->id,


### PR DESCRIPTION
## Summary
- stop selecting log_template column in card load helpers
- delete unused log_template property from `Card`

## Testing
- `php -l card_rpg_mvp/public/api/battle_simulate.php`
- `php -l card_rpg_mvp/public/api/test_ai_decision.php`
- `php -l card_rpg_mvp/public/includes/Card.php`


------
https://chatgpt.com/codex/tasks/task_e_684a196d7bc88327a0c682f08012c584