### PR TITLE
Remove deprecated energy gain particle effect

### DIFF
--- a/hero-game/js/scenes/BattleScene.js
+++ b/hero-game/js/scenes/BattleScene.js
@@ -182,7 +182,7 @@ export class BattleScene {
         attacker.currentEnergy += 1;
         this._logToBattle(`${attacker.heroData.name} gains 1 energy!`, 'heal');
 
-        await this._triggerEnergyChargeUp(attacker.element);
+        // await this._triggerEnergyChargeUp(attacker.element); // This effect is deprecated
         if (attacker.currentHp <= 0) {
             this.executeNextTurn();
             return;

--- a/hero-game/style.css
+++ b/hero-game/style.css
@@ -883,18 +883,6 @@ button:disabled {
     transition-timing-function: linear !important; /* Use linear for a classic slo-mo feel */
 }
 
-/* Energy gain particles */
-.energy-particle {
-    position: fixed;
-    width: 10px;
-    height: 10px;
-    background-color: #3b82f6;
-    border-radius: 50%;
-    box-shadow: 0 0 10px 4px rgba(59, 130, 246, 0.7);
-    z-index: 98;
-    pointer-events: none;
-    transition: transform 0.6s cubic-bezier(0.5, 0, 1, 1), opacity 0.6s ease;
-}
 
 .hit-spark {
     position: fixed;


### PR DESCRIPTION
## Summary
- stop triggering `_triggerEnergyChargeUp`
- clean up `.energy-particle` CSS

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_685182da72608327a65e58a264b33920