### PR TITLE
Refactor: Use relative API paths in app.js

### DIFF
--- a/card_rpg_mvp/public/app.js
+++ b/card_rpg_mvp/public/app.js
@@ -61,7 +61,7 @@ let selectedPersonaId = AI_PERSONAS[0].id;
 // --- API Helper Functions ---
 async function callApi(endpoint, method = 'GET', data = null) {
     // Prefix API calls with /public/ so requests hit the proper PHP scripts
-    const url = `/public/api/${endpoint}`;
+    const url = `api/${endpoint}`;
     const options = {
         method: method,
         headers: {


### PR DESCRIPTION
I've updated the `callApi` function in `card_rpg_mvp/public/app.js` to use relative paths for API calls. This was done by changing the `url` variable from `/public/api/${endpoint}` to `api/${endpoint}`.

This change makes your application more resilient to different server configurations and resolves potential 404 errors when accessing API endpoints.