### PR TITLE
Implement recap screen

### DIFF
--- a/hero-game/index.html
+++ b/hero-game/index.html
@@ -44,6 +44,41 @@
         </header>
         <div id="draft-pool" class="draft-pool"></div>
     </div>
+
+    <!-- Recap Scene for first champion -->
+    <div id="recap-scene" class="scene hidden">
+        <header class="text-center mb-8">
+            <h1 class="text-5xl font-cinzel tracking-wider">Champion Assembled</h1>
+            <p class="text-lg text-gray-400 mt-2">Your first champion is ready for battle.</p>
+        </header>
+
+        <!-- Main display area for the cards -->
+        <div id="recap-display-area" class="flex flex-col lg:flex-row items-center gap-8">
+            <!-- Slot for the main Hero Card -->
+            <div id="recap-hero-slot" class="flex flex-col items-center">
+                <h3 class="text-2xl font-cinzel mb-2">Hero</h3>
+                <!-- Hero card will be inserted here by JS -->
+            </div>
+
+            <!-- Slots for the equipped items -->
+            <div id="recap-items-slot" class="grid grid-cols-1 md:grid-cols-3 lg:grid-cols-1 gap-6">
+                <div class="flex flex-col items-center">
+                    <h4 class="text-xl font-cinzel mb-2">Ability</h4>
+                    <div id="recap-ability-slot"></div>
+                </div>
+                <div class="flex flex-col items-center">
+                    <h4 class="text-xl font-cinzel mb-2">Weapon</h4>
+                    <div id="recap-weapon-slot"></div>
+                </div>
+                <div class="flex flex-col items-center">
+                    <h4 class="text-xl font-cinzel mb-2">Armor</h4>
+                    <div id="recap-armor-slot"></div>
+                </div>
+            </div>
+        </div>
+
+        <button id="recap-continue-button" class="confirm-button mt-12">Draft Next Champion</button>
+    </div>
     
     <div id="weapon-scene" class="scene hidden">
         <header class="text-center mb-8">

--- a/hero-game/js/main.js
+++ b/hero-game/js/main.js
@@ -5,6 +5,7 @@ import { allPossibleHeroes, allPossibleWeapons, allPossibleArmors, allPossibleAb
 import { PackScene } from './scenes/PackScene.js';
 import { DraftScene } from './scenes/DraftScene.js';
 import { WeaponScene } from './scenes/WeaponScene.js';
+import { RecapScene } from './scenes/RecapScene.js';
 // RevealScene handles displaying cards from a pack
 import { RevealScene } from './scenes/RevealScene.js';
 import { BattleScene } from './scenes/BattleScene.js';
@@ -27,6 +28,7 @@ const sceneElements = {
     draft: document.getElementById('draft-scene'),
     weapon: document.getElementById('weapon-scene'),
     battle: document.getElementById('battle-scene'),
+    recap: document.getElementById('recap-scene'),
 };
 
 const packElements = {
@@ -82,6 +84,9 @@ const draftScene = new DraftScene(sceneElements.draft, (selectedItem) => {
     advanceDraft();
 });
 const weaponScene = new WeaponScene(sceneElements.weapon, null, () => openPack());
+const recapScene = new RecapScene(sceneElements.recap, () => {
+    advanceDraft();
+});
 
 const battleScene = new BattleScene(sceneElements.battle);
 
@@ -161,6 +166,15 @@ function advanceDraft() {
         configurePackScene(gameState.draft.stage);
         transitionToScene('pack');
     } else if (stage === 'ARMOR_1_DRAFT' && team.armor1) {
+        gameState.draft.stage = 'RECAP_1_DRAFT';
+        recapScene.render({
+            hero: team.hero1,
+            ability: team.ability1,
+            weapon: team.weapon1,
+            armor: team.armor1
+        });
+        transitionToScene('recap');
+    } else if (stage === 'RECAP_1_DRAFT') {
         gameState.draft.stage = 'HERO_2_PACK';
         packScene.reset();
         packScene.render(gameState.draft.stage);

--- a/hero-game/js/scenes/RecapScene.js
+++ b/hero-game/js/scenes/RecapScene.js
@@ -1,0 +1,37 @@
+import { createDetailCard } from '../ui/CardRenderer.js';
+import { allPossibleHeroes, allPossibleAbilities, allPossibleWeapons, allPossibleArmors } from '../data.js';
+
+export class RecapScene {
+    constructor(element, onContinue) {
+        this.element = element;
+        this.onContinue = onContinue;
+
+        // Get references to all the slots
+        this.heroSlot = this.element.querySelector('#recap-hero-slot');
+        this.abilitySlot = this.element.querySelector('#recap-ability-slot');
+        this.weaponSlot = this.element.querySelector('#recap-weapon-slot');
+        this.armorSlot = this.element.querySelector('#recap-armor-slot');
+
+        this.element.querySelector('#recap-continue-button').addEventListener('click', () => this.onContinue());
+    }
+
+    render(championData) {
+        // Clear any previous cards
+        this.heroSlot.innerHTML = '<h3 class="text-2xl font-cinzel mb-2">Hero</h3>';
+        this.abilitySlot.innerHTML = '';
+        this.weaponSlot.innerHTML = '';
+        this.armorSlot.innerHTML = '';
+
+        // Find the full data object for each selected item using its ID
+        const hero = allPossibleHeroes.find(h => h.id === championData.hero);
+        const ability = allPossibleAbilities.find(a => a.id === championData.ability);
+        const weapon = allPossibleWeapons.find(w => w.id === championData.weapon);
+        const armor = allPossibleArmors.find(a => a.id === championData.armor);
+
+        // Create and append the cards to their slots
+        if (hero) this.heroSlot.appendChild(createDetailCard(hero));
+        if (ability) this.abilitySlot.appendChild(createDetailCard(ability));
+        if (weapon) this.weaponSlot.appendChild(createDetailCard(weapon));
+        if (armor) this.armorSlot.appendChild(createDetailCard(armor));
+    }
+}

--- a/hero-game/style.css
+++ b/hero-game/style.css
@@ -308,3 +308,9 @@ body {
     font-size: 0.8rem;
     opacity: 0.8;
 }
+
+/* Recap Scene Styles */
+#recap-items-slot .hero-card-container {
+    transform: scale(0.75);
+    margin-top: -50px; /* Adjust spacing for smaller scale */
+}


### PR DESCRIPTION
## Summary
- add Recap scene markup after draft scene
- style recap item slots
- create RecapScene controller
- integrate recap stage in draft flow

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684f39fa2e18832798516b9d2bc65c7f