### PR TITLE
Add gradient and inset shadow to hero cards

### DIFF
--- a/hero-game/style.css
+++ b/hero-game/style.css
@@ -79,7 +79,19 @@ body {
 
 /* --- Detail Card Styles --- */
 .hero-card-container { width: 320px; height: 450px; position: relative; perspective: 1500px; }
-.hero-card { box-shadow: 0 10px 25px rgba(0,0,0,0.5); transform-style: preserve-3d; cursor: pointer; border: 4px solid transparent; transition: all 0.3s; width: 100%; height: 100%; position: absolute; border-radius: 1.25rem; background-size: cover; background-position: center; overflow: hidden; }
+.hero-card {
+    background: radial-gradient(circle at 50% 0%, #2d3748, #111827);
+    box-shadow: inset 0 0 50px -10px rgba(0,0,0,0.7), 0 10px 25px rgba(0,0,0,0.5);
+    transform-style: preserve-3d;
+    cursor: pointer;
+    border: 4px solid transparent;
+    transition: all 0.3s;
+    width: 100%;
+    height: 100%;
+    position: absolute;
+    border-radius: 1.25rem;
+    overflow: hidden;
+}
 .hero-card:hover { transform: translateY(-10px) scale(1.05); }
 .hero-card.selected { border-color: #f59e0b; box-shadow: 0 0 25px #f59e0b, 0 10px 30px rgba(0,0,0,0.7); transform: translateY(-5px) scale(1.02); }
 .hero-card.disabled { opacity: 0.5; pointer-events: none; }


### PR DESCRIPTION
## Summary
- update hero card styling with radial gradient and inset shadow

## Testing
- `grep -n '\.hero-card' hero-game/style.css`

------
https://chatgpt.com/codex/tasks/task_e_684de683088883279bf7ca4645022220