### PR TITLE
Add visual ability announcer

### DIFF
--- a/hero-game/index.html
+++ b/hero-game/index.html
@@ -107,6 +107,8 @@
             <h1 id="announcer-main-text"></h1>
             <p id="announcer-subtitle"></p>
         </div>
+        <div id="card-announcer-container">
+        </div>
 
         <div id="battle-log-container">
             <div id="battle-log-panel">

--- a/hero-game/js/scenes/BattleScene.js
+++ b/hero-game/js/scenes/BattleScene.js
@@ -1,4 +1,4 @@
-import { createCompactCard, updateHealthBar, updateEnergyDisplay } from '../ui/CardRenderer.js';
+import { createCompactCard, updateHealthBar, updateEnergyDisplay, createAnnouncerCard } from '../ui/CardRenderer.js';
 import { sleep } from '../utils.js';
 import { battleSpeeds, allPossibleMinions } from '../data.js';
 
@@ -45,6 +45,7 @@ export class BattleScene {
         this.abilityAnnouncer = this.element.querySelector('#ability-announcer');
         this.announcerMainText = this.element.querySelector('#announcer-main-text');
         this.announcerSubtitle = this.element.querySelector('#announcer-subtitle');
+        this.cardAnnouncerContainer = this.element.querySelector('#card-announcer-container');
         this.statusTooltip = document.getElementById('status-tooltip');
 
         this.comboCount = 0;
@@ -458,7 +459,7 @@ export class BattleScene {
             updateEnergyDisplay(attacker, attacker.element);
             this._updateChargedStatus(attacker);
 
-            this._showBattleAnnouncement(ability.name, 'ability', ability.effect);
+            this._showAbilityCard(ability);
             this._triggerArenaEffect('ability-zoom');
             this._logToBattle(`${attacker.heroData.name} unleashes ${ability.name}!`, 'ability-cast', attacker, 2);
 
@@ -958,6 +959,20 @@ export class BattleScene {
             }
         }
         this._logToBattle(`Turn order updated!`, 'info', null, 1);
+    }
+
+    _showAbilityCard(abilityData) {
+        if (!this.cardAnnouncerContainer || !abilityData) return;
+
+        this.cardAnnouncerContainer.innerHTML = '';
+        const cardElement = createAnnouncerCard(abilityData);
+        this.cardAnnouncerContainer.appendChild(cardElement);
+        this.cardAnnouncerContainer.classList.add('is-announcing');
+
+        setTimeout(() => {
+            this.cardAnnouncerContainer.classList.remove('is-announcing');
+            this.cardAnnouncerContainer.innerHTML = '';
+        }, 1500);
     }
 
     _showBattleAnnouncement(text, styleClass = '', subtitle = '') {

--- a/hero-game/js/ui/CardRenderer.js
+++ b/hero-game/js/ui/CardRenderer.js
@@ -115,6 +115,35 @@ export function createDetailCard(item, selectionHandler) {
 }
 
 /**
+ * Creates a simplified card element for ability announcements.
+ * @param {object} ability - The ability data object.
+ * @returns {HTMLElement} The created card element.
+ */
+export function createAnnouncerCard(ability) {
+    const clone = detailCardTemplate.content.cloneNode(true);
+    const cardElement = clone.querySelector('.hero-card');
+    const rarityClass = (ability.rarity || 'common').toLowerCase().replace(' ', '-');
+    cardElement.classList.add(rarityClass);
+
+    clone.querySelector('.hero-art').style.backgroundImage = `url('${ability.art}')`;
+    clone.querySelector('.hero-name').textContent = ability.name;
+
+    const statsHtml = `
+        <div class="stat-block"><span class="stat-value">${ability.energyCost}</span><span class="stat-label">ENERGY</span></div>
+        <div class="stat-block"><span class="stat-value">${ability.category.toUpperCase()}</span><span class="stat-label">TYPE</span></div>
+    `;
+    const descriptionHtml = `
+        <div class="item-ability">
+            <p class="ability-description">${ability.effect}</p>
+        </div>`;
+
+    clone.querySelector('.hero-stats').innerHTML = statsHtml;
+    clone.querySelector('.hero-abilities').innerHTML = descriptionHtml;
+
+    return clone.querySelector('.hero-card-container');
+}
+
+/**
  * Creates a smaller, compact card for the battle scene.
  * @param {object} combatant - The combatant object from the battle state.
  * @returns {HTMLElement} The created card element.

--- a/hero-game/style.css
+++ b/hero-game/style.css
@@ -1134,6 +1134,48 @@ button:disabled {
     text-shadow: 0 0 10px #000, 0 0 20px #b91c1c;
 }
 
+#card-announcer-container {
+    position: absolute;
+    inset: 0;
+    z-index: 175;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    opacity: 0;
+    pointer-events: none;
+    background-color: transparent;
+    transition: background-color 0.3s ease, opacity 0.3s ease;
+}
+
+#card-announcer-container.is-announcing {
+    opacity: 1;
+    pointer-events: auto;
+    background-color: rgba(0, 0, 0, 0.6);
+}
+
+@keyframes fly-in-and-hold {
+    0% {
+        transform: translateY(100vh) scale(0.5) rotate(15deg);
+        opacity: 0;
+    }
+    40% {
+        transform: translateY(0) scale(1.05) rotate(-2deg);
+        opacity: 1;
+    }
+    80% {
+        transform: translateY(0) scale(1) rotate(0deg);
+        opacity: 1;
+    }
+    100% {
+        transform: translateY(0) scale(0.95);
+        opacity: 0;
+    }
+}
+
+#card-announcer-container.is-announcing .hero-card-container {
+    animation: fly-in-and-hold 1.5s ease-out forwards;
+}
+
 /* --- 1. Combo Counter Styles --- */
 .combo-counter {
     position: absolute;


### PR DESCRIPTION
## Summary
- add card announcer container in battle scene
- style new overlay and animations
- provide CardRenderer helper `createAnnouncerCard`
- show ability card during battle instead of text announcement

## Testing
- `node -v`

------
https://chatgpt.com/codex/tasks/task_e_6853015e65408327ae285936fad541e2