### PR TITLE
Implement Upgrade Scene phase 1 redesign

### DIFF
--- a/hero-game/index.html
+++ b/hero-game/index.html
@@ -139,35 +139,52 @@
 
     <!-- Post-battle upgrade scene -->
     <div id="upgrade-scene" class="scene hidden">
-        <header class="text-center mb-6">
-            <h1 class="text-5xl font-cinzel tracking-wider">Choose an Upgrade</h1>
-            <p id="upgrade-instructions" class="text-lg text-gray-400 mt-2">Select a reward then replace a matching item.</p>
-        </header>
-        <div id="upgrade-pack-container" class="package-wrapper mb-6">
-            <div id="upgrade-package" class="package flex flex-col rounded-lg">
-                <div id="upgrade-top-crimp" class="crimp h-6 rounded-t-lg"></div>
-                <div id="upgrade-image-area" class="image-area flex-grow flex items-center justify-center">
-                    <img id="upgrade-pack-img" src="img/ability_booster.png" alt="bonus booster pack" class="booster-pack-image w-[320px] h-auto" draggable="false" />
-                </div>
-                <div class="crimp h-6 rounded-b-lg"></div>
-            </div>
-        </div>
-        <div id="upgrade-reveal-area" class="hidden"></div>
-        <div id="reveal-actions" class="mt-4 flex gap-4 hidden">
-            <button id="take-card-btn" class="action-btn">Take Card</button>
-            <button id="dismiss-card-btn" class="action-btn">Dismiss</button>
-        </div>
-        <div id="upgrade-team-roster" class="flex flex-col lg:flex-row gap-4 mt-8"></div>
-        <div id="upgrade-confirm-modal" class="modal hidden">
-            <div class="modal-backdrop">
-                <div class="modal-content">
-                    <p class="mb-4">Replace this item with the selected card?</p>
-                    <div class="flex gap-4 justify-end">
-                        <button id="upgrade-confirm-yes" class="confirm-button">Confirm</button>
-                        <button id="upgrade-confirm-no" class="secondary-button">Cancel</button>
+        <!-- STAGE 1: Pack Opening -->
+        <div id="upgrade-stage-pack" class="w-full h-full flex flex-col items-center justify-center">
+            <header class="text-center mb-6">
+                <h1 class="text-5xl font-cinzel tracking-wider">A Reward!</h1>
+                <p id="upgrade-pack-instructions" class="text-lg text-gray-400 mt-2">Click the pack to reveal your bonus card.</p>
+            </header>
+            <div id="upgrade-pack-container" class="package-wrapper">
+                <div id="upgrade-package" class="package flex flex-col rounded-lg">
+                    <div id="upgrade-top-crimp" class="crimp h-6 rounded-t-lg"></div>
+                    <div id="upgrade-image-area" class="image-area flex-grow flex items-center justify-center">
+                        <img id="upgrade-pack-img" src="img/ability_booster.png" alt="bonus booster pack" class="booster-pack-image w-[320px] h-auto" draggable="false" />
                     </div>
+                    <div class="crimp h-6 rounded-b-lg"></div>
                 </div>
             </div>
