### PR TITLE
Add additional battle speed options

### DIFF
--- a/hero-game/js/data.js
+++ b/hero-game/js/data.js
@@ -277,7 +277,10 @@ export const allPossibleArmors = [
 // NOTE: Placeholder art links ('...') and new IDs have been assigned. 'Block' reduces physical damage, 'MagicResist' reduces magic damage.
 
 export const battleSpeeds = [
+    { label: '0.5x', multiplier: 4 },
     { label: '1x', multiplier: 2 },
     { label: '2x', multiplier: 1 },
-    { label: '0.5x', multiplier: 4 }
+    { label: '3x', multiplier: 0.67 },
+    { label: '4x', multiplier: 0.5 },
+    { label: '5x', multiplier: 0.4 }
 ];


### PR DESCRIPTION
## Summary
- expand battle speeds with 3x–5x multipliers

## Testing
- `npm test` *(fails: cannot find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684f5261f6288327b32e1ae4f793aebf