### PR TITLE
Add armor equipment system

### DIFF
--- a/hero-game/js/data.js
+++ b/hero-game/js/data.js
@@ -102,6 +102,33 @@ export const allPossibleWeapons = [
 ];
 // NOTE: Placeholder art links ('...') and IDs have been assigned.
 
+export const allPossibleArmors = [
+    // 1. Light Armor (Evasion & Speed)
+    { id: 2101, type: 'armor', name: 'Leather Padding', rarity: 'Common', armorType: 'Light', art: '...', statBonuses: { Block: 1 }, ability: null },
+    { id: 2102, type: 'armor', name: 'Agile Reflexes', rarity: 'Uncommon', armorType: 'Light', art: '...', statBonuses: { Evasion: 2 }, ability: null },
+    { id: 2103, type: 'armor', name: 'Shadow Garb', rarity: 'Rare', armorType: 'Light', art: '...', statBonuses: { Evasion: 2, SPD: 1 }, ability: null },
+    { id: 2104, type: 'armor', name: 'Phantom Cloak', rarity: 'Epic', armorType: 'Light', art: '...', statBonuses: { Evasion: 3 }, ability: { name: 'Untouchable', description: 'Once per combat, the first time this hero is attacked, they ignore it.' } },
+
+    // 2. Medium Armor (Balanced Defense & Utility)
+    { id: 2201, type: 'armor', name: 'Studded Vest', rarity: 'Common', armorType: 'Medium', art: '...', statBonuses: { Block: 1, Evasion: 1 }, ability: null },
+    { id: 2202, type: 'armor', name: 'Chainmail Guard', rarity: 'Uncommon', armorType: 'Medium', art: '...', statBonuses: { Block: 2 }, ability: null },
+    { id: 2203, type: 'armor', name: 'Vanguard Mail', rarity: 'Rare', armorType: 'Medium', art: '...', statBonuses: { Block: 2 }, ability: { name: 'Thorns', description: 'When hit by a melee attack, reflect 1 damage back to the attacker.' } },
+    { id: 2204, type: 'armor', name: 'Captain’s Bulwark', rarity: 'Epic', armorType: 'Medium', art: '...', statBonuses: { Block: 2 }, ability: { name: 'Inspiring Presence', description: 'Adjacent allies gain +1 Block.' } },
+
+    // 3. Heavy Armor (Pure Damage Soak)
+    { id: 2301, type: 'armor', name: 'Iron Plate', rarity: 'Common', armorType: 'Heavy', art: '...', statBonuses: { Block: 2 }, ability: null },
+    { id: 2302, type: 'armor', name: 'Reinforced Plating', rarity: 'Uncommon', armorType: 'Heavy', art: '...', statBonuses: { Block: 3, SPD: -1 }, ability: null },
+    { id: 2303, type: 'armor', name: 'Juggernaut Armor', rarity: 'Rare', armorType: 'Heavy', art: '...', statBonuses: { Block: 3 }, ability: { name: 'Unstoppable', description: 'This hero is immune to Stun effects.' } },
+    { id: 2304, type: 'armor', name: 'Aegis of the Colossus', rarity: 'Epic', armorType: 'Heavy', art: '...', statBonuses: { Block: 1 }, ability: { name: 'Aegis Protection', description: 'Once per combat, completely nullify the damage from one attack.' } },
+
+    // 4. Magic Armor (Magical Defense)
+    { id: 2401, type: 'armor', name: 'Mystic Robes', rarity: 'Common', armorType: 'Magic', art: '...', statBonuses: { MagicResist: 2 }, ability: null },
+    { id: 2402, type: 'armor', name: 'Arcane Shielding', rarity: 'Uncommon', armorType: 'Magic', art: '...', statBonuses: {}, ability: { name: 'Spell Ward', description: 'Once per combat, block the effects of the next enemy ability.' } },
+    { id: 2403, type: 'armor', name: 'Runed Cloak', rarity: 'Rare', armorType: 'Magic', art: '...', statBonuses: { MagicResist: 3, SPD: 1 }, ability: null },
+    { id: 2404, type: 'armor', name: 'Ward of Eternity', rarity: 'Epic', armorType: 'Magic', art: '...', statBonuses: { MagicResist: 2 }, ability: { name: 'Magic Immunity', description: 'This hero is immune to all magic damage.' } },
+];
+// NOTE: Placeholder art links ('...') and new IDs have been assigned. 'Block' reduces physical damage, 'MagicResist' reduces magic damage.
+
 export const battleSpeeds = [
     { label: '1x', multiplier: 2 },
     { label: '2x', multiplier: 1 },

--- a/hero-game/js/main.js
+++ b/hero-game/js/main.js
@@ -1,5 +1,5 @@
 // Import data and utilities
-import { allPossibleHeroes, allPossibleWeapons } from './data.js';
+import { allPossibleHeroes, allPossibleWeapons, allPossibleArmors } from './data.js';
 
 // Import UI and Scene classes
 import { PackScene } from './scenes/PackScene.js';
@@ -15,7 +15,7 @@ const gameState = {
     currentScene: 'pack', // 'pack', 'draft', 'weapon', 'battle'
     draft: {
         stage: 'HERO_1_PACK', // HERO_1_PACK, HERO_1_DRAFT, WEAPON_1_DRAFT, HERO_2_PACK, etc.
-        playerTeam: { hero1: null, weapon1: null, hero2: null, weapon2: null },
+        playerTeam: { hero1: null, weapon1: null, armor1: null, hero2: null, weapon2: null, armor2: null },
     }
 };
 
@@ -56,6 +56,10 @@ const draftScene = new DraftScene(sceneElements.draft, (selectedItem) => {
         gameState.draft.playerTeam.weapon1 = selectedItem.id;
     } else if (stage === 'WEAPON_2_DRAFT') {
         gameState.draft.playerTeam.weapon2 = selectedItem.id;
+    } else if (stage === 'ARMOR_1_DRAFT') {
+        gameState.draft.playerTeam.armor1 = selectedItem.id;
+    } else if (stage === 'ARMOR_2_DRAFT') {
+        gameState.draft.playerTeam.armor2 = selectedItem.id;
     }
     advanceDraft();
 });
