### PR TITLE
Update recap screen with socket modals

### DIFF
--- a/hero-game/js/scenes/RecapScene.js
+++ b/hero-game/js/scenes/RecapScene.js
@@ -12,23 +12,24 @@ export class RecapScene {
     }
 
     render(championData) {
-        this.heroSlot.innerHTML = '';
+        this.heroSlot.innerHTML = ''; // Clear previous content
 
         // Find the full data objects for all equipped items
-        const heroData = { ...allPossibleHeroes.find(h => h.id === championData.hero) };
+        const heroData = { ...allPossibleHeroes.find(h => h.id === championData.hero) }; // Create a mutable copy
         const ability = allPossibleAbilities.find(a => a.id === championData.ability);
         const weapon = allPossibleWeapons.find(w => w.id === championData.weapon);
         const armor = allPossibleArmors.find(a => a.id === championData.armor);
 
-        // --- NEW LOGIC: Dynamically add the selected ability to the hero's data ---
+        // --- Dynamically add the selected ability to the hero's data ---
         if (ability) {
-            heroData.abilities = [ability];
+            heroData.abilities = [ability]; 
         }
 
+        // Create the main hero card using the updated heroData
         const heroCardContainer = createDetailCard(heroData);
         if (!heroCardContainer) return;
 
-        // --- NEW LOGIC: Create and append sockets ---
+        // --- Create and append sockets with new modal popups ---
         if (weapon) {
             const weaponSocket = this.createGearSocket(weapon, 'recap-weapon-socket');
             heroCardContainer.appendChild(weaponSocket);
@@ -42,26 +43,24 @@ export class RecapScene {
         this.heroSlot.appendChild(heroCardContainer);
     }
 
-    // Helper function to create a socket with its card and tooltip
+    // Helper function to create a socket with its card and modal popup
     createGearSocket(itemData, socketClass) {
         const socket = document.createElement('div');
         socket.className = `gear-socket ${socketClass}`;
+        // Set the artwork directly on the socket's background
+        socket.style.backgroundImage = `url('${itemData.art}')`;
 
-        const miniCardContainer = document.createElement('div');
-        miniCardContainer.className = 'hero-card-container';
-        const miniCard = document.createElement('div');
-        miniCard.className = `hero-card ${(itemData.rarity || 'common').toLowerCase().replace(' ', '-')}`;
-        miniCard.innerHTML = `
-            <div class="hero-art" style="background-image: url('${itemData.art}')"></div>
-            <h3 class="hero-name font-cinzel">${itemData.name}</h3>
-        `;
-        miniCardContainer.appendChild(miniCard);
-        socket.appendChild(miniCardContainer);
+        // Create the modal container that will hold the full card
+        const modalPopup = document.createElement('div');
+        modalPopup.className = 'socket-modal-popup';
 
-        const tooltip = document.createElement('div');
-        tooltip.className = 'tooltip';
-        tooltip.innerHTML = `<strong>${itemData.name}</strong><br>${itemData.ability ? itemData.ability.description : 'Passive Bonuses'}`;
-        socket.appendChild(tooltip);
+        // Create the full, detailed card for the item
+        const detailCard = createDetailCard(itemData);
+        if (detailCard) {
+            modalPopup.appendChild(detailCard);
+        }
+
+        socket.appendChild(modalPopup);
 
         return socket;
     }

--- a/hero-game/style.css
+++ b/hero-game/style.css
@@ -363,3 +363,70 @@ body {
 .gear-socket .item-ability {
     display: none;
 }
+
+/* Main container for the socketed gear card */
+#recap-hero-slot .hero-card-container {
+    position: relative; 
+}
+
+/* Styling for the socket itself */
+.gear-socket {
+    position: absolute;
+    width: 80px;
+    height: 110px;
+    z-index: 10;
+    transition: transform 0.3s ease;
+    border-radius: 0.75rem;
+    border: 2px solid rgba(255, 255, 255, 0.3);
+    box-shadow: inset 0 0 10px rgba(0,0,0,0.7);
+    background-size: cover;
+    background-position: center;
+    cursor: pointer;
+}
+
+.gear-socket:hover {
+    transform: scale(1.1);
+    z-index: 20;
+}
+
+/* Position the weapon socket on the right side */
+.recap-weapon-socket {
+    top: 20%;
+    right: -40px;
+    transform: rotate(10deg);
+}
+.recap-weapon-socket:hover {
+    transform: rotate(5deg) scale(1.1);
+}
+
+/* Position the armor socket on the left side */
+.recap-armor-socket {
+    top: 45%;
+    left: -40px;
+    transform: rotate(-10deg);
+}
+.recap-armor-socket:hover {
+    transform: rotate(-5deg) scale(1.1);
+}
+
+/* Styling for the new modal popup (replaces simple tooltip) */
+.gear-socket .socket-modal-popup {
+    visibility: hidden;
+    opacity: 0;
+    position: absolute;
+    bottom: 50%;
+    left: 110%; /* Position it to the right of the socket */
+    z-index: 100;
+    transition: opacity 0.3s, visibility 0.3s;
+    pointer-events: none;
+}
+
+.recap-armor-socket .socket-modal-popup {
+    left: auto;
+    right: 110%; /* Position armor modal to the left */
+}
+
+.gear-socket:hover .socket-modal-popup {
+    visibility: visible;
+    opacity: 1;
+}


### PR DESCRIPTION
## Summary
- add modal-based socket display to RecapScene
- style sockets and popup card modal

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684f464b16508327969c458239913e3c