### PR TITLE
UI-347 clickable booster pack

### DIFF
--- a/hero-game/index.html
+++ b/hero-game/index.html
@@ -27,7 +27,7 @@
             </div>
         </div>
 
-        <p id="pack-scene-instructions" class="text-lg text-gray-400 mt-8">Click the top of the pack to tear it open.</p>
+        <p id="pack-scene-instructions" class="text-lg text-gray-400 mt-8">Click anywhere on the pack to tear it open.</p>
 
         <button id="random-hero-button" class="mt-6 text-gray-400 border border-gray-600 rounded-lg px-4 py-2 hover:bg-gray-700 hover:text-white transition-colors">
             ... or add a Random Hero

--- a/hero-game/js/scenes/PackScene.js
+++ b/hero-game/js/scenes/PackScene.js
@@ -13,12 +13,14 @@ export class PackScene {
         this.imageArea = this.element.querySelector('#image-area');
 
         // Bind interactions
-        if (this.topCrimp) {
-            this.topCrimp.addEventListener('click', () => this._handleTearOff());
-        }
         if (this.packageEl) {
+            this.packageEl.addEventListener('click', () => this._handleTearOff());
             this.packageEl.addEventListener('mousemove', (e) => this._handleMouseMove(e));
             this.packageEl.addEventListener('mouseleave', () => this._handleMouseLeave());
+        }
+        if (this.topCrimp) {
+            // The crimp element still hosts the tear-off animation but no longer
+            // directly receives click events.
         }
     }
 
@@ -70,7 +72,7 @@ export class PackScene {
         } else if (draftStage.includes('HERO_2')) {
             this.titleElement.textContent = 'Forge Your Second Champion';
         }
-        this.instructionsElement.textContent = 'Click the top of the pack to tear it open.';
+        this.instructionsElement.textContent = 'Click anywhere on the pack to tear it open.';
     }
 
     reset() {

--- a/hero-game/style.css
+++ b/hero-game/style.css
@@ -1274,6 +1274,7 @@ button:disabled {
     box-shadow: 0 25px 50px -12px rgba(0, 0, 0, 0.5);
     transition: transform 0.05s linear;
     transform-style: preserve-3d;
+    cursor: pointer;
 }
 
 .image-area {
@@ -1300,7 +1301,6 @@ button:disabled {
 }
 
 #top-crimp {
-    cursor: pointer;
     z-index: 10;
 }
 


### PR DESCRIPTION
## Summary
- make the whole booster pack clickable instead of just the top crimp
- show pointer cursor for the entire pack
- clarify instructions to click anywhere on the pack

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68509dcbe9d48327900adc6d0273c076