### PR TITLE
Refactor energy gain to occur on attack attempts

### DIFF
--- a/hero-game/js/scenes/BattleScene.js
+++ b/hero-game/js/scenes/BattleScene.js
@@ -263,14 +263,14 @@ export class BattleScene {
             }
 
             // --- Auto-attack after ability ---
-            // --- ADD ENERGY GAIN HERE AS WELL ---
-            attacker.currentEnergy += 1;
+            // --- GAIN ENERGY FOR ATTEMPTING ATTACK ---
+            attacker.currentEnergy = Math.min(attacker.currentEnergy + 1, 10); // Cap energy at 10
+            this._logToBattle(`${attacker.heroData.name} gains 1 energy for attacking!`, 'heal');
             this._showCombatText(attacker.element, '+1', 'energy');
             updateEnergyDisplay(attacker, attacker.element);
             this._updateChargedStatus(attacker);
-            this._logToBattle(`${attacker.heroData.name} gains 1 energy from attacking!`, 'heal');
             await sleep(400 * battleSpeeds[this.currentSpeedIndex].multiplier);
-            // --- END OF ADDITION ---
+            // --- END ENERGY GAIN ---
 
             this._logToBattle(`${attacker.heroData.name} also performs a basic attack!`);
             await this._fireProjectile(attacker.element, target.element);
@@ -287,14 +287,14 @@ export class BattleScene {
                 return;
             }
         } else {
-            // --- NEW LOCATION FOR ENERGY GAIN ---
-            attacker.currentEnergy += 1;
+            // --- GAIN ENERGY FOR ATTEMPTING ATTACK ---
+            attacker.currentEnergy = Math.min(attacker.currentEnergy + 1, 10); // Cap energy at 10
+            this._logToBattle(`${attacker.heroData.name} gains 1 energy for attacking!`, 'heal');
             this._showCombatText(attacker.element, '+1', 'energy');
             updateEnergyDisplay(attacker, attacker.element);
             this._updateChargedStatus(attacker);
-            this._logToBattle(`${attacker.heroData.name} gains 1 energy from attacking!`, 'heal');
-            await sleep(400 * battleSpeeds[this.currentSpeedIndex].multiplier); // A small pause for the text to be readable
-            // --- END OF NEW LOGIC ---
+            await sleep(400 * battleSpeeds[this.currentSpeedIndex].multiplier);
+            // --- END ENERGY GAIN ---
 
             this._logToBattle(`${attacker.heroData.name} attacks ${target.heroData.name}!`);
 


### PR DESCRIPTION
## Summary
- move energy gain to occur only when a unit attempts an attack
- remove outdated placeholder comments
- cap energy at 10 and log energy gain before attack action

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68518c47c30c8327bb6c9e87737d851d