### PR TITLE
Remove card hover effect

### DIFF
--- a/hero-game/style.css
+++ b/hero-game/style.css
@@ -92,7 +92,6 @@ body {
     border-radius: 1.25rem;
     overflow: hidden;
 }
-.hero-card:hover { transform: translateY(-10px) scale(1.05); }
 .hero-card.selected { border-color: #f59e0b; box-shadow: 0 0 25px #f59e0b, 0 10px 30px rgba(0,0,0,0.7); transform: translateY(-5px) scale(1.02); }
 .hero-card.disabled { opacity: 0.5; pointer-events: none; }
 .hero-card.common { border-color: #9ca3af; }


### PR DESCRIPTION
## Summary
- remove zoom/translation on hero cards when hovered

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684dfd98d4e483279526eccc07a454d9