### PR TITLE
Fix: Revamp Upgrade Scene functionality and layout

### DIFF
--- a/hero-game/index.html
+++ b/hero-game/index.html
@@ -154,8 +154,12 @@
         </div>
         <div id="upgrade-reveal-area" class="hidden"></div>
         <div id="reveal-actions" class="mt-4 flex gap-4 hidden">
-            <button id="take-card-btn" class="action-btn">Take Card</button>
-            <button id="dismiss-card-btn" class="action-btn">Dismiss</button>
+            <button id="take-card-btn" class="action-btn">
+                <i class="fas fa-check-circle mr-2"></i>Take Card
+            </button>
+            <button id="dismiss-card-btn" class="action-btn bg-red-800 hover:bg-red-700 border-red-600">
+                <i class="fas fa-times-circle mr-2"></i>Dismiss
+            </button>
         </div>
         <div id="upgrade-team-roster" class="flex flex-col lg:flex-row gap-4 mt-8"></div>
         <div id="upgrade-confirm-modal" class="modal hidden">
@@ -169,6 +173,7 @@
                 </div>
             </div>
         </div>
+    <button id="continue-button" class="action-btn hidden mt-8">Proceed to Next Battle</button>
     </div>
 
     <div id="tournament-end-screen" class="scene hidden flex-col items-center justify-center bg-gray-900 bg-opacity-90">
@@ -244,7 +249,341 @@
         <p id="tooltip-effect" class="text-gray-200"></p>
     </div>
 
