### PR TITLE
Implement socketed recap screen

### DIFF
--- a/hero-game/index.html
+++ b/hero-game/index.html
@@ -52,9 +52,9 @@
             <p class="text-lg text-gray-400 mt-2">Your first champion is ready for battle.</p>
         </header>
 
-        <!-- Main display area for the hero card with socketed gear -->
+        <!-- Main display area for the hero card with its attached gear -->
         <div id="recap-hero-slot" class="relative">
-            <!-- The full hero card and its gear will be inserted here by JS -->
+            <!-- The fully assembled hero card will be injected here by JavaScript -->
         </div>
 
         <button id="recap-continue-button" class="confirm-button mt-12">Draft Next Champion</button>

--- a/hero-game/js/scenes/RecapScene.js
+++ b/hero-game/js/scenes/RecapScene.js
@@ -1,5 +1,5 @@
 import { createDetailCard } from '../ui/CardRenderer.js';
-import { allPossibleHeroes, allPossibleWeapons, allPossibleArmors } from '../data.js';
+import { allPossibleHeroes, allPossibleAbilities, allPossibleWeapons, allPossibleArmors } from '../data.js';
 
 export class RecapScene {
     constructor(element, onContinue) {
@@ -12,37 +12,57 @@ export class RecapScene {
     }
 
     render(championData) {
-        // Clear any previous content
         this.heroSlot.innerHTML = '';
 
-        // Find the full data objects for the hero, weapon, and armor
-        const hero = allPossibleHeroes.find(h => h.id === championData.hero);
+        // Find the full data objects for all equipped items
+        const heroData = { ...allPossibleHeroes.find(h => h.id === championData.hero) };
+        const ability = allPossibleAbilities.find(a => a.id === championData.ability);
         const weapon = allPossibleWeapons.find(w => w.id === championData.weapon);
         const armor = allPossibleArmors.find(a => a.id === championData.armor);
 
-        // Create the main hero card container
-        const heroCardContainer = createDetailCard(hero);
+        // --- NEW LOGIC: Dynamically add the selected ability to the hero's data ---
+        if (ability) {
+            heroData.abilities = [ability];
+        }
+
+        const heroCardContainer = createDetailCard(heroData);
         if (!heroCardContainer) return;
 
-        // Create the weapon socket if a weapon is equipped
+        // --- NEW LOGIC: Create and append sockets ---
         if (weapon) {
-            const weaponSocket = document.createElement('div');
-            weaponSocket.className = 'gear-socket recap-weapon-socket';
-            const weaponCard = createDetailCard(weapon);
-            weaponSocket.appendChild(weaponCard);
+            const weaponSocket = this.createGearSocket(weapon, 'recap-weapon-socket');
             heroCardContainer.appendChild(weaponSocket);
         }
 
-        // Create the armor socket if armor is equipped
         if (armor) {
-            const armorSocket = document.createElement('div');
-            armorSocket.className = 'gear-socket recap-armor-socket';
-            const armorCard = createDetailCard(armor);
-            armorSocket.appendChild(armorCard);
+            const armorSocket = this.createGearSocket(armor, 'recap-armor-socket');
             heroCardContainer.appendChild(armorSocket);
         }
 
-        // Append the fully assembled hero card with its gear to the scene
         this.heroSlot.appendChild(heroCardContainer);
+    }
+
+    // Helper function to create a socket with its card and tooltip
+    createGearSocket(itemData, socketClass) {
+        const socket = document.createElement('div');
+        socket.className = `gear-socket ${socketClass}`;
+
+        const miniCardContainer = document.createElement('div');
+        miniCardContainer.className = 'hero-card-container';
+        const miniCard = document.createElement('div');
+        miniCard.className = `hero-card ${(itemData.rarity || 'common').toLowerCase().replace(' ', '-')}`;
+        miniCard.innerHTML = `
+            <div class="hero-art" style="background-image: url('${itemData.art}')"></div>
+            <h3 class="hero-name font-cinzel">${itemData.name}</h3>
+        `;
+        miniCardContainer.appendChild(miniCard);
+        socket.appendChild(miniCardContainer);
+
+        const tooltip = document.createElement('div');
+        tooltip.className = 'tooltip';
+        tooltip.innerHTML = `<strong>${itemData.name}</strong><br>${itemData.ability ? itemData.ability.description : 'Passive Bonuses'}`;
+        socket.appendChild(tooltip);
+
+        return socket;
     }
 }

--- a/hero-game/js/ui/CardRenderer.js
+++ b/hero-game/js/ui/CardRenderer.js
@@ -31,7 +31,16 @@ export function createDetailCard(item, selectionHandler) {
             statsHtml = `
                 <div class="stat-block"><span class="stat-value">${item.hp}</span><span class="stat-label">HP</span></div>
                 <div class="stat-block"><span class="stat-value">${item.attack}</span><span class="stat-label">Attack</span></div>`;
-            descriptionHtml = `<p class="item-description">Class: ${item.class}</p>`;
+
+            if (item.abilities && item.abilities.length > 0) {
+                descriptionHtml = item.abilities.map(ab => `
+                    <li class="ability-item">${ab.name}
+                        <div class="tooltip">${ab.effect}</div>
+                    </li>
+                `).join('');
+            } else {
+                descriptionHtml = `<p class="item-description">Class: ${item.class}</p>`;
+            }
             break;
         case 'ability':
             cardElement.style.backgroundColor = '#1e293b';

--- a/hero-game/style.css
+++ b/hero-game/style.css
@@ -310,6 +310,10 @@ body {
 }
 
 /* Recap Scene Styles */
+#recap-hero-slot .hero-card-container {
+    position: relative;
+}
+
 .gear-socket {
     position: absolute;
     width: 80px;
@@ -323,7 +327,7 @@ body {
     z-index: 20;
 }
 
-/* Position the weapon on the right, slightly rotated */
+/* Position the weapon socket on the right side */
 .recap-weapon-socket {
     top: 20%;
     right: -40px;
@@ -333,7 +337,7 @@ body {
     transform: rotate(5deg) scale(1.1);
 }
 
-/* Position the armor on the left, slightly rotated */
+/* Position the armor socket on the left side */
 .recap-armor-socket {
     top: 45%;
     left: -40px;
@@ -343,11 +347,19 @@ body {
     transform: rotate(-5deg) scale(1.1);
 }
 
-/* Style for the gear card itself inside the socket */
+/* Style for the mini-card placed inside a socket */
+.gear-socket .hero-card-container {
+    transform: scale(0.9);
+    width: 100%;
+    height: 100%;
+}
 .gear-socket .hero-card {
     border-width: 2px;
 }
-.gear-socket .hero-art {
-    height: 95%;
-    top: 2.5%;
+.gear-socket .hero-name {
+    font-size: 0.75rem;
+}
+.gear-socket .hero-stats,
+.gear-socket .item-ability {
+    display: none;
 }


### PR DESCRIPTION
## Summary
- refine recap scene markup
- show selected abilities on hero cards
- build socketed gear display in `RecapScene`
- style gear sockets

## Testing
- `node -v`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684f4433ee588327b384273b00ab5150