### PR TITLE
Add background reactions and slow motion effects

### DIFF
--- a/hero-game/style.css
+++ b/hero-game/style.css
@@ -15,6 +15,30 @@ body {
     z-index: -1;
     background-color: #111827;
 }
+
+/* This pseudo-element will act as our color overlay */
+#background-canvas::after {
+    content: '';
+    position: fixed;
+    top: 0; left: 0;
+    width: 100%; height: 100%;
+    z-index: -1; /* Ensures it's on top of the canvas but behind cards */
+    opacity: 0;
+    transition: opacity 0.5s ease-in-out;
+}
+
+/* Style for a "Holy" or "Buff" ability */
+#background-canvas.holy-mode::after {
+    background-color: rgba(253, 224, 71, 0.2); /* Soft Gold */
+    opacity: 1;
+}
+
+/* Style for a "Chaos" or "Debuff" ability */
+#background-canvas.chaos-mode::after {
+    background-color: rgba(167, 139, 250, 0.2); /* Soft Purple */
+    opacity: 1;
+}
+
 .font-cinzel { font-family: 'Cinzel', serif; }
 
 /* --- Scene Containers --- */
@@ -636,6 +660,12 @@ body {
     pointer-events: none;
 }
 
+/* Slows down the projectile travel time */
+.battle-projectile.slow-motion {
+    transition-duration: 1.5s !important;
+    transition-timing-function: linear !important; /* Use linear for a classic slo-mo feel */
+}
+
 /* Energy gain particles */
 .energy-particle {
     position: fixed;
@@ -724,6 +754,11 @@ body {
 }
 .battle-arena.camera-pan-left {
     animation: camera-pan-to-left 1s ease-in-out;
+}
+
+/* Slows down the pan/zoom animation */
+.battle-arena.slow-motion {
+    animation-duration: 2s !important;
 }
 
 @keyframes screen-shake {


### PR DESCRIPTION
## Summary
- implement background overlay reactions for holy and chaos abilities
- trigger holy overlay when using Holy Barrier
- add slow-motion camera and projectile styles
- detect final blow to play slow-motion pan and projectile

## Testing
- `npm test` *(fails: Could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68505598db7083278d0af904288467b3