### PR TITLE
Add Random Hero draft option

### DIFF
--- a/hero-game/index.html
+++ b/hero-game/index.html
@@ -34,8 +34,8 @@
 
         <p id="pack-scene-instructions" class="text-lg text-gray-400 mt-8">Click the pack to begin.</p>
 
-        <button id="random-team-button" class="mt-6 text-gray-400 border border-gray-600 rounded-lg px-4 py-2 hover:bg-gray-700 hover:text-white transition-colors">
-            ... or start with a Random Team
+        <button id="random-hero-button" class="mt-6 text-gray-400 border border-gray-600 rounded-lg px-4 py-2 hover:bg-gray-700 hover:text-white transition-colors">
+            ... or add a Random Hero
         </button>
     </div>
 

--- a/hero-game/js/main.js
+++ b/hero-game/js/main.js
@@ -219,6 +219,8 @@ function advanceDraft() {
         gameState.draft.stage = 'DONE';
         confirmationBar.classList.add('visible');
     }
+
+    updateRandomHeroButtonState();
 }
 
 // --- DATA GENERATION ---
@@ -303,6 +305,59 @@ function generateRandomTeamAndStartBattle() {
     confirmationBar.classList.remove('visible');
 
     startNextBattle();
+}
+
+// Generate a single random hero and advance the draft appropriately
+function generateSingleRandomHero() {
+    const team = gameState.draft.playerTeam;
+    let slot = null;
+    if (!team.hero1) slot = 1;
+    else if (!team.hero2) slot = 2;
+    if (!slot) return; // team full
+
+    const champion = generateRandomChampion();
+
+    if (slot === 1) {
+        team.hero1 = champion.hero;
+        team.ability1 = champion.ability;
+        team.weapon1 = champion.weapon;
+        team.armor1 = champion.armor;
+
+        gameState.draft.stage = 'RECAP_1_DRAFT';
+        recapScene.render({
+            hero: team.hero1,
+            ability: team.ability1,
+            weapon: team.weapon1,
+            armor: team.armor1
+        });
+        recapScene.setContinueButtonLabel('Draft Next Champion');
+        transitionToScene('recap');
+    } else {
+        team.hero2 = champion.hero;
+        team.ability2 = champion.ability;
+        team.weapon2 = champion.weapon;
+        team.armor2 = champion.armor;
+
+        gameState.draft.stage = 'RECAP_2_DRAFT';
+        recapScene.render({
+            hero: team.hero2,
+            ability: team.ability2,
+            weapon: team.weapon2,
+            armor: team.armor2
+        });
+        recapScene.setContinueButtonLabel('Start Battle');
+        transitionToScene('recap');
+    }
+
+    updateRandomHeroButtonState();
+}
+
+function updateRandomHeroButtonState() {
+    const button = document.getElementById('random-hero-button');
+    if (!button) return;
+    const team = gameState.draft.playerTeam;
+    const disabled = team.hero1 && team.hero2;
+    button.disabled = disabled;
 }
 
 // --- BATTLE SETUP ---
@@ -450,9 +505,9 @@ function endTournament() {
 
 // --- EVENT LISTENERS ---
 confirmDraftButton.addEventListener('click', startNextBattle);
-const randomTeamButton = document.getElementById('random-team-button');
-if (randomTeamButton) {
-    randomTeamButton.addEventListener('click', generateRandomTeamAndStartBattle);
+const randomHeroButton = document.getElementById('random-hero-button');
+if (randomHeroButton) {
+    randomHeroButton.addEventListener('click', generateSingleRandomHero);
 }
 
 // --- INITIALIZE ---
@@ -461,3 +516,4 @@ initBackgroundAnimation();
 packScene.render(gameState.draft.stage);
 configurePackScene(gameState.draft.stage);
 transitionToScene('pack');
+updateRandomHeroButtonState();

--- a/hero-game/style.css
+++ b/hero-game/style.css
@@ -192,6 +192,11 @@ body {
 }
 .hero-card.selected { border-color: #f59e0b; box-shadow: 0 0 25px #f59e0b, 0 10px 30px rgba(0,0,0,0.7); transform: translateY(-5px) scale(1.02); }
 .hero-card.disabled { opacity: 0.5; pointer-events: none; }
+
+button:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+}
 .hero-card.common { border-color: #9ca3af; }
 .hero-card.uncommon { border-color: #22c55e; }
 .hero-card.rare { border-color: #f59e0b; }


### PR DESCRIPTION
## Summary
- rename Random Team button to Random Hero
- allow filling a single hero slot with a randomly generated champion
- disable button when team is full

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68505fb4ca0083279f7582cf442b447c