### PR TITLE
Fix duplicate ability banners

### DIFF
--- a/hero-game/js/scenes/BattleScene.js
+++ b/hero-game/js/scenes/BattleScene.js
@@ -196,12 +196,15 @@ export class BattleScene {
             this._triggerArenaEffect('ability-zoom');
             this._logToBattle(`${attacker.heroData.name} unleashes ${ability.name}!`, 'ability-cast');
 
+            // This is now redundant with the main _announceAbility call.
+            /*
             if (ability.target === 'ALLIES') {
                 this._triggerTeamBanner(attacker.team, ability.name, 'buff');
             } else if (ability.target === 'ENEMIES') {
                 const enemyTeam = attacker.team === 'player' ? 'enemy' : 'player';
                 this._triggerTeamBanner(enemyTeam, ability.name, 'debuff');
             }
+            */
 
             if (ability.env_effect) {
                 this._triggerEnvironmentalEffect(ability.env_effect);


### PR DESCRIPTION
## Summary
- remove redundant team banner announcement

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6851886ddae88327942cd7e796eb98ca