### PR TITLE
Add log for selectedCard in executeSwap

### DIFF
--- a/hero-game/js/scenes/UpgradeScene.js
+++ b/hero-game/js/scenes/UpgradeScene.js
@@ -327,6 +327,7 @@ export class UpgradeScene {
 
     executeSwap() {
         console.log('[executeSwap] Starting swap...');
+        console.log('Value of this.selectedCard at start of executeSwap:', this.selectedCard);
         if (!this.pendingSlot || !this.selectedCard) {
             console.error('[executeSwap] Error: pendingSlot or selectedCard is null.');
             return;


### PR DESCRIPTION
## Summary
- add debugging log to confirm the value of `selectedCard` when `executeSwap` runs

## Testing
- `node test_executeSwap.mjs` *(using jsdom)*

------
https://chatgpt.com/codex/tasks/task_e_68543513bdf88327891dd4a525c655b5