### PR TITLE
Add Progression & Economy doc

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -7,6 +7,7 @@ This directory contains design documents and technical references for the auto�
 - `gdd.md` – High level game design document.
 - `mechanics_gdd.md` – Detailed notes on combat and card mechanics.
 - `game_modes_gdd.md` – Descriptions of proposed game modes.
+- `progression_economy_gdd.md` – Progression and economy details.
 - `armor_gdd.md`, `class_card_gdd.md`, `items_gdd.md`, `monster_gdd.md`, `weapons_gdd.md` – Additional design information.
 - `technical_overview.md` – Overview of the project structure and suggested improvements.
 - `event_schema.md` – JSON schema used by the battle simulator.

--- a/docs/gdd.md
+++ b/docs/gdd.md
@@ -432,7 +432,7 @@ For detailed information on the PvP Tournament Flowchart with XP System and PvP 
 For detailed information on Core Status Conditions, Buff Keywords, and Debuff Keywords, please refer to the separate **Game Mechanics Design Document - Status Effects**.
 
 ## 18. Progression & Economy
-For detailed information on Deck Size Progression, Card Power Curves, and Loot Distribution, please refer to the separate **Progression & Economy Design Document**.
+For detailed information on Deck Size Progression, Card Power Curves, and Loot Distribution, please refer to the separate **[Progression & Economy Design Document](progression_economy_gdd.md)**.
 
 ## 19. Auto-Battle Scene
 ### Scene Layout

--- a/docs/gdd.md.backup
+++ b/docs/gdd.md.backup
@@ -141,4 +141,4 @@ For detailed information on the PvP Tournament Flowchart with XP System and PvP 
 For detailed information on Core Status Conditions, Buff Keywords, and Debuff Keywords, please refer to the separate **Game Mechanics Design Document - Status Effects**.
 
 ## 18. Progression & Economy
-For detailed information on Deck Size Progression, Card Power Curves, and Loot Distribution, please refer to the separate **Progression & Economy Design Document**.
+For detailed information on Deck Size Progression, Card Power Curves, and Loot Distribution, please refer to the separate **[Progression & Economy Design Document](progression_economy_gdd.md)**.

--- a/docs/progression_economy_gdd.md
+++ b/docs/progression_economy_gdd.md
@@ -1,0 +1,14 @@
+# Progression & Economy Design Document
+
+## 1. Deck Size Progression
+- Deck starts small and grows by 2 slots each draft round.
+- Maximum size reached near the end of a full run.
+
+## 2. Card Power Curve
+- Higher tier cards appear as player level increases.
+- Costs and effects scale to match late-game damage.
+
+## 3. Loot Distribution
+- Packs contain a mix of common, uncommon and rare cards.
+- Gold drops allow purchasing extra packs between battles.
+


### PR DESCRIPTION
## Summary
- document progression and economy system
- link the new doc from the main GDD
- mention the doc in the documentation index

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6852fc29269883279ff0acff323e661c