-    <script type="module" src="js/main.js"></script>
+    <script>
+    document.addEventListener('DOMContentLoaded', () => {
+        // --- MOCK DATA ---
+        const bonusPackData = [
+            { id: 1103, type: 'weapon', name: 'Steel Longsword', rarity: 'Rare', art: 'https://storage.googleapis.com/gemini-prod-us-west1-assets/sxfoster/steel_longsword_card.png', statBonuses: { ATK: 7, HP: 3 } },
+            { id: 2102, type: 'armor', name: 'Agile Reflexes', rarity: 'Uncommon', art: 'https://storage.googleapis.com/gemini-prod-us-west1-assets/sxfoster/agile_reflexes_card.png', statBonuses: { Evasion: 2 } },
+            { id: 3121, type: 'ability', name: 'Crippling Blow', rarity: 'Uncommon', art: 'https://storage.googleapis.com/gemini-prod-us-west1-assets/sxfoster/ability_uncommon.png', effect: 'Deal 3 damage and reduce enemy attack by 1.', energyCost: 2 },
+            { id: 101, type: 'hero', name: 'Recruit', class: 'stalwart-defender', rarity: 'Common', art: 'https://storage.googleapis.com/gemini-prod-us-west1-assets/sxfoster/recruit_card.png', hp: 22, attack: 4 },
+            { id: 404, type: 'hero', name: 'Chaos Conduit', class: 'raw-power-mage', rarity: 'Epic', art: 'https://storage.googleapis.com/gemini-prod-us-west1-assets/sxfoster/chaos_conduit_card.png', hp: 27, attack: 5 },
+            { id: 103, type: 'hero', name: 'Vanguard', class: 'stalwart-defender', rarity: 'Rare', art: 'https://storage.googleapis.com/gemini-prod-us-west1-assets/sxfoster/vanguard_card.png', hp: 42, attack: 8 },
+        ].sort(() => 0.5 - Math.random());
 
+        let playerTeam = {
+            hero1: { id: 102, type: 'hero', name: 'Soldier', class: 'stalwart-defender', rarity: 'Uncommon', art: 'https://storage.googleapis.com/gemini-prod-us-west1-assets/sxfoster/soldier_card.png', hp: 30, attack: 6 },
+            ability1: { id: 3111, type: 'ability', name: 'Power Strike', rarity: 'Common', art: 'https://storage.googleapis.com/gemini-prod-us-west1-assets/sxfoster/ability_common.png', effect: 'Deal 2 damage.', energyCost: 1 },
+            weapon1: { id: 1101, type: 'weapon', name: 'Worn Sword', rarity: 'Common', art: 'https://storage.googleapis.com/gemini-prod-us-west1-assets/sxfoster/worn_sword_card.png', statBonuses: { ATK: 3 } },
+            armor1: null, // Start with an empty slot for testing
+            hero2: { id: 202, type: 'hero', name: 'Crusader', class: 'holy-warrior', rarity: 'Uncommon', art: 'https://storage.googleapis.com/gemini-prod-us-west1-assets/sxfoster/crusader_card.png', hp: 28, attack: 7 },
+            ability2: { id: 3211, type: 'ability', name: 'Divine Strike', rarity: 'Common', art: 'https://storage.googleapis.com/gemini-prod-us-west1-assets/sxfoster/ability_common_alt.png', effect: 'Deal 2 damage, heal 2 HP.', energyCost: 1 },
+            weapon2: { id: 1201, type: 'weapon', name: 'Rusty Axe', rarity: 'Common', art: 'https://storage.googleapis.com/gemini-prod-us-west1-assets/sxfoster/rusty_axe_card.png', statBonuses: { ATK: 4 } },
+            armor2: { id: 2201, type: 'armor', name: 'Studded Vest', rarity: 'Common', art: 'https://storage.googleapis.com/gemini-prod-us-west1-assets/sxfoster/studded_vest_card.png', statBonuses: { Block: 1, Evasion: 1 } },
+        };
+
+        // --- STATE MANAGEMENT ---
+        let scenePhase = 'PACK'; // Initial phase for the upgrade scene
+        let currentCardIndex = -1;
+        let selectedCardData = null;
+        let targetSocketInfo = null;
+
+        // --- DOM ELEMENTS ---
+        // Corrected IDs for elements within the upgrade scene
+        const mainHeader = document.querySelector('#upgrade-scene > header'); // Target header within upgrade scene
+        const mainInstruction = document.querySelector('#upgrade-scene > header > h1');
+        const subInstruction = document.getElementById('upgrade-instructions'); // This is the <p> tag for sub-instructions
+
+        const boosterPackArea = document.getElementById('upgrade-pack-container'); // Corrected
+        const revealArea = document.getElementById('upgrade-reveal-area'); // Corrected
+        const revealActions = document.getElementById('reveal-actions'); // This ID is directly in HTML for the buttons
+        const takeCardBtn = document.getElementById('take-card-btn');
+        const dismissCardBtn = document.getElementById('dismiss-card-btn');
+        const teamRoster = document.getElementById('upgrade-team-roster'); // Corrected
+        const continueButton = document.getElementById('continue-button'); // Newly added button
+        const modal = document.getElementById('upgrade-confirm-modal'); // Corrected
+        const tooltip = document.getElementById('item-tooltip');
+
+        // Make the upgrade scene visible by default if main.js is removed
+        const upgradeSceneElement = document.getElementById('upgrade-scene');
+        if (upgradeSceneElement) {
+            // Hide all other scenes that might be visible
+            document.querySelectorAll('.scene').forEach(s => s.classList.add('hidden'));
+            upgradeSceneElement.classList.remove('hidden');
+        }
+         // Also ensure pack area is visible initially for the upgrade scene flow
+        if (boosterPackArea) {
+            boosterPackArea.classList.remove('hidden');
+        }
+        if(mainHeader) mainHeader.classList.remove('hidden');
+
+
+        // --- RENDER FUNCTIONS ---
+        function createFullCardElement(item) {
+            if (!item) {
+                const container = document.createElement('div');
+                container.className = 'card-container empty-slot flex items-center justify-center bg-black/20 border-2 border-dashed border-gray-600 rounded-lg';
+                container.innerHTML = `<i class="fas fa-plus text-gray-500 text-4xl"></i>`;
+                return container;
+            }
+            const container = document.createElement('div');
+            container.className = 'card-container';
+            const card = document.createElement('div');
+            card.className = `item-card ${item.rarity.toLowerCase()} ${item.class || ''}`;
+            let statsHtml = '', abilitiesHtml = '';
+            switch (item.type) {
+                case 'hero': statsHtml = `<div class="stat-block"><span class="stat-value">${item.hp}</span><span class="stat-label">HP</span></div><div class="stat-block"><span class="stat-value">${item.attack}</span><span class="stat-label">Attack</span></div>`; break;
+                case 'weapon': case 'armor': statsHtml = Object.entries(item.statBonuses).map(([stat, val]) => `<div class="stat-block"><span class="stat-value">+${val}</span><span class="stat-label">${stat}</span></div>`).join(''); break;
+                case 'ability': abilitiesHtml = `<div class="item-ability"><p>${item.effect}</p></div>`; break;
+            }
+            card.innerHTML = `<div class="card-rarity-glow"></div><div class="card-frame-base"></div><div class="card-frame-inlay"></div><div class="hero-art" style="background-image: url('${item.art}')"></div><div class="hero-title-plate"></div><h3 class="hero-name font-cinzel">${item.name}</h3><div class="hero-stats">${statsHtml}</div><div class="hero-abilities">${abilitiesHtml}</div>`;
+            container.appendChild(card);
+            return container;
+        }
+
+        function createSocket(type, item) {
+            const socket = document.createElement('div');
+            socket.className = `equipment-socket ${type}-socket`;
+            socket.dataset.type = type;
+            socket.dataset.name = item ? item.name : 'Empty';
+            socket.appendChild(createFullCardElement(item));
+            addTooltipListeners(socket, item);
+            return socket;
+        }
+
+        function renderTeam() {
+            if (!teamRoster) return;
+            teamRoster.innerHTML = '';
+            for (let i = 1; i <= 2; i++) {
+                const championDisplayContainer = document.createElement('div'); // Create a container for each champion
+                championDisplayContainer.id = `champion-${i}-display`; // Assign ID for targeting
+                championDisplayContainer.className = 'champion-display'; // Add class for styling if needed
+
+                const heroCard = createFullCardElement(playerTeam[\`hero\${i}\`]);
+                heroCard.dataset.type = "hero";
+                addTooltipListeners(heroCard, playerTeam[\`hero\${i}\`]);
+
+                championDisplayContainer.append(
+                    heroCard,
+                    createSocket('ability', playerTeam[\`ability\${i}\`]),
+                    createSocket('weapon', playerTeam[\`weapon\${i}\`]),
+                    createSocket('armor', playerTeam[\`armor\${i}\`])
+                );
+                teamRoster.appendChild(championDisplayContainer); // Append the container to the roster
+            }
+        }
+
+        // --- INTERACTION LOGIC ---
+        function handlePackOpen() {
+            if (scenePhase !== 'PACK' || !boosterPackArea) return;
+            scenePhase = 'REVEAL';
+
+            boosterPackArea.style.transition = 'transform 0.5s, opacity 0.5s';
+            boosterPackArea.style.transform = 'scale(1.2)';
+            boosterPackArea.style.opacity = '0';
+
+            setTimeout(() => {
+                boosterPackArea.classList.add('hidden');
+                if(mainHeader) mainHeader.classList.add('hidden'); // Manage main header visibility
+                if(revealArea) revealArea.classList.remove('hidden');
+                if(revealActions) {
+                    revealActions.classList.remove('hidden', 'flex'); // remove flex before adding it
+                    revealActions.classList.add('flex');
+                }
+                if(teamRoster) {
+                    teamRoster.classList.remove('hidden');
+                    teamRoster.classList.add('flex'); // ensure teamRoster is flex if it's supposed to be
+                }
+                revealNextCard();
+            }, 500);
+        }
+
+        function revealNextCard() {
+            currentCardIndex++;
+            if (currentCardIndex >= bonusPackData.length) {
+                skipUpgrade();
+                return;
+            }
+
+            if(!revealArea) return;
+            revealArea.innerHTML = '';
+            const cardData = bonusPackData[currentCardIndex];
+            const cardEl = createFullCardElement(cardData);
+            cardEl.style.transform = 'scale(0.8) rotateY(180deg)';
+            cardEl.style.opacity = '0';
+            addTooltipListeners(cardEl, cardData);
+            revealArea.appendChild(cardEl);
+
+            setTimeout(() => {
+                cardEl.style.transition = 'transform 0.6s, opacity 0.6s';
+                cardEl.style.transform = 'scale(1) rotateY(0deg)';
+                cardEl.style.opacity = '1';
+            }, 100);
+
+            if (dismissCardBtn && currentCardIndex === bonusPackData.length - 1) {
+                dismissCardBtn.innerHTML = \`<i class="fas fa-forward mr-2"></i>Skip\`;
+            } else if (dismissCardBtn) {
+                dismissCardBtn.innerHTML = \`<i class="fas fa-times-circle mr-2"></i>Dismiss\`; // Reset if not last card
+            }
+        }
+
+        function handleTakeCard() {
+            if (scenePhase !== 'REVEAL') return;
+            scenePhase = 'REPLACEMENT';
+
+            selectedCardData = bonusPackData[currentCardIndex];
+            if(mainHeader) mainHeader.classList.remove('hidden');
+            if(mainInstruction) mainInstruction.textContent = "Choose an Item to Replace";
+            if(subInstruction) subInstruction.textContent = \`Select a matching slot for \${selectedCardData.name}.\`;
+
+            if(revealActions) revealActions.classList.add('hidden');
+            if(revealArea) revealArea.classList.add('hidden');
+
+            updateTargetableSockets();
+        }
+
+        function handleDismissCard() {
+            if (scenePhase !== 'REVEAL' || !revealArea) return;
+            const cardEl = revealArea.querySelector('.card-container');
+            if (cardEl) {
+                cardEl.style.transform = 'translateY(100%) scale(0.5)';
+                cardEl.style.opacity = '0';
+                setTimeout(revealNextCard, 500);
+            } else { // If no card element is found, still try to reveal next or skip
+                revealNextCard();
+            }
+        }
+
+        function updateTargetableSockets() {
+            if (!teamRoster) return;
+            teamRoster.querySelectorAll('.equipment-socket, .card-container[data-type="hero"]').forEach(el => {
+                el.classList.remove('targetable', 'disabled');
+                el.removeEventListener('click', handleSocketSelectListener); // Use a named listener for removal
+                const type = el.dataset.type;
+                if (selectedCardData && type === selectedCardData.type) {
+                    el.classList.add('targetable');
+                    el.addEventListener('click', handleSocketSelectListener);
+                } else {
+                    el.classList.add('disabled');
+                }
+            });
+        }
+
+        // Named listener for easier add/remove
+        function handleSocketSelectListener(event) {
+            handleSocketSelect(event);
+        }
+
+        function handleSocketSelect(event) {
+            const socketEl = event.currentTarget.closest('.equipment-socket, .card-container');
+            if (!socketEl || !socketEl.closest('.champion-display')) {
+                console.error("Could not find champion display for socket:", socketEl);
+                return;
+            }
+            const championKey = socketEl.closest('.champion-display').id.slice(-1); // Relies on champion-X-display ID
+            const type = socketEl.dataset.type;
+            const originalItemKey = type === 'hero' ? \`hero\${championKey}\` : \`\${type}\${championKey}\`;
+            const originalItem = playerTeam[originalItemKey];
+
+            targetSocketInfo = { championKey, type };
+
+            if(modal) {
+                const modalText = modal.querySelector('#modal-text'); // Assuming modal-text id exists in your modal
+                 if(!modalText && modal.querySelector('.modal-content p')) { // Fallback to first p in modal-content
+                    modal.querySelector('.modal-content p').textContent = \`Replace \${originalItem ? originalItem.name : 'empty slot'} with \${selectedCardData.name}?\`;
+                 } else if (modalText) {
+                    modalText.textContent = \`Replace \${originalItem ? originalItem.name : 'empty slot'} with \${selectedCardData.name}?\`;
+                 }
+                modal.classList.remove('hidden');
+                modal.classList.add('flex');
+            }
+        }
+
+        function executeSwap() {
+            if (!targetSocketInfo || !playerTeam) return;
+            const { championKey, type } = targetSocketInfo;
+            const teamKey = type === 'hero' ? \`hero\${championKey}\` : \`\${type}\${championKey}\`;
+            playerTeam[teamKey] = selectedCardData;
+
+            renderTeam(); // Re-render the team to show the swapped item
+
+            if(mainInstruction) mainInstruction.textContent = "Upgrade Complete!";
+            if(subInstruction) subInstruction.textContent = "Your team is ready for the next battle.";
+            if(teamRoster) teamRoster.classList.add('hidden'); // Hide roster after swap
+            if(revealArea) revealArea.classList.add('hidden');
+            if(revealActions) revealActions.classList.add('hidden');
+
+            if(continueButton) continueButton.classList.remove('hidden');
+            if(modal) modal.classList.add('hidden');
+            if(modal) modal.classList.remove('flex');
+        }
+
+        function skipUpgrade() {
+            if(mainInstruction) mainInstruction.textContent = "Upgrade Skipped";
+            if(subInstruction) subInstruction.textContent = "Your team remains unchanged.";
+            if(revealArea) revealArea.classList.add('hidden');
+            if(revealActions) revealActions.classList.add('hidden');
+            if(teamRoster) teamRoster.classList.add('hidden');
+            if(continueButton) continueButton.classList.remove('hidden');
+        }
+
+        // --- TOOLTIP LOGIC ---
+        function addTooltipListeners(element, item) {
+            if (!item || !tooltip) return;
+            element.addEventListener('mouseenter', (e) => showTooltip(e, item));
+            element.addEventListener('mousemove', (e) => {
+                tooltip.style.left = \`\${e.clientX + 15}px\`;
+                tooltip.style.top = \`\${e.clientY + 15}px\`;
+            });
+            element.addEventListener('mouseleave', hideTooltip);
+        }
+
+        function showTooltip(event, item) {
+            if (!item || !tooltip) return;
+            let statsText = '';
+            let effectText = item.effect || '';
+            if (item.statBonuses) {
+                 statsText = Object.entries(item.statBonuses).map(([stat, val]) => \`+\${val} \${stat}\`).join(', ');
+            } else if (item.hp) {
+                 statsText = \`\${item.hp} HP, \${item.attack} Attack\`;
+            }
+            const tooltipName = tooltip.querySelector('#tooltip-name');
+            const tooltipStats = tooltip.querySelector('#tooltip-stats');
+            const tooltipEffect = tooltip.querySelector('#tooltip-effect');
+
+            if(tooltipName) tooltipName.textContent = item.name;
+            if(tooltipStats) tooltipStats.textContent = statsText;
+            if(tooltipEffect) tooltipEffect.textContent = effectText;
+            tooltip.classList.remove('hidden');
+        }
+
+        function hideTooltip() {
+            if(tooltip) tooltip.classList.add('hidden');
+        }
+
+        // --- EVENT LISTENERS ---
+        if(boosterPackArea) boosterPackArea.addEventListener('click', handlePackOpen);
+        if(takeCardBtn) takeCardBtn.addEventListener('click', handleTakeCard);
+        if(dismissCardBtn) dismissCardBtn.addEventListener('click', handleDismissCard);
+
+        if(modal) {
+            const confirmSwapBtn = modal.querySelector('#confirm-swap-button'); // Assuming this ID for confirm
+            const cancelSwapBtn = modal.querySelector('#cancel-swap-button'); // Assuming this ID for cancel
+            // Fallback for confirm/cancel buttons if specific IDs aren't present (e.g. use provided `upgrade-confirm-yes`)
+            const confirmActual = confirmSwapBtn || modal.querySelector('#upgrade-confirm-yes');
+            const cancelActual = cancelSwapBtn || modal.querySelector('#upgrade-confirm-no');
+
+            if(confirmActual) confirmActual.addEventListener('click', executeSwap);
+            if(cancelActual) cancelActual.addEventListener('click', () => {
+                modal.classList.add('hidden');
+                modal.classList.remove('flex');
+            });
+        }
+
+        if(continueButton) {
+            continueButton.addEventListener('click', () => {
+                alert("Proceeding to the next battle (simulation)!");
+                // Here you would typically transition to the next game state/scene
+                // For this prototype, we can just hide the upgrade scene or reload
+                if (upgradeSceneElement) upgradeSceneElement.classList.add('hidden');
+                // Optionally, show another scene, e.g., a placeholder "Battle Scene"
+                // document.getElementById('battle-scene')?.classList.remove('hidden');
+            });
+        }
+
+        // --- INITIALIZATION ---
+        renderTeam();
+    });
+    </script>
 </body>
 </html>

--- a/hero-game/style.css
+++ b/hero-game/style.css
@@ -52,8 +52,9 @@ body {
     display: flex;
     flex-direction: column;
     align-items: center;
-    justify-content: center;
-    padding: 1rem;
+    justify-content: flex-start;
+    padding: 2rem;
+    gap: 3rem; /* Increased gap for better separation */
     transition: opacity 0.3s ease-out, transform 0.3s ease-out;
 }
 .scene.hidden {
@@ -1864,6 +1865,14 @@ button:disabled {
 /* Upgrade Scene Styles                                                       */
 /* -------------------------------------------------------------------------- */
 
+.team-roster {
+    display: flex;
+    flex-direction: column; /* Changed from row-based media query */
+    align-items: center;
+    gap: 2.5rem; /* Consistent gap between champions */
+    width: 100%;
+    margin-top: 1rem;
+}
 
 #upgrade-reveal-area { display: flex; justify-content: center; align-items: center; position: relative; }
 


### PR DESCRIPTION
- Updated CSS for .scene and .team-roster to improve layout and spacing in the upgrade scene.
- Modified dismiss/take card buttons in the upgrade scene with new icons and styling.
- Replaced previous JavaScript logic for the upgrade scene with a new, self-contained script embedded in index.html.
- Removed reference to main.js to allow the new script to take full control of the page, focusing it on the upgrade scene prototype.
- Added a 'Proceed to Next Battle' button to complete the upgrade scene flow.

This addresses layout issues, missing dismiss functionality, and broken confirmation logic in the original upgrade scene prototype by implementing the provided specification.