### PR TITLE
Implement upgrade scene QoL and polish

### DIFF
--- a/hero-game/index.html
+++ b/hero-game/index.html
@@ -147,7 +147,21 @@
             <div id="upgrade-bonus-pool" class="grid grid-cols-3 gap-4"></div>
             <div id="upgrade-team-roster" class="flex flex-col lg:flex-row gap-4"></div>
         </div>
-        <button id="upgrade-continue-button" class="confirm-button mt-6 hidden">Continue</button>
+        <div class="mt-6 flex gap-4">
+            <button id="upgrade-continue-button" class="confirm-button hidden">Continue</button>
+            <button id="upgrade-skip-button" class="secondary-button">Skip Upgrade</button>
+        </div>
+        <div id="upgrade-confirm-modal" class="modal hidden">
+            <div class="modal-backdrop">
+                <div class="modal-content">
+                    <p class="mb-4">Replace this item with the selected card?</p>
+                    <div class="flex gap-4 justify-end">
+                        <button id="upgrade-confirm-yes" class="confirm-button">Confirm</button>
+                        <button id="upgrade-confirm-no" class="secondary-button">Cancel</button>
+                    </div>
+                </div>
+            </div>
+        </div>
     </div>
 
     <div id="tournament-end-screen" class="scene hidden flex-col items-center justify-center bg-gray-900 bg-opacity-90">

--- a/hero-game/js/main.js
+++ b/hero-game/js/main.js
@@ -91,7 +91,9 @@ const recapScene = new RecapScene(sceneElements.recap, () => {
 });
 
 const upgradeScene = new UpgradeScene(sceneElements.upgrade, (slot, newId) => {
-    gameState.draft.playerTeam[slot] = newId;
+    if (slot && newId) {
+        gameState.draft.playerTeam[slot] = newId;
+    }
     startNextBattle();
 });
 

--- a/hero-game/style.css
+++ b/hero-game/style.css
@@ -278,6 +278,21 @@ button:disabled {
 .confirmation-bar.visible { bottom: 0; }
 .confirm-button { background-color: #f59e0b; color: #111827; padding: 0.75rem 2rem; border-radius: 0.5rem; font-size: 1.125rem; font-weight: 600; cursor: pointer; transition: background-color 0.2s; }
 .confirm-button:hover { background-color: #fbbf24; }
+.secondary-button {
+    background-color: transparent;
+    color: #d1d5db;
+    padding: 0.75rem 2rem;
+    border-radius: 0.5rem;
+    font-size: 1.125rem;
+    font-weight: 600;
+    border: 2px solid #6b7280;
+    cursor: pointer;
+    transition: background-color 0.2s, color 0.2s;
+}
+.secondary-button:hover {
+    background-color: #374151;
+    color: white;
+}
 
 /* --- Battle Scene Styles --- */
 #battle-scene-background {
@@ -1832,6 +1847,16 @@ button:disabled {
     border-radius: 0.5rem;
     cursor: pointer;
     transition: transform 0.2s;
+    opacity: 0;
+}
+
+.deal-in {
+    animation: deal-in 0.3s forwards;
+}
+
+@keyframes deal-in {
+    from { opacity: 0; transform: translateY(30px); }
+    to { opacity: 1; transform: translateY(0); }
 }
 
 .bonus-card.selected {
@@ -1864,8 +1889,36 @@ button:disabled {
     transition: transform 0.2s;
 }
 
+.equipment-socket.card-pop-out {
+    animation: card-pop-out 0.2s forwards;
+}
+
+.equipment-socket.card-pop-in {
+    animation: card-pop-in 0.2s forwards;
+}
+
+@keyframes card-pop-out {
+    from { opacity: 1; transform: scale(1); }
+    to { opacity: 0; transform: scale(0); }
+}
+
+@keyframes card-pop-in {
+    from { opacity: 0; transform: scale(0.5); }
+    to { opacity: 1; transform: scale(1); }
+}
+
 .equipment-socket:hover {
     transform: scale(1.05);
+}
+
+.empty-socket {
+    background-color: rgba(255,255,255,0.1);
+    display:flex;
+    align-items:center;
+    justify-content:center;
+    color:#9ca3af;
+    font-size:1.5rem;
+    font-weight:bold;
 }
 
 .weapon-socket {
@@ -1888,4 +1941,37 @@ button:disabled {
 
 .targetable {
     outline: 2px dashed #f59e0b;
+}
+
+/* Modal styles */
+.modal-backdrop {
+    position: fixed;
+    inset: 0;
+    background: rgba(0,0,0,0.6);
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    animation: modal-fade 0.2s forwards;
+    z-index: 50;
+}
+
+.modal-content {
+    background: #1f2937;
+    padding: 1.5rem;
+    border-radius: 0.5rem;
+    animation: modal-scale 0.2s forwards;
+}
+
+.modal.hidden {
+    display: none;
+}
+
+@keyframes modal-fade {
+    from { opacity: 0; }
+    to { opacity: 1; }
+}
+
+@keyframes modal-scale {
+    from { transform: scale(0.8); opacity: 0; }
+    to { transform: scale(1); opacity: 1; }
 }


### PR DESCRIPTION
## Summary
- add skip button and confirmation modal to Upgrade scene
- animate bonus card deal-in and swap transitions
- render placeholders for empty equipment slots
- support skipping upgrades in game flow

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_685352abd29c83279e042ca3dbacdf37