### PR TITLE
Add custom scrollbar to battle log

### DIFF
--- a/hero-game/style.css
+++ b/hero-game/style.css
@@ -690,15 +690,15 @@ button:disabled {
     padding: 1rem;
     display: flex;
     flex-direction: column;
-    overflow-y: auto;
+    overflow-y: hidden;
     max-height: 0;
-    overflow: hidden;
     transition: max-height 0.4s ease-in-out;
     margin-bottom: -1px;
 }
 
 #battle-log-panel.expanded {
     max-height: 40vh;
+    overflow-y: auto;
 }
 
 #battle-log-panel.expanded + #battle-log-summary i {
@@ -1726,4 +1726,29 @@ button:disabled {
 .vfx-overlay.vfx-ice {
     background: radial-gradient(circle, rgba(3, 169, 244, 0.1), rgba(173, 216, 230, 0.3));
     box-shadow: inset 0 0 20px 8px #e0f7fa;
+}
+
+/* --- Custom Scrollbar for Battle Log --- */
+
+/* Target the scrollbar within the battle log panel */
+#battle-log-panel::-webkit-scrollbar {
+    width: 10px;
+}
+
+/* Style the track (the background of the scrollbar) */
+#battle-log-panel::-webkit-scrollbar-track {
+    background: rgba(0, 0, 0, 0.3);
+    border-radius: 5px;
+}
+
+/* Style the thumb (the draggable part of the scrollbar) */
+#battle-log-panel::-webkit-scrollbar-thumb {
+    background-color: #4b5563;
+    border-radius: 5px;
+    border: 1px solid #6b7280;
+}
+
+/* Add a hover effect for the thumb */
+#battle-log-panel::-webkit-scrollbar-thumb:hover {
+    background-color: #6b7280;
 }


### PR DESCRIPTION
## Summary
- allow overflow when the log is expanded
- style the battle log scrollbar to match the game's theme

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68530c6fbab08327bd258c9ccebf0acd