### PR TITLE
Add dynamic announcements and battle log filters

### DIFF
--- a/hero-game/index.html
+++ b/hero-game/index.html
@@ -107,6 +107,13 @@
 
         <div id="battle-log-container">
             <div id="battle-log-panel">
+                <div id="battle-log-filters">
+                    <button class="filter-btn active" data-filter="all">All</button>
+                    <button class="filter-btn" data-filter="combat">Combat</button>
+                    <button class="filter-btn" data-filter="healing">Healing</button>
+                    <button class="filter-btn" data-filter="status">Status</button>
+                </div>
+                <div id="log-entries-container"></div>
             </div>
             <div id="battle-log-summary" title="Click to expand log">
                 The battle is about to begin...

--- a/hero-game/style.css
+++ b/hero-game/style.css
@@ -688,6 +688,38 @@ button:disabled {
     margin-bottom: -1px;
 }
 
+#battle-log-filters {
+    display: flex;
+    gap: 0.5rem;
+    padding-bottom: 1rem;
+    border-bottom: 1px solid rgba(255, 255, 255, 0.2);
+    margin-bottom: 1rem;
+}
+
+.filter-btn {
+    background-color: #4b5563;
+    border: 1px solid #6b7280;
+    color: white;
+    padding: 0.25rem 0.75rem;
+    border-radius: 0.5rem;
+    cursor: pointer;
+    transition: background-color 0.2s;
+}
+
+.filter-btn:hover {
+    background-color: #6b7280;
+}
+
+.filter-btn.active {
+    background-color: #f59e0b;
+    color: #111827;
+    font-weight: 600;
+}
+
+.log-entry.hidden-by-filter {
+    display: none;
+}
+
 #battle-log-panel.expanded {
     opacity: 1;
     visibility: visible;
@@ -1049,6 +1081,21 @@ button:disabled {
 }
 .ability-announcer.show {
     animation: announce-and-fade 1.5s ease-out forwards;
+}
+
+.ability-announcer.critical {
+    color: #f97316;
+    text-shadow: 0 0 10px #000, 0 0 20px #dc2626;
+}
+
+.ability-announcer.victory {
+    color: #fde047;
+    text-shadow: 0 0 10px #000, 0 0 20px #f59e0b;
+}
+
+.ability-announcer.defeat {
+    color: #ef4444;
+    text-shadow: 0 0 10px #000, 0 0 20px #b91c1c;
 }
 
 /* --- 1. Combo Counter Styles --- */


### PR DESCRIPTION
## Summary
- improve the battle announcer for critical hits and victory/defeat
- add filter buttons to the battle log UI
- implement log filtering logic and support categories
- style filter buttons and new announcer states

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6852e855f44883279ace866bcc558ed6