### PR TITLE
Add battle combo counter and speed lines effect

### DIFF
--- a/hero-game/index.html
+++ b/hero-game/index.html
@@ -95,6 +95,8 @@
             <div id="player-team-container" class="team-container"></div>
             <div id="enemy-team-container" class="team-container"></div>
         </div>
+        <div id="player-combo-counter" class="combo-counter player-side"></div>
+        <div id="enemy-combo-counter" class="combo-counter enemy-side"></div>
         <div id="ability-announcer" class="ability-announcer"></div>
         <div id="battle-log">The battle is about to begin...</div>
         <div id="end-screen">

--- a/hero-game/js/background-animation.js
+++ b/hero-game/js/background-animation.js
@@ -35,12 +35,21 @@ function draw() {
 }
 
 function update() {
-    stars.forEach(star => {
-        star.x += star.vx;
-        star.y += star.vy;
+    const isSpeedActive = canvas.classList.contains('speed-lines-active');
 
+    stars.forEach(star => {
+        if (isSpeedActive) {
+            // Speed Lines Effect: Stars streak horizontally
+            star.x -= star.radius * 5;
+        } else {
+            // Normal Effect: Stars drift slowly
+            star.x += star.vx;
+            star.y += star.vy;
+        }
+
+        // Wrap stars around the screen
         if (star.x < 0) star.x = canvas.width;
-        if (star.x > canvas.width) star.x = 0;
+        if (star.x > canvas.width && !isSpeedActive) star.x = 0; // Prevent wrapping when streaking
         if (star.y < 0) star.y = canvas.height;
         if (star.y > canvas.height) star.y = 0;
     });

--- a/hero-game/js/scenes/BattleScene.js
+++ b/hero-game/js/scenes/BattleScene.js
@@ -18,6 +18,11 @@ export class BattleScene {
         this.speedButton = this.element.querySelector('#speed-cycle-button');
         this.arena = this.element.querySelector('.battle-arena');
         this.abilityAnnouncer = this.element.querySelector('#ability-announcer');
+
+        this.comboCount = 0;
+        this.lastAttackingTeam = null;
+        this.playerComboCounter = document.getElementById('player-combo-counter');
+        this.enemyComboCounter = document.getElementById('enemy-combo-counter');
         
         // State
         this.state = [];
@@ -48,6 +53,10 @@ export class BattleScene {
         this.isBattleOver = false;
         this.state = initialState;
         this.turnQueue = [];
+        this.comboCount = 0;
+        this.lastAttackingTeam = null;
+        this.playerComboCounter.classList.remove('active');
+        this.enemyComboCounter.classList.remove('active');
 
         // --- UI Setup ---
         this.playerContainer.innerHTML = '';
@@ -140,6 +149,8 @@ export class BattleScene {
         }
 
         const attacker = this.turnQueue.shift();
+
+        this._updateCombo(attacker.team);
 
         attacker.element.classList.add('is-active-turn');
 
@@ -367,6 +378,28 @@ export class BattleScene {
         setTimeout(() => {
             background.classList.remove(effectClass);
         }, duration);
+    }
+
+    _updateCombo(attackerTeam) {
+        if (this.lastAttackingTeam === attackerTeam) {
+            this.comboCount++;
+        } else {
+            this.comboCount = 1;
+            this.playerComboCounter.classList.remove('active');
+            this.enemyComboCounter.classList.remove('active');
+        }
+
+        this.lastAttackingTeam = attackerTeam;
+        const backgroundCanvas = document.getElementById('background-canvas');
+
+        if (this.comboCount > 1) {
+            const counter = attackerTeam === 'player' ? this.playerComboCounter : this.enemyComboCounter;
+            counter.textContent = `COMBO x${this.comboCount}`;
+            counter.classList.add('active');
+            if (backgroundCanvas) backgroundCanvas.classList.add('speed-lines-active');
+        } else {
+            if (backgroundCanvas) backgroundCanvas.classList.remove('speed-lines-active');
+        }
     }
 
     async _fireProjectile(startElement, endElement, isFinalBlow = false) {

--- a/hero-game/style.css
+++ b/hero-game/style.css
@@ -39,6 +39,11 @@ body {
     opacity: 1;
 }
 
+/* --- 2. Speed Lines Background Effect --- */
+#background-canvas.speed-lines-active {
+    /* We will control the speed lines via JavaScript */
+}
+
 .font-cinzel { font-family: 'Cinzel', serif; }
 
 /* --- Scene Containers --- */
@@ -726,6 +731,34 @@ body {
 }
 .ability-announcer.show {
     animation: announce-and-fade 1.5s ease-out forwards;
+}
+
+/* --- 1. Combo Counter Styles --- */
+.combo-counter {
+    position: absolute;
+    top: 50%;
+    transform: translateY(-50%);
+    font-family: 'Cinzel', serif;
+    font-size: 3rem;
+    font-weight: 900;
+    color: #fff;
+    text-shadow: 0 0 5px #000, 0 0 10px #f59e0b, 0 0 15px #f59e0b;
+    pointer-events: none;
+    opacity: 0;
+    transition: opacity 0.3s ease-out, transform 0.3s ease-out;
+}
+.combo-counter.player-side { left: 20%; }
+.combo-counter.enemy-side { right: 20%; }
+
+/* Animation for when the counter appears and updates */
+@keyframes combo-pop-in {
+    0% { transform: translateY(-50%) scale(0.5); }
+    70% { transform: translateY(-50%) scale(1.2); }
+    100% { transform: translateY(-50%) scale(1); }
+}
+.combo-counter.active {
+    opacity: 1;
+    animation: combo-pop-in 0.3s ease-out;
 }
 @keyframes announce-and-fade {
     0% { transform: translateX(-50%) scale(0.5); opacity: 0; }


### PR DESCRIPTION
## Summary
- show combo counters on each side of the battle scene
- style combo counter and background speed lines
- track consecutive turns in `BattleScene`
- activate speed lines in `background-animation.js`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68505c1347508327bc15f93f5f923266