+        </div>
+
+        <!-- STAGE 2: Card Reveal & Choice -->
+        <div id="upgrade-stage-reveal" class="w-full h-full flex flex-col items-center justify-center hidden">
+            <header class="text-center mb-6">
+                <h1 class="text-5xl font-cinzel tracking-wider">Choose Your Upgrade</h1>
+                <p id="upgrade-reveal-instructions" class="text-lg text-gray-400 mt-2">Take the card to upgrade your team, or dismiss it.</p>
+            </header>
+            <div id="upgrade-reveal-area" class="mb-4">
+                <!-- The revealed card will be injected here by JS -->
+            </div>
+            <div id="reveal-actions" class="flex gap-4">
+                <button id="take-card-btn" class="action-btn">Take Card</button>
+                <button id="dismiss-card-btn" class="action-btn">Dismiss</button>
+            </div>
+        </div>
+
+        <!-- STAGE 3: Champion & Socket Selection -->
+        <div id="upgrade-stage-champions" class="w-full h-full flex flex-col items-center justify-center hidden">
+             <header class="text-center mb-6">
+                <h1 class="text-5xl font-cinzel tracking-wider">Equip Your Upgrade</h1>
+                <p id="upgrade-champions-instructions" class="text-lg text-gray-400 mt-2">Select a highlighted slot to equip your new item.</p>
+            </header>
+            <div id="upgrade-team-roster" class="flex flex-col lg:flex-row gap-8 mt-8">
+                <!-- Champion cards will be injected here by JS -->
+            </div>
+        </div>
+
+        <!-- MODAL (No longer used for confirmation, can be removed or kept for future use) -->
+        <div id="upgrade-confirm-modal" class="modal hidden">
+            <!-- Content of the modal can be left as is for now -->
         </div>
     </div>
 

--- a/hero-game/js/scenes/UpgradeScene.js
+++ b/hero-game/js/scenes/UpgradeScene.js
@@ -1,282 +1,164 @@
 import { createDetailCard } from '../ui/CardRenderer.js';
 import { allPossibleHeroes, allPossibleWeapons, allPossibleArmors, allPossibleAbilities } from '../data.js';
 
