### PR TITLE
Add hero-specific signature banners

### DIFF
--- a/hero-game/img/banners/holy_warrior_banner.svg
+++ b/hero-game/img/banners/holy_warrior_banner.svg
@@ -1,0 +1,9 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="800" height="150">
+<rect width="800" height="150" fill="url(#grad)" stroke="#daa520" stroke-width="10" rx="20"/>
+<defs>
+<linearGradient id="grad" x1="0" x2="0" y1="0" y2="1">
+<stop offset="0%" stop-color="#fff8dc"/>
+<stop offset="100%" stop-color="#f1c40f"/>
+</linearGradient>
+</defs>
+</svg>

--- a/hero-game/img/banners/raging_fighter_banner.svg
+++ b/hero-game/img/banners/raging_fighter_banner.svg
@@ -1,0 +1,9 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="800" height="150">
+<rect width="800" height="150" fill="url(#grad)" stroke="#8b4513" stroke-width="10" rx="15"/>
+<defs>
+<linearGradient id="grad" x1="0" x2="1" y1="0" y2="1">
+<stop offset="0%" stop-color="#704214"/>
+<stop offset="100%" stop-color="#3e2723"/>
+</linearGradient>
+</defs>
+</svg>

--- a/hero-game/img/banners/raw_power_mage_banner.svg
+++ b/hero-game/img/banners/raw_power_mage_banner.svg
@@ -1,0 +1,9 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="800" height="150">
+<rect width="800" height="150" fill="url(#grad)" stroke="#6b21a8" stroke-width="10" rx="15"/>
+<defs>
+<linearGradient id="grad" x1="0" x2="0" y1="0" y2="1">
+<stop offset="0%" stop-color="#b39ddb"/>
+<stop offset="100%" stop-color="#512da8"/>
+</linearGradient>
+</defs>
+</svg>

--- a/hero-game/index.html
+++ b/hero-game/index.html
@@ -107,7 +107,11 @@
             <h1 id="announcer-main-text"></h1>
             <p id="announcer-subtitle"></p>
         </div>
-        <div id="card-announcer-container">
+        <div id="banner-announcer-container">
+            <div id="banner-content">
+                <div id="banner-background"></div>
+                <h1 id="banner-text"></h1>
+            </div>
         </div>
 
         <div id="battle-log-container">

--- a/hero-game/js/scenes/BattleScene.js
+++ b/hero-game/js/scenes/BattleScene.js
@@ -1,4 +1,4 @@
-import { createCompactCard, updateHealthBar, updateEnergyDisplay, createAnnouncerCard } from '../ui/CardRenderer.js';
+import { createCompactCard, updateHealthBar, updateEnergyDisplay } from '../ui/CardRenderer.js';
 import { sleep } from '../utils.js';
 import { battleSpeeds, allPossibleMinions } from '../data.js';
 
