### PR TITLE
Fix upgrade scene stage visibility

### DIFF
--- a/hero-game/index.html
+++ b/hero-game/index.html
@@ -157,7 +157,7 @@
         </div>
 
         <!-- STAGE 2: Card Reveal & Choice -->
-        <div id="upgrade-stage-reveal" class="w-full h-full flex flex-col items-center justify-center hidden">
+        <div id="upgrade-stage-reveal" class="w-full h-full flex flex-col items-center justify-center upgrade-stage-transition upgrade-stage-hidden">
             <header class="text-center mb-6">
                 <h1 class="text-5xl font-cinzel tracking-wider">Choose Your Upgrade</h1>
                 <p id="upgrade-reveal-instructions" class="text-lg text-gray-400 mt-2">Take the card to upgrade your team, or dismiss it.</p>
@@ -171,7 +171,7 @@
         </div>
 
         <!-- STAGE 3: Champion & Socket Selection -->
-        <div id="upgrade-stage-champions" class="w-full h-full flex flex-col items-center justify-center hidden">
+        <div id="upgrade-stage-champions" class="w-full h-full flex flex-col items-center justify-center upgrade-stage-transition upgrade-stage-hidden">
              <header class="text-center mb-6">
                 <h1 class="text-5xl font-cinzel tracking-wider">Equip Your Upgrade</h1>
                 <p id="upgrade-champions-instructions" class="text-lg text-gray-400 mt-2">Select a highlighted slot to equip your new item.</p>


### PR DESCRIPTION
## Summary
- use `upgrade-stage-hidden` and `upgrade-stage-transition` classes for the upgrade scene's sub-stages

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685456df6a588327bd4103ec557aa1dd