@@ -81,6 +85,9 @@ function openPack() {
         case 'WEAPON':
             choices = generateWeaponChoices();
             break;
+        case 'ARMOR':
+            choices = generateArmorChoices();
+            break;
     }
 
     transitionToScene('reveal');
@@ -98,6 +105,11 @@ function advanceDraft() {
         weaponScene.updateInstructions(`Choose a weapon pack for ${heroName}`);
         transitionToScene('weapon');
     } else if (stage === 'WEAPON_1_DRAFT' && team.weapon1) {
+        gameState.draft.stage = 'ARMOR_1_PACK';
+        packScene.reset();
+        packScene.render(gameState.draft.stage);
+        transitionToScene('pack');
+    } else if (stage === 'ARMOR_1_DRAFT' && team.armor1) {
         gameState.draft.stage = 'HERO_2_PACK';
         packScene.reset();
         packScene.render(gameState.draft.stage);
@@ -109,6 +121,11 @@ function advanceDraft() {
         weaponScene.updateInstructions(`Choose a weapon pack for ${heroName}`);
         transitionToScene('weapon');
     } else if (stage === 'WEAPON_2_DRAFT' && team.weapon2) {
+        gameState.draft.stage = 'ARMOR_2_PACK';
+        packScene.reset();
+        packScene.render(gameState.draft.stage);
+        transitionToScene('pack');
+    } else if (stage === 'ARMOR_2_DRAFT' && team.armor2) {
         gameState.draft.stage = 'DONE';
         confirmationBar.classList.add('visible');
     }
@@ -145,6 +162,11 @@ function generateHeroPack() {
 
 function generateWeaponChoices() {
     const shuffled = [...allPossibleWeapons].sort(() => 0.5 - Math.random());
+    return shuffled.slice(0, 3);
+}
+
+function generateArmorChoices() {
+    const shuffled = [...allPossibleArmors].sort(() => 0.5 - Math.random());
     return shuffled.slice(0, 3);
 }
 

--- a/hero-game/js/scenes/DraftScene.js
+++ b/hero-game/js/scenes/DraftScene.js
@@ -16,6 +16,8 @@ export class DraftScene {
             instruction = `Choose your ${draftStage === 'HERO_1_DRAFT' ? 'first' : 'second'} hero.`;
         } else if (draftStage.startsWith('WEAPON')) {
             instruction = 'Select a weapon.';
+        } else if (draftStage.startsWith('ARMOR')) {
+            instruction = 'Select an armor.';
         } else {
             instruction = 'Select a card.';
         }

--- a/hero-game/js/scenes/PackScene.js
+++ b/hero-game/js/scenes/PackScene.js
@@ -22,7 +22,13 @@ export class PackScene {
     }
     
     render(draftStage) {
-        this.titleElement.textContent = draftStage === 'HERO_1_PACK' ? 'Open Your Hero Pack' : 'Open Pack for Second Hero';
+        if (draftStage.startsWith('HERO')) {
+            this.titleElement.textContent = draftStage === 'HERO_1_PACK' ? 'Open Your Hero Pack' : 'Open Pack for Second Hero';
+        } else if (draftStage.startsWith('ARMOR')) {
+            this.titleElement.textContent = draftStage === 'ARMOR_1_PACK' ? 'Open Your Armor Pack' : 'Open Pack for Second Armor';
+        } else {
+            this.titleElement.textContent = 'Open Pack';
+        }
     }
 
     reset() {

--- a/hero-game/js/ui/CardRenderer.js
+++ b/hero-game/js/ui/CardRenderer.js
@@ -60,10 +60,24 @@ export function createDetailCard(item, selectionHandler) {
             break;
         case 'armor':
             cardElement.style.backgroundColor = '#1e293b';
-            statsHtml = `<div class="stat-block"><span class="stat-value">+${item.hp}</span><span class="stat-label">HP</span></div>`;
-            if (item.abilities && item.abilities.length > 0) {
-                descriptionHtml = `<ul class="hero-abilities">${item.abilities.map(ab => `<li>${ab.name}</li>`).join('')}</ul>`;
+
+            // Dynamically create stat blocks from the statBonuses object
+            if (item.statBonuses) {
+                statsHtml = Object.entries(item.statBonuses).map(([stat, value]) => {
+                    const sign = value > 0 ? '+' : '';
+                    return `<div class="stat-block"><span class="stat-value">${sign}${value}</span><span class="stat-label">${stat}</span></div>`;
+                }).join('');
             }
+
+            // Display the armor type and passive ability if present
+            descriptionHtml = `
+                <div class="item-ability">
+                    <span class="armor-type-label">${item.armorType} Armor</span>
+                    ${item.ability ? `
+                        <span class="ability-name">${item.ability.name}</span>
+                        <p class="ability-description">${item.ability.description}</p>
+                    ` : ''}
+                </div>`;
             break;
         default:
             cardElement.style.backgroundColor = '#263238';


### PR DESCRIPTION
## Summary
- implement complete armor roster in `data.js`
- render armor stat bonuses and abilities in `CardRenderer`
- wire up armor case in `main.js` and add state handling
- support armor draft instructions in `DraftScene`
- display proper pack titles in `PackScene`

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684de027789083279890a2fe78129f9f