### PR TITLE
Improve battle clarity with VFX and active turn highlight

### DIFF
--- a/hero-game/js/scenes/BattleScene.js
+++ b/hero-game/js/scenes/BattleScene.js
@@ -85,6 +85,8 @@ export class BattleScene {
     async executeNextTurn() {
         if (this.isBattleOver) return;
 
+        this.state.forEach(c => c.element.classList.remove('is-active-turn'));
+
         if (this.turnQueue.length === 0) {
             await sleep(1000 * battleSpeeds[this.currentSpeedIndex].multiplier);
             this.runCombatRound();
@@ -92,6 +94,8 @@ export class BattleScene {
         }
 
         const attacker = this.turnQueue.shift();
+
+        attacker.element.classList.add('is-active-turn');
 
         this.state.forEach(c => c.element.classList.remove('is-attacking', 'is-lunging'));
         attacker.element.classList.add('is-attacking', 'is-lunging');
@@ -169,8 +173,9 @@ export class BattleScene {
         
         target.element.classList.add('is-taking-damage');
         setTimeout(() => target.element.classList.remove('is-taking-damage'), 400 * battleSpeeds[this.currentSpeedIndex].multiplier);
-        
+
         this._showCombatText(target.element, `-${amount}`, 'damage');
+        this._createVFX(target.element, 'physical-hit');
         updateHealthBar(target, target.element);
 
         if (target.currentHp <= 0) {
@@ -267,6 +272,13 @@ export class BattleScene {
         spark.style.top = `${rect.top + rect.height/2}px`;
         this.element.appendChild(spark);
         setTimeout(() => spark.remove(), 300);
+    }
+
+    _createVFX(targetElement, effectType) {
+        const vfx = document.createElement('div');
+        vfx.className = `vfx-container ${effectType}`;
+        targetElement.appendChild(vfx);
+        setTimeout(() => vfx.remove(), 1200);
     }
 
     _endBattle(didPlayerWin) {

--- a/hero-game/style.css
+++ b/hero-game/style.css
@@ -224,6 +224,11 @@ body {
 }
 .compact-card.is-attacking { transform: scale(1.1) translateY(-10px); z-index: 50; }
 .compact-card.is-lunging { transform: scale(1.1) translateY(-15px); z-index: 50; }
+.compact-card.is-active-turn {
+    transform: scale(1.05);
+    box-shadow: 0 0 20px 5px #fde047, 0 0 10px #fff inset;
+    z-index: 50;
+}
 .compact-card.is-taking-damage { animation: shake-horizontal 0.4s ease-in-out; }
 @keyframes shake-horizontal {
   0%, 100% { transform: translateX(0); }
@@ -578,4 +583,79 @@ body {
   0%, 100% { transform: translate(0, 0) rotate(0); }
   25% { transform: translate(5px, 2px) rotate(0.5deg); }
   75% { transform: translate(-5px, -2px) rotate(-0.5deg); }
+}
+
+/* Generic container for all visual effects */
+.vfx-container {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    pointer-events: none;
+    z-index: 101;
+    opacity: 0;
+}
+
+/* --- Physical Hit Effect (A sharp starburst) --- */
+.vfx-container.physical-hit {
+    animation: vfx-hit-and-fade 0.4s ease-out forwards;
+}
+.vfx-container.physical-hit::before {
+    content: '★';
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    font-size: 4rem;
+    color: #fff;
+    text-shadow: 0 0 10px #fde047;
+}
+
+/* --- Healing Effect (A soft, green upwards flow) --- */
+.vfx-container.heal {
+    animation: vfx-heal-and-fade 1s ease-out forwards;
+}
+.vfx-container.heal::before {
+    content: '✚';
+    position: absolute;
+    top: 70%;
+    left: 50%;
+    transform: translateX(-50%);
+    font-size: 3rem;
+    color: #22c55e;
+    text-shadow: 0 0 10px #fff;
+}
+
+/* --- Defensive Buff Effect (A shimmering shield outline) --- */
+.vfx-container.buff {
+    animation: vfx-buff-and-fade 1.2s ease-out forwards;
+}
+.vfx-container.buff::before {
+    content: '⛨';
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    font-size: 5rem;
+    color: #3b82f6;
+    text-shadow: 0 0 15px #fff;
+}
+
+/* --- Keyframe Animations --- */
+@keyframes vfx-hit-and-fade {
+    0% { transform: scale(0.5); opacity: 1; }
+    100% { transform: scale(1.5); opacity: 0; }
+}
+
+@keyframes vfx-heal-and-fade {
+    0% { transform: translateY(0) scale(0.8); opacity: 1; }
+    100% { transform: translateY(-40px) scale(1.2); opacity: 0; }
+}
+
+@keyframes vfx-buff-and-fade {
+    0% { transform: scale(1.2); opacity: 0; }
+    20% { transform: scale(0.9); opacity: 1; }
+    80% { transform: scale(1.1); opacity: 1; }
+    100% { transform: scale(0.8); opacity: 0; }
 }


### PR DESCRIPTION
## Summary
- add persistent active-turn glow on combat cards
- add new visual effect styles for physical hits, heals and buffs
- integrate VFX helper into battle logic
- mark attacker card as active each turn

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68503926e9548327959925036f02f360