### PR TITLE
Enhance upgrade UI feedback

### DIFF
--- a/hero-game/style.css
+++ b/hero-game/style.css
@@ -1924,6 +1924,29 @@ button:disabled {
     outline: 2px dashed #f59e0b;
 }
 
+/* Upgrade selection highlights */
+.bonus-card.selected {
+    transform: scale(1.05);
+    box-shadow: 0 0 25px #f59e0b;
+    border-color: #fde047;
+}
+
+.equipment-socket.targetable {
+    animation: pulse-yellow 1.5s infinite;
+    filter: drop-shadow(0 0 10px #f59e0b);
+}
+
+@keyframes pulse-yellow {
+    0% { filter: drop-shadow(0 0 8px #f59e0b); }
+    50% { filter: drop-shadow(0 0 15px #fde047); }
+    100% { filter: drop-shadow(0 0 8px #f59e0b); }
+}
+
+.equipment-socket.disabled {
+    filter: grayscale(80%) brightness(0.7);
+    cursor: not-allowed;
+}
+
 /* Modal styles */
 .modal-backdrop {
     position: fixed;


### PR DESCRIPTION
## Summary
- add highlight styles for selecting upgrade cards and sockets
- mark sockets and heroes with dataset type for targeting
- implement selectable bonus cards in `UpgradeScene`
- show valid/invalid sockets using targetable and disabled classes

## Testing
- `node --version`

------
https://chatgpt.com/codex/tasks/task_e_68536cc4f05083278946491b2fe2ca7b