### PR TITLE
Enhance battle announcer and combine log entries

### DIFF
--- a/hero-game/index.html
+++ b/hero-game/index.html
@@ -103,7 +103,10 @@
         </div>
         <div id="player-combo-counter" class="combo-counter player-side"></div>
         <div id="enemy-combo-counter" class="combo-counter enemy-side"></div>
-        <div id="ability-announcer" class="ability-announcer"></div>
+        <div id="ability-announcer" class="ability-announcer">
+            <h1 id="announcer-main-text"></h1>
+            <p id="announcer-subtitle"></p>
+        </div>
 
         <div id="battle-log-container">
             <div id="battle-log-panel">

--- a/hero-game/js/scenes/BattleScene.js
+++ b/hero-game/js/scenes/BattleScene.js
@@ -41,6 +41,8 @@ export class BattleScene {
         this.speedButton = this.element.querySelector('#speed-cycle-button');
         this.arena = this.element.querySelector('.battle-arena');
         this.abilityAnnouncer = this.element.querySelector('#ability-announcer');
+        this.announcerMainText = this.element.querySelector('#announcer-main-text');
+        this.announcerSubtitle = this.element.querySelector('#announcer-subtitle');
         this.statusTooltip = document.getElementById('status-tooltip');
 
         this.comboCount = 0;
@@ -386,11 +388,11 @@ export class BattleScene {
             updateEnergyDisplay(attacker, attacker.element);
             this._updateChargedStatus(attacker);
 
-            this._announceAbility(ability.name);
+            this._showBattleAnnouncement(ability.name, 'ability', ability.effect);
             this._triggerArenaEffect('ability-zoom');
             this._logToBattle(`${attacker.heroData.name} unleashes ${ability.name}!`, 'ability-cast', attacker);
 
-            // This is now redundant with the main _announceAbility call.
+            // This is now redundant with the main announcement call.
             /*
             if (ability.target === 'ALLIES') {
                 this._triggerTeamBanner(attacker.team, ability.name, 'buff');
@@ -499,7 +501,6 @@ export class BattleScene {
             await sleep(400 * battleSpeeds[this.currentSpeedIndex].multiplier);
             // --- END ENERGY GAIN ---
 
-            this._logToBattle(`${attacker.heroData.name} attacks ${target.heroData.name}!`, 'info', attacker);
 
             const isMeleeClash = (attacker.position === 0 && target.position === 0);
 
@@ -594,15 +595,16 @@ export class BattleScene {
 
         const isOverkill = (target.currentHp - finalDamage) < -5;
 
+        const verb = sourceAbility ? 'hits' : 'strikes';
         let logMessage;
         if (attacker === target) {
-            logMessage = `${target.heroData.name} takes ${finalDamage} damage.`;
+            logMessage = `${target.heroData.name} takes ${finalDamage} damage from an effect.`;
         } else {
-            logMessage = `${attacker.heroData.name} hits ${target.heroData.name} for ${finalDamage} damage.`;
+            logMessage = `${attacker.heroData.name} ${verb} ${target.heroData.name} for ${finalDamage} damage.`;
         }
         if (isVulnerable) logMessage += ' (+1 Vulnerable)';
-        if(isCritical) logMessage += ' CRITICAL HIT!';
-        if(isOverkill) logMessage += ' OVERKILL!';
+        if (isCritical) logMessage += ' CRITICAL HIT!';
+        if (isOverkill) logMessage += ' OVERKILL!';
         const type = sourceAbility ? 'ability-result damage' : 'damage';
         this._logToBattle(logMessage, type, target);
 
@@ -851,11 +853,21 @@ export class BattleScene {
         this._logToBattle(`Turn order updated!`, 'info');
     }
 
-    _announceAbility(name){
-        if(!this.abilityAnnouncer) return;
-        this.abilityAnnouncer.textContent = name;
+    _showBattleAnnouncement(text, styleClass = '', subtitle = '') {
+        if (!this.abilityAnnouncer) return;
+
+        this.announcerMainText.textContent = text;
+        this.announcerSubtitle.textContent = subtitle;
+
+        this.abilityAnnouncer.className = 'ability-announcer';
+        if (styleClass) {
+            this.abilityAnnouncer.classList.add(styleClass);
+        }
+
         this.abilityAnnouncer.classList.add('show');
-        setTimeout(() => this.abilityAnnouncer.classList.remove('show'), 1500);
+        setTimeout(() => {
+            this.abilityAnnouncer.classList.remove('show');
+        }, 1500);
     }
 
     _triggerArenaEffect(cls){

--- a/hero-game/style.css
+++ b/hero-game/style.css
@@ -1038,14 +1038,32 @@ button:disabled {
     top: 40%;
     left: 50%;
     transform: translateX(-50%);
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    pointer-events: none;
+    opacity: 0;
+    z-index: 100;
+}
+
+#announcer-main-text {
     font-family: 'Cinzel', serif;
     font-size: 4rem;
     font-weight: 700;
     color: #fde047;
     text-shadow: 0 0 10px #000, 0 0 20px #f59e0b;
-    pointer-events: none;
-    opacity: 0;
-    z-index: 100;
+    margin: 0;
+    padding: 0;
+}
+
+#announcer-subtitle {
+    font-family: 'Inter', sans-serif;
+    font-size: 1.25rem;
+    color: #e5e7eb;
+    text-shadow: 1px 1px 2px #000;
+    margin-top: -0.5rem;
+    opacity: 0.9;
 }
 .ability-announcer.show {
     animation: announce-and-fade 1.5s ease-out forwards;


### PR DESCRIPTION
## Summary
- allow announcer div to have main text and subtitle
- style new subtitle in CSS
- show ability description as subtitle in battles
- log attack and damage in one line

## Testing
- `npm test` *(fails: missing `package.json`)*

------
https://chatgpt.com/codex/tasks/task_e_6852ebd9aa0c832792a4d61321c6bd0a