### PR TITLE
Add upgrade screen highlighting and animations

### DIFF
--- a/hero-game/index.html
+++ b/hero-game/index.html
@@ -165,6 +165,8 @@
                 <div id="upgrade-card-counter" class="flex justify-center gap-3 mt-4">
                     </div>
             </header>
+            <div id="upgrade-holding-slot" class="relative w-full h-96 -mt-24">
+            </div>
             <div id="upgrade-reveal-area" class="mb-4">
                 <!-- The revealed card will be injected here by JS -->
             </div>

--- a/hero-game/style.css
+++ b/hero-game/style.css
@@ -2122,3 +2122,48 @@ button:disabled {
 #dismiss-card-btn:hover {
     background-color: #6b7280;
 }
+
+/* --- Upgrade Scene Champion Highlighting --- */
+.champion-display.is-invalid {
+    filter: grayscale(80%) brightness(0.6);
+    transition: filter 0.3s ease-in-out;
+    pointer-events: none;
+}
+
+.champion-display:not(.is-invalid) {
+    transition: transform 0.2s ease-out;
+}
+
+.champion-display:not(.is-invalid):hover {
+    transform: scale(1.03);
+}
+
+/* --- Upgrade Scene Animations & Holding Slot --- */
+#upgrade-holding-slot {
+    pointer-events: none;
+}
+
+#upgrade-holding-slot .hero-card-container {
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%) scale(0.8);
+}
+
+@keyframes card-select-to-hold {
+    to {
+        transform: translateY(-200px) scale(0.8);
+        opacity: 0.8;
+    }
+}
+
+@keyframes card-equip-to-socket {
+    to {
+        transform: var(--card-equip-transform);
+        opacity: 0.5;
+    }
+}
+
+#upgrade-reveal-area .is-selecting {
+    animation: card-select-to-hold 0.5s ease-in-out forwards;
+}


### PR DESCRIPTION
## Summary
- add holding slot container for upgrade scene
- implement animation and highlighting CSS
- animate upgrade card selection & equip flow in JavaScript
- dim invalid champions when they cannot equip a card

## Testing
- `node --check hero-game/js/scenes/UpgradeScene.js`

------
https://chatgpt.com/codex/tasks/task_e_68547b02fa0483279aa3e81908bcb071