### PR TITLE
Implement upgrade scene instructions and animations

### DIFF
--- a/hero-game/index.html
+++ b/hero-game/index.html
@@ -141,7 +141,7 @@
     <div id="upgrade-scene" class="scene hidden">
         <header class="text-center mb-6">
             <h1 class="text-5xl font-cinzel tracking-wider">Choose an Upgrade</h1>
-            <p class="text-lg text-gray-400 mt-2">Select a reward then replace a matching item.</p>
+            <p id="upgrade-instructions" class="text-lg text-gray-400 mt-2">Select a reward then replace a matching item.</p>
         </header>
         <div id="upgrade-pack-container" class="package-wrapper mb-6">
             <div id="upgrade-package" class="package flex flex-col rounded-lg">

--- a/hero-game/js/scenes/UpgradeScene.js
+++ b/hero-game/js/scenes/UpgradeScene.js
@@ -20,6 +20,7 @@ export class UpgradeScene {
         this.dismissButton = element.querySelector('#upgrade-dismiss-button');
         this.teamRoster = element.querySelector('#upgrade-team-roster');
         this.confirmModal = element.querySelector('#upgrade-confirm-modal');
+        this.instructionsEl = element.querySelector('#upgrade-instructions');
 
         if (this.packEl) {
             this.packEl.addEventListener('click', () => this.handlePackOpen());
@@ -51,6 +52,9 @@ export class UpgradeScene {
         this.phase = 'PACK';
         this.selectedCard = null;
         this.pendingSlot = null;
+        if (this.instructionsEl) {
+            this.instructionsEl.textContent = 'Click the pack to reveal your reward cards.';
+        }
 
         if (this.topCrimp) {
             this.topCrimp.classList.remove('torn-off');
@@ -80,6 +84,9 @@ export class UpgradeScene {
                 this.packEl.classList.add('hidden');
                 this.revealArea.classList.remove('hidden');
                 this.phase = 'REVEAL';
+                if (this.instructionsEl) {
+                    this.instructionsEl.textContent = 'Take the card or dismiss it.';
+                }
                 this.revealNextCard();
             }, 100);
         }, { once: true });
@@ -134,6 +141,9 @@ export class UpgradeScene {
             this.revealArea.appendChild(wrapper);
         });
         if (this.actionContainer) this.actionContainer.classList.remove('hidden');
+        if (this.instructionsEl) {
+            this.instructionsEl.textContent = 'Take the card or dismiss it.';
+        }
     }
 
     handleTakeCard() {
@@ -142,17 +152,33 @@ export class UpgradeScene {
         this.phase = 'REPLACEMENT';
         if (this.actionContainer) this.actionContainer.classList.add('hidden');
         if (this.revealArea) this.revealArea.classList.add('hidden');
+        if (this.instructionsEl) {
+            this.instructionsEl.textContent = 'Select an item to replace.';
+        }
         this.updateTargetableSockets();
     }
 
     handleDismissCard() {
         if (this.phase !== 'REVEAL') return;
-        this.currentCardIndex++;
-        if (this.currentCardIndex >= this.packContents.length) {
-            this.onComplete();
-            return;
+        const card = this.revealArea.querySelector('.revealed-card:last-child');
+        if (card) {
+            card.classList.add('is-dismissed');
+            card.addEventListener('transitionend', () => {
+                this.currentCardIndex++;
+                if (this.currentCardIndex >= this.packContents.length) {
+                    this.onComplete();
+                } else {
+                    this.revealNextCard();
+                }
+            }, { once: true });
+        } else {
+            this.currentCardIndex++;
+            if (this.currentCardIndex >= this.packContents.length) {
+                this.onComplete();
+            } else {
+                this.revealNextCard();
+            }
         }
-        this.revealNextCard();
     }
 
     renderTeam(team) {


### PR DESCRIPTION
## Summary
- add upgrade instructions element to HTML
- highlight instructions during pack open, reveal and replacement phases
- animate card dismissal for smoother mini draft

## Testing
- `node -v`

------
https://chatgpt.com/codex/tasks/task_e_68536a8d9c2c8327b9729e5b3e84007f