### PR TITLE
Remove battle scene background image

### DIFF
--- a/hero-game/style.css
+++ b/hero-game/style.css
@@ -222,9 +222,15 @@ button:disabled {
 
 /* --- Battle Scene Styles --- */
 #battle-scene-background {
-    position: absolute; top: 0; left: 0; width: 100%; height: 100%;
-    background-image: url('https://placehold.co/1920x1080/292524/78716c?text=Rocky+Cave');
-    background-size: cover; background-position: center; z-index: -1; filter: blur(4px) brightness(0.7);
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background-size: cover;
+    background-position: center;
+    z-index: -1;
+    filter: blur(4px) brightness(0.7);
 }
 
 #environmental-vfx-container {

--- a/poc3.html
+++ b/poc3.html
@@ -119,7 +119,6 @@
         /* --- Battle Scene Styles --- */
         #battle-scene-background {
             position: absolute; top: 0; left: 0; width: 100%; height: 100%;
-            background-image: url('https://placehold.co/1920x1080/292524/78716c?text=Rocky+Cave');
             background-size: cover; background-position: center; z-index: -1; filter: blur(4px) brightness(0.7);
         }
         .battle-arena { display: grid; grid-template-columns: 1fr 1fr; gap: 2rem; width: 100%; max-width: 1200px; padding: 2rem; align-items: center; }


### PR DESCRIPTION
## Summary
- keep the battle scene container but drop the Rocky Cave background
- update the prototype battle page accordingly

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_68507a70968c8327ad8697438d1db114