### PR TITLE
Add card pack opening animation

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -12,6 +12,7 @@ import CraftingPage from "./components/CraftingPage.tsx";
 import Shop from "./routes/Shop.jsx";
 import DeckManager from "./components/DeckManager.jsx";
 import BattleScene from "./components/BattleScene.tsx";
+import PackOpener from "./components/PackOpener.jsx";
 
 export default function App() {
   const location = useLocation();
@@ -29,6 +30,7 @@ export default function App() {
       <Route path="/battle" element={<BattleScene />} />
       <Route path="/event" element={<Event />} />
       <Route path="/decks" element={<DeckManager />} />
+      <Route path="/open-pack" element={<PackOpener />} />
     </Routes>
   );
 }

--- a/client/src/assets/card_pack.svg
+++ b/client/src/assets/card_pack.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 150 200">
+  <rect x="20" y="20" width="110" height="160" rx="10" ry="10" fill="#d2b48c" stroke="#8b5a2b" stroke-width="4"/>
+  <rect x="20" y="60" width="110" height="20" fill="#c0a080"/>
+  <rect x="20" y="120" width="110" height="20" fill="#c0a080"/>
+</svg>

--- a/client/src/assets/chains.svg
+++ b/client/src/assets/chains.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200">
+  <g stroke="#cccccc" stroke-width="6" fill="none">
+    <line x1="40" y1="0" x2="160" y2="200"/>
+    <line x1="160" y1="0" x2="40" y2="200"/>
+  </g>
+</svg>

--- a/client/src/assets/magic_circle.svg
+++ b/client/src/assets/magic_circle.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200">
+  <circle cx="100" cy="100" r="90" stroke="#7cc7ff" stroke-width="4" fill="none"/>
+  <circle cx="100" cy="100" r="60" stroke="#7cc7ff" stroke-width="2" fill="none"/>
+  <circle cx="100" cy="100" r="30" stroke="#7cc7ff" stroke-width="2" fill="none"/>
+</svg>

--- a/client/src/components/MainMenu.jsx
+++ b/client/src/components/MainMenu.jsx
@@ -53,6 +53,12 @@ function MainMenu() {
         >
           Inventory
         </button>
+        <button
+          className={styles.button}
+          onClick={() => navigate('/open-pack')}
+        >
+          Open Pack
+        </button>
       </nav>
     </main>
   )

--- a/client/src/components/PackOpener.jsx
+++ b/client/src/components/PackOpener.jsx
@@ -1,0 +1,23 @@
+import React, { useState } from 'react'
+import { Link } from 'react-router-dom'
+import PackOpeningAnimation from './PackOpeningAnimation.jsx'
+import styles from './TownFeaturePage.module.css'
+
+export default function PackOpener() {
+  const [showAnim, setShowAnim] = useState(false)
+
+  return (
+    <div className={styles.container}>
+      <Link to="/town" className={styles.back}>
+        Back to Town
+      </Link>
+      <div style={{ textAlign: 'center', marginTop: '2rem' }}>
+        <button onClick={() => setShowAnim(true)}>Open Pack</button>
+      </div>
+      <PackOpeningAnimation
+        visible={showAnim}
+        onUnlock={() => setShowAnim(false)}
+      />
+    </div>
+  )
+}

--- a/client/src/components/PackOpeningAnimation.css
+++ b/client/src/components/PackOpeningAnimation.css
@@ -1,0 +1,52 @@
+.pack-animation-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.7);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 50;
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.3s ease;
+}
+.pack-animation-overlay.show {
+  opacity: 1;
+  pointer-events: auto;
+}
+.pack-animation-inner {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+.magic-circle,
+.chains {
+  position: absolute;
+}
+.magic-circle img {
+  width: 20rem;
+  height: 20rem;
+  opacity: 0.7;
+  animation: spin-slow 3s linear infinite;
+}
+.chains img {
+  width: 16rem;
+  height: 16rem;
+  opacity: 0.8;
+  animation: pulse 1.5s ease-in-out infinite;
+}
+.pack-image {
+  width: 12rem;
+  height: 12rem;
+  box-shadow: 0 0 12px rgba(0, 0, 0, 0.5);
+  border-radius: 1rem;
+}
+@keyframes spin-slow {
+  from { transform: rotate(0deg); }
+  to { transform: rotate(360deg); }
+}
+@keyframes pulse {
+  0%, 100% { transform: scale(1); }
+  50% { transform: scale(1.05); }
+}

--- a/client/src/components/PackOpeningAnimation.jsx
+++ b/client/src/components/PackOpeningAnimation.jsx
@@ -1,0 +1,48 @@
+import React, { useEffect, useRef } from 'react'
+import './PackOpeningAnimation.css'
+
+export default function PackOpeningAnimation({ onUnlock, visible }) {
+  const overlayRef = useRef(null)
+  const packRef = useRef(null)
+
+  useEffect(() => {
+    if (!visible) return
+    const overlay = overlayRef.current
+    const pack = packRef.current
+    if (!overlay || !pack) return
+    pack.style.transform = 'scale(0.6) translateY(200px)'
+    pack.style.opacity = '0'
+    setTimeout(() => {
+      pack.style.transition =
+        'transform 0.6s cubic-bezier(.68,-0.55,.27,1.55), opacity 0.4s'
+      pack.style.transform = 'scale(1.2) translateY(0)'
+      pack.style.opacity = '1'
+    }, 100)
+    const unlockTimeout = setTimeout(() => {
+      if (typeof onUnlock === 'function') onUnlock()
+    }, 1800)
+    return () => clearTimeout(unlockTimeout)
+  }, [visible, onUnlock])
+
+  return (
+    <div
+      ref={overlayRef}
+      className={`pack-animation-overlay ${visible ? 'show' : 'hide'}`}
+    >
+      <div className="pack-animation-inner">
+        <div className="magic-circle">
+          <img src="/src/assets/magic_circle.svg" alt="Magic Circle" />
+        </div>
+        <div className="chains">
+          <img src="/src/assets/chains.svg" alt="Chains" />
+        </div>
+        <img
+          ref={packRef}
+          className="pack-image"
+          src="/src/assets/card_pack.svg"
+          alt="Card Pack"
+        />
+      </div>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- prototype animated pack opening overlay
- add placeholder images for pack art
- add page and route to demo the overlay
- link to demo from main menu

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6850901bdd1083279e0f11b1d015892c