### PR TITLE
Add full ability data and implement ability pack logic

### DIFF
--- a/hero-game/js/data.js
+++ b/hero-game/js/data.js
@@ -157,7 +157,90 @@ export const allPossibleAbilities = [
     { id: 3342, type: 'ability', name: 'Berserker’s Rage', class: 'Raging Fighter', rarity: 'Epic', art: '...', effect: 'For 2 turns, all attacks deal +2 damage and you cannot be stunned or debuffed.', energyCost: 4, category: 'Defense' },
     { id: 3343, type: 'ability', name: 'Unending Rage', class: 'Raging Fighter', rarity: 'Epic', art: '...', effect: 'Your abilities cost 1 less energy for the rest of combat.', energyCost: 4, category: 'Support' },
 
-    // ...Continue for all other classes...
+    // === Raw Power Mage (Sorcerer) ===
+    // Common
+    { id: 3411, type: 'ability', name: 'Chaos Bolt', class: 'Raw Power Mage', rarity: 'Common', art: 'https://placehold.co/150x126/ef4444/FFFFFF?text=Ability', effect: 'Deal 3 damage of a random element.', energyCost: 1, category: 'Offense' },
+    { id: 3412, type: 'ability', name: 'Mana Surge', class: 'Raw Power Mage', rarity: 'Common', art: 'https://placehold.co/150x126/ef4444/FFFFFF?text=Ability', effect: 'Restore 2 energy and gain +1 attack this turn.', energyCost: 1, category: 'Support' },
+    { id: 3413, type: 'ability', name: 'Elemental Spark', class: 'Raw Power Mage', rarity: 'Common', art: 'https://placehold.co/150x126/ef4444/FFFFFF?text=Ability', effect: 'Deal 2 damage and apply a random debuff.', energyCost: 1, category: 'Offense' },
+    // Uncommon
+    { id: 3421, type: 'ability', name: 'Arcane Explosion', class: 'Raw Power Mage', rarity: 'Uncommon', art: 'https://placehold.co/150x126/ef4444/FFFFFF?text=Ability', effect: 'Deal 2 damage to all enemies.', energyCost: 2, category: 'Offense' },
+    { id: 3422, type: 'ability', name: 'Elemental Infusion', class: 'Raw Power Mage', rarity: 'Uncommon', art: 'https://placehold.co/150x126/ef4444/FFFFFF?text=Ability', effect: 'Spells deal +1 damage for 2 turns.', energyCost: 2, category: 'Support' },
+    { id: 3423, type: 'ability', name: 'Chain Lightning', class: 'Raw Power Mage', rarity: 'Uncommon', art: 'https://placehold.co/150x126/ef4444/FFFFFF?text=Ability', effect: 'Deal 3 lightning damage to one enemy and 2 to another.', energyCost: 2, category: 'Offense' },
+    // Rare
+    { id: 3431, type: 'ability', name: 'Firestorm', class: 'Raw Power Mage', rarity: 'Rare', art: 'https://placehold.co/150x126/ef4444/FFFFFF?text=Ability', effect: 'Deal 3 fire damage to all enemies and apply Burn.', energyCost: 3, category: 'Offense' },
+    { id: 3432, type: 'ability', name: 'Elemental Rift', class: 'Raw Power Mage', rarity: 'Rare', art: 'https://placehold.co/150x126/ef4444/FFFFFF?text=Ability', effect: 'Deal 4 random elemental damage and root the enemy.', energyCost: 3, category: 'Offense' },
+    { id: 3433, type: 'ability', name: 'Spell Mirror', class: 'Raw Power Mage', rarity: 'Rare', art: 'https://placehold.co/150x126/ef4444/FFFFFF?text=Ability', effect: 'Reflect the next enemy spell.', energyCost: 3, category: 'Defense' },
+    // Epic
+    { id: 3441, type: 'ability', name: 'Annihilation Sphere', class: 'Raw Power Mage', rarity: 'Epic', art: 'https://placehold.co/150x126/ef4444/FFFFFF?text=Ability', effect: 'Deal 5 damage to all enemies and apply a random status.', energyCost: 4, category: 'Offense' },
+    { id: 3442, type: 'ability', name: 'Chaos Mastery', class: 'Raw Power Mage', rarity: 'Epic', art: 'https://placehold.co/150x126/ef4444/FFFFFF?text=Ability', effect: 'For 3 turns, spells deal +2 damage and cannot be resisted.', energyCost: 4, category: 'Support' },
+
+    // === Divine Healer (Cleric) ===
+    // Common
+    { id: 3511, type: 'ability', name: 'Divine Light', class: 'Divine Healer', rarity: 'Common', art: 'https://placehold.co/150x126/ef4444/FFFFFF?text=Ability', effect: 'Heal an ally for 4 HP.', energyCost: 1, category: 'Support' },
+    { id: 3512, type: 'ability', name: 'Smite Evil', class: 'Divine Healer', rarity: 'Common', art: 'https://placehold.co/150x126/ef4444/FFFFFF?text=Ability', effect: 'Deal 2 damage (4 to undead).', energyCost: 1, category: 'Offense' },
+    { id: 3513, type: 'ability', name: 'Holy Barrier', class: 'Divine Healer', rarity: 'Common', art: 'https://placehold.co/150x126/ef4444/FFFFFF?text=Ability', effect: 'All allies take 1 less damage this turn.', energyCost: 1, category: 'Defense' },
+    // Uncommon
+    { id: 3521, type: 'ability', name: 'Bless', class: 'Divine Healer', rarity: 'Uncommon', art: 'https://placehold.co/150x126/ef4444/FFFFFF?text=Ability', effect: 'All allies gain +1 attack and +1 evasion for 2 turns.', energyCost: 2, category: 'Support' },
+    { id: 3522, type: 'ability', name: 'Purify', class: 'Divine Healer', rarity: 'Uncommon', art: 'https://placehold.co/150x126/ef4444/FFFFFF?text=Ability', effect: 'Cleanse all debuffs from an ally and heal 3 HP.', energyCost: 2, category: 'Support' },
+    { id: 3523, type: 'ability', name: 'Sacred Shield', class: 'Divine Healer', rarity: 'Uncommon', art: 'https://placehold.co/150x126/ef4444/FFFFFF?text=Ability', effect: 'One ally becomes immune to damage this turn.', energyCost: 2, category: 'Defense' },
+    // Rare
+    { id: 3531, type: 'ability', name: 'Judgment', class: 'Divine Healer', rarity: 'Rare', art: 'https://placehold.co/150x126/ef4444/FFFFFF?text=Ability', effect: 'Deal 3 damage and reduce enemy defense by 1 for 2 turns.', energyCost: 3, category: 'Offense' },
+    { id: 3532, type: 'ability', name: 'Radiant Wave', class: 'Divine Healer', rarity: 'Rare', art: 'https://placehold.co/150x126/ef4444/FFFFFF?text=Ability', effect: 'Heal all allies for 3 HP and remove 1 debuff.', energyCost: 3, category: 'Support' },
+    { id: 3533, type: 'ability', name: 'Divine Retribution', class: 'Divine Healer', rarity: 'Rare', art: 'https://placehold.co/150x126/ef4444/FFFFFF?text=Ability', effect: 'Deal 3 damage to all enemies and heal allies for 2 HP.', energyCost: 3, category: 'Offense' },
+    // Epic
+    { id: 3541, type: 'ability', name: 'Lay on Hands', class: 'Divine Healer', rarity: 'Epic', art: 'https://placehold.co/150x126/ef4444/FFFFFF?text=Ability', effect: 'Fully restore one ally\'s HP.', energyCost: 4, category: 'Support' },
+    { id: 3542, type: 'ability', name: 'Resurrect', class: 'Divine Healer', rarity: 'Epic', art: 'https://placehold.co/150x126/ef4444/FFFFFF?text=Ability', effect: 'Revive a fallen ally at 50% HP.', energyCost: 4, category: 'Support' },
+
+    // === Nature Shaper (Druid) ===
+    // Common
+    { id: 3611, type: 'ability', name: 'Nature\'s Wrath', class: 'Nature Shaper', rarity: 'Common', art: 'https://placehold.co/150x126/ef4444/FFFFFF?text=Ability', effect: 'Deal 1 damage and apply Poison for 2 turns.', energyCost: 1, category: 'Offense' },
+    { id: 3612, type: 'ability', name: 'Regrowth', class: 'Nature Shaper', rarity: 'Common', art: 'https://placehold.co/150x126/ef4444/FFFFFF?text=Ability', effect: 'Heal an ally for 2 HP per turn over 3 turns.', energyCost: 1, category: 'Support' },
+    { id: 3613, type: 'ability', name: 'Entangle', class: 'Nature Shaper', rarity: 'Common', art: 'https://placehold.co/150x126/ef4444/FFFFFF?text=Ability', effect: 'Root an enemy so they cannot act next turn.', energyCost: 1, category: 'Defense' },
+    // Uncommon
+    { id: 3621, type: 'ability', name: 'Wild Growth', class: 'Nature Shaper', rarity: 'Uncommon', art: 'https://placehold.co/150x126/ef4444/FFFFFF?text=Ability', effect: 'Heal all allies for 2 HP and give +1 defense.', energyCost: 2, category: 'Support' },
+    { id: 3622, type: 'ability', name: 'Shapeshift – Bear Form', class: 'Nature Shaper', rarity: 'Uncommon', art: 'https://placehold.co/150x126/ef4444/FFFFFF?text=Ability', effect: 'Gain +2 attack and +2 defense for 2 turns.', energyCost: 2, category: 'Offense' },
+    { id: 3623, type: 'ability', name: 'Venom Thorns', class: 'Nature Shaper', rarity: 'Uncommon', art: 'https://placehold.co/150x126/ef4444/FFFFFF?text=Ability', effect: 'Deal 2 damage and Poison the attacker if hit next turn.', energyCost: 2, category: 'Offense' },
+    // Rare
+    { id: 3631, type: 'ability', name: 'Shapeshift – Wolf Form', class: 'Nature Shaper', rarity: 'Rare', art: 'https://placehold.co/150x126/ef4444/FFFFFF?text=Ability', effect: 'Gain +2 speed and +1 attack for 3 turns.', energyCost: 3, category: 'Offense' },
+    { id: 3632, type: 'ability', name: 'Poison Storm', class: 'Nature Shaper', rarity: 'Rare', art: 'https://placehold.co/150x126/ef4444/FFFFFF?text=Ability', effect: 'Deal 1 damage to all enemies and Poison them.', energyCost: 3, category: 'Offense' },
+    { id: 3633, type: 'ability', name: 'Barkskin', class: 'Nature Shaper', rarity: 'Rare', art: 'https://placehold.co/150x126/ef4444/FFFFFF?text=Ability', effect: 'All allies reduce damage by 2 for 1 turn.', energyCost: 3, category: 'Defense' },
+    // Epic
+    { id: 3641, type: 'ability', name: 'Avatar of the Wild', class: 'Nature Shaper', rarity: 'Epic', art: 'https://placehold.co/150x126/ef4444/FFFFFF?text=Ability', effect: 'Shapeshift for 3 turns, gaining +2 attack and +2 defense.', energyCost: 4, category: 'Offense' },
+    { id: 3642, type: 'ability', name: 'Nature\'s Renewal', class: 'Nature Shaper', rarity: 'Epic', art: 'https://placehold.co/150x126/ef4444/FFFFFF?text=Ability', effect: 'Heal all allies for 6 HP and remove all debuffs.', energyCost: 4, category: 'Support' },
+
+    // === Inspiring Artist (Bard) ===
+    // Common
+    { id: 3711, type: 'ability', name: 'Inspiring Tune', class: 'Inspiring Artist', rarity: 'Common', art: 'https://placehold.co/150x126/ef4444/FFFFFF?text=Ability', effect: 'All allies gain +1 attack for 2 turns.', energyCost: 1, category: 'Support' },
+    { id: 3712, type: 'ability', name: 'Dissonant Chord', class: 'Inspiring Artist', rarity: 'Common', art: 'https://placehold.co/150x126/ef4444/FFFFFF?text=Ability', effect: 'Deal 1 damage and reduce enemy attack by 1.', energyCost: 1, category: 'Offense' },
+    { id: 3713, type: 'ability', name: 'Quick Tempo', class: 'Inspiring Artist', rarity: 'Common', art: 'https://placehold.co/150x126/ef4444/FFFFFF?text=Ability', effect: 'Choose an ally to immediately take an extra action.', energyCost: 1, category: 'Support' },
+    // Uncommon
+    { id: 3721, type: 'ability', name: 'Song of Restoration', class: 'Inspiring Artist', rarity: 'Uncommon', art: 'https://placehold.co/150x126/ef4444/FFFFFF?text=Ability', effect: 'Heal an ally for 3 HP per turn over 2 turns.', energyCost: 2, category: 'Support' },
+    { id: 3722, type: 'ability', name: 'Encore', class: 'Inspiring Artist', rarity: 'Uncommon', art: 'https://placehold.co/150x126/ef4444/FFFFFF?text=Ability', effect: 'Replay your last Bard ability.', energyCost: 2, category: 'Support' },
+    { id: 3723, type: 'ability', name: 'Harmony', class: 'Inspiring Artist', rarity: 'Uncommon', art: 'https://placehold.co/150x126/ef4444/FFFFFF?text=Ability', effect: 'All allies gain +1 attack and +1 evasion for 1 turn.', energyCost: 2, category: 'Defense' },
+    // Rare
+    { id: 3731, type: 'ability', name: 'Ballad of Courage', class: 'Inspiring Artist', rarity: 'Rare', art: 'https://placehold.co/150x126/ef4444/FFFFFF?text=Ability', effect: 'All allies gain +2 attack and +2 speed for 2 turns.', energyCost: 3, category: 'Support' },
+    { id: 3732, type: 'ability', name: 'Discordant Blast', class: 'Inspiring Artist', rarity: 'Rare', art: 'https://placehold.co/150x126/ef4444/FFFFFF?text=Ability', effect: 'Deal 2 damage to all enemies and reduce their attack by 1.', energyCost: 3, category: 'Offense' },
+    { id: 3733, type: 'ability', name: 'Rhythm Shift', class: 'Inspiring Artist', rarity: 'Rare', art: 'https://placehold.co/150x126/ef4444/FFFFFF?text=Ability', effect: 'Move an ally to the top of the initiative order.', energyCost: 3, category: 'Support' },
+    // Epic
+    { id: 3741, type: 'ability', name: 'Crescendo', class: 'Inspiring Artist', rarity: 'Epic', art: 'https://placehold.co/150x126/ef4444/FFFFFF?text=Ability', effect: 'All allies gain +3 attack and take an immediate action.', energyCost: 4, category: 'Support' },
+    { id: 3742, type: 'ability', name: 'Song of Rebirth', class: 'Inspiring Artist', rarity: 'Epic', art: 'https://placehold.co/150x126/ef4444/FFFFFF?text=Ability', effect: 'Revive all fallen allies at 50% HP.', energyCost: 4, category: 'Support' },
+
+    // === Wilderness Expert (Ranger) ===
+    // Common
+    { id: 3811, type: 'ability', name: 'Precision Shot', class: 'Wilderness Expert', rarity: 'Common', art: 'https://placehold.co/150x126/ef4444/FFFFFF?text=Ability', effect: 'Deal 3 damage to a single enemy.', energyCost: 1, category: 'Offense' },
+    { id: 3812, type: 'ability', name: 'Camouflage', class: 'Wilderness Expert', rarity: 'Common', art: 'https://placehold.co/150x126/ef4444/FFFFFF?text=Ability', effect: 'Gain +2 evasion for 1 turn and +1 speed next turn.', energyCost: 1, category: 'Defense' },
+    { id: 3813, type: 'ability', name: 'Animal Companion – Wolf', class: 'Wilderness Expert', rarity: 'Common', art: 'https://placehold.co/150x126/ef4444/FFFFFF?text=Ability', effect: 'Summon a Wolf that deals 2 damage for 1 turn.', energyCost: 1, category: 'Support' },
+    // Uncommon
+    { id: 3821, type: 'ability', name: 'Multi-Shot', class: 'Wilderness Expert', rarity: 'Uncommon', art: 'https://placehold.co/150x126/ef4444/FFFFFF?text=Ability', effect: 'Deal 2 damage to up to 3 enemies.', energyCost: 2, category: 'Offense' },
+    { id: 3822, type: 'ability', name: 'Hawk Eye', class: 'Wilderness Expert', rarity: 'Uncommon', art: 'https://placehold.co/150x126/ef4444/FFFFFF?text=Ability', effect: 'Gain +1 attack and +1 crit chance for 2 turns.', energyCost: 2, category: 'Support' },
+    { id: 3823, type: 'ability', name: 'Animal Companion – Bear', class: 'Wilderness Expert', rarity: 'Uncommon', art: 'https://placehold.co/150x126/ef4444/FFFFFF?text=Ability', effect: 'Summon a Bear that deals 3 damage and taunts enemies.', energyCost: 2, category: 'Defense' },
+    // Rare
+    { id: 3831, type: 'ability', name: 'Rain of Arrows', class: 'Wilderness Expert', rarity: 'Rare', art: 'https://placehold.co/150x126/ef4444/FFFFFF?text=Ability', effect: 'Deal 3 damage to all enemies.', energyCost: 3, category: 'Offense' },
+    { id: 3832, type: 'ability', name: 'Trap Mastery', class: 'Wilderness Expert', rarity: 'Rare', art: 'https://placehold.co/150x126/ef4444/FFFFFF?text=Ability', effect: 'Next enemy to attack you takes 4 damage and is rooted.', energyCost: 3, category: 'Defense' },
+    { id: 3833, type: 'ability', name: 'Animal Companion – Falcon', class: 'Wilderness Expert', rarity: 'Rare', art: 'https://placehold.co/150x126/ef4444/FFFFFF?text=Ability', effect: 'Summon a Falcon that grants +1 attack and reveals enemies.', energyCost: 3, category: 'Support' },
+    // Epic
+    { id: 3841, type: 'ability', name: 'Alpha\'s Call', class: 'Wilderness Expert', rarity: 'Epic', art: 'https://placehold.co/150x126/ef4444/FFFFFF?text=Ability', effect: 'Summon all three animal companions simultaneously.', energyCost: 4, category: 'Support' },
+    { id: 3842, type: 'ability', name: 'True Shot', class: 'Wilderness Expert', rarity: 'Epic', art: 'https://placehold.co/150x126/ef4444/FFFFFF?text=Ability', effect: 'Deal 7 damage ignoring evasion and armor.', energyCost: 4, category: 'Offense' }
 ];
 // NOTE: Placeholder art links ('...') and new IDs have been assigned.
 

