### PR TITLE
Update booster pack visuals

### DIFF
--- a/hero-game/index.html
+++ b/hero-game/index.html
@@ -12,11 +12,23 @@
 <body>
 
     <div id="pack-scene" class="scene">
-        <h1 id="pack-scene-title" class="text-5xl font-cinzel tracking-wider mb-8 text-center">Open Your Hero Pack</h1>
-        <div id="booster-pack" class="booster-pack">
-            <i class="fa-solid fa-user-group text-8xl text-yellow-200 opacity-80"></i>
+        <h1 id="pack-scene-title" class="text-5xl font-cinzel tracking-wider mb-8 text-center">Open Your Pack</h1>
+
+        <!-- Container for all the pack types -->
+        <div id="pack-display-area" class="relative">
+            <!-- Hero Pack -->
+            <div id="hero-pack" class="pack hidden"></div>
+
+            <!-- Ability Pack -->
+            <div id="ability-pack" class="pack hidden"></div>
+
+            <!-- Weapon Pack -->
+            <div id="weapon-pack" class="pack hidden"></div>
+
+            <!-- Armor Pack -->
+            <div id="armor-pack" class="pack hidden"></div>
         </div>
-        <div id="pack-tear-overlay" class="pack-tear-overlay hidden"></div>
+
         <p id="pack-scene-instructions" class="text-lg text-gray-400 mt-8">Click the pack to begin.</p>
     </div>
 
@@ -38,7 +50,7 @@
             <h1 id="weapon-scene-title" class="text-5xl font-cinzel tracking-wider">Choose a Weapon</h1>
             <p id="weapon-instructions" class="text-lg text-gray-400 mt-2">Select one weapon.</p>
         </header>
-        <div id="weapon-pack" class="weapon-pack">
+        <div id="weapon-pack-draft" class="weapon-pack">
             <i class="fa-solid fa-box text-8xl text-yellow-200 opacity-80"></i>
         </div>
         <div id="weapon-draft-pool" class="draft-pool weapon-draft-pool mt-8" style="display: none;"></div>

--- a/hero-game/js/main.js
+++ b/hero-game/js/main.js
@@ -28,6 +28,13 @@ const sceneElements = {
     weapon: document.getElementById('weapon-scene'),
     battle: document.getElementById('battle-scene'),
 };
+
+const packElements = {
+    hero: document.getElementById('hero-pack'),
+    ability: document.getElementById('ability-pack'),
+    weapon: document.getElementById('weapon-pack'),
+    armor: document.getElementById('armor-pack')
+};
 const confirmationBar = document.getElementById('confirmation-bar');
 const confirmDraftButton = document.getElementById('confirm-draft');
 
@@ -86,6 +93,16 @@ function transitionToScene(sceneName) {
     sceneElements[sceneName].classList.remove('hidden');
 }
 
