### PR TITLE
Improve battle announcements and logs

### DIFF
--- a/hero-game/index.html
+++ b/hero-game/index.html
@@ -103,7 +103,10 @@
         </div>
         <div id="player-combo-counter" class="combo-counter player-side"></div>
         <div id="enemy-combo-counter" class="combo-counter enemy-side"></div>
-        <div id="ability-announcer" class="ability-announcer"></div>
+        <div id="ability-announcer" class="ability-announcer">
+            <h1 id="announcer-main-text"></h1>
+            <p id="announcer-subtitle"></p>
+        </div>
 
         <div id="battle-log-container">
             <div id="battle-log-panel">

--- a/hero-game/style.css
+++ b/hero-game/style.css
@@ -1047,14 +1047,32 @@ button:disabled {
     top: 40%;
     left: 50%;
     transform: translateX(-50%);
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    pointer-events: none;
+    opacity: 0;
+    z-index: 100;
+}
+
+#announcer-main-text {
     font-family: 'Cinzel', serif;
     font-size: 4rem;
     font-weight: 700;
     color: #fde047;
     text-shadow: 0 0 10px #000, 0 0 20px #f59e0b;
-    pointer-events: none;
-    opacity: 0;
-    z-index: 100;
+    margin: 0;
+    padding: 0;
+}
+
+#announcer-subtitle {
+    font-family: 'Inter', sans-serif;
+    font-size: 1.25rem;
+    color: #e5e7eb;
+    text-shadow: 1px 1px 2px #000;
+    margin-top: -0.5rem;
+    opacity: 0.9;
 }
 .ability-announcer.show {
     animation: announce-and-fade 1.5s ease-out forwards;


### PR DESCRIPTION
## Summary
- add subtitle element for battle announcer and style it
- display ability effect in announcer with `_showBattleAnnouncement`
- remove duplicate attack log entries
- condense logging inside `_dealDamage`

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6852efd110b88327a2fd9f4a9f2a8bfc