### PR TITLE
Remove margin from upgrade reveal area

### DIFF
--- a/hero-game/style.css
+++ b/hero-game/style.css
@@ -1883,7 +1883,12 @@ button:disabled {
     margin-bottom: 18rem;
 }
 
-#upgrade-reveal-area { display: flex; justify-content: center; align-items: center; position: relative; margin-top: 25rem;}
+#upgrade-reveal-area {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    position: relative;
+}
 
 #upgrade-team-roster {
     display: flex;


### PR DESCRIPTION
## Summary
- delete the `margin-top` on `#upgrade-reveal-area`

## Testing
- `grep -n upgrade-reveal-area hero-game/style.css`

------
https://chatgpt.com/codex/tasks/task_e_685475ce20008327b0b7f6c1a3e4a772