+function configurePackScene(stage) {
+    const stageType = stage.split('_')[0].toLowerCase();
+    for (const key in packElements) {
+        packElements[key].classList.add('hidden');
+    }
+    if (packElements[stageType]) {
+        packElements[stageType].classList.remove('hidden');
+    }
+}
+
 function openPack() {
     const stage = gameState.draft.stage;
     const stageType = stage.split('_')[0].toUpperCase();
@@ -130,38 +147,43 @@ function advanceDraft() {
         gameState.draft.stage = 'ABILITY_1_PACK';
         packScene.reset();
         packScene.render(gameState.draft.stage);
+        configurePackScene(gameState.draft.stage);
         transitionToScene('pack');
     } else if (stage === 'ABILITY_1_DRAFT' && team.ability1) {
         gameState.draft.stage = 'WEAPON_1_PACK';
-        weaponScene.reset();
-        const heroName = allPossibleHeroes.find(h => h.id === team.hero1).name;
-        weaponScene.updateInstructions(`Choose a weapon pack for ${heroName}`);
-        transitionToScene('weapon');
+        packScene.reset();
+        packScene.render(gameState.draft.stage);
+        configurePackScene(gameState.draft.stage);
+        transitionToScene('pack');
     } else if (stage === 'WEAPON_1_DRAFT' && team.weapon1) {
         gameState.draft.stage = 'ARMOR_1_PACK';
         packScene.reset();
         packScene.render(gameState.draft.stage);
+        configurePackScene(gameState.draft.stage);
         transitionToScene('pack');
     } else if (stage === 'ARMOR_1_DRAFT' && team.armor1) {
         gameState.draft.stage = 'HERO_2_PACK';
         packScene.reset();
         packScene.render(gameState.draft.stage);
+        configurePackScene(gameState.draft.stage);
         transitionToScene('pack');
     } else if (stage === 'HERO_2_DRAFT' && team.hero2) {
         gameState.draft.stage = 'ABILITY_2_PACK';
         packScene.reset();
         packScene.render(gameState.draft.stage);
+        configurePackScene(gameState.draft.stage);
         transitionToScene('pack');
     } else if (stage === 'ABILITY_2_DRAFT' && team.ability2) {
         gameState.draft.stage = 'WEAPON_2_PACK';
-        weaponScene.reset();
-        const heroName = allPossibleHeroes.find(h => h.id === team.hero2).name;
-        weaponScene.updateInstructions(`Choose a weapon pack for ${heroName}`);
-        transitionToScene('weapon');
+        packScene.reset();
+        packScene.render(gameState.draft.stage);
+        configurePackScene(gameState.draft.stage);
+        transitionToScene('pack');
     } else if (stage === 'WEAPON_2_DRAFT' && team.weapon2) {
         gameState.draft.stage = 'ARMOR_2_PACK';
         packScene.reset();
         packScene.render(gameState.draft.stage);
+        configurePackScene(gameState.draft.stage);
         transitionToScene('pack');
     } else if (stage === 'ARMOR_2_DRAFT' && team.armor2) {
         gameState.draft.stage = 'DONE';
@@ -252,4 +274,5 @@ confirmDraftButton.addEventListener('click', startBattle);
 // --- INITIALIZE ---
 // Set up the initial scene on page load
 packScene.render(gameState.draft.stage);
+configurePackScene(gameState.draft.stage);
 transitionToScene('pack');

--- a/hero-game/js/scenes/PackScene.js
+++ b/hero-game/js/scenes/PackScene.js
@@ -4,19 +4,27 @@ export class PackScene {
         this.onPackOpened = onPackOpened;
 
         this.titleElement = this.element.querySelector('#pack-scene-title');
-        this.packElement = this.element.querySelector('#booster-pack');
-        
-        this.packElement.addEventListener('click', () => this._handlePackOpen());
+        this.packElements = {
+            hero: this.element.querySelector('#hero-pack'),
+            ability: this.element.querySelector('#ability-pack'),
+            weapon: this.element.querySelector('#weapon-pack'),
+            armor: this.element.querySelector('#armor-pack')
+        };
+
+        Object.values(this.packElements).forEach(el => {
+            el.addEventListener('click', () => this._handlePackOpen(el));
+        });
     }
 
-    _handlePackOpen() {
+    _handlePackOpen(packElement) {
         if (this.isOpening) return;
         this.isOpening = true;
 
-        this.packElement.style.pointerEvents = 'none';
-        this.packElement.classList.add('opening');
+        this.currentPackElement = packElement;
+        packElement.style.pointerEvents = 'none';
+        packElement.classList.add('opening');
 
-        this.packElement.addEventListener('animationend', () => {
+        packElement.addEventListener('animationend', () => {
             this.onPackOpened();
         }, { once: true });
     }
@@ -28,6 +36,8 @@ export class PackScene {
             this.titleElement.textContent = draftStage === 'ARMOR_1_PACK' ? 'Open Your Armor Pack' : 'Open Pack for Second Armor';
         } else if (draftStage.startsWith('ABILITY')) {
             this.titleElement.textContent = 'Open Ability Pack';
+        } else if (draftStage.startsWith('WEAPON')) {
+            this.titleElement.textContent = draftStage === 'WEAPON_1_PACK' ? 'Open Your Weapon Pack' : 'Open Pack for Second Weapon';
         } else {
             this.titleElement.textContent = 'Open Pack';
         }
@@ -35,8 +45,10 @@ export class PackScene {
 
     reset() {
         this.isOpening = false;
-        this.packElement.classList.remove('opening');
-        this.packElement.style.pointerEvents = 'auto';
+        Object.values(this.packElements).forEach(el => {
+            el.classList.remove('opening');
+            el.style.pointerEvents = 'auto';
+        });
     }
     
     show() {

--- a/hero-game/js/scenes/WeaponScene.js
+++ b/hero-game/js/scenes/WeaponScene.js
@@ -7,7 +7,7 @@ export class WeaponScene {
         this.onPackClicked = onPackClicked;
         
         this.instructionsElement = this.element.querySelector('#weapon-instructions');
-        this.packElement = this.element.querySelector('#weapon-pack');
+        this.packElement = this.element.querySelector('#weapon-pack-draft');
         this.draftPoolElement = this.element.querySelector('#weapon-draft-pool');
         
         this.packElement.addEventListener('click', () => this._handlePackOpen());

--- a/hero-game/style.css
+++ b/hero-game/style.css
@@ -27,6 +27,65 @@ body {
     top: 0;
 }
 
+/* Generic booster pack style */
+.pack {
+    width: 280px;
+    height: 400px;
+    cursor: pointer;
+    border-radius: 1.25rem;
+    transition: transform 0.3s ease, box-shadow 0.3s ease;
+    position: absolute;
+    top: 0;
+    left: 0;
+    overflow: hidden;
+}
+
+.pack:hover {
+    transform: scale(1.05) translateY(-10px);
+}
+
+/* --- HERO PACK --- */
+#hero-pack {
+    background-image: url('https://github.com/sxfoster/auto-battler/blob/main/img/character_booster.jpg?raw=true');
+    background-size: cover;
+    background-position: center;
+    border: 2px solid rgba(217, 182, 126, 0.5);
+    box-shadow: 0 15px 35px rgba(0,0,0,0.5), inset 0 0 20px rgba(217, 182, 126, 0.2);
+}
+
+/* --- ABILITY PACK --- */
+#ability-pack {
+    width: 320px;
+    height: 400px;
+    background-image: url('https://images.unsplash.com/photo-1544947950-fa07a98d237f?q=80&w=1887&auto=format&fit=crop');
+    background-size: cover;
+    background-position: center;
+    border: 2px solid rgba(132, 188, 217, 0.5);
+    box-shadow: 0 15px 35px rgba(0,0,0,0.5), inset 0 0 20px rgba(132, 188, 217, 0.2);
+}
+
+/* --- WEAPON PACK --- */
+#weapon-pack {
+    width: 350px;
+    height: 350px;
+    background-image: url('https://images.unsplash.com/photo-1599411452403-151b8d2645c8?q=80&w=1770&auto=format&fit=crop');
+    background-size: cover;
+    background-position: center;
+    border: 2px solid rgba(200, 150, 150, 0.5);
+    box-shadow: 0 15px 35px rgba(0,0,0,0.5), inset 0 0 20px rgba(200, 150, 150, 0.2);
+}
+
+/* --- ARMOR PACK --- */
+#armor-pack {
+    width: 320px;
+    height: 380px;
+    background-image: url('https://images.unsplash.com/photo-1593839686923-16782259a851?q=80&w=1887&auto=format&fit=crop');
+    background-size: cover;
+    background-position: center;
+    border: 2px solid rgba(190, 190, 190, 0.5);
+    box-shadow: 0 15px 35px rgba(0,0,0,0.5), inset 0 0 20px rgba(190, 190, 190, 0.2);
+}
+
 /* --- Booster Pack Scene --- */
 .booster-pack, .weapon-pack {
     border-radius: 1rem;


### PR DESCRIPTION
## Summary
- implement unique booster pack elements in `pack-scene`
- add CSS styles for hero, ability, weapon and armor packs
- control pack visibility via `configurePackScene`
- update PackScene to handle multiple packs
- avoid duplicate IDs for weapon pack scene

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684e05fdd1148327831645fc196bddcf