### PR TITLE
Enable pack art per booster type

### DIFF
--- a/hero-game/index.html
+++ b/hero-game/index.html
@@ -21,7 +21,9 @@
             <div id="package" class="package flex flex-col rounded-lg">
                 <div id="top-crimp" class="crimp h-6 rounded-t-lg"></div>
 
-                <div id="image-area" class="image-area flex-grow"></div>
+                <div id="image-area" class="image-area flex-grow flex items-center justify-center">
+                    <img id="booster-pack-img" src="img/character_booster.png" alt="character booster pack" class="booster-pack-image w-[320px] h-auto" draggable="false" />
+                </div>
 
                 <div class="crimp h-6 rounded-b-lg"></div>
             </div>

--- a/hero-game/js/scenes/PackScene.js
+++ b/hero-game/js/scenes/PackScene.js
@@ -1,3 +1,10 @@
+const boosterPackImages = {
+    hero: 'img/character_booster.png',
+    ability: 'img/ability_booster.png',
+    weapon: 'img/weapon_booster.png',
+    armor: 'img/armor_booster.png'
+};
+
 export class PackScene {
     constructor(element, onPackOpened) {
         this.element = element;
@@ -11,6 +18,7 @@ export class PackScene {
         this.packageEl = this.element.querySelector('#package');
         this.topCrimp = this.element.querySelector('#top-crimp');
         this.imageArea = this.element.querySelector('#image-area');
+        this.imageElem = this.imageArea.querySelector('#booster-pack-img');
 
         // Bind interactions
         if (this.packageEl) {
@@ -67,6 +75,12 @@ export class PackScene {
 
     render(draftStage) {
         this.isOpening = false;
+        const type = draftStage.split('_')[0].toLowerCase();
+        this.packType = type;
+        if (this.imageElem) {
+            this.imageElem.src = boosterPackImages[type] || boosterPackImages.hero;
+            this.imageElem.alt = `${type} booster pack`;
+        }
         if (draftStage.includes('HERO_1')) {
             this.titleElement.textContent = 'Forge Your First Champion';
         } else if (draftStage.includes('HERO_2')) {

--- a/hero-game/style.css
+++ b/hero-game/style.css
@@ -1283,6 +1283,13 @@ button:disabled {
     position: relative;
 }
 
+.booster-pack-image {
+    width: 100%;
+    height: auto;
+    display: block;
+    user-select: none;
+}
+
 .image-area::before {
     content: '';
     position: absolute;


### PR DESCRIPTION
## Summary
- show a dedicated `<img>` for the pack art in `index.html`
- style the booster pack image
- choose the pack art dynamically in `PackScene`
- remove duplicate pack images

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68516f666bdc8327b9020cd522fe6a4b