### PR TITLE
Finalize battle log functionality

### DIFF
--- a/hero-game/index.html
+++ b/hero-game/index.html
@@ -115,6 +115,7 @@
                     <button class="filter-btn" data-filter="combat">Combat</button>
                     <button class="filter-btn" data-filter="healing">Healing</button>
                     <button class="filter-btn" data-filter="status">Status</button>
+                    <button class="filter-btn" data-filter="utility">Utility</button>
                 </div>
                 <div id="log-entries-container"></div>
             </div>

--- a/hero-game/js/scenes/BattleScene.js
+++ b/hero-game/js/scenes/BattleScene.js
@@ -148,6 +148,7 @@ export class BattleScene {
         if (type.includes('damage')) category = 'combat';
         if (type.includes('heal')) category = 'healing';
         if (type.includes('status')) category = 'status';
+        if (type.includes('energy')) category = 'utility';
         entry.dataset.category = category;
 
         if (combatant && combatant.id) {
@@ -164,6 +165,9 @@ export class BattleScene {
                 break;
             case 'heal':
                 icon.classList.add('fa-heart');
+                break;
+            case 'energy':
+                icon.classList.add('fa-bolt');
                 break;
             case 'ability-cast':
             case 'ability-result':
@@ -190,9 +194,6 @@ export class BattleScene {
         const container = this.logEntriesContainer || this.battleLogPanel;
         container.prepend(entry);
 
-        if (container.children.length > 50) {
-            container.lastChild.remove();
-        }
 
         if (linkedPopupId) {
             const popupElement = document.getElementById(linkedPopupId);
@@ -539,7 +540,7 @@ export class BattleScene {
             // --- Auto-attack after ability ---
             // --- GAIN ENERGY FOR ATTEMPTING ATTACK ---
             attacker.currentEnergy = Math.min(attacker.currentEnergy + 1, 10); // Cap energy at 10
-            this._logToBattle(`${attacker.heroData.name} gains 1 energy for attacking!`, 'heal', attacker, 1);
+            this._logToBattle(`${attacker.heroData.name} gains 1 energy for attacking!`, 'energy', attacker, 1);
             this._showCombatText(attacker.element, '+1', 'energy');
             updateEnergyDisplay(attacker, attacker.element);
             this._updateChargedStatus(attacker);
@@ -563,7 +564,7 @@ export class BattleScene {
         } else {
             // --- GAIN ENERGY FOR ATTEMPTING ATTACK ---
             attacker.currentEnergy = Math.min(attacker.currentEnergy + 1, 10); // Cap energy at 10
-            this._logToBattle(`${attacker.heroData.name} gains 1 energy for attacking!`, 'heal', attacker, 1);
+            this._logToBattle(`${attacker.heroData.name} gains 1 energy for attacking!`, 'energy', attacker, 1);
             this._showCombatText(attacker.element, '+1', 'energy');
             updateEnergyDisplay(attacker, attacker.element);
             this._updateChargedStatus(attacker);

--- a/hero-game/style.css
+++ b/hero-game/style.css
@@ -760,6 +760,7 @@ button:disabled {
 .log-entry.info { color: #9ca3af; }
 .log-entry.damage { color: #f87171; }
 .log-entry.heal { color: #4ade80; }
+.log-entry.energy { color: #60a5fa; }
 .log-entry.ability { color: #fde047; font-weight: 600; background-color: rgba(253, 224, 71, 0.1); }
 .log-entry.ability-cast { color: #fde047; font-weight: 600; background-color: rgba(253, 224, 71, 0.1); }
 .log-entry.ability-result { margin-left: 1rem; position: relative; }
@@ -819,7 +820,7 @@ button:disabled {
     background-color: #6b7280;
 }
 
-#end-screen { position: absolute; top: 0; left: 0; width: 100%; height: 100%; background-color: rgba(0,0,0,0.7); backdrop-filter: blur(8px); display: flex; flex-direction: column; align-items: center; justify-content: center; z-index: 200; opacity: 0; transition: opacity 1s ease; pointer-events: none; }
+#end-screen { position: absolute; top: 0; left: 0; width: 100%; height: 100%; background-color: rgba(0,0,0,0.7); backdrop-filter: blur(8px); display: flex; flex-direction: column; align-items: center; justify-content: center; z-index: 50; opacity: 0; transition: opacity 1s ease; pointer-events: none; }
 #end-screen.visible { opacity: 1; pointer-events: all; }
 #end-screen-result-text { font-size: 6rem; font-weight: 700; text-transform: uppercase; }
 #end-screen.victory #end-screen-result-text { color: #fde047; text-shadow: 0 0 20px #f59e0b; }
@@ -1568,6 +1569,9 @@ button:disabled {
 
 .log-entry.heal .log-entry-icon {
     color: #4ade80;
+}
+.log-entry.energy .log-entry-icon {
+    color: #60a5fa;
 }
 
 .log-entry.ability-cast .log-entry-icon,


### PR DESCRIPTION
## Summary
- surface new `Utility` filter and add energy log styling
- map `energy` log type to `utility` and give it a bolt icon
- remove battle log entry cap so full history shows
- keep log panel accessible on victory screen

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6852f67079688327a1ec5f1d1ee0058d