### PR TITLE
Add data-driven ability system

### DIFF
--- a/hero-game/index.html
+++ b/hero-game/index.html
@@ -63,7 +63,14 @@
                 <div class="shimmer-effect" style="display: none;"></div>
                 <div class="hero-art"></div>
                 <h3 class="hero-name font-cinzel"></h3>
-                <div class="hero-stats"></div>
+                <div class="hero-stats">
+                    <div class="stat-block hp-stat">
+                        <span class="stat-value"></span><span class="stat-label">HP</span>
+                    </div>
+                    <div class="stat-block attack-stat">
+                        <span class="stat-value"></span><span class="stat-label">Attack</span>
+                    </div>
+                </div>
                 <ul class="hero-abilities"></ul>
             </div>
         </div>

--- a/hero-game/js/data.js
+++ b/hero-game/js/data.js
@@ -3,55 +3,120 @@
 
 export const allPossibleHeroes = [
     // Warrior Class
-    { type: 'hero', id: 1, name: 'Recruit', rarity: 'Common', art: 'https://placehold.co/150x126/6b7280/FFFFFF?text=Recruit', hp: 18, attack: 3, abilities: [{ name: 'Basic Strike', description: 'Deals 3 damage.' }] },
-    { type: 'hero', id: 2, name: 'Squire', rarity: 'Uncommon', art: 'https://placehold.co/150x126/78716c/FFFFFF?text=Squire', hp: 22, attack: 5, abilities: [{ name: 'Power Strike', description: 'Deals 5 damage.' }, { name: 'Fortify', description: 'Passive: Reduce all incoming damage by 1.' }] },
-    { type: 'hero', id: 3, name: 'Warrior', rarity: 'Rare', art: 'https://placehold.co/150x126/57534e/FFFFFF?text=Warrior', hp: 25, attack: 7, abilities: [{ name: 'Shield Bash', description: 'Deals 1 damage and Stuns the target for 1 turn.' }, { name: 'Power Strike', description: 'Deals 7 damage.' }] },
-    { type: 'hero', id: 4, name: 'Champion', rarity: 'Ultra Rare', art: 'https://placehold.co/150x126/1c1917/FFFFFF?text=Champ', hp: 30, attack: 10, abilities: [{ name: 'Whirlwind', description: 'Deals 4 damage to all enemies.' }, { name: 'Execute', description: 'Deals 10 damage to a single target.' }] },
+    { type: 'hero', id: 1, name: 'Recruit', rarity: 'Common', art: 'https://placehold.co/150x126/6b7280/FFFFFF?text=Recruit', hp: 18, attack: 3, abilities: [
+        { name: 'Basic Strike', description: 'Deals 3 damage.', target: 'ENEMY_SINGLE', effects: [{ type: 'DEAL_DAMAGE', amount: 3 }] }
+    ] },
+    { type: 'hero', id: 2, name: 'Squire', rarity: 'Uncommon', art: 'https://placehold.co/150x126/78716c/FFFFFF?text=Squire', hp: 22, attack: 5, abilities: [
+        { name: 'Power Strike', description: 'Deals 5 damage.', target: 'ENEMY_SINGLE', effects: [{ type: 'DEAL_DAMAGE', amount: 5 }] },
+        { name: 'Fortify', description: 'Passive: Reduce all incoming damage by 1.' }
+    ] },
+    { type: 'hero', id: 3, name: 'Warrior', rarity: 'Rare', art: 'https://placehold.co/150x126/57534e/FFFFFF?text=Warrior', hp: 25, attack: 7, abilities: [
+        { name: 'Shield Bash', description: 'Deals 1 damage and Stuns the target for 1 turn.', target: 'ENEMY_SINGLE', effects: [ { type: 'DEAL_DAMAGE', amount: 1 }, { type: 'APPLY_STATUS', status: 'Stun', duration: 1 } ] },
+        { name: 'Power Strike', description: 'Deals 7 damage.', target: 'ENEMY_SINGLE', effects: [{ type: 'DEAL_DAMAGE', amount: 7 }] }
+    ] },
+    { type: 'hero', id: 4, name: 'Champion', rarity: 'Ultra Rare', art: 'https://placehold.co/150x126/1c1917/FFFFFF?text=Champ', hp: 30, attack: 10, abilities: [
+        { name: 'Whirlwind', description: 'Deals 4 damage to all enemies.', target: 'ALL_ENEMIES', effects: [{ type: 'DEAL_DAMAGE', amount: 4 }] },
+        { name: 'Execute', description: 'Deals 10 damage to a single target.', target: 'ENEMY_SINGLE', effects: [{ type: 'DEAL_DAMAGE', amount: 10 }] }
+    ] },
     
     // Mage Class
-    { type: 'hero', id: 5, name: 'Apprentice', rarity: 'Common', art: 'https://placehold.co/150x126/93c5fd/1e3a8a?text=Apprentice', hp: 15, attack: 2, abilities: [{ name: 'Magic Bolt', description: 'Deals 2 damage.' }] },
-    { type: 'hero', id: 6, name: 'Mage', rarity: 'Rare', art: 'https://placehold.co/150x126/60a5fa/1e3a8a?text=Mage', hp: 20, attack: 4, abilities: [{ name: 'Fireball', description: 'Deals 8 damage.' }, { name: 'Frost Armor', description: 'Gain 5 temporary HP.' }] },
+    { type: 'hero', id: 5, name: 'Apprentice', rarity: 'Common', art: 'https://placehold.co/150x126/93c5fd/1e3a8a?text=Apprentice', hp: 15, attack: 2, abilities: [
+        { name: 'Magic Bolt', description: 'Deals 2 damage.', target: 'ENEMY_SINGLE', effects: [{ type: 'DEAL_DAMAGE', amount: 2 }] }
+    ] },
+    { type: 'hero', id: 6, name: 'Mage', rarity: 'Rare', art: 'https://placehold.co/150x126/60a5fa/1e3a8a?text=Mage', hp: 20, attack: 4, abilities: [
+        { name: 'Fireball', description: 'Deals 8 damage.', target: 'ENEMY_SINGLE', effects: [{ type: 'DEAL_DAMAGE', amount: 8 }] },
+        { name: 'Frost Armor', description: 'Gain 5 temporary HP.', target: 'SELF', effects: [{ type: 'HEAL', amount: 5 }] }
+    ] },
     
     // Rogue Class
-    { type: 'hero', id: 7, name: 'Thief', rarity: 'Common', art: 'https://placehold.co/150x126/a78bfa/4c1d95?text=Thief', hp: 16, attack: 4, abilities: [{ name: 'Quick Stab', description: 'Deals 4 damage.' }] },
-    { type: 'hero', id: 8, name: 'Assassin', rarity: 'Rare', art: 'https://placehold.co/150x126/8b5cf6/4c1d95?text=Assassin', hp: 21, attack: 8, abilities: [{ name: 'Backstab', description: 'Deals 12 damage if target is above 50% HP.' }, { name: 'Vanish', description: 'Become untargetable for 1 turn.' }] },
+    { type: 'hero', id: 7, name: 'Thief', rarity: 'Common', art: 'https://placehold.co/150x126/a78bfa/4c1d95?text=Thief', hp: 16, attack: 4, abilities: [
+        { name: 'Quick Stab', description: 'Deals 4 damage.', target: 'ENEMY_SINGLE', effects: [{ type: 'DEAL_DAMAGE', amount: 4 }] }
+    ] },
+    { type: 'hero', id: 8, name: 'Assassin', rarity: 'Rare', art: 'https://placehold.co/150x126/8b5cf6/4c1d95?text=Assassin', hp: 21, attack: 8, abilities: [
+        { name: 'Backstab', description: 'Deals 12 damage if target is above 50% HP.', target: 'ENEMY_SINGLE', effects: [{ type: 'DEAL_DAMAGE', amount: 12 }] },
+        { name: 'Vanish', description: 'Become untargetable for 1 turn.', target: 'SELF', effects: [{ type: 'APPLY_STATUS', status: 'Untargetable', duration: 1 }] }
+    ] },
     
     // Priest Class
-    { type: 'hero', id: 9, name: 'Acolyte', rarity: 'Common', art: 'https://placehold.co/150x126/fef08a/b45309?text=Acolyte', hp: 17, attack: 2, abilities: [{ name: 'Minor Heal', description: 'Restores 4 HP to an ally.' }] },
-    { type: 'hero', id: 10, name: 'Priest', rarity: 'Uncommon', art: 'https://placehold.co/150x126/fde047/b45309?text=Priest', hp: 21, attack: 3, abilities: [{ name: 'Heal', description: 'Restores 8 HP.' }, { name: 'Smite', description: 'Deals 3 damage.' }] },
+    { type: 'hero', id: 9, name: 'Acolyte', rarity: 'Common', art: 'https://placehold.co/150x126/fef08a/b45309?text=Acolyte', hp: 17, attack: 2, abilities: [
+        { name: 'Minor Heal', description: 'Restores 4 HP to an ally.', target: 'ALLY_SINGLE', effects: [{ type: 'HEAL', amount: 4 }] }
+    ] },
+    { type: 'hero', id: 10, name: 'Priest', rarity: 'Uncommon', art: 'https://placehold.co/150x126/fde047/b45309?text=Priest', hp: 21, attack: 3, abilities: [
+        { name: 'Heal', description: 'Restores 8 HP.', target: 'ALLY_SINGLE', effects: [{ type: 'HEAL', amount: 8 }] },
+        { name: 'Smite', description: 'Deals 3 damage.', target: 'ENEMY_SINGLE', effects: [{ type: 'DEAL_DAMAGE', amount: 3 }] }
+    ] },
 
     // Ranger Class
-    { type: 'hero', id: 11, name: 'Hunter', rarity: 'Common', art: 'https://placehold.co/150x126/86efac/15803d?text=Hunter', hp: 17, attack: 4, abilities: [{ name: 'Aimed Shot', description: 'Deals 4 damage.' }] },
-    { type: 'hero', id: 12, name: 'Ranger', rarity: 'Uncommon', art: 'https://placehold.co/150x126/4ade80/15803d?text=Ranger', hp: 22, attack: 6, abilities: [{ name: 'Rapid Fire', description: 'Attacks twice for 3 damage each.' }, { name: 'Tracking Shot', description: 'Target takes +1 damage from all sources.' }] },
+    { type: 'hero', id: 11, name: 'Hunter', rarity: 'Common', art: 'https://placehold.co/150x126/86efac/15803d?text=Hunter', hp: 17, attack: 4, abilities: [
+        { name: 'Aimed Shot', description: 'Deals 4 damage.', target: 'ENEMY_SINGLE', effects: [{ type: 'DEAL_DAMAGE', amount: 4 }] }
+    ] },
+    { type: 'hero', id: 12, name: 'Ranger', rarity: 'Uncommon', art: 'https://placehold.co/150x126/4ade80/15803d?text=Ranger', hp: 22, attack: 6, abilities: [
+        { name: 'Rapid Fire', description: 'Attacks twice for 3 damage each.', target: 'ENEMY_SINGLE', effects: [{ type: 'DEAL_DAMAGE', amount: 3 }, { type: 'DEAL_DAMAGE', amount: 3 }] },
+        { name: 'Tracking Shot', description: 'Target takes +1 damage from all sources.', target: 'ENEMY_SINGLE', effects: [{ type: 'APPLY_STATUS', status: 'Marked', duration: 2 }] }
+    ] },
 
     // Paladin Class
-    { type: 'hero', id: 13, name: 'Vindicator', rarity: 'Rare', art: 'https://placehold.co/150x126/fef9c3/a16207?text=Vindicator', hp: 28, attack: 5, abilities: [{ name: 'Divine Strike', description: 'Deals 5 damage and heals self for 2.' }] },
-    { type: 'hero', id: 14, name: 'Paladin', rarity: 'Ultra Rare', art: 'https://placehold.co/150x126/fefce8/a16207?text=Paladin', hp: 32, attack: 8, abilities: [{ name: 'Holy Smite', description: 'Deals 8 damage and heals all allies for 2.' }, {name: 'Divine Shield', description: 'Become immune to damage for 1 turn.'}] },
+    { type: 'hero', id: 13, name: 'Vindicator', rarity: 'Rare', art: 'https://placehold.co/150x126/fef9c3/a16207?text=Vindicator', hp: 28, attack: 5, abilities: [
+        { name: 'Divine Strike', description: 'Deals 5 damage and heals self for 2.', target: 'ENEMY_SINGLE', effects: [{ type: 'DEAL_DAMAGE', amount: 5 }, { type: 'HEAL', amount: 2, targetSelf: true }] }
+    ] },
+    { type: 'hero', id: 14, name: 'Paladin', rarity: 'Ultra Rare', art: 'https://placehold.co/150x126/fefce8/a16207?text=Paladin', hp: 32, attack: 8, abilities: [
+        { name: 'Holy Smite', description: 'Deals 8 damage and heals all allies for 2.', target: 'ENEMY_SINGLE', effects: [{ type: 'DEAL_DAMAGE', amount: 8 }, { type: 'HEAL', amount: 2, target: 'ALL_ALLIES' }] },
+        { name: 'Divine Shield', description: 'Become immune to damage for 1 turn.', target: 'SELF', effects: [{ type: 'APPLY_STATUS', status: 'Divine Shield', duration: 1 }] }
+    ] },
 
     // Barbarian Class
-    { type: 'hero', id: 15, name: 'Brute', rarity: 'Common', art: 'https://placehold.co/150x126/fca5a5/991b1b?text=Brute', hp: 20, attack: 4, abilities: [{ name: 'Heavy Swing', description: 'Deals 4 damage.'}] },
-    { type: 'hero', id: 16, name: 'Barbarian', rarity: 'Uncommon', art: 'https://placehold.co/150x126/f87171/991b1b?text=Barbarian', hp: 26, attack: 6, abilities: [{ name: 'Reckless Attack', description: 'Deals 10 damage, but take 3 damage.'}, {name: 'Enrage', description: '+2 Attack for 3 turns.'}] },
+    { type: 'hero', id: 15, name: 'Brute', rarity: 'Common', art: 'https://placehold.co/150x126/fca5a5/991b1b?text=Brute', hp: 20, attack: 4, abilities: [
+        { name: 'Heavy Swing', description: 'Deals 4 damage.', target: 'ENEMY_SINGLE', effects: [{ type: 'DEAL_DAMAGE', amount: 4 }] }
+    ] },
+    { type: 'hero', id: 16, name: 'Barbarian', rarity: 'Uncommon', art: 'https://placehold.co/150x126/f87171/991b1b?text=Barbarian', hp: 26, attack: 6, abilities: [
+        { name: 'Reckless Attack', description: 'Deals 10 damage, but take 3 damage.', target: 'ENEMY_SINGLE', effects: [{ type: 'DEAL_DAMAGE', amount: 10 }, { type: 'DEAL_DAMAGE', amount: 3, targetSelf: true }] },
+        { name: 'Enrage', description: '+2 Attack for 3 turns.', target: 'SELF', effects: [{ type: 'APPLY_STATUS', status: 'Enrage', duration: 3 }] }
+    ] },
 
     // Monk Class
-    { type: 'hero', id: 17, name: 'Initiate', rarity: 'Common', art: 'https://placehold.co/150x126/fdba74/c2410c?text=Initiate', hp: 16, attack: 4, abilities: [{ name: 'Swift Fist', description: 'Deals 4 damage.'}] },
-    { type: 'hero', id: 18, name: 'Monk', rarity: 'Rare', art: 'https://placehold.co/150x126/fb923c/c2410c?text=Monk', hp: 24, attack: 5, abilities: [{ name: 'Flurry of Blows', description: 'Attack 3 times for 2 damage each.'}, {name: 'Stunning Palm', description: 'Has a 25% chance to Stun.'}] },
+    { type: 'hero', id: 17, name: 'Initiate', rarity: 'Common', art: 'https://placehold.co/150x126/fdba74/c2410c?text=Initiate', hp: 16, attack: 4, abilities: [
+        { name: 'Swift Fist', description: 'Deals 4 damage.', target: 'ENEMY_SINGLE', effects: [{ type: 'DEAL_DAMAGE', amount: 4 }] }
+    ] },
+    { type: 'hero', id: 18, name: 'Monk', rarity: 'Rare', art: 'https://placehold.co/150x126/fb923c/c2410c?text=Monk', hp: 24, attack: 5, abilities: [
+        { name: 'Flurry of Blows', description: 'Attack 3 times for 2 damage each.', target: 'ENEMY_SINGLE', effects: [{ type: 'DEAL_DAMAGE', amount: 2 }, { type: 'DEAL_DAMAGE', amount: 2 }, { type: 'DEAL_DAMAGE', amount: 2 }] },
+        { name: 'Stunning Palm', description: 'Has a 25% chance to Stun.', target: 'ENEMY_SINGLE', effects: [{ type: 'APPLY_STATUS', status: 'Stun', duration: 1 }] }
+    ] },
     
     // Druid Class
-    { type: 'hero', id: 19, name: 'Shapeshifter', rarity: 'Uncommon', art: 'https://placehold.co/150x126/a3e635/3f6212?text=Shapeshifter', hp: 23, attack: 5, abilities: [{ name: 'Bear Form', description: 'Gain +5 HP and +2 Attack for 2 turns.'}] },
-    { type: 'hero', id: 20, name: 'Archdruid', rarity: 'Ultra Rare', art: 'https://placehold.co/150x126/84cc16/3f6212?text=Archdruid', hp: 28, attack: 7, abilities: [{ name: 'Entangling Roots', description: 'Target cannot attack for 2 turns.'}, { name: 'Starfall', description: 'Deals 3 damage to all enemies for 2 turns.'}] },
+    { type: 'hero', id: 19, name: 'Shapeshifter', rarity: 'Uncommon', art: 'https://placehold.co/150x126/a3e635/3f6212?text=Shapeshifter', hp: 23, attack: 5, abilities: [
+        { name: 'Bear Form', description: 'Gain +5 HP and +2 Attack for 2 turns.', target: 'SELF', effects: [{ type: 'APPLY_STATUS', status: 'Bear Form', duration: 2 }] }
+    ] },
+    { type: 'hero', id: 20, name: 'Archdruid', rarity: 'Ultra Rare', art: 'https://placehold.co/150x126/84cc16/3f6212?text=Archdruid', hp: 28, attack: 7, abilities: [
+        { name: 'Entangling Roots', description: 'Target cannot attack for 2 turns.', target: 'ENEMY_SINGLE', effects: [{ type: 'APPLY_STATUS', status: 'Rooted', duration: 2 }] },
+        { name: 'Starfall', description: 'Deals 3 damage to all enemies for 2 turns.', target: 'ALL_ENEMIES', effects: [{ type: 'DEAL_DAMAGE', amount: 3 }, { type: 'DEAL_DAMAGE', amount: 3 }] }
+    ] },
 
     // Warlock Class
-    { type: 'hero', id: 21, name: 'Cultist', rarity: 'Common', art: 'https://placehold.co/150x126/c084fc/581c87?text=Cultist', hp: 16, attack: 3, abilities: [{ name: 'Shadow Bolt', description: 'Deals 3 damage.'}] },
-    { type: 'hero', id: 22, name: 'Warlock', rarity: 'Rare', art: 'https://placehold.co/150x126/a855f7/581c87?text=Warlock', hp: 22, attack: 6, abilities: [{ name: 'Life Drain', description: 'Deals 5 damage and heal for the same amount.'}, { name: 'Curse of Weakness', description: 'Target deals -2 damage for 3 turns.'}] },
+    { type: 'hero', id: 21, name: 'Cultist', rarity: 'Common', art: 'https://placehold.co/150x126/c084fc/581c87?text=Cultist', hp: 16, attack: 3, abilities: [
+        { name: 'Shadow Bolt', description: 'Deals 3 damage.', target: 'ENEMY_SINGLE', effects: [{ type: 'DEAL_DAMAGE', amount: 3 }] }
+    ] },
+    { type: 'hero', id: 22, name: 'Warlock', rarity: 'Rare', art: 'https://placehold.co/150x126/a855f7/581c87?text=Warlock', hp: 22, attack: 6, abilities: [
+        { name: 'Life Drain', description: 'Deals 5 damage and heal for the same amount.', target: 'ENEMY_SINGLE', effects: [{ type: 'DEAL_DAMAGE', amount: 5 }, { type: 'HEAL', amount: 5, targetSelf: true }] },
+        { name: 'Curse of Weakness', description: 'Target deals -2 damage for 3 turns.', target: 'ENEMY_SINGLE', effects: [{ type: 'APPLY_STATUS', status: 'Weakened', duration: 3 }] }
+    ] },
 
     // Bard Class
-    { type: 'hero', id: 23, name: 'Minstrel', rarity: 'Uncommon', art: 'https://placehold.co/150x126/f9a8d4/9d2667?text=Minstrel', hp: 20, attack: 2, abilities: [{ name: 'Song of Vigor', description: 'All allies gain +1 attack.'}, { name: 'Dissonance', description: 'Confuses target, 50% chance to attack ally.'}] },
+    { type: 'hero', id: 23, name: 'Minstrel', rarity: 'Uncommon', art: 'https://placehold.co/150x126/f9a8d4/9d2667?text=Minstrel', hp: 20, attack: 2, abilities: [
+        { name: 'Song of Vigor', description: 'All allies gain +1 attack.', target: 'ALL_ALLIES', effects: [{ type: 'APPLY_STATUS', status: 'Vigor', duration: 3 }] },
+        { name: 'Dissonance', description: 'Confuses target, 50% chance to attack ally.', target: 'ENEMY_SINGLE', effects: [{ type: 'APPLY_STATUS', status: 'Confused', duration: 1 }] }
+    ] },
 ];
 
 export const allPossibleWeapons = [
-    { type: 'weapon', id: 101, name: 'Iron Sword', rarity: 'Common', art: 'https://placehold.co/256x202/6b7280/FFFFFF?text=Sword', damage: 2, abilities: [{ name: 'Cleave', description: 'Deals 50% damage to the second target.' }] },
-    { type: 'weapon', id: 102, name: 'Mage Staff', rarity: 'Uncommon', art: 'https://placehold.co/256x202/5b21b6/FFFFFF?text=Staff', damage: 1, abilities: [{ name: 'Fireball', description: 'The wielder\'s basic attack becomes Fireball.' }] },
-    { type: 'weapon', id: 103, name: 'Glimmering Dagger', rarity: 'Rare', art: 'https://placehold.co/256x202/facc15/000000?text=Dagger', damage: 3, abilities: [{ name: 'Poison Tip', description: '10% chance to apply Poison on hit.' }] },
+    { type: 'weapon', id: 101, name: 'Iron Sword', rarity: 'Common', art: 'https://placehold.co/256x202/6b7280/FFFFFF?text=Sword', damage: 2, abilities: [
+        { name: 'Cleave', description: 'Deals 50% damage to the second target.', target: 'ENEMY_ADDITIONAL', effects: [{ type: 'DEAL_DAMAGE_PERCENT', percent: 50 }] }
+    ] },
+    { type: 'weapon', id: 102, name: 'Mage Staff', rarity: 'Uncommon', art: 'https://placehold.co/256x202/5b21b6/FFFFFF?text=Staff', damage: 1, abilities: [
+        { name: 'Fireball', description: 'The wielder\'s basic attack becomes Fireball.' }
+    ] },
+    { type: 'weapon', id: 103, name: 'Glimmering Dagger', rarity: 'Rare', art: 'https://placehold.co/256x202/facc15/000000?text=Dagger', damage: 3, abilities: [
+        { name: 'Poison Tip', description: '10% chance to apply Poison on hit.', target: 'ENEMY_SINGLE', effects: [{ type: 'APPLY_STATUS_CHANCE', status: 'Poison', duration: 3, chance: 0.1 }] }
+    ] },
 ];
 
 export const battleSpeeds = [

--- a/hero-game/js/systems/EffectProcessor.js
+++ b/hero-game/js/systems/EffectProcessor.js
@@ -1,0 +1,24 @@
+export function processEffect(effect, attacker, target, scene) {
+    switch (effect.type) {
+        case 'DEAL_DAMAGE':
+            scene._dealDamage(attacker, target, effect.amount);
+            break;
+        case 'DEAL_DAMAGE_PERCENT':
+            const dmg = Math.ceil((attacker.heroData.attack + attacker.weaponData.damage) * (effect.percent / 100));
+            scene._dealDamage(attacker, target, dmg);
+            break;
+        case 'HEAL':
+            scene._heal(effect.targetSelf ? attacker : target, effect.amount);
+            break;
+        case 'APPLY_STATUS':
+            scene._applyStatus(target, effect.status, effect.duration);
+            break;
+        case 'APPLY_STATUS_CHANCE':
+            if (Math.random() < effect.chance) {
+                scene._applyStatus(target, effect.status, effect.duration);
+            }
+            break;
+        default:
+            console.warn('Unknown effect type', effect);
+    }
+}

--- a/hero-game/js/ui/CardRenderer.js
+++ b/hero-game/js/ui/CardRenderer.js
@@ -20,15 +20,13 @@ export function createDetailCard(item, selectionHandler) {
     clone.querySelector('.hero-art').style.backgroundImage = `url('${item.art}')`;
     clone.querySelector('.hero-name').textContent = item.name;
 
-    let statsHtml = '';
     if (item.type === 'hero') {
-        statsHtml = `
-            <div class="stat-block"><span class="stat-value">${item.hp}</span><span class="stat-label">HP</span></div>
-            <div class="stat-block"><span class="stat-value">${item.attack}</span><span class="stat-label">Attack</span></div>`;
+        clone.querySelector('.hp-stat .stat-value').textContent = item.hp;
+        clone.querySelector('.attack-stat .stat-value').textContent = item.attack;
     } else {
-        statsHtml = `<div class="stat-block"><span class="stat-value">+${item.damage}</span><span class="stat-label">Damage</span></div>`;
+        const statsContainer = clone.querySelector('.hero-stats');
+        statsContainer.innerHTML = `<div class="stat-block"><span class="stat-value">+${item.damage}</span><span class="stat-label">Damage</span></div>`;
     }
-    clone.querySelector('.hero-stats').innerHTML = statsHtml;
 
     const abilitiesHtml = item.abilities.map(ab => 
         `<li>${ab.name}<div class="tooltip">${ab.description}</div></li>`


### PR DESCRIPTION
## Summary
- define ability effects in `data.js`
- process ability effects via new `EffectProcessor`
- refactor battle scene AI to use effect data
- add healing helper
- refine detail card HTML template and renderer logic

## Testing
- `node -e "import('./hero-game/js/data.js').then(()=>console.log('ok')).catch(e=>console.error(e))"`
- `node -e "import('./hero-game/js/scenes/BattleScene.js').then(()=>console.log('ok')).catch(e=>console.error(e))"` *(fails: document is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_684b8cd5b9908327bff2660d85cc5538