### PR TITLE
Add dynamic camera panning and zoom

### DIFF
--- a/hero-game/js/scenes/BattleScene.js
+++ b/hero-game/js/scenes/BattleScene.js
@@ -151,6 +151,10 @@ export class BattleScene {
             this._announceAbility(ability.name);
             this._triggerArenaEffect('ability-zoom');
             this._logToBattle(`${attacker.heroData.name} uses ${ability.name}!`);
+
+            if (ability.rarity === 'Epic' || ability.rarity === 'Rare') {
+                this._triggerCameraEffect('camera-zoom', 1200);
+            }
             await sleep(500 * battleSpeeds[this.currentSpeedIndex].multiplier);
 
             if (ability.effect && ability.effect.includes('damage')) {
@@ -170,6 +174,13 @@ export class BattleScene {
             this._dealDamage(attacker, target, autoAttackDamage);
         } else {
             this._logToBattle(`${attacker.heroData.name} attacks ${target.heroData.name}!`);
+
+            if (attacker.team === 'player') {
+                this._triggerCameraEffect('camera-pan-right', 1000);
+            } else {
+                this._triggerCameraEffect('camera-pan-left', 1000);
+            }
+
             await sleep(500 * battleSpeeds[this.currentSpeedIndex].multiplier);
             this._fireProjectile(attacker.element, target.element);
             await sleep(500 * battleSpeeds[this.currentSpeedIndex].multiplier);
@@ -270,6 +281,17 @@ export class BattleScene {
         this.arena.classList.add(cls);
         const duration = cls === 'ability-zoom' ? 1000 : 300;
         setTimeout(() => this.arena.classList.remove(cls), duration);
+    }
+
+    _triggerCameraEffect(effectClass, duration = 1000) {
+        const arena = this.element.querySelector('.battle-arena');
+        if (!arena) return;
+
+        arena.classList.add(effectClass);
+
+        setTimeout(() => {
+            arena.classList.remove(effectClass);
+        }, duration);
     }
 
     _fireProjectile(startElement, endElement){

--- a/hero-game/style.css
+++ b/hero-game/style.css
@@ -579,6 +579,29 @@ body {
   50% { transform: scale(1.03); }
 }
 
+/* --- Camera Effects --- */
+@keyframes camera-zoom-in {
+    50% { transform: scale(1.04); }
+}
+
+.battle-arena.camera-zoom {
+    animation: camera-zoom-in 1.2s ease-in-out;
+}
+
+@keyframes camera-pan-to-right {
+    50% { transform: translateX(-15px) scale(1.02); }
+}
+.battle-arena.camera-pan-right {
+    animation: camera-pan-to-right 1s ease-in-out;
+}
+
+@keyframes camera-pan-to-left {
+    50% { transform: translateX(15px) scale(1.02); }
+}
+.battle-arena.camera-pan-left {
+    animation: camera-pan-to-left 1s ease-in-out;
+}
+
 @keyframes screen-shake {
   0%, 100% { transform: translate(0, 0) rotate(0); }
   25% { transform: translate(5px, 2px) rotate(0.5deg); }


### PR DESCRIPTION
## Summary
- add new camera zoom and pan effects in CSS
- add `_triggerCameraEffect` helper to BattleScene
- pan camera on auto attacks
- zoom camera when using epic or rare abilities

## Testing
- `node -e "require('./hero-game/js/scenes/BattleScene.js');"` *(fails: document is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68504aa86f348327b83e6eb3731a77bf