### PR TITLE
Add reveal scene with card flipping flow

### DIFF
--- a/hero-game/index.html
+++ b/hero-game/index.html
@@ -16,7 +16,13 @@
         <div id="booster-pack" class="booster-pack">
             <i class="fa-solid fa-user-group text-8xl text-yellow-200 opacity-80"></i>
         </div>
+        <div id="pack-tear-overlay" class="pack-tear-overlay hidden"></div>
         <p id="pack-scene-instructions" class="text-lg text-gray-400 mt-8">Click the pack to begin.</p>
+    </div>
+
+    <div id="reveal-scene" class="scene hidden">
+        <div id="reveal-area"></div>
+        <p id="reveal-instructions" class="text-lg text-gray-400 mt-8 absolute bottom-16">Click a card to reveal it.</p>
     </div>
 
     <div id="draft-scene" class="scene hidden">

--- a/hero-game/js/scenes/DraftScene.js
+++ b/hero-game/js/scenes/DraftScene.js
@@ -1,9 +1,9 @@
 import { createDetailCard } from '../ui/CardRenderer.js';
 
 export class DraftScene {
-    constructor(element, onHeroSelected) {
+    constructor(element, onItemSelected) {
         this.element = element;
-        this.onHeroSelected = onHeroSelected;
+        this.onItemSelected = onItemSelected;
 
         this.instructionsElement = this.element.querySelector('#draft-instructions');
         this.poolElement = this.element.querySelector('#draft-pool');
@@ -11,10 +11,18 @@ export class DraftScene {
 
     render(packData, draftStage) {
         this.poolElement.innerHTML = '';
-        this.instructionsElement.textContent = `Choose your ${draftStage === 'HERO_1_DRAFT' ? 'first' : 'second'} hero.`;
+        let instruction = '';
+        if (draftStage.startsWith('HERO')) {
+            instruction = `Choose your ${draftStage === 'HERO_1_DRAFT' ? 'first' : 'second'} hero.`;
+        } else if (draftStage.startsWith('WEAPON')) {
+            instruction = 'Select a weapon.';
+        } else {
+            instruction = 'Select a card.';
+        }
+        this.instructionsElement.textContent = instruction;
 
-        packData.forEach(hero => {
-            const cardElement = createDetailCard(hero, () => this.onHeroSelected(hero));
+        packData.forEach(item => {
+            const cardElement = createDetailCard(item, () => this.onItemSelected(item));
             this.poolElement.appendChild(cardElement);
         });
     }

--- a/hero-game/js/scenes/RevealScene.js
+++ b/hero-game/js/scenes/RevealScene.js
@@ -1,0 +1,70 @@
+import { createDetailCard } from '../ui/CardRenderer.js';
+
+export class RevealScene {
+    constructor(element, onRevealComplete) {
+        this.element = element;
+        this.onRevealComplete = onRevealComplete;
+
+        this.revealArea = this.element.querySelector('#reveal-area');
+        this.instructions = this.element.querySelector('#reveal-instructions');
+
+        this.packContents = [];
+        this.revealedCardCount = 0;
+    }
+
+    startReveal(choices) {
+        this.packContents = choices;
+        this.revealedCardCount = 0;
+        this.revealArea.innerHTML = '';
+        this.instructions.textContent = 'Click a card to reveal it.';
+
+        choices.slice().reverse().forEach((item, index) => {
+            const cardWrapper = document.createElement('div');
+            cardWrapper.className = 'revealed-card';
+            cardWrapper.dataset.cardIndex = choices.length - 1 - index;
+
+            const rotation = (index - 1) * 5;
+            const yOffset = Math.abs(index - 1) * 20;
+            cardWrapper.style.transform = `rotate(${rotation}deg) translateY(${yOffset}px) translateZ(${index * -20}px)`;
+            cardWrapper.style.zIndex = index;
+
+            const rarity = (item.rarity || 'common').toLowerCase();
+            if (rarity === 'rare') cardWrapper.classList.add('pre-reveal-rare');
+            else if (rarity === 'ultra-rare') cardWrapper.classList.add('pre-reveal-ultra-rare');
+
+            cardWrapper.addEventListener('click', this.handleCardClick.bind(this));
+            this.revealArea.appendChild(cardWrapper);
+        });
+    }
+
+    handleCardClick(e) {
+        const cardWrapper = e.currentTarget;
+        if (cardWrapper.classList.contains('is-dismissed')) return;
+
+        if (cardWrapper.classList.contains('is-flipping')) {
+            cardWrapper.classList.add('is-dismissed');
+            this.revealedCardCount++;
+            if (this.revealedCardCount >= this.packContents.length) {
+                this.instructions.textContent = 'All cards revealed!';
+                setTimeout(() => {
+                    this.onRevealComplete(this.packContents);
+                }, 800);
+            }
+        } else {
+            const cardIndex = parseInt(cardWrapper.dataset.cardIndex);
+            const itemData = this.packContents[cardIndex];
+
+            const cardFace = document.createElement('div');
+            cardFace.className = 'card-face';
+            const detailCard = createDetailCard(itemData);
+            cardFace.appendChild(detailCard);
+            cardWrapper.appendChild(cardFace);
+
+            cardWrapper.classList.add('is-flipping');
+            this.instructions.textContent = 'Click the card again to dismiss it.';
+        }
+    }
+
+    show() { this.element.classList.remove('hidden'); }
+    hide() { this.element.classList.add('hidden'); }
+}

--- a/hero-game/js/scenes/WeaponScene.js
+++ b/hero-game/js/scenes/WeaponScene.js
@@ -1,9 +1,10 @@
 import { createDetailCard } from '../ui/CardRenderer.js';
 
 export class WeaponScene {
-    constructor(element, onWeaponSelected) {
+    constructor(element, onWeaponSelected, onPackClicked) {
         this.element = element;
         this.onWeaponSelected = onWeaponSelected;
+        this.onPackClicked = onPackClicked;
         
         this.instructionsElement = this.element.querySelector('#weapon-instructions');
         this.packElement = this.element.querySelector('#weapon-pack');
@@ -20,8 +21,7 @@ export class WeaponScene {
         this.packElement.classList.add('opening');
 
         this.packElement.addEventListener('animationend', () => {
-            this.packElement.style.display = 'none';
-            this.draftPoolElement.style.display = 'grid';
+            if (this.onPackClicked) this.onPackClicked();
         }, { once: true });
     }
 
@@ -33,6 +33,10 @@ export class WeaponScene {
             const cardElement = createDetailCard(weapon, () => this.onWeaponSelected(weapon));
             this.draftPoolElement.appendChild(cardElement);
         });
+    }
+
+    updateInstructions(text) {
+        this.instructionsElement.textContent = text;
     }
 
     reset() {

--- a/hero-game/js/ui/CardRenderer.js
+++ b/hero-game/js/ui/CardRenderer.js
@@ -10,7 +10,7 @@ const compactCardTemplate = document.getElementById('compact-card-template');
 export function createDetailCard(item, selectionHandler) {
     const clone = detailCardTemplate.content.cloneNode(true);
     const cardElement = clone.querySelector('.hero-card');
-    const rarityClass = item.rarity.toLowerCase().replace(' ', '-');
+    const rarityClass = (item.rarity || 'common').toLowerCase().replace(' ', '-');
     cardElement.classList.add(rarityClass);
 
     if (item.rarity === 'Ultra Rare') {
@@ -20,21 +20,36 @@ export function createDetailCard(item, selectionHandler) {
     clone.querySelector('.hero-art').style.backgroundImage = `url('${item.art}')`;
     clone.querySelector('.hero-name').textContent = item.name;
 
-    if (item.type === 'hero') {
-        clone.querySelector('.hp-stat .stat-value').textContent = item.hp;
-        clone.querySelector('.attack-stat .stat-value').textContent = item.attack;
-    } else {
-        const statsContainer = clone.querySelector('.hero-stats');
-        statsContainer.innerHTML = `<div class="stat-block"><span class="stat-value">+${item.damage}</span><span class="stat-label">Damage</span></div>`;
+    let statsHtml = '', descriptionHtml = '';
+
+    switch(item.type) {
+        case 'hero':
+            statsHtml = `<div class="stat-block"><span class="stat-value">${item.hp}</span><span class="stat-label">HP</span></div>` +
+                        `<div class="stat-block"><span class="stat-value">${item.attack}</span><span class="stat-label">Attack</span></div>`;
+            descriptionHtml = `<p class="item-description">Class: ${item.class}</p>`;
+            break;
+        case 'ability':
+            descriptionHtml = `<p class="item-description">${item.description}</p>`;
+            break;
+        case 'weapon':
+            statsHtml = `<div class="stat-block"><span class="stat-value">+${item.damage}</span><span class="stat-label">Damage</span></div>`;
+            descriptionHtml = `<ul class="hero-abilities">${item.abilities.map(ab => `<li>${ab.name}</li>`).join('')}</ul>`;
+            break;
+        case 'armor':
+            statsHtml = `<div class="stat-block"><span class="stat-value">+${item.hp}</span><span class="stat-label">HP</span></div>`;
+            descriptionHtml = `<ul class="hero-abilities">${item.abilities.map(ab => `<li>${ab.name}</li>`).join('')}</ul>`;
+            break;
     }
 
-    const abilitiesHtml = item.abilities.map(ab => 
-        `<li>${ab.name}<div class="tooltip">${ab.description}</div></li>`
-    ).join('');
-    clone.querySelector('.hero-abilities').innerHTML = abilitiesHtml;
+    clone.querySelector('.hero-stats').innerHTML = statsHtml;
+    const abilitiesEl = clone.querySelector('.hero-abilities');
+    abilitiesEl.innerHTML = descriptionHtml;
 
-    cardElement.addEventListener('click', () => selectionHandler(item));
-    return clone;
+    if (selectionHandler) {
+        cardElement.addEventListener('click', () => selectionHandler(item));
+    }
+
+    return clone.querySelector('.hero-card-container');
 }
 
 /**

--- a/hero-game/style.css
+++ b/hero-game/style.css
@@ -161,3 +161,28 @@ body {
 #play-again-button { margin-top: 2rem; background-color: #fde047; color: #111827; padding: 1rem 3rem; border: none; border-radius: 0.5rem; font-size: 1.5rem; font-weight: 600; cursor: pointer; transition: transform 0.2s; }
 #play-again-button:hover { transform: scale(1.1); }
 #end-screen-results { display: flex; gap: 1rem; margin-top: 2rem; }
+
+/* ==========================================================================
+   Pack Opening & Reveal Scene Styles
+   ========================================================================== */
+
+/* --- Pack Styles from Prototype --- */
+.pack.opening { animation: shake-and-glow-short 0.5s ease-in-out forwards; }
+@keyframes shake-and-glow-short {
+    0%, 100% { transform: scale(1) rotate(0deg); }
+    20%, 60% { transform: scale(1.05) rotate(2deg); }
+    40%, 80% { transform: scale(1.05) rotate(-2deg); }
+    50% { box-shadow: 0 0 60px rgba(253, 224, 71, 0.8); }
+}
+
+.pack-tear-overlay { position: absolute; top: 0; left: 0; width: 100%; height: 100%; pointer-events: none; background: rgba(0,0,0,0.5); display: none; }
+
+/* --- Reveal Scene & Animations from Prototype --- */
+#reveal-area { display: flex; justify-content: center; align-items: center; position: relative; }
+.revealed-card { width: 320px; height: 450px; position: absolute; cursor: pointer; transition: transform 0.4s; transform-style: preserve-3d; }
+.revealed-card.is-flipping { transform: rotateY(180deg); }
+.revealed-card.is-dismissed { opacity: 0; transform: translateY(200px); pointer-events: none; }
+.revealed-card.pre-reveal-rare { animation: pulse-glow-rare 1s infinite alternate; }
+.revealed-card.pre-reveal-ultra-rare { animation: pulse-glow-ultra 1s infinite alternate; }
+@keyframes pulse-glow-rare { from { box-shadow: 0 0 10px #f59e0b; } to { box-shadow: 0 0 20px #f59e0b; } }
+@keyframes pulse-glow-ultra { from { box-shadow: 0 0 10px #a78bfa; } to { box-shadow: 0 0 25px #a78bfa; } }


### PR DESCRIPTION
## Summary
- add a new RevealScene for pack card flipping
- wire the reveal scene into the draft flow
- update CardRenderer to handle more item types
- make DraftScene generic for items
- tweak WeaponScene for new pack opening logic
- support new scene in styles and markup

## Testing
- `no tests`

------
https://chatgpt.com/codex/tasks/task_e_684b8f19ebb48327bc5e20060ed9451e