-const tooltipEl = document.getElementById('item-tooltip');
-const tooltipNameEl = document.getElementById('tooltip-name');
-const tooltipStatsEl = document.getElementById('tooltip-stats');
-const tooltipEffectEl = document.getElementById('tooltip-effect');
-
 export class UpgradeScene {
     constructor(element, onComplete) {
         this.element = element;
         this.onComplete = onComplete;
 
-        this.packEl = element.querySelector('#upgrade-package');
-        this.topCrimp = element.querySelector('#upgrade-top-crimp');
-        this.imageArea = element.querySelector('#upgrade-image-area');
+        // Get references to the new stage containers
+        this.packStage = element.querySelector('#upgrade-stage-pack');
+        this.revealStage = element.querySelector('#upgrade-stage-reveal');
+        this.championsStage = element.querySelector('#upgrade-stage-champions');
+
+        // References to interactive elements
+        this.packContainer = element.querySelector('#upgrade-pack-container');
         this.revealArea = element.querySelector('#upgrade-reveal-area');
-        this.actionContainer = element.querySelector('#reveal-actions');
+        this.teamRoster = element.querySelector('#upgrade-team-roster');
         this.takeButton = element.querySelector('#take-card-btn');
         this.dismissButton = element.querySelector('#dismiss-card-btn');
-        this.teamRoster = element.querySelector('#upgrade-team-roster');
-        this.confirmModal = element.querySelector('#upgrade-confirm-modal');
-        this.instructionsEl = element.querySelector('#upgrade-instructions');
 
-        if (this.packEl) {
-            this.packEl.addEventListener('click', () => this.handlePackOpen());
-            this.packEl.addEventListener('mousemove', e => this.handleMouseMove(e));
-            this.packEl.addEventListener('mouseleave', () => this.handleMouseLeave());
+        // State management for the new flow
+        this.phase = 'PACK'; // PACK, REVEAL, EQUIP
+        this.packContents = [];
+        this.currentCardIndex = 0;
+        this.lockedCard = null;
+
+        // Bind event listeners
+        if (this.packContainer) {
+            this.packContainer.addEventListener('click', () => this.handlePackOpen());
         }
         if (this.takeButton) {
-            this.takeButton.addEventListener('click', () => {
-                console.log('Take Card button clicked.');
-                this.handleTakeCard();
-            });
+            this.takeButton.addEventListener('click', () => this.handleTakeCard());
         }
-        // dismissButton's handler is assigned dynamically in revealNextCard
-
-        if (this.confirmModal) {
-            this.confirmYes = this.confirmModal.querySelector('#upgrade-confirm-yes');
-            this.confirmNo = this.confirmModal.querySelector('#upgrade-confirm-no');
-            this.confirmYes.addEventListener('click', () => {
-                this.confirmModal.classList.add('hidden');
-                this.executeSwap();
-            });
-            this.confirmNo.addEventListener('click', () => {
-                this.confirmModal.classList.add('hidden');
-                this.pendingSlot = null;
-                this.updateTargetableSockets();
-            });
+        if (this.dismissButton) {
+            this.dismissButton.addEventListener('click', () => this.handleDismissCard());
         }
     }
+
+    // --- Core Flow Methods ---
 
     render(packContents, playerTeam) {
         this.packContents = packContents;
-        this.revealedCards = [];
+        this.playerTeam = playerTeam;
         this.currentCardIndex = 0;
+        this.lockedCard = null;
         this.phase = 'PACK';
-        this.selectedCard = null;
-        this.pendingSlot = null;
-        if (this.instructionsEl) {
-            this.instructionsEl.textContent = 'Click the pack to reveal your reward cards.';
-        }
-
-        if (this.topCrimp) {
-            this.topCrimp.classList.remove('torn-off');
-            this.topCrimp.style.pointerEvents = 'auto';
-        }
-        if (this.packEl) {
-            this.packEl.classList.remove('is-open', 'hidden');
-        }
-        if (this.revealArea) {
-            this.revealArea.classList.add('hidden');
-            this.revealArea.innerHTML = '';
-        }
-        if (this.actionContainer) this.actionContainer.classList.add('hidden');
-        if (this.confirmModal) this.confirmModal.classList.add('hidden');
-
-        this.renderTeam(playerTeam);
+        
+        // Reset to the initial state: only the pack is visible
+        this.packStage.classList.remove('upgrade-stage-hidden');
+        this.revealStage.classList.add('upgrade-stage-hidden');
+        this.championsStage.classList.add('upgrade-stage-hidden');
     }
 
     handlePackOpen() {
-        if (this.phase !== 'PACK' || this.isOpening) return;
-        this.isOpening = true;
-        this.topCrimp.classList.add('torn-off');
-        this.topCrimp.style.pointerEvents = 'none';
-        this.topCrimp.addEventListener('animationend', () => {
-            this.packEl.classList.add('is-open');
-            setTimeout(() => {
-                this.packEl.classList.add('hidden');
-                this.revealArea.classList.remove('hidden');
-                this.phase = 'REVEAL';
-                if (this.instructionsEl) {
-                    this.instructionsEl.textContent = 'Take the card or dismiss it.';
-                }
-                this.revealNextCard();
-            }, 100);
-        }, { once: true });
-    }
+        if (this.phase !== 'PACK') return;
+        this.phase = 'REVEAL';
 
-    handleMouseMove(e) {
-        if (!this.packEl) return;
-        const rect = this.packEl.getBoundingClientRect();
-        const x = e.clientX - rect.left - rect.width / 2;
-        const y = e.clientY - rect.top - rect.height / 2;
-        const maxTilt = 10;
-        const rotateY = (x / (rect.width / 2)) * maxTilt;
-        const rotateX = (y / (rect.height / 2)) * -maxTilt;
-        this.packEl.style.transform = `rotateX(${rotateX}deg) rotateY(${rotateY}deg)`;
-        this.imageArea.style.setProperty('--glare-x', `${(e.clientX - rect.left) * 100 / rect.width}%`);
-        this.imageArea.style.setProperty('--glare-y', `${(e.clientY - rect.top) * 100 / rect.height}%`);
-        this.imageArea.style.setProperty('--glare-opacity', '1');
-    }
-
-    handleMouseLeave() {
-        if (!this.packEl) return;
-        this.packEl.style.transform = 'rotateX(0deg) rotateY(0deg)';
-        this.imageArea.style.setProperty('--glare-opacity', '0');
+        // Animate pack out, reveal stage in
+        this.packStage.classList.add('upgrade-stage-hidden');
+        setTimeout(() => {
+            this.revealStage.classList.remove('upgrade-stage-hidden');
+            this.revealNextCard();
+        }, 500); // Wait for fade out animation
     }
 
     revealNextCard() {
         if (this.currentCardIndex >= this.packContents.length) {
-            this.onComplete();
+            // No more cards, end the scene
+            this.onComplete(null, null); // Pass null to indicate no upgrade was chosen
             return;
         }
+
+        const cardData = this.packContents[this.currentCardIndex];
         this.revealArea.innerHTML = '';
-        const remaining = this.packContents.slice(this.currentCardIndex);
-        const stack = remaining.slice().reverse();
-        stack.forEach((card, idx) => {
-            const wrapper = document.createElement('div');
-            wrapper.className = 'revealed-card bonus-card';
-            const rotation = (idx - 1) * 5;
-            const yOffset = Math.abs(idx - 1) * 20;
-            wrapper.style.transform = `rotate(${rotation}deg) translateY(${yOffset}px) translateZ(${idx * -20}px)`;
-            wrapper.style.zIndex = idx;
-            if (idx === stack.length - 1) {
-                const face = document.createElement('div');
-                face.className = 'card-face';
-                face.appendChild(createDetailCard(card));
-                wrapper.appendChild(face);
-                wrapper.addEventListener('click', () => this.handleBonusCardSelect(wrapper, card));
-            } else {
-                wrapper.classList.add('card-back-unrevealed');
-                const rarity = (card.rarity || 'common').toLowerCase();
-                if (rarity === 'rare') wrapper.classList.add('pre-reveal-rare');
-                else if (rarity === 'epic') wrapper.classList.add('pre-reveal-epic');
-            }
-            this.revealArea.appendChild(wrapper);
-        });
-        if (this.actionContainer) this.actionContainer.classList.remove('hidden');
-        if (this.instructionsEl) {
-            this.instructionsEl.textContent = 'Take the card or dismiss it.';
-        }
-        if (this.dismissButton) {
-            this.dismissButton.onclick = null;
-            if (this.currentCardIndex === this.packContents.length - 1) {
-                this.dismissButton.textContent = 'Skip';
-                this.dismissButton.onclick = () => {
-                    console.log('Skip button clicked.');
-                    this.skipUpgrade();
-                };
-            } else {
-                this.dismissButton.textContent = 'Dismiss';
-                this.dismissButton.onclick = () => {
-                    console.log('Dismiss button clicked.');
-                    this.handleDismissCard();
-                };
-            }
-        }
-    }
-
-    clearSelections() {
-        this.element.querySelectorAll('.bonus-card.selected').forEach(el => el.classList.remove('selected'));
-        this.selectedCard = null;
-        this.element.querySelectorAll('.equipment-socket, .champion-display').forEach(el => {
-            el.classList.remove('targetable', 'disabled');
-        });
-    }
-
-    handleBonusCardSelect(cardEl, cardData) {
-        if (cardEl.classList.contains('selected')) {
-            this.clearSelections();
-            this.phase = 'REVEAL';
-            if (this.actionContainer) this.actionContainer.classList.remove('hidden');
-            if (this.instructionsEl) {
-                this.instructionsEl.textContent = 'Take the card or dismiss it.';
-            }
-            return;
-        }
-        this.clearSelections();
-        this.phase = 'REPLACEMENT';
-        this.selectedCard = cardData;
-        cardEl.classList.add('selected');
-        if (this.actionContainer) this.actionContainer.classList.add('hidden');
-        if (this.instructionsEl) {
-            this.instructionsEl.textContent = 'Select an item to replace.';
-        }
-        this.updateTargetableSockets();
+        const cardElement = createDetailCard(cardData);
+        this.revealArea.appendChild(cardElement);
     }
 
     handleTakeCard() {
         if (this.phase !== 'REVEAL') return;
-        const cardEl = this.revealArea.querySelector('.bonus-card:last-child');
-        const cardData = this.packContents[this.currentCardIndex];
-        if (cardEl) {
-            this.handleBonusCardSelect(cardEl, cardData);
-        }
-    }
+        this.phase = 'EQUIP';
+        this.lockedCard = this.packContents[this.currentCardIndex];
 
+        // Animate reveal stage out
+        this.revealStage.classList.add('upgrade-stage-hidden');
+        
+        // Render and animate champions stage in
+        setTimeout(() => {
+            this.renderTeamForEquip();
+            this.championsStage.classList.remove('upgrade-stage-hidden');
+        }, 500);
+    }
+    
     handleDismissCard() {
         if (this.phase !== 'REVEAL') return;
-        this.clearSelections();
-        const card = this.revealArea.querySelector('.revealed-card:last-child');
-        if (card) {
-            card.classList.add('is-dismissed');
-            card.addEventListener('transitionend', () => {
-                this.currentCardIndex++;
-                if (this.currentCardIndex >= this.packContents.length) {
-                    this.onComplete();
-                } else {
-                    this.revealNextCard();
-                }
-            }, { once: true });
-        } else {
-            this.currentCardIndex++;
-            if (this.currentCardIndex >= this.packContents.length) {
-                this.onComplete();
-            } else {
-                this.revealNextCard();
-            }
+        this.currentCardIndex++;
+        this.revealNextCard();
+    }
+
+    // This is the final step, triggered by clicking a socket
+    handleSocketSelect(slotKey) {
+        if (this.phase !== 'EQUIP' || !this.lockedCard) return;
+
+        // Check if the clicked slot type matches the locked card type
+        const expectedType = this.lockedCard.type;
+        if (!slotKey.startsWith(expectedType)) {
+            console.warn(`Invalid slot selected. Expected ${expectedType}, got ${slotKey}`);
+            return;
         }
+
+        // Immediately call onComplete with the final choice
+        this.onComplete(slotKey, this.lockedCard.id);
     }
 
-    skipUpgrade() {
-        this.onComplete();
-    }
+    // --- Helper & Rendering Methods ---
 
-    renderTeam(team) {
+    renderTeamForEquip() {
         this.teamRoster.innerHTML = '';
-        [1,2].forEach(num => {
-            const heroId = team[`hero${num}`];
+        if (!this.playerTeam || !this.lockedCard) return;
+
+        [1, 2].forEach(num => {
+            const heroId = this.playerTeam[`hero${num}`];
             if (!heroId) return;
+
             const heroData = { ...allPossibleHeroes.find(h => h.id === heroId) };
-            const ability = allPossibleAbilities.find(a => a.id === team[`ability${num}`]);
-            const weapon = allPossibleWeapons.find(w => w.id === team[`weapon${num}`]);
-            const armor = allPossibleArmors.find(a => a.id === team[`armor${num}`]);
-            if (ability) heroData.abilities = [ability];
-
-            const container = document.createElement('div');
-            container.className = 'champion-display';
-            container.dataset.slot = `hero${num}`;
-            container.dataset.type = 'hero';
-
-            const cardElem = createDetailCard(heroData);
-            const heroCard = cardElem.querySelector('.hero-card');
-            heroCard.addEventListener('click', () => this.handleSocketSelect(`hero${num}`));
-            heroCard.addEventListener('mouseover', e => this.showTooltip(e, heroData));
-            heroCard.addEventListener('mouseout', () => this.hideTooltip());
-            container.appendChild(cardElem);
-
-            const abilitySocket = this.createSocket(ability, `ability${num}`, 'ability-socket');
-            if (abilitySocket) {
-                abilitySocket.addEventListener('mouseover', e => ability && this.showTooltip(e, ability));
-                abilitySocket.addEventListener('mouseout', () => this.hideTooltip());
-                container.appendChild(abilitySocket);
-            }
-            const weaponSocket = this.createSocket(weapon, `weapon${num}`, 'weapon-socket');
-            if (weaponSocket) {
-                weaponSocket.addEventListener('mouseover', e => weapon && this.showTooltip(e, weapon));
-                weaponSocket.addEventListener('mouseout', () => this.hideTooltip());
-                container.appendChild(weaponSocket);
-            }
-            const armorSocket = this.createSocket(armor, `armor${num}`, 'armor-socket');
-            if (armorSocket) {
-                armorSocket.addEventListener('mouseover', e => armor && this.showTooltip(e, armor));
-                armorSocket.addEventListener('mouseout', () => this.hideTooltip());
-                container.appendChild(armorSocket);
-            }
-            this.teamRoster.appendChild(container);
+            const championContainer = this.createChampionDisplay(heroData, num);
+            
+            // Highlight the correct sockets
+            championContainer.querySelectorAll('.equipment-socket').forEach(socket => {
+                if (socket.dataset.type === this.lockedCard.type) {
+                    socket.classList.add('targetable');
+                }
+            });
+            
+            this.teamRoster.appendChild(championContainer);
         });
+    }
+
+    createChampionDisplay(heroData, num) {
+        const ability = allPossibleAbilities.find(a => a.id === this.playerTeam[`ability${num}`]);
+        const weapon = allPossibleWeapons.find(w => w.id === this.playerTeam[`weapon${num}`]);
+        const armor = allPossibleArmors.find(a => a.id === this.playerTeam[`armor${num}`]);
+        if (ability) heroData.abilities = [ability];
+
+        const container = document.createElement('div');
+        container.className = 'champion-display';
+        container.dataset.slot = `hero${num}`;
+        container.dataset.type = 'hero';
+
+        const cardElem = createDetailCard(heroData);
+        container.appendChild(cardElem);
+
+        const abilitySocket = this.createSocket(ability, `ability${num}`, 'ability-socket');
+        const weaponSocket = this.createSocket(weapon, `weapon${num}`, 'weapon-socket');
+        const armorSocket = this.createSocket(armor, `armor${num}`, 'armor-socket');
+        
+        container.appendChild(abilitySocket);
+        container.appendChild(weaponSocket);
+        container.appendChild(armorSocket);
+        
+        return container;
     }
 
     createSocket(itemData, slotKey, cssClass) {
@@ -295,102 +177,5 @@ export class UpgradeScene {
             this.handleSocketSelect(slotKey);
         });
         return socket;
-    }
-
-    updateTargetableSockets() {
-        this.element.querySelectorAll('.equipment-socket, .champion-display').forEach(el => {
-            el.classList.remove('targetable', 'disabled');
-        });
-        if (!this.selectedCard) return;
-        const type = this.selectedCard.type;
-        this.element.querySelectorAll('.equipment-socket, .champion-display').forEach(el => {
-            const slotType = el.dataset.type || (el.dataset.slot ? el.dataset.slot.replace(/\d+$/, '') : '');
-            if (slotType === type) {
-                el.classList.add('targetable');
-            } else {
-                el.classList.add('disabled');
-            }
-        });
-    }
-
-    handleSocketSelect(slotKey) {
-        if (this.phase !== 'REPLACEMENT' || !this.selectedCard) return;
-        const expected = this.selectedCard.type;
-        if (!slotKey.startsWith(expected)) return;
-        this.pendingSlot = slotKey;
-        if (this.confirmModal) {
-            this.confirmModal.classList.remove('hidden');
-        } else {
-            this.executeSwap();
-        }
-    }
-
-    executeSwap() {
-        console.log('[executeSwap] Starting swap with new timer-based logic...');
-        if (!this.pendingSlot || !this.selectedCard) {
-            console.error('[executeSwap] Error: pendingSlot or selectedCard is null.');
-            return;
-        }
-
-        const socket = this.element.querySelector(`[data-slot='${this.pendingSlot}']`);
-        if (!socket) {
-            console.error(`[executeSwap] Error: Could not find socket for ${this.pendingSlot}.`);
-            return;
-        }
-
-        const animationDuration = 200; // This must match the duration in style.css (0.2s)
-
-        const finishSwap = () => {
-            console.log('[executeSwap] Finishing swap and calling onComplete.');
-            this.onComplete(this.pendingSlot, this.selectedCard.id);
-            this.clearSelections();
-        };
-
-        const applyNewCard = () => {
-            console.log('[executeSwap] Applying new card art and starting pop-in animation.');
-            socket.style.backgroundImage = `url('${this.selectedCard.art}')`;
-            socket.classList.remove('empty-socket', 'card-pop-out');
-            socket.classList.add('card-pop-in');
-            setTimeout(finishSwap, animationDuration);
-        };
-
-        if (socket.classList.contains('empty-socket')) {
-            console.log('[executeSwap] Socket is empty. Applying new card immediately.');
-            applyNewCard();
-        } else {
-            console.log('[executeSwap] Socket has an item. Starting pop-out animation.');
-            socket.classList.add('card-pop-out');
-            setTimeout(applyNewCard, animationDuration);
-        }
-    }
-
-    showTooltip(event, item) {
-        if (!tooltipEl || !item) return;
-        tooltipNameEl.textContent = item.name || '';
-        tooltipStatsEl.textContent = this.formatStats(item);
-        const effect = item.effect || (item.ability ? item.ability.description || item.ability.effect : '') || (item.class ? `Class: ${item.class}` : '');
-        tooltipEffectEl.textContent = effect;
-        tooltipEl.style.left = `${event.clientX + 12}px`;
-        tooltipEl.style.top = `${event.clientY + 12}px`;
-        tooltipEl.classList.remove('hidden');
-    }
-
-    hideTooltip() {
-        if (tooltipEl) tooltipEl.classList.add('hidden');
-    }
-
-    formatStats(item) {
-        if (item.statBonuses) {
-            return Object.entries(item.statBonuses)
-                .map(([stat, val]) => `${val > 0 ? '+' : ''}${val} ${stat}`)
-                .join(' ');
-        }
-        if (typeof item.energyCost !== 'undefined') {
-            return `${item.energyCost} ENERGY`;
-        }
-        if (typeof item.hp !== 'undefined' && typeof item.attack !== 'undefined') {
-            return `${item.hp} HP  ${item.attack} ATK`;
-        }
-        return '';
     }
 }

--- a/hero-game/style.css
+++ b/hero-game/style.css
@@ -2011,3 +2011,34 @@ button:disabled {
     from { transform: scale(0.8); opacity: 0; }
     to { transform: scale(1); opacity: 1; }
 }
+
+/* Add these new rules to the end of style.css */
+
+/* Generic fade transition for our stage containers */
+.upgrade-stage-transition {
+    transition: opacity 0.5s ease-in-out, transform 0.5s ease-in-out;
+}
+
+.upgrade-stage-hidden {
+    opacity: 0;
+    transform: scale(0.95);
+    pointer-events: none;
+    position: absolute;
+}
+
+/* Ensure the roster animates in smoothly */
+#upgrade-team-roster {
+    transition: opacity 0.5s ease-in-out;
+    opacity: 1;
+}
+
+/* Ensure the sockets are clickable */
+.equipment-socket, .champion-display {
+    position: relative;
+    z-index: 1;
+}
+
+#reveal-actions {
+    position: relative;
+    z-index: 1;
+}


### PR DESCRIPTION
## Summary
- overhaul upgrade-scene HTML structure for new three-stage layout
- append CSS rules for stage transitions and socket interactions
- rewrite `UpgradeScene` JS to handle pack, reveal, and equip phases

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68544f5ec6808327acf6828ff0fee979