### PR TITLE
Add tournament run feature

### DIFF
--- a/hero-game/index.html
+++ b/hero-game/index.html
@@ -81,6 +81,10 @@
     <div id="battle-scene" class="scene hidden">
         <div id="battle-scene-background"></div>
         <button id="speed-cycle-button">Speed: 1x</button>
+        <div id="tournament-tracker" class="absolute top-4 right-4 bg-gray-900 bg-opacity-70 p-4 rounded-lg border border-gray-600 text-lg font-cinzel hidden">
+            <p>Wins: <span id="tournament-wins">0</span></p>
+            <p>Losses: <span id="tournament-losses">0</span></p>
+        </div>
         <div class="battle-arena">
             <div id="player-team-container" class="team-container"></div>
             <div id="enemy-team-container" class="team-container"></div>
@@ -91,6 +95,13 @@
             <div id="end-screen-results"></div>
             <button id="play-again-button">Play Again</button>
         </div>
+    </div>
+
+    <div id="tournament-end-screen" class="scene hidden flex-col items-center justify-center bg-gray-900 bg-opacity-90">
+        <h1 id="tournament-end-title" class="text-6xl font-cinzel">Tournament Complete</h1>
+        <p class="text-2xl mt-4">Final Record:</p>
+        <p id="tournament-final-record" class="text-4xl font-cinzel mt-2"></p>
+        <button id="tournament-play-again-button" class="confirm-button mt-12">Play Again</button>
     </div>
 
     <div id="confirmation-bar" class="confirmation-bar">

--- a/hero-game/js/scenes/BattleScene.js
+++ b/hero-game/js/scenes/BattleScene.js
@@ -3,8 +3,9 @@ import { sleep } from '../utils.js';
 import { battleSpeeds } from '../data.js';
 
 export class BattleScene {
-    constructor(element) {
+    constructor(element, onBattleComplete) {
         this.element = element;
+        this.onBattleComplete = onBattleComplete;
         
         // DOM Elements
         this.playerContainer = this.element.querySelector('#player-team-container');
@@ -22,7 +23,6 @@ export class BattleScene {
         this.currentSpeedIndex = 0;
         this.isBattleOver = false;
 
-        this.playAgainButton.addEventListener('click', () => window.location.reload());
         this.speedButton.addEventListener('click', () => this._cycleSpeed());
     }
 
@@ -185,7 +185,8 @@ export class BattleScene {
         this._logToBattle(didPlayerWin ? "Player team is victorious!" : "Enemy team is victorious!");
 
         this.endScreen.className = didPlayerWin ? 'victory' : 'defeat';
-        this.resultText.textContent = didPlayerWin ? 'Victory' : 'Defeat';
+        this.resultText.textContent = didPlayerWin ? 'Victory!' : 'Defeat!';
+        this.playAgainButton.textContent = 'Continue';
 
         this.resultsContainer.innerHTML = '';
         this.state.filter(c => c.team === 'player').forEach(c => {
@@ -193,6 +194,15 @@ export class BattleScene {
             if(c.currentHp <= 0) card.classList.add('is-defeated');
             this.resultsContainer.appendChild(card);
         });
+
+        const continueButton = this.element.querySelector('#play-again-button');
+        const newContinueButton = continueButton.cloneNode(true);
+        continueButton.parentNode.replaceChild(newContinueButton, continueButton);
+
+        newContinueButton.addEventListener('click', () => {
+            this.endScreen.classList.remove('visible');
+            this.onBattleComplete(didPlayerWin);
+        }, { once: true });
 
         setTimeout(() => this.endScreen.classList.add('visible'), 167 * battleSpeeds[this.currentSpeedIndex].multiplier);
     }


### PR DESCRIPTION
## Summary
- track tournament wins and losses in `gameState`
- display tournament tracker in battle scene
- show final tournament end overlay
- add callback flow from BattleScene to main logic
- manage persistent multi-battle tournament loop with difficulty scaling

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684f5112a4f08327bf1389898adde914