### PR TITLE
Add dismiss button to upgrade scene

### DIFF
--- a/hero-game/index.html
+++ b/hero-game/index.html
@@ -153,9 +153,9 @@
             </div>
         </div>
         <div id="upgrade-reveal-area" class="hidden"></div>
-        <div id="upgrade-actions" class="mt-4 flex gap-4 hidden">
-            <button id="upgrade-take-button" class="confirm-button">Take Card</button>
-            <button id="upgrade-dismiss-button" class="secondary-button">Dismiss</button>
+        <div id="reveal-actions" class="mt-4 flex gap-4 hidden">
+            <button id="take-card-btn" class="action-btn">Take Card</button>
+            <button id="dismiss-card-btn" class="action-btn">Dismiss</button>
         </div>
         <div id="upgrade-team-roster" class="flex flex-col lg:flex-row gap-4 mt-8"></div>
         <div id="upgrade-confirm-modal" class="modal hidden">

--- a/hero-game/js/scenes/UpgradeScene.js
+++ b/hero-game/js/scenes/UpgradeScene.js
@@ -15,9 +15,9 @@ export class UpgradeScene {
         this.topCrimp = element.querySelector('#upgrade-top-crimp');
         this.imageArea = element.querySelector('#upgrade-image-area');
         this.revealArea = element.querySelector('#upgrade-reveal-area');
-        this.actionContainer = element.querySelector('#upgrade-actions');
-        this.takeButton = element.querySelector('#upgrade-take-button');
-        this.dismissButton = element.querySelector('#upgrade-dismiss-button');
+        this.actionContainer = element.querySelector('#reveal-actions');
+        this.takeButton = element.querySelector('#take-card-btn');
+        this.dismissButton = element.querySelector('#dismiss-card-btn');
         this.teamRoster = element.querySelector('#upgrade-team-roster');
         this.confirmModal = element.querySelector('#upgrade-confirm-modal');
         this.instructionsEl = element.querySelector('#upgrade-instructions');
@@ -28,7 +28,7 @@ export class UpgradeScene {
             this.packEl.addEventListener('mouseleave', () => this.handleMouseLeave());
         }
         if (this.takeButton) this.takeButton.addEventListener('click', () => this.handleTakeCard());
-        if (this.dismissButton) this.dismissButton.addEventListener('click', () => this.handleDismissCard());
+        // dismissButton's handler is assigned dynamically in revealNextCard
 
         if (this.confirmModal) {
             this.confirmYes = this.confirmModal.querySelector('#upgrade-confirm-yes');
@@ -145,6 +145,16 @@ export class UpgradeScene {
         if (this.instructionsEl) {
             this.instructionsEl.textContent = 'Take the card or dismiss it.';
         }
+        if (this.dismissButton) {
+            this.dismissButton.onclick = null;
+            if (this.currentCardIndex === this.packContents.length - 1) {
+                this.dismissButton.textContent = 'Skip';
+                this.dismissButton.onclick = () => this.skipUpgrade();
+            } else {
+                this.dismissButton.textContent = 'Dismiss';
+                this.dismissButton.onclick = () => this.handleDismissCard();
+            }
+        }
     }
 
     clearSelections() {
@@ -202,6 +212,10 @@ export class UpgradeScene {
                 this.revealNextCard();
             }
         }
+    }
+
+    skipUpgrade() {
+        this.onComplete();
     }
 
     renderTeam(team) {

--- a/hero-game/style.css
+++ b/hero-game/style.css
@@ -278,6 +278,14 @@ button:disabled {
 .confirmation-bar.visible { bottom: 0; }
 .confirm-button { background-color: #f59e0b; color: #111827; padding: 0.75rem 2rem; border-radius: 0.5rem; font-size: 1.125rem; font-weight: 600; cursor: pointer; transition: background-color 0.2s; }
 .confirm-button:hover { background-color: #fbbf24; }
+.action-btn {
+    padding: 0.75rem 2rem;
+    border-radius: 0.5rem;
+    font-size: 1.125rem;
+    font-weight: 600;
+    cursor: pointer;
+    transition: background-color 0.2s;
+}
 .secondary-button {
     background-color: transparent;
     color: #d1d5db;
@@ -292,6 +300,21 @@ button:disabled {
 .secondary-button:hover {
     background-color: #374151;
     color: white;
+}
+#take-card-btn {
+    background-color: #f59e0b;
+    color: #111827;
+}
+#take-card-btn:hover {
+    background-color: #fbbf24;
+}
+#dismiss-card-btn {
+    background-color: #991b1b;
+    border: 2px solid #b91c1c;
+    color: white;
+}
+#dismiss-card-btn:hover {
+    background-color: #7f1d1d;
 }
 
 /* --- Battle Scene Styles --- */


### PR DESCRIPTION
## Summary
- implement dismiss button for post-battle mini draft
- style new button and take button
- adjust UpgradeScene logic to allow skipping remaining cards

## Testing
- `node -e "import('./hero-game/js/scenes/UpgradeScene.js').then(()=>console.log('ok')).catch(err=>console.error(err))" (fails: ReferenceError: document is not defined)`

------
https://chatgpt.com/codex/tasks/task_e_6853744fcae08327915f986f255ea288