--- a/hero-game/js/main.js
+++ b/hero-game/js/main.js
@@ -90,31 +90,29 @@ function openPack() {
     const stage = gameState.draft.stage;
     const stageType = stage.split('_')[0].toUpperCase();
     let choices = [];
+    let dataSource = [];
     switch(stageType) {
         case 'HERO':
             choices = generateHeroPack();
-            break;
-        case 'WEAPON':
-            choices = generateWeaponChoices();
-            break;
-        case 'ARMOR':
-            choices = generateArmorChoices();
             break;
         case 'ABILITY':
             const heroSlot = stage.includes('_1_') ? 'hero1' : 'hero2';
             const heroId = gameState.draft.playerTeam[heroSlot];
             const heroClass = allPossibleHeroes.find(h => h.id === heroId).class;
-            let dataSource = allPossibleAbilities.filter(a => a.class === heroClass);
 
-            const offense = dataSource.filter(a => a.category === 'Offense' && a.rarity === 'Common');
-            const defense = dataSource.filter(a => a.category === 'Defense' && a.rarity === 'Common');
-            const support = dataSource.filter(a => a.category === 'Support' && a.rarity === 'Common');
+            dataSource = allPossibleAbilities.filter(a => a.class === heroClass);
 
-            choices = [
-                offense[Math.floor(Math.random() * offense.length)],
-                defense[Math.floor(Math.random() * defense.length)],
-                support[Math.floor(Math.random() * support.length)],
-            ];
+            const shuffledAbilities = [...dataSource].sort(() => 0.5 - Math.random());
+            choices = shuffledAbilities.slice(0, 3);
+
+            transitionToScene('reveal');
+            revealScene.startReveal(choices);
+            return;
+        case 'WEAPON':
+            choices = generateWeaponChoices();
+            break;
+        case 'ARMOR':
+            choices = generateArmorChoices();
             break;
     }
 


### PR DESCRIPTION
## Summary
- populate ability data for all hero classes
- filter abilities by hero class when opening ability packs

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684e06573c848327b8a72a7f4a86f151