### PR TITLE
Implement mini draft upgrade flow

### DIFF
--- a/hero-game/index.html
+++ b/hero-game/index.html
@@ -143,14 +143,21 @@
             <h1 class="text-5xl font-cinzel tracking-wider">Choose an Upgrade</h1>
             <p class="text-lg text-gray-400 mt-2">Select a reward then replace a matching item.</p>
         </header>
-        <div id="upgrade-content" class="flex flex-col lg:flex-row gap-8">
-            <div id="upgrade-bonus-pool" class="grid grid-cols-3 gap-4"></div>
-            <div id="upgrade-team-roster" class="flex flex-col lg:flex-row gap-4"></div>
+        <div id="upgrade-pack-container" class="package-wrapper mb-6">
+            <div id="upgrade-package" class="package flex flex-col rounded-lg">
+                <div id="upgrade-top-crimp" class="crimp h-6 rounded-t-lg"></div>
+                <div id="upgrade-image-area" class="image-area flex-grow flex items-center justify-center">
+                    <img id="upgrade-pack-img" src="img/ability_booster.png" alt="bonus booster pack" class="booster-pack-image w-[320px] h-auto" draggable="false" />
+                </div>
+                <div class="crimp h-6 rounded-b-lg"></div>
+            </div>
         </div>
-        <div class="mt-6 flex gap-4">
-            <button id="upgrade-continue-button" class="confirm-button hidden">Continue</button>
-            <button id="upgrade-skip-button" class="secondary-button">Skip Upgrade</button>
+        <div id="upgrade-reveal-area" class="hidden"></div>
+        <div id="upgrade-actions" class="mt-4 flex gap-4 hidden">
+            <button id="upgrade-take-button" class="confirm-button">Take Card</button>
+            <button id="upgrade-dismiss-button" class="secondary-button">Dismiss</button>
         </div>
+        <div id="upgrade-team-roster" class="flex flex-col lg:flex-row gap-4 mt-8"></div>
         <div id="upgrade-confirm-modal" class="modal hidden">
             <div class="modal-backdrop">
                 <div class="modal-content">

