### PR TITLE
Fix ability announcement queue after battle ends

### DIFF
--- a/hero-game/js/scenes/BattleScene.js
+++ b/hero-game/js/scenes/BattleScene.js
@@ -1009,7 +1009,7 @@ export class BattleScene {
     }
 
     _showAbilityCard(abilityData) {
-        if (!this.cardAnnouncerContainer || !abilityData) return;
+        if (!this.cardAnnouncerContainer || !abilityData || this.isBattleOver) return;
 
         this.announcementQueue.push({ abilityData });
         this._processAnnouncementQueue();
@@ -1227,6 +1227,8 @@ export class BattleScene {
 
     async _endBattle(didPlayerWin) {
         this.isBattleOver = true;
+        // Clear any pending ability announcements but let the current one finish
+        this.announcementQueue = [];
         const winningTeam = didPlayerWin ? 'player' : 'enemy';
         this._logToBattle(didPlayerWin ? "Player team is victorious!" : "Enemy team is victorious!", didPlayerWin ? 'victory' : 'defeat', null, 3);
 


### PR DESCRIPTION
## Summary
- stop queuing new ability cards after the battle is over
- clear pending ability announcements when a team is defeated

## Testing
- `npm test --silent` *(fails: no test script)*

------
https://chatgpt.com/codex/tasks/task_e_68531628483c83278c399397684ad575