### PR TITLE
Add DoT stacking, cleanse helper and tooltips

### DIFF
--- a/hero-game/index.html
+++ b/hero-game/index.html
@@ -170,6 +170,12 @@
         </div>
     </template>
 
+    <div id="status-tooltip" class="status-tooltip">
+        <h4 class="status-tooltip-name"></h4>
+        <p class="status-tooltip-duration"></p>
+        <p class="status-tooltip-description"></p>
+    </div>
+
     <script type="module" src="js/main.js"></script>
 
 </body>

--- a/hero-game/style.css
+++ b/hero-game/style.css
@@ -472,6 +472,27 @@ button:disabled {
     animation: icon-flash 0.6s ease-in-out;
 }
 
+/* Tooltip for status effects */
+.status-tooltip {
+    position: absolute;
+    background-color: rgba(0,0,0,0.85);
+    color: #fff;
+    padding: 0.5rem 0.75rem;
+    border-radius: 0.5rem;
+    box-shadow: 0 2px 8px rgba(0,0,0,0.5);
+    pointer-events: none;
+    opacity: 0;
+    visibility: hidden;
+    transition: opacity 0.2s ease;
+    z-index: 9999;
+    font-size: 0.8rem;
+}
+
+.status-tooltip.visible {
+    opacity: 1;
+    visibility: visible;
+}
+
 /* Base style for all auras to enable positioning */
 .compact-card.has-aura::after {
     content: '';


### PR DESCRIPTION
## Summary
- extend status effect objects and add duration stacking
- add helper for cleansing negative status effects
- attach status data attributes and add tooltip handling
- style tooltip popup and insert tooltip container

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6852de4d7e408327a16ea451b50bb2cf