### PR TITLE
Add card back artwork

### DIFF
--- a/hero-game/style.css
+++ b/hero-game/style.css
@@ -201,8 +201,10 @@ body {
 
 /* Card back appearance for unrevealed cards */
 .revealed-card.card-back-unrevealed {
-    background: url('../img/card_back.png');
-    border: 4px solid #9ca3af;
+    background-image: url('https://images.unsplash.com/photo-1555448248-2571daf6344b?q=80&w=1887&auto=format&fit=crop');
+    background-size: cover;
+    background-position: center;
+    border: 1px solid rgba(255, 255, 255, 0.1);
 }
 
 /* Maintain glow for rare cards while showing the back */
@@ -216,7 +218,7 @@ body {
 
 /* Remove card back styles when the card is flipping */
 .revealed-card.is-flipping.card-back-unrevealed {
-    background-color: transparent;
+    background-image: none;
     border-color: transparent;
 }
 


### PR DESCRIPTION
## Summary
- add high quality artwork for the card back image
- hide the card back image when flipping

## Testing
- `npm test` *(fails: package.json not found)*

------
https://chatgpt.com/codex/tasks/task_e_684df6420b9083279580a151e367a1d4