### PR TITLE
Fix upgrade scene button interactions

### DIFF
--- a/hero-game/js/scenes/UpgradeScene.js
+++ b/hero-game/js/scenes/UpgradeScene.js
@@ -27,7 +27,12 @@ export class UpgradeScene {
             this.packEl.addEventListener('mousemove', e => this.handleMouseMove(e));
             this.packEl.addEventListener('mouseleave', () => this.handleMouseLeave());
         }
-        if (this.takeButton) this.takeButton.addEventListener('click', () => this.handleTakeCard());
+        if (this.takeButton) {
+            this.takeButton.addEventListener('click', () => {
+                console.log('Take Card button clicked.');
+                this.handleTakeCard();
+            });
+        }
         // dismissButton's handler is assigned dynamically in revealNextCard
 
         if (this.confirmModal) {
@@ -149,10 +154,16 @@ export class UpgradeScene {
             this.dismissButton.onclick = null;
             if (this.currentCardIndex === this.packContents.length - 1) {
                 this.dismissButton.textContent = 'Skip';
-                this.dismissButton.onclick = () => this.skipUpgrade();
+                this.dismissButton.onclick = () => {
+                    console.log('Skip button clicked.');
+                    this.skipUpgrade();
+                };
             } else {
                 this.dismissButton.textContent = 'Dismiss';
-                this.dismissButton.onclick = () => this.handleDismissCard();
+                this.dismissButton.onclick = () => {
+                    console.log('Dismiss button clicked.');
+                    this.handleDismissCard();
+                };
             }
         }
     }

--- a/hero-game/style.css
+++ b/hero-game/style.css
@@ -1864,6 +1864,12 @@ button:disabled {
 /* Upgrade Scene Styles                                                       */
 /* -------------------------------------------------------------------------- */
 
+/* Action button container during card reveal */
+#reveal-actions {
+    position: relative;
+    z-index: 1;
+}
+
 
 #upgrade-reveal-area { display: flex; justify-content: center; align-items: center; position: relative; }
 


### PR DESCRIPTION
## Summary
- ensure upgrade action buttons sit above overlapping elements
- log click events for Take Card, Dismiss, and Skip actions

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_685422e76bd48327a1999e24313d5a7a