--- a/hero-game/js/scenes/UpgradeScene.js
+++ b/hero-game/js/scenes/UpgradeScene.js
@@ -10,24 +10,25 @@ export class UpgradeScene {
     constructor(element, onComplete) {
         this.element = element;
         this.onComplete = onComplete;
-        this.bonusPool = this.element.querySelector('#upgrade-bonus-pool');
-        this.teamRoster = this.element.querySelector('#upgrade-team-roster');
-        this.continueButton = this.element.querySelector('#upgrade-continue-button');
-        this.skipButton = this.element.querySelector('#upgrade-skip-button');
-        this.confirmModal = this.element.querySelector('#upgrade-confirm-modal');
-        if (this.continueButton) {
-            this.continueButton.addEventListener('click', () => {
-                if (this.skipMode) {
-                    this.skipMode = false;
-                    this.onComplete();
-                } else if (this.pendingSlot && this.selectedCard) {
-                    this.onComplete(this.pendingSlot, this.selectedCard.id);
-                }
-            });
+
+        this.packEl = element.querySelector('#upgrade-package');
+        this.topCrimp = element.querySelector('#upgrade-top-crimp');
+        this.imageArea = element.querySelector('#upgrade-image-area');
+        this.revealArea = element.querySelector('#upgrade-reveal-area');
+        this.actionContainer = element.querySelector('#upgrade-actions');
+        this.takeButton = element.querySelector('#upgrade-take-button');
+        this.dismissButton = element.querySelector('#upgrade-dismiss-button');
+        this.teamRoster = element.querySelector('#upgrade-team-roster');
+        this.confirmModal = element.querySelector('#upgrade-confirm-modal');
+
+        if (this.packEl) {
+            this.packEl.addEventListener('click', () => this.handlePackOpen());
+            this.packEl.addEventListener('mousemove', e => this.handleMouseMove(e));
+            this.packEl.addEventListener('mouseleave', () => this.handleMouseLeave());
         }
-        if (this.skipButton) {
-            this.skipButton.addEventListener('click', () => this.handleSkip());
-        }
+        if (this.takeButton) this.takeButton.addEventListener('click', () => this.handleTakeCard());
+        if (this.dismissButton) this.dismissButton.addEventListener('click', () => this.handleDismissCard());
+
         if (this.confirmModal) {
             this.confirmYes = this.confirmModal.querySelector('#upgrade-confirm-yes');
             this.confirmNo = this.confirmModal.querySelector('#upgrade-confirm-no');
@@ -43,27 +44,115 @@ export class UpgradeScene {
         }
     }
 
-    render(bonusCards, playerTeam) {
+    render(packContents, playerTeam) {
+        this.packContents = packContents;
+        this.revealedCards = [];
+        this.currentCardIndex = 0;
+        this.phase = 'PACK';
         this.selectedCard = null;
         this.pendingSlot = null;
-        this.skipMode = false;
-        if (this.continueButton) this.continueButton.classList.add('hidden');
-        if (this.skipButton) this.skipButton.classList.remove('hidden');
+
+        if (this.topCrimp) {
+            this.topCrimp.classList.remove('torn-off');
+            this.topCrimp.style.pointerEvents = 'auto';
+        }
+        if (this.packEl) {
+            this.packEl.classList.remove('is-open', 'hidden');
+        }
+        if (this.revealArea) {
+            this.revealArea.classList.add('hidden');
+            this.revealArea.innerHTML = '';
+        }
+        if (this.actionContainer) this.actionContainer.classList.add('hidden');
         if (this.confirmModal) this.confirmModal.classList.add('hidden');
-        this.renderBonusPool(bonusCards);
+
         this.renderTeam(playerTeam);
     }
 
-    renderBonusPool(cards) {
-        this.bonusPool.innerHTML = '';
-        cards.forEach((card, index) => {
-            const el = document.createElement('div');
-            el.className = 'bonus-card deal-in';
-            el.style.animationDelay = `${index * 100}ms`;
-            el.style.backgroundImage = `url('${card.art}')`;
-            el.addEventListener('click', () => this.handleBonusCardSelect(card, el));
-            this.bonusPool.appendChild(el);
+    handlePackOpen() {
+        if (this.phase !== 'PACK' || this.isOpening) return;
+        this.isOpening = true;
+        this.topCrimp.classList.add('torn-off');
+        this.topCrimp.style.pointerEvents = 'none';
+        this.topCrimp.addEventListener('animationend', () => {
+            this.packEl.classList.add('is-open');
+            setTimeout(() => {
+                this.packEl.classList.add('hidden');
+                this.revealArea.classList.remove('hidden');
+                this.phase = 'REVEAL';
+                this.revealNextCard();
+            }, 100);
+        }, { once: true });
+    }
+
+    handleMouseMove(e) {
+        if (!this.packEl) return;
+        const rect = this.packEl.getBoundingClientRect();
+        const x = e.clientX - rect.left - rect.width / 2;
+        const y = e.clientY - rect.top - rect.height / 2;
+        const maxTilt = 10;
+        const rotateY = (x / (rect.width / 2)) * maxTilt;
+        const rotateX = (y / (rect.height / 2)) * -maxTilt;
+        this.packEl.style.transform = `rotateX(${rotateX}deg) rotateY(${rotateY}deg)`;
+        this.imageArea.style.setProperty('--glare-x', `${(e.clientX - rect.left) * 100 / rect.width}%`);
+        this.imageArea.style.setProperty('--glare-y', `${(e.clientY - rect.top) * 100 / rect.height}%`);
+        this.imageArea.style.setProperty('--glare-opacity', '1');
+    }
+
+    handleMouseLeave() {
+        if (!this.packEl) return;
+        this.packEl.style.transform = 'rotateX(0deg) rotateY(0deg)';
+        this.imageArea.style.setProperty('--glare-opacity', '0');
+    }
+
+    revealNextCard() {
+        if (this.currentCardIndex >= this.packContents.length) {
+            this.onComplete();
+            return;
+        }
+        this.revealArea.innerHTML = '';
+        const remaining = this.packContents.slice(this.currentCardIndex);
+        const stack = remaining.slice().reverse();
+        stack.forEach((card, idx) => {
+            const wrapper = document.createElement('div');
+            wrapper.className = 'revealed-card';
+            const rotation = (idx - 1) * 5;
+            const yOffset = Math.abs(idx - 1) * 20;
+            wrapper.style.transform = `rotate(${rotation}deg) translateY(${yOffset}px) translateZ(${idx * -20}px)`;
+            wrapper.style.zIndex = idx;
+            if (idx === stack.length - 1) {
+                const face = document.createElement('div');
+                face.className = 'card-face';
+                face.appendChild(createDetailCard(card));
+                wrapper.appendChild(face);
+            } else {
+                wrapper.classList.add('card-back-unrevealed');
+                const rarity = (card.rarity || 'common').toLowerCase();
+                if (rarity === 'rare') wrapper.classList.add('pre-reveal-rare');
+                else if (rarity === 'epic') wrapper.classList.add('pre-reveal-epic');
+            }
+            this.revealArea.appendChild(wrapper);
         });
+        if (this.actionContainer) this.actionContainer.classList.remove('hidden');
+    }
+
+    handleTakeCard() {
+        if (this.phase !== 'REVEAL') return;
+        this.selectedCard = this.packContents[this.currentCardIndex];
+        this.phase = 'REPLACEMENT';
+        if (this.actionContainer) this.actionContainer.classList.add('hidden');
+        if (this.revealArea) this.revealArea.classList.add('hidden');
+        this.updateTargetableSockets();
+    }
+
+    handleDismissCard() {
+        if (this.phase !== 'REVEAL') return;
+        this.currentCardIndex++;
+        if (this.currentCardIndex >= this.packContents.length) {
+            this.onComplete();
+            return;
+        }
+        this.revealNextCard();
     }
 
     renderTeam(team) {
@@ -84,29 +173,28 @@ export class UpgradeScene {
             const cardElem = createDetailCard(heroData);
             const heroCard = cardElem.querySelector('.hero-card');
             heroCard.addEventListener('click', () => this.handleSocketSelect(`hero${num}`));
-            heroCard.addEventListener('mouseover', (e) => this.showTooltip(e, heroData));
+            heroCard.addEventListener('mouseover', e => this.showTooltip(e, heroData));
             heroCard.addEventListener('mouseout', () => this.hideTooltip());
             container.appendChild(cardElem);
 
             const abilitySocket = this.createSocket(ability, `ability${num}`, 'ability-socket');
             if (abilitySocket) {
-                abilitySocket.addEventListener('mouseover', (e) => ability && this.showTooltip(e, ability));
+                abilitySocket.addEventListener('mouseover', e => ability && this.showTooltip(e, ability));
                 abilitySocket.addEventListener('mouseout', () => this.hideTooltip());
                 container.appendChild(abilitySocket);
             }
             const weaponSocket = this.createSocket(weapon, `weapon${num}`, 'weapon-socket');
             if (weaponSocket) {
-                weaponSocket.addEventListener('mouseover', (e) => weapon && this.showTooltip(e, weapon));
+                weaponSocket.addEventListener('mouseover', e => weapon && this.showTooltip(e, weapon));
                 weaponSocket.addEventListener('mouseout', () => this.hideTooltip());
                 container.appendChild(weaponSocket);
             }
             const armorSocket = this.createSocket(armor, `armor${num}`, 'armor-socket');
             if (armorSocket) {
-                armorSocket.addEventListener('mouseover', (e) => armor && this.showTooltip(e, armor));
+                armorSocket.addEventListener('mouseover', e => armor && this.showTooltip(e, armor));
                 armorSocket.addEventListener('mouseout', () => this.hideTooltip());
                 container.appendChild(armorSocket);
             }
-
             this.teamRoster.appendChild(container);
         });
     }
@@ -121,20 +209,11 @@ export class UpgradeScene {
             socket.textContent = '+';
         }
         socket.dataset.slot = slotKey;
-        socket.addEventListener('click', (e) => {
+        socket.addEventListener('click', e => {
             e.stopPropagation();
             this.handleSocketSelect(slotKey);
         });
         return socket;
-    }
-
-    handleBonusCardSelect(card, element) {
-        this.selectedCard = card;
-        this.pendingSlot = null;
-        if (this.continueButton) this.continueButton.classList.add('hidden');
-        this.bonusPool.querySelectorAll('.bonus-card').forEach(el => el.classList.remove('selected'));
-        element.classList.add('selected');
-        this.updateTargetableSockets();
     }
 
     updateTargetableSockets() {
@@ -153,7 +232,7 @@ export class UpgradeScene {
     }
 
     handleSocketSelect(slotKey) {
-        if (!this.selectedCard) return;
+        if (this.phase !== 'REPLACEMENT' || !this.selectedCard) return;
         const expected = this.selectedCard.type;
         if (!slotKey.startsWith(expected)) return;
         this.pendingSlot = slotKey;
@@ -178,7 +257,7 @@ export class UpgradeScene {
         const finishSwap = () => {
             socket.removeEventListener('animationend', finishSwap);
             socket.classList.remove('card-pop-in');
-            if (this.continueButton) this.continueButton.classList.remove('hidden');
+            this.onComplete(this.pendingSlot, this.selectedCard.id);
         };
         if (socket.classList.contains('empty-socket')) {
             applyNewCard();
@@ -186,16 +265,6 @@ export class UpgradeScene {
             socket.classList.add('card-pop-out');
             socket.addEventListener('animationend', applyNewCard);
         }
-    }
-
-    handleSkip() {
-        this.selectedCard = null;
-        this.pendingSlot = null;
-        this.skipMode = true;
-        this.bonusPool.classList.add('hidden');
-        this.teamRoster.classList.add('hidden');
-        if (this.continueButton) this.continueButton.classList.remove('hidden');
-        if (this.confirmModal) this.confirmModal.classList.add('hidden');
     }
 
     showTooltip(event, item) {

--- a/hero-game/style.css
+++ b/hero-game/style.css
@@ -1841,38 +1841,8 @@ button:disabled {
 /* Upgrade Scene Styles                                                       */
 /* -------------------------------------------------------------------------- */
 
-#upgrade-bonus-pool {
-    display: grid;
-    grid-template-columns: repeat(3, 1fr);
-    gap: 1rem;
-}
 
-.bonus-card {
-    width: 100px;
-    height: 140px;
-    background-color: #1e293b;
-    background-size: cover;
-    background-position: center;
-    border: 2px solid #9ca3af;
-    border-radius: 0.5rem;
-    cursor: pointer;
-    transition: transform 0.2s;
-    opacity: 0;
-}
-
-.deal-in {
-    animation: deal-in 0.3s forwards;
-}
-
-@keyframes deal-in {
-    from { opacity: 0; transform: translateY(30px); }
-    to { opacity: 1; transform: translateY(0); }
-}
-
-.bonus-card.selected {
-    outline: 2px solid #f59e0b;
-    transform: translateY(-4px);
-}
+#upgrade-reveal-area { display: flex; justify-content: center; align-items: center; position: relative; }
 
 #upgrade-team-roster {
     display: flex;


### PR DESCRIPTION
## Summary
- refactor upgrade scene markup for booster pack reveal
- add styles for upgrade reveal area and remove obsolete grid styles
- implement new `UpgradeScene` class with pack opening and card drafting

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68535b6973848327806e0fa5a7203ef2