### PR TITLE
Add DoT log style

### DIFF
--- a/hero-game/js/scenes/BattleScene.js
+++ b/hero-game/js/scenes/BattleScene.js
@@ -190,7 +190,7 @@ export class BattleScene {
         if (dotEffects.length > 0) {
             for (const effect of dotEffects) {
                 const dotDamage = effect.name === 'Poison' ? 2 : 3;
-                this._logToBattle(`${attacker.heroData.name} takes ${dotDamage} damage from ${effect.name}.`, 'damage');
+                this._logToBattle(`${attacker.heroData.name} takes ${dotDamage} damage from ${effect.name}.`, 'status-damage');
                 this._dealDamage(attacker, attacker, dotDamage, false, false, null);
                 effect.turnsRemaining--;
             }

--- a/hero-game/style.css
+++ b/hero-game/style.css
@@ -1337,3 +1337,16 @@ button:disabled {
     border-image: url("data:image/svg+xml,%3csvg width='100' height='2' preserveAspectRatio='none' viewBox='0 0 100 2' xmlns='http://www.w3.org/2000/svg'%3e%3cpath d='M0 1 L10 1.5 L20 0 L30 1.2 L40 0.5 L50 1.5 L60 0 L70 1.8 L80 0.2 L90 1.5 L100 1' stroke='%233c1a6e' stroke-width='1.5' fill='none' /%3e%3c/svg%3e") 2 stretch;
     box-shadow: inset 7px 0 15px rgba(0,0,0,0.4), inset -7px 0 15px rgba(0,0,0,0.4), inset 0 5px 10px -3px rgba(0,0,0,0.6);
 }
+
+/* --- Damage over Time Log Entry --- */
+.log-entry.status-damage {
+    color: #c084fc;
+    font-style: italic;
+    background-color: rgba(167, 139, 250, 0.1);
+}
+
+.log-entry.status-damage::before {
+    content: '☣';
+    margin-right: 0.5rem;
+    color: #a855f7;
+}


### PR DESCRIPTION
## Summary
- highlight DoT damage log entries
- color them purple with a biohazard icon

## Testing
- `npm test` *(fails: could not find package.json)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6851f5d8854483279801d5b3ca3153a7