### PR TITLE
Fix synergy icon flash check

### DIFF
--- a/hero-game/js/scenes/BattleScene.js
+++ b/hero-game/js/scenes/BattleScene.js
@@ -522,7 +522,7 @@ export class BattleScene {
                         finalDamage *= ability.synergy.bonus_multiplier;
 
                         const iconToFlash = Array.from(target.element.querySelectorAll('.status-icon'))
-                            .find(icon => icon.title.includes(ability.synergy.condition));
+                            .find(icon => (icon.dataset.statusName || '').includes(ability.synergy.condition));
                         if (iconToFlash) {
                             iconToFlash.classList.add('synergy-flash');
                             setTimeout(() => iconToFlash.classList.remove('synergy-flash'), 600);


### PR DESCRIPTION
## Summary
- correct status icon lookup for synergy flash effect

## Testing
- `find hero-game/js -name '*.js' -print0 | xargs -0 -n 1 node --check`

------
https://chatgpt.com/codex/tasks/task_e_685434a9c00c8327923c9a19e32130bf