### PR TITLE
Speed up pack opening

### DIFF
--- a/hero-game/js/scenes/PackScene.js
+++ b/hero-game/js/scenes/PackScene.js
@@ -37,7 +37,7 @@ export class PackScene {
             this.packageEl.classList.add('is-open');
             setTimeout(() => {
                 this.onPackOpened();
-            }, 300);
+            }, 100);
         }, { once: true });
     }
 

--- a/hero-game/js/scenes/RevealScene.js
+++ b/hero-game/js/scenes/RevealScene.js
@@ -55,7 +55,7 @@ export class RevealScene {
                 }
                 setTimeout(() => {
                     this.onRevealComplete(this.packContents);
-                }, 800);
+                }, 300);
             }
         } else {
             const cardIndex = parseInt(cardWrapper.dataset.cardIndex);

--- a/hero-game/style.css
+++ b/hero-game/style.css
@@ -54,7 +54,7 @@ body {
     align-items: center;
     justify-content: center;
     padding: 1rem;
-    transition: opacity 0.7s ease-out, transform 0.7s ease-out;
+    transition: opacity 0.3s ease-out, transform 0.3s ease-out;
 }
 .scene.hidden {
     opacity: 0;
@@ -156,7 +156,7 @@ body {
 
 /* Pack opening animations */
 .opening {
-    animation: shake-and-glow 1.5s ease-in-out, fade-out 0.5s ease-in 1.5s forwards;
+    animation: shake-and-glow 0.6s ease-in-out, fade-out 0.3s ease-in 0.6s forwards;
 }
 @keyframes shake-and-glow {
     0%, 100% { transform: scale(1.0) rotate(0deg); }
@@ -1309,7 +1309,7 @@ button:disabled {
 }
 
 .torn-off {
-    animation: tear-off 0.8s forwards ease-in;
+    animation: tear-off 0.3s forwards ease-in;
 }
 
 .package.is-open {


### PR DESCRIPTION
## Summary
- make scene transitions faster
- shorten pack opening and tear-off animations
- shorten timeouts before starting reveal
- cut delay after all cards reveal

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6850a8f9114c8327a51fd7cbf33774fe