### PR TITLE
Implement tiered drafting based on wins

### DIFF
--- a/hero-game/js/main.js
+++ b/hero-game/js/main.js
@@ -119,11 +119,7 @@ function openPack() {
             const heroId = gameState.draft.playerTeam[heroSlot];
             const heroClass = allPossibleHeroes.find(h => h.id === heroId).class;
             dataSource = allPossibleAbilities.filter(a => a.class === heroClass);
-            const shuffledAbilities = [...dataSource].sort(() => 0.5 - Math.random());
-            choices = shuffledAbilities.slice(0, 3);
-            transitionToScene('reveal');
-            revealScene.startReveal(choices);
-            return;
+            break;
         }
         case 'WEAPON':
             dataSource = allPossibleWeapons;
@@ -133,7 +129,20 @@ function openPack() {
             break;
     }
 
-    const shuffled = [...dataSource].sort(() => 0.5 - Math.random());
+    const wins = gameState.tournament.wins;
+    let allowedRarities;
+    if (wins <= 1) {
+        allowedRarities = ['Common'];
+    } else if (wins <= 3) {
+        allowedRarities = ['Common', 'Uncommon'];
+    } else if (wins <= 5) {
+        allowedRarities = ['Common', 'Uncommon', 'Rare'];
+    } else {
+        allowedRarities = ['Common', 'Uncommon', 'Rare', 'Epic'];
+    }
+
+    const filteredDataSource = dataSource.filter(item => allowedRarities.includes(item.rarity));
+    const shuffled = [...filteredDataSource].sort(() => 0.5 - Math.random());
     choices = shuffled.slice(0, 3);
     transitionToScene('reveal');
     revealScene.startReveal(choices);


### PR DESCRIPTION
## Summary
- filter pack generation by tournament wins
- ensure ability packs also respect rarity restrictions

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6853443717e48327afb1be969a60c856