### PR TITLE
Fix booster pack artwork fill

### DIFF
--- a/hero-game/style.css
+++ b/hero-game/style.css
@@ -1290,6 +1290,14 @@ button:disabled {
     user-select: none;
 }
 
+/* Ensure any artwork inside the booster pack fills the full area */
+#image-area img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    object-position: center;
+}
+
 .image-area::before {
     content: '';
     position: absolute;


### PR DESCRIPTION
## Summary
- ensure images inside `#image-area` stretch to fill the booster pack height

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68517753225883279f7b95d02eb38812