### PR TITLE
Fix API path and battle result variable

### DIFF
--- a/card_rpg_mvp/public/app.js
+++ b/card_rpg_mvp/public/app.js
@@ -60,8 +60,8 @@ let selectedPersonaId = AI_PERSONAS[0].id;
 
 // --- API Helper Functions ---
 async function callApi(endpoint, method = 'GET', data = null) {
-    // Prefix API calls with /public/ so requests hit the proper PHP scripts
-    const url = `/public/api/${endpoint}`;
+    // Prefix API calls with /api/ so requests hit the PHP API endpoints
+    const url = `/api/${endpoint}`;
     const options = {
         method: method,
         headers: {
@@ -412,7 +412,7 @@ async function renderBattleScene() {
         return;
     }
 
-    const battleResult = await callApi('battle_simulate.php', 'POST', { persona_id: selectedPersonaId });
+    let battleResult = await callApi('battle_simulate.php', 'POST', { persona_id: selectedPersonaId });
     if (!battleResult) {
         alert('Failed to simulate battle.');
         return;


### PR DESCRIPTION
## Summary
- correct fetch URLs by removing redundant `/public`
- allow reassignment for `battleResult`

## Testing
- `git log -1 --stat`


------
https://chatgpt.com/codex/tasks/task_e_684a1d37b88c8327941a7a02783ee65c