### PR TITLE
Fix UI-481: show recap after each draft round

### DIFF
--- a/hero-game/js/main.js
+++ b/hero-game/js/main.js
@@ -179,6 +179,7 @@ function advanceDraft() {
             weapon: team.weapon1,
             armor: team.armor1
         });
+        recapScene.setContinueButtonLabel('Draft Next Champion');
         transitionToScene('recap');
     } else if (stage === 'RECAP_1_DRAFT') {
         gameState.draft.stage = 'HERO_2_PACK';
@@ -205,6 +206,16 @@ function advanceDraft() {
         configurePackScene(gameState.draft.stage);
         transitionToScene('pack');
     } else if (stage === 'ARMOR_2_DRAFT' && team.armor2) {
+        gameState.draft.stage = 'RECAP_2_DRAFT';
+        recapScene.render({
+            hero: team.hero2,
+            ability: team.ability2,
+            weapon: team.weapon2,
+            armor: team.armor2
+        });
+        recapScene.setContinueButtonLabel('Start Battle');
+        transitionToScene('recap');
+    } else if (stage === 'RECAP_2_DRAFT') {
         gameState.draft.stage = 'DONE';
         confirmationBar.classList.add('visible');
     }

--- a/hero-game/js/scenes/RecapScene.js
+++ b/hero-game/js/scenes/RecapScene.js
@@ -10,7 +10,14 @@ export class RecapScene {
         this.cardViewer = this.element.querySelector('#recap-card-viewer');
         this.socketContainer = this.element.querySelector('#recap-socket-container');
 
-        this.element.querySelector('#recap-continue-button').addEventListener('click', () => this.onContinue());
+        this.continueButton = this.element.querySelector('#recap-continue-button');
+        this.continueButton.addEventListener('click', () => this.onContinue());
+    }
+
+    setContinueButtonLabel(text) {
+        if (this.continueButton) {
+            this.continueButton.textContent = text;
+        }
     }
 
     render(championData) {


### PR DESCRIPTION
## Summary
- store recap 'Continue' button for dynamic label updates
- add `setContinueButtonLabel` in RecapScene
- show recap after the second champion draft as well
- update button label depending on the draft stage

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68504eee6f008327833843a4892f4603