### PR TITLE
Improve combat text visuals

### DIFF
--- a/hero-game/js/scenes/BattleScene.js
+++ b/hero-game/js/scenes/BattleScene.js
@@ -100,6 +100,7 @@ export class BattleScene {
         attacker.currentEnergy += 1;
         updateEnergyDisplay(attacker, attacker.element);
         this._logToBattle(`${attacker.heroData.name} gains 1 energy!`);
+        this._showCombatText(attacker.element, '+1', 'energy');
         await sleep(500 * battleSpeeds[this.currentSpeedIndex].multiplier);
 
         const potentialTargets = this.state.filter(c => c.team !== attacker.team && c.currentHp > 0);
@@ -169,7 +170,7 @@ export class BattleScene {
         target.element.classList.add('is-taking-damage');
         setTimeout(() => target.element.classList.remove('is-taking-damage'), 400 * battleSpeeds[this.currentSpeedIndex].multiplier);
         
-        this._showDamagePopup(target.element, amount);
+        this._showCombatText(target.element, `-${amount}`, 'damage');
         updateHealthBar(target, target.element);
 
         if (target.currentHp <= 0) {
@@ -191,12 +192,12 @@ export class BattleScene {
         this._updateStatusIcons(target);
     }
     
-    _showDamagePopup(targetElement, amount) {
+    _showCombatText(targetElement, text, type) {
         const popup = document.createElement('div');
-        popup.className = 'damage-popup';
-        popup.textContent = amount;
+        popup.className = `combat-text-popup ${type}`;
+        popup.textContent = text;
         targetElement.appendChild(popup);
-        setTimeout(() => popup.remove(), 234 * battleSpeeds[this.currentSpeedIndex].multiplier);
+        setTimeout(() => popup.remove(), 1200 * battleSpeeds[this.currentSpeedIndex].multiplier);
     }
 
     _updateStatusIcons(combatant){

--- a/hero-game/style.css
+++ b/hero-game/style.css
@@ -231,8 +231,40 @@ body {
   20%, 40%, 60%, 80% { transform: translateX(8px); }
 }
 .compact-card.is-defeated { opacity: 0.4; filter: grayscale(100%); transform: translateY(20px) scale(0.9); }
-.damage-popup { position: absolute; top: 50%; left: 50%; transform: translate(-50%, -50%); font-size: 2rem; font-weight: 700; color: #ef4444; text-shadow: 1px 1px 2px black; animation: popup-and-fade 0.25s ease-out forwards; pointer-events: none; z-index: 100; }
-@keyframes popup-and-fade { 0% { transform: translate(-50%, -50%) scale(0.5); opacity: 1; } 100% { transform: translate(-50%, -150%) scale(1.2); opacity: 0; } }
+.combat-text-popup {
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    font-family: 'Cinzel', serif;
+    font-size: 2.5rem;
+    font-weight: 700;
+    text-shadow: 1px 1px 3px black;
+    pointer-events: none;
+    z-index: 100;
+    animation: combat-text-float 1.2s ease-out forwards;
+}
+.combat-text-popup.damage { color: #ef4444; }
+.combat-text-popup.heal { color: #22c55e; }
+.combat-text-popup.energy { color: #fde047; }
+.combat-text-popup.block { color: #60a5fa; }
+
+@keyframes combat-text-float {
+  0% {
+    transform: translate(-50%, -50%) scale(0.5);
+    opacity: 1;
+  }
+  20% {
+    transform: translate(-50%, -100%) scale(1.2);
+  }
+  80% {
+    transform: translate(-50%, -180%) scale(1);
+    opacity: 1;
+  }
+  100% {
+    transform: translate(-50%, -220%) scale(0.8);
+    opacity: 0;
+  }
+}
 .status-icon-container { position: absolute; top: -10px; right: -10px; display: flex; gap: 0.25rem; }
 .status-icon { width: 24px; height: 24px; background-color: rgba(0,0,0,0.7); border-radius: 50%; display: flex; align-items: center; justify-content: center; font-size: 0.8rem; border: 1px solid white; }
 #battle-log { position: absolute; bottom: 1rem; left: 50%; transform: translateX(-50%); width: 90%; max-width: 600px; background-color: rgba(0,0,0,0.5); backdrop-filter: blur(4px); padding: 0.75rem; border-radius: 0.5rem; text-align: center; font-size: 1.1rem; transition: opacity 0.5s; }


### PR DESCRIPTION
## Summary
- replace `.damage-popup` styling with versatile `.combat-text-popup`
- color-code text for damage, healing, energy and block effects
- add longer animation for floating text
- show energy gain with gold "+1" popup
- generalize popup function to `_showCombatText`

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68502fe8e0808327aa3ba4b8f528a9f4