### PR TITLE
Add advanced battle VFX

### DIFF
--- a/hero-game/style.css
+++ b/hero-game/style.css
@@ -259,7 +259,33 @@ body {
   10%, 30%, 50%, 70% { transform: translateX(-8px); }
   20%, 40%, 60%, 80% { transform: translateX(8px); }
 }
-.compact-card.is-defeated { opacity: 0.4; filter: grayscale(100%); transform: translateY(20px) scale(0.9); }
+.compact-card.is-defeated {
+    /* This class will now trigger the animation */
+    animation: defeat-animation 1.5s forwards ease-in-out;
+}
+
+@keyframes defeat-animation {
+    0% {
+        transform: scale(1);
+        filter: grayscale(0);
+        opacity: 1;
+    }
+    30% {
+        /* Shatter/Shake effect */
+        transform: scale(1.1) rotate(5deg) translateX(-10px);
+        filter: grayscale(80%);
+        opacity: 0.8;
+    }
+    40% {
+        transform: scale(1.05) rotate(-5deg) translateX(10px);
+    }
+    100% {
+        /* Fall off screen */
+        transform: translateY(200%) rotate(20deg) scale(0.5);
+        filter: grayscale(100%);
+        opacity: 0;
+    }
+}
 .combat-text-popup {
     position: absolute;
     top: 50%;
@@ -306,6 +332,37 @@ body {
 }
 .status-icon-container { position: absolute; top: -10px; right: -10px; display: flex; gap: 0.25rem; }
 .status-icon { width: 24px; height: 24px; background-color: rgba(0,0,0,0.7); border-radius: 50%; display: flex; align-items: center; justify-content: center; font-size: 0.8rem; border: 1px solid white; }
+
+/* Base style for all auras to enable positioning */
+.compact-card.has-aura::after {
+    content: '';
+    position: absolute;
+    top: -5px; left: -5px;
+    right: -5px; bottom: -5px;
+    border-radius: 10px;
+    pointer-events: none;
+    z-index: -1; /* Place it behind the card but in front of the background */
+}
+
+/* Poison Aura - Bubbling Green */
+@keyframes poison-aura-bubble {
+    0% { box-shadow: 0 0 12px 3px #16a34a, inset 0 0 10px #166534; }
+    50% { box-shadow: 0 0 18px 5px #22c55e, inset 0 0 14px #16a34a; }
+    100% { box-shadow: 0 0 12px 3px #16a34a, inset 0 0 10px #166534; }
+}
+.compact-card.aura-poison::after {
+    animation: poison-aura-bubble 2s ease-in-out infinite;
+}
+
+/* Buff Aura - Solid Blue Shield */
+@keyframes buff-aura-pulse {
+    0% { box-shadow: 0 0 12px 3px #2563eb, inset 0 0 10px #1d4ed8; }
+    50% { box-shadow: 0 0 18px 5px #3b82f6, inset 0 0 14px #2563eb; }
+    100% { box-shadow: 0 0 12px 3px #2563eb, inset 0 0 10px #1d4ed8; }
+}
+.compact-card.aura-buff::after {
+    animation: buff-aura-pulse 2.5s ease-in-out infinite;
+}
 #battle-log { position: absolute; bottom: 1rem; left: 50%; transform: translateX(-50%); width: 90%; max-width: 600px; background-color: rgba(0,0,0,0.5); backdrop-filter: blur(4px); padding: 0.75rem; border-radius: 0.5rem; text-align: center; font-size: 1.1rem; transition: opacity 0.5s; }
 
 #screen-flash {
@@ -577,6 +634,19 @@ body {
     transition: transform 0.4s cubic-bezier(0.5, 0, 1, 0.5); /* Easing for a sense of speed */
     z-index: 99;
     pointer-events: none;
+}
+
+/* Energy gain particles */
+.energy-particle {
+    position: fixed;
+    width: 10px;
+    height: 10px;
+    background-color: #fde047;
+    border-radius: 50%;
+    box-shadow: 0 0 10px 4px rgba(253, 224, 71, 0.7);
+    z-index: 98;
+    pointer-events: none;
+    transition: transform 0.6s cubic-bezier(0.5, 0, 1, 1), opacity 0.6s ease;
 }
 
 .hit-spark {


### PR DESCRIPTION
## Summary
- animate defeat with dramatic fall and grayscale
- add persistent aura VFX for status effects
- implement energy charge-up particles
- update status icon logic for aura classes
- animate energy gain in the battle turn

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6850531b8ce8832796c53864493d14c0