@@ -45,7 +45,9 @@ export class BattleScene {
         this.abilityAnnouncer = this.element.querySelector('#ability-announcer');
         this.announcerMainText = this.element.querySelector('#announcer-main-text');
         this.announcerSubtitle = this.element.querySelector('#announcer-subtitle');
-        this.cardAnnouncerContainer = this.element.querySelector('#card-announcer-container');
+        this.bannerAnnouncerContainer = this.element.querySelector('#banner-announcer-container');
+        this.bannerContent = this.element.querySelector('#banner-content');
+        this.bannerText = this.element.querySelector('#banner-text');
         this.statusTooltip = document.getElementById('status-tooltip');
 
         this.comboCount = 0;
@@ -459,7 +461,7 @@ export class BattleScene {
             updateEnergyDisplay(attacker, attacker.element);
             this._updateChargedStatus(attacker);
 
-            this._showAbilityCard(ability);
+            this._showSignatureBanner(ability, attacker);
             this._triggerArenaEffect('ability-zoom');
             this._logToBattle(`${attacker.heroData.name} unleashes ${ability.name}!`, 'ability-cast', attacker, 2);
 
@@ -961,34 +963,20 @@ export class BattleScene {
         this._logToBattle(`Turn order updated!`, 'info', null, 1);
     }
 
-    _showAbilityCard(abilityData) {
-        if (!this.cardAnnouncerContainer || !abilityData) return;
+    _showSignatureBanner(abilityData, caster) {
+        if (!this.bannerAnnouncerContainer || !caster) return;
 
-        this.cardAnnouncerContainer.innerHTML = '';
-        const cardElement = createAnnouncerCard(abilityData);
+        const cssClassName = caster.heroData.class.toLowerCase().replace(/\s+/g, '-');
 
-        const maxTilt = 15;
-        cardElement.addEventListener('mousemove', (e) => {
-            const rect = cardElement.getBoundingClientRect();
-            const x = e.clientX - rect.left - rect.width / 2;
-            const y = e.clientY - rect.top - rect.height / 2;
+        this.bannerText.textContent = abilityData.name;
 
-            const rotateY = (x / (rect.width / 2)) * maxTilt;
-            const rotateX = (y / (rect.height / 2)) * -maxTilt;
+        this.bannerContent.className = '';
+        this.bannerContent.classList.add(cssClassName);
 
-            cardElement.style.transform = `rotateX(${rotateX}deg) rotateY(${rotateY}deg)`;
-        });
-
-        cardElement.addEventListener('mouseleave', () => {
-            cardElement.style.transform = 'rotateX(0deg) rotateY(0deg)';
-        });
-
-        this.cardAnnouncerContainer.appendChild(cardElement);
-        this.cardAnnouncerContainer.classList.add('is-announcing');
+        this.bannerAnnouncerContainer.classList.add('is-announcing');
 
         setTimeout(() => {
-            this.cardAnnouncerContainer.classList.remove('is-announcing');
-            this.cardAnnouncerContainer.innerHTML = '';
+            this.bannerAnnouncerContainer.classList.remove('is-announcing');
         }, 1500);
     }
 

--- a/hero-game/style.css
+++ b/hero-game/style.css
@@ -1134,7 +1134,7 @@ button:disabled {
     text-shadow: 0 0 10px #000, 0 0 20px #b91c1c;
 }
 
-#card-announcer-container {
+#banner-announcer-container {
     position: absolute;
     inset: 0;
     z-index: 175;
@@ -1142,44 +1142,65 @@ button:disabled {
     align-items: center;
     justify-content: center;
     opacity: 0;
-    pointer-events: none;
-    background-color: transparent;
-    transition: background-color 0.3s ease, opacity 0.3s ease;
-    perspective: 1000px;
+    visibility: hidden;
+    transition: opacity 0.3s, visibility 0.3s;
 }
 
-#card-announcer-container.is-announcing {
+#banner-announcer-container.is-announcing {
     opacity: 1;
-    pointer-events: auto;
-    background-color: rgba(0, 0, 0, 0.6);
+    visibility: visible;
 }
 
-#card-announcer-container .hero-card-container {
-    transform-style: preserve-3d;
-    transition: transform 0.1s linear;
+#banner-content {
+    position: relative;
+    width: 800px;
+    height: 150px;
+    transform: scaleX(0);
 }
 
-@keyframes fly-in-and-hold {
-    0% {
-        transform: translateY(100vh) scale(0.6) rotateX(-60deg) rotateY(20deg);
-        opacity: 0;
-    }
-    40% {
-        transform: translateY(0) scale(1.05) rotateX(10deg) rotateY(-5deg);
-        opacity: 1;
-    }
-    80% {
-        transform: translateY(0) scale(1) rotateX(0deg) rotateY(0deg);
-        opacity: 1;
-    }
-    100% {
-        transform: translateY(0) scale(0.95);
-        opacity: 0;
-    }
+#banner-announcer-container.is-announcing #banner-content {
+    animation: unfurl-animation 0.8s cubic-bezier(0.34, 1.56, 0.64, 1) forwards;
 }
 
-#card-announcer-container.is-announcing .hero-card-container {
-    animation: fly-in-and-hold 1.5s ease-out forwards;
+@keyframes unfurl-animation {
+    0% { transform: scaleX(0); }
+    70% { transform: scaleX(1.05); }
+    100% { transform: scaleX(1); }
+}
+
+#banner-background {
+    position: absolute;
+    inset: 0;
+    background-size: 100% 100%;
+    background-repeat: no-repeat;
+}
+
+#banner-text {
+    position: relative;
+    color: white;
+    font-family: 'Cinzel', serif;
+    font-size: 2.5rem;
+    text-shadow: 2px 2px 4px rgba(0,0,0,0.7);
+    text-align: center;
+    line-height: 150px;
+    opacity: 0;
+    transition: opacity 0.3s ease-in 0.2s;
+}
+
+#banner-announcer-container.is-announcing #banner-text {
+    opacity: 1;
+}
+
+#banner-content.holy-warrior #banner-background {
+    background-image: url('img/banners/holy_warrior_banner.svg');
+}
+
+#banner-content.raging-fighter #banner-background {
+    background-image: url('img/banners/raging_fighter_banner.svg');
+}
+
+#banner-content.raw-power-mage #banner-background {
+    background-image: url('img/banners/raw_power_mage_banner.svg');
 }
 
 /* --- 1. Combo Counter Styles --- */


### PR DESCRIPTION
## Summary
- replace ability card announcer with new banner announcer markup
- style signature banners with unfurl animation
- add banner logic in BattleScene
- include placeholder banner SVGs for three hero classes

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6853052803608327870882de633a09e9