### PR TITLE
Implement upgrade card counter UI

### DIFF
--- a/hero-game/index.html
+++ b/hero-game/index.html
@@ -161,6 +161,9 @@
             <header class="text-center mb-6">
                 <h1 class="text-5xl font-cinzel tracking-wider">Choose Your Upgrade</h1>
                 <p id="upgrade-reveal-instructions" class="text-lg text-gray-400 mt-2">Take the card to upgrade your team, or dismiss it.</p>
+
+                <div id="upgrade-card-counter" class="flex justify-center gap-3 mt-4">
+                    </div>
             </header>
             <div id="upgrade-reveal-area" class="mb-4">
                 <!-- The revealed card will be injected here by JS -->

--- a/hero-game/js/scenes/UpgradeScene.js
+++ b/hero-game/js/scenes/UpgradeScene.js
@@ -45,6 +45,8 @@ export class UpgradeScene {
         this.packStage.classList.remove('upgrade-stage-hidden');
         this.revealStage.classList.add('upgrade-stage-hidden');
         this.championsStage.classList.add('upgrade-stage-hidden');
+
+        this._updateCardCounter();
     }
 
     handlePackOpen() {
@@ -60,6 +62,7 @@ export class UpgradeScene {
     revealNextCard() {
         this.championsStage.classList.add('upgrade-stage-hidden');
         this.clearSelection();
+        this._updateCardCounter();
         if (this.currentCardIndex >= this.packContents.length) {
             this.onComplete(null, null);
             return;
@@ -141,5 +144,22 @@ export class UpgradeScene {
 
             this.teamRoster.appendChild(championContainer);
         });
+    }
+
+    _updateCardCounter() {
+        const counterElement = this.element.querySelector('#upgrade-card-counter');
+        if (!counterElement) return;
+
+        counterElement.innerHTML = '';
+        const totalCards = this.packContents.length;
+
+        for (let i = 0; i < totalCards; i++) {
+            const pip = document.createElement('div');
+            pip.className = 'card-pip';
+            if (i >= this.currentCardIndex) {
+                pip.classList.add('active');
+            }
+            counterElement.appendChild(pip);
+        }
     }
 }

--- a/hero-game/style.css
+++ b/hero-game/style.css
@@ -1865,6 +1865,13 @@ button:disabled {
     z-index: 1;
 }
 
+
+
+
+
+
+
+
 /* Visual highlight when a reward card is selected */
 #upgrade-reveal-area .hero-card-container.selected .hero-card {
     border-color: #fde047;
@@ -2048,4 +2055,28 @@ button:disabled {
 #reveal-actions {
     position: relative;
     z-index: 1;
+}
+/* --- Upgrade Scene Card Counter --- */
+#upgrade-card-counter {
+    min-height: 32px; /* Ensures layout doesn't shift */
+}
+
+.card-pip {
+    width: 20px;
+    height: 30px;
+    background-color: rgba(75, 85, 99, 0.5); /* Inactive/Used color */
+    border: 1px solid #6b7280;
+    border-radius: 3px;
+    box-shadow: inset 0 0 5px rgba(0,0,0,0.4);
+    transition: all 0.4s ease-in-out;
+    transform: scale(0.9);
+    opacity: 0.5;
+}
+
+.card-pip.active {
+    background-color: #fde047; /* Glowing color for available cards */
+    border-color: #f59e0b;
+    box-shadow: 0 0 10px #f59e0b;
+    transform: scale(1);
+    opacity: 1;
 }


### PR DESCRIPTION
## Summary
- add counter element to upgrade scene
- style card pips for upgrade counter
- update UpgradeScene logic to draw and update pips

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68546d0009688327b15dfb269529ba20