### PR TITLE
Implement upgrade popup and timer-based swap

### DIFF
--- a/hero-game/index.html
+++ b/hero-game/index.html
@@ -244,6 +244,14 @@
         <p id="tooltip-effect" class="text-gray-200"></p>
     </div>
 
+    <div id="transition-popup" class="modal hidden">
+        <div class="modal-backdrop">
+            <div class="modal-content text-center">
+                <p id="transition-popup-message" class="text-2xl font-cinzel"></p>
+            </div>
+        </div>
+    </div>
+
     <script type="module" src="js/main.js"></script>
 
 </body>

--- a/hero-game/js/main.js
+++ b/hero-game/js/main.js
@@ -42,6 +42,9 @@ const sceneElements = {
 const confirmationBar = document.getElementById('confirmation-bar');
 const confirmDraftButton = document.getElementById('confirm-draft');
 
+const transitionPopup = document.getElementById('transition-popup');
+const transitionMessage = document.getElementById('transition-popup-message');
+
 // --- SCENE INSTANTIATION ---
 // Create instances of each scene, passing their root element and necessary callbacks.
 const packScene = new PackScene(sceneElements.pack, () => openPack());
@@ -91,9 +94,9 @@ const recapScene = new RecapScene(sceneElements.recap, () => {
 });
 
 const upgradeScene = new UpgradeScene(sceneElements.upgrade, (slot, newId) => {
+    // This is the onComplete callback
     if (slot && newId) {
         gameState.draft.playerTeam[slot] = newId;
-
         if (slot.startsWith('hero')) {
             const idx = slot.endsWith('1') ? '1' : '2';
             gameState.draft.playerTeam[`ability${idx}`] = null;
@@ -102,19 +105,15 @@ const upgradeScene = new UpgradeScene(sceneElements.upgrade, (slot, newId) => {
         }
     }
 
-    const upgradePack = sceneElements.upgrade.querySelector('#upgrade-pack-container');
-    const revealArea = sceneElements.upgrade.querySelector('#upgrade-reveal-area');
-    const teamRoster = sceneElements.upgrade.querySelector('#upgrade-team-roster');
-    if (upgradePack) upgradePack.classList.add('hidden');
-    if (revealArea) revealArea.classList.add('hidden');
-    if (teamRoster) teamRoster.classList.add('hidden');
+    // --- NEW LOGIC FOR POPUP ---
+    // Determine the message based on whether an upgrade was made
+    const message = slot ? 'Upgrade Complete!' : 'Returning to Battle!';
+    transitionMessage.textContent = message;
+    transitionPopup.classList.remove('hidden');
 
-    const instructions = sceneElements.upgrade.querySelector('#upgrade-instructions');
-    if (instructions) {
-        instructions.textContent = 'Upgrade complete! Returning to the tournament...';
-    }
-
+    // Wait 2 seconds before hiding the popup and starting the next battle
     setTimeout(() => {
+        transitionPopup.classList.add('hidden');
         startNextBattle();
     }, 2000);
 });

--- a/hero-game/js/scenes/UpgradeScene.js
+++ b/hero-game/js/scenes/UpgradeScene.js
@@ -326,8 +326,7 @@ export class UpgradeScene {
     }
 
     executeSwap() {
-        console.log('[executeSwap] Starting swap...');
-        console.log('Value of this.selectedCard at start of executeSwap:', this.selectedCard);
+        console.log('[executeSwap] Starting swap with new timer-based logic...');
         if (!this.pendingSlot || !this.selectedCard) {
             console.error('[executeSwap] Error: pendingSlot or selectedCard is null.');
             return;
@@ -339,32 +338,29 @@ export class UpgradeScene {
             return;
         }
 
-        const applyNewCard = () => {
-            console.log('[executeSwap] Running applyNewCard callback.');
-            socket.removeEventListener('animationend', applyNewCard);
-            socket.style.backgroundImage = `url('${this.selectedCard.art}')`;
-            socket.classList.remove('empty-socket', 'card-pop-out');
-            socket.classList.add('card-pop-in');
-            socket.addEventListener('animationend', finishSwap);
-        };
+        const animationDuration = 200; // This must match the duration in style.css (0.2s)
 
         const finishSwap = () => {
-            console.log('[executeSwap] Running finishSwap callback.');
-            socket.removeEventListener('animationend', finishSwap);
-            socket.classList.remove('card-pop-in');
-
-            console.log('[executeSwap] Calling onComplete to finalize state and transition.');
+            console.log('[executeSwap] Finishing swap and calling onComplete.');
             this.onComplete(this.pendingSlot, this.selectedCard.id);
             this.clearSelections();
         };
 
+        const applyNewCard = () => {
+            console.log('[executeSwap] Applying new card art and starting pop-in animation.');
+            socket.style.backgroundImage = `url('${this.selectedCard.art}')`;
+            socket.classList.remove('empty-socket', 'card-pop-out');
+            socket.classList.add('card-pop-in');
+            setTimeout(finishSwap, animationDuration);
+        };
+
         if (socket.classList.contains('empty-socket')) {
-            console.log('[executeSwap] Socket is empty, applying card directly.');
+            console.log('[executeSwap] Socket is empty. Applying new card immediately.');
             applyNewCard();
         } else {
-            console.log('[executeSwap] Socket has an item, starting pop-out animation.');
+            console.log('[executeSwap] Socket has an item. Starting pop-out animation.');
             socket.classList.add('card-pop-out');
-            socket.addEventListener('animationend', applyNewCard);
+            setTimeout(applyNewCard, animationDuration);
         }
     }
 

--- a/hero-game/style.css
+++ b/hero-game/style.css
@@ -225,17 +225,12 @@ button:disabled {
 /* -------------------------------------------------------------------------- */
 
 /* Define the variables for each class */
-.hero-card.raw-power-mage {
-    --frame-base-image: url('../img/frames/mage-base-texture.png');
-    --frame-inlay-image: url('../img/frames/mage-runic-inlay.png');
-    --title-plate-image: url('../img/frames/mage-title-plate.png');
-}
 
-.hero-card.stalwart-defender {
-    --frame-base-image: url('../img/frames/warrior-base-metal.png');
-    --frame-inlay-image: url('../img/frames/warrior-forged-inlay.png');
-    --title-plate-image: url('../img/frames/warrior-title-plate.png');
-}
+
+/* Remove frame image references to avoid 404 errors */
+.hero-card.raw-power-mage {}
+
+.hero-card.stalwart-defender {}
 
 /* Additional hero class themes can be added here */
 


### PR DESCRIPTION
## Summary
- refactor upgrade swap logic away from animation listeners
- show a popup before returning to tournament
- update main callback to use new popup
- remove placeholder frame assets and drop CSS references

## Testing
- `npm test` *(fails: Could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6854420660f08327a0c481a079a6cef2