### PR TITLE
Add padding styles for upgrade UI

### DIFF
--- a/hero-game/style.css
+++ b/hero-game/style.css
@@ -1900,6 +1900,7 @@ button:disabled {
 .champion-display {
     width: 320px;
     height: 450px;
+    position: relative;
 }
 
 .equipment-socket {
@@ -2077,4 +2078,18 @@ button:disabled {
     box-shadow: 0 0 10px #f59e0b;
     transform: scale(1);
     opacity: 1;
+}
+
+/* Additional layout adjustments */
+#upgrade-stage-champions {
+    padding-top: 2rem;
+}
+
+#reveal-actions {
+    padding-top: 1rem;
+}
+
+/* Space out champion displays in the upgrade roster */
+#upgrade-team-roster .champion-display {
+    margin-right: 5rem;
 }


### PR DESCRIPTION
## Summary
- style `#upgrade-stage-champions` so the upgrade stage content has space at the top
- add top padding to `#reveal-actions`
- ensure `.champion-display` uses relative positioning
- space champion displays within `#upgrade-team-roster` for better layout

## Testing
- `npm test` *(fails: no `package.json`)*

------
https://chatgpt.com/codex/tasks/task_e_68547657f1bc8327ab77b96673cd4b51