### PR TITLE
Implement upgrade scene edge cases

### DIFF
--- a/hero-game/js/scenes/UpgradeScene.js
+++ b/hero-game/js/scenes/UpgradeScene.js
@@ -89,7 +89,7 @@ export class UpgradeScene {
     }
 
     updateTargetableSockets() {
-        this.element.querySelectorAll('.equipment-socket, .champion-display').forEach(el => el.classList.remove('targetable'));
+        this.element.querySelectorAll('.equipment-socket, .champion-display, .hero-card-container').forEach(el => el.classList.remove('targetable'));
         if (!this.selectedCard) return;
         const type = this.selectedCard.type;
         if (type === 'weapon') {
@@ -99,7 +99,7 @@ export class UpgradeScene {
         } else if (type === 'ability') {
             this.element.querySelectorAll('.ability-socket').forEach(el => el.classList.add('targetable'));
         } else if (type === 'hero') {
-            this.element.querySelectorAll('.champion-display').forEach(el => el.classList.add('targetable'));
+            this.element.querySelectorAll('.champion-display, .hero-card-container').forEach(el => el.classList.add('targetable'));
         }
     }
 


### PR DESCRIPTION
## Summary
- support hero replacement and reset gear on swap
- adjust upgrade rewards based on battle outcome
- highlight hero cards again when replacing a champion

## Testing
- `node --check hero-game/js/main.js`
- `node --check hero-game/js/scenes/UpgradeScene.js`

------
https://chatgpt.com/codex/tasks/task_e_6853540fecdc8327a4702139c2d0dd33