### PR TITLE
Fix upgrade phase resetting

### DIFF
--- a/hero-game/js/scenes/UpgradeScene.js
+++ b/hero-game/js/scenes/UpgradeScene.js
@@ -36,6 +36,7 @@ export class UpgradeScene {
     // --- Core Flow Methods ---
 
     render(packContents, playerTeam) {
+        this.phase = 'PACK';
         this.packContents = packContents;
         this.playerTeam = playerTeam;
         this.currentCardIndex = 0;


### PR DESCRIPTION
## Summary
- fix upgrade scene state not resetting by setting phase to `PACK` when rendering

## Testing
- `node --version`

------
https://chatgpt.com/codex/tasks/task_e_6854591831348327a6d1a007e9a4b4d2