### PR TITLE
Fix upgrade confirmation logic and add user feedback

### DIFF
--- a/hero-game/js/main.js
+++ b/hero-game/js/main.js
@@ -101,7 +101,22 @@ const upgradeScene = new UpgradeScene(sceneElements.upgrade, (slot, newId) => {
             gameState.draft.playerTeam[`armor${idx}`] = null;
         }
     }
-    startNextBattle();
+
+    const upgradePack = sceneElements.upgrade.querySelector('#upgrade-pack-container');
+    const revealArea = sceneElements.upgrade.querySelector('#upgrade-reveal-area');
+    const teamRoster = sceneElements.upgrade.querySelector('#upgrade-team-roster');
+    if (upgradePack) upgradePack.classList.add('hidden');
+    if (revealArea) revealArea.classList.add('hidden');
+    if (teamRoster) teamRoster.classList.add('hidden');
+
+    const instructions = sceneElements.upgrade.querySelector('#upgrade-instructions');
+    if (instructions) {
+        instructions.textContent = 'Upgrade complete! Returning to the tournament...';
+    }
+
+    setTimeout(() => {
+        startNextBattle();
+    }, 2000);
 });
 
 const battleScene = new BattleScene(sceneElements.battle, handleBattleComplete);

--- a/hero-game/js/scenes/UpgradeScene.js
+++ b/hero-game/js/scenes/UpgradeScene.js
@@ -326,25 +326,42 @@ export class UpgradeScene {
     }
 
     executeSwap() {
-        if (!this.pendingSlot || !this.selectedCard) return;
+        console.log('[executeSwap] Starting swap...');
+        if (!this.pendingSlot || !this.selectedCard) {
+            console.error('[executeSwap] Error: pendingSlot or selectedCard is null.');
+            return;
+        }
+
         const socket = this.element.querySelector(`[data-slot='${this.pendingSlot}']`);
-        if (!socket) return;
+        if (!socket) {
+            console.error(`[executeSwap] Error: Could not find socket for ${this.pendingSlot}.`);
+            return;
+        }
+
         const applyNewCard = () => {
+            console.log('[executeSwap] Running applyNewCard callback.');
             socket.removeEventListener('animationend', applyNewCard);
             socket.style.backgroundImage = `url('${this.selectedCard.art}')`;
             socket.classList.remove('empty-socket', 'card-pop-out');
             socket.classList.add('card-pop-in');
             socket.addEventListener('animationend', finishSwap);
         };
+
         const finishSwap = () => {
+            console.log('[executeSwap] Running finishSwap callback.');
             socket.removeEventListener('animationend', finishSwap);
             socket.classList.remove('card-pop-in');
+
+            console.log('[executeSwap] Calling onComplete to finalize state and transition.');
             this.onComplete(this.pendingSlot, this.selectedCard.id);
             this.clearSelections();
         };
+
         if (socket.classList.contains('empty-socket')) {
+            console.log('[executeSwap] Socket is empty, applying card directly.');
             applyNewCard();
         } else {
+            console.log('[executeSwap] Socket has an item, starting pop-out animation.');
             socket.classList.add('card-pop-out');
             socket.addEventListener('animationend', applyNewCard);
         }


### PR DESCRIPTION
## Summary
- add logging statements in `executeSwap` to trace upgrade flow
- show message and delay before returning to tournament after upgrade

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68543055a7708327b30fcd7907865fd8