### PR TITLE
Add dynamic stat preview on equipment hover

### DIFF
--- a/hero-game/js/scenes/UpgradeScene.js
+++ b/hero-game/js/scenes/UpgradeScene.js
@@ -2,7 +2,7 @@
 
 import { createDetailCard } from '../ui/CardRenderer.js';
 import { createChampionDisplay } from '../ui/ChampionDisplay.js';
-import { allPossibleWeapons, allPossibleArmors, allPossibleHeroes } from '../data.js';
+import { allPossibleWeapons, allPossibleArmors, allPossibleHeroes, allPossibleAbilities } from '../data.js';
 
 export class UpgradeScene {
     constructor(element, onComplete, onDismantle, onReroll) {
@@ -258,6 +258,66 @@ export class UpgradeScene {
         }
     }
 
+    // NEW HELPER METHOD: To update stats for preview
+    _updatePreviewStats(slotKey) {
+        const championNum = slotKey.includes('1') ? 1 : 2;
+        const heroData = allPossibleHeroes.find(h => h.id === this.playerTeam[`hero${championNum}`]);
+        if (!heroData) return;
+
+        const championContainer = this.teamRoster.querySelector(`.champion-display:nth-child(${championNum})`);
+        if (!championContainer) return;
+
+        const newStats = this.selectedCardData.statBonuses || {};
+
+        const itemPool = slotKey.startsWith('weapon') ? allPossibleWeapons : allPossibleArmors;
+        const equippedItem = this.playerTeam[slotKey] ? itemPool.find(i => i.id === this.playerTeam[slotKey]) : null;
+        const oldStats = equippedItem ? equippedItem.statBonuses || {} : {};
+
+        const allStatKeys = [...new Set([...Object.keys(newStats), ...Object.keys(oldStats)])];
+
+        allStatKeys.forEach(statKey => {
+            const diff = (newStats[statKey] || 0) - (oldStats[statKey] || 0);
+
+            if (diff === 0) return;
+
+            let statElement, baseStatValue;
+            if (statKey.toUpperCase() === 'HP') {
+                statElement = championContainer.querySelector('.hp-stat .stat-value');
+                baseStatValue = heroData.hp;
+            } else if (statKey.toUpperCase() === 'ATK') {
+                statElement = championContainer.querySelector('.attack-stat .stat-value');
+                baseStatValue = heroData.attack;
+            }
+
+            if (statElement) {
+                if (!statElement.dataset.originalValue) {
+                    statElement.dataset.originalValue = statElement.textContent;
+                }
+
+                const originalNumericValue = parseInt(statElement.dataset.originalValue);
+                const newDisplayValue = originalNumericValue + diff;
+
+                statElement.textContent = newDisplayValue;
+                statElement.classList.add('stat-updating');
+                statElement.classList.toggle('stat-buff', diff > 0);
+                statElement.classList.toggle('stat-nerf', diff < 0);
+            }
+        });
+    }
+
+    // NEW HELPER METHOD: To revert stats after preview
+    _revertPreviewStats(slotKey) {
+        const championNum = slotKey.includes('1') ? 1 : 2;
+        const championContainer = this.teamRoster.querySelector(`.champion-display:nth-child(${championNum})`);
+        if (!championContainer) return;
+
+        championContainer.querySelectorAll('.stat-value[data-original-value]').forEach(statElement => {
+            statElement.textContent = statElement.dataset.originalValue;
+            statElement.classList.remove('stat-updating', 'stat-buff', 'stat-nerf');
+            delete statElement.dataset.originalValue;
+        });
+    }
+
     renderTeamForEquip() {
         this.teamRoster.innerHTML = '';
         if (!this.playerTeam || !this.selectedCardData) return;
@@ -288,10 +348,17 @@ export class UpgradeScene {
 
             if (isChampionValid) {
                 championContainer.querySelectorAll('.equipment-socket.targetable').forEach(socket => {
-                    socket.addEventListener('mouseover', (e) => this._showComparisonTooltip(e, socket.dataset.slot));
-                    socket.addEventListener('mouseout', () => this._hideComparisonTooltip());
+                    socket.addEventListener('mouseover', (e) => {
+                        this._showComparisonTooltip(e, socket.dataset.slot);
+                        this._updatePreviewStats(socket.dataset.slot);
+                    });
+                    socket.addEventListener('mouseout', () => {
+                        this._hideComparisonTooltip();
+                        this._revertPreviewStats(socket.dataset.slot);
+                    });
                     socket.addEventListener('click', (e) => {
                         e.stopPropagation();
+                        this._revertPreviewStats(socket.dataset.slot);
                         this.handleSocketSelect(socket.dataset.slot);
                     });
                 });

--- a/hero-game/style.css
+++ b/hero-game/style.css
@@ -2167,3 +2167,22 @@ button:disabled {
 #upgrade-reveal-area .is-selecting {
     animation: card-select-to-hold 0.5s ease-in-out forwards;
 }
+
+/* --- Dynamic Stat Update Styles --- */
+.stat-block .stat-value.stat-updating {
+    transition: all 0.2s ease-in-out;
+}
+
+/* Style for a stat that is increasing */
+.stat-block .stat-value.stat-buff {
+    color: #4ade80; /* Bright Green */
+    transform: scale(1.2);
+    text-shadow: 0 0 8px #4ade80;
+}
+
+/* Style for a stat that is decreasing */
+.stat-block .stat-value.stat-nerf {
+    color: #f87171; /* Bright Red */
+    transform: scale(1.2);
+    text-shadow: 0 0 8px #f87171;
+}


### PR DESCRIPTION
## Summary
- style.css: add visual feedback styles for stat changes
- UpgradeScene.js: implement stat preview and revert functions
- UpgradeScene.js: hook preview functions into equipment socket events

## Testing
- `npm test` *(fails: no `package.json`)*

------
https://chatgpt.com/codex/tasks/task_e_685480f5f3688327bd4247c4b336602c