### PR TITLE
Fix upgrade scene deselection

### DIFF
--- a/hero-game/js/scenes/UpgradeScene.js
+++ b/hero-game/js/scenes/UpgradeScene.js
@@ -168,6 +168,11 @@ export class UpgradeScene {
     handleBonusCardSelect(cardEl, cardData) {
         if (cardEl.classList.contains('selected')) {
             this.clearSelections();
+            this.phase = 'REVEAL';
+            if (this.actionContainer) this.actionContainer.classList.remove('hidden');
+            if (this.instructionsEl) {
+                this.instructionsEl.textContent = 'Take the card or dismiss it.';
+            }
             return;
         }
         this.clearSelections();


### PR DESCRIPTION
## Summary
- fix UI lockup if you deselect a bonus card in the upgrade scene

## Testing
- `npm test` *(fails: missing `package.json`)*

------
https://chatgpt.com/codex/tasks/task_e_68541f807174832796f70ca8906e2662