### PR TITLE
Implement fly down equip animation

### DIFF
--- a/hero-game/js/scenes/UpgradeScene.js
+++ b/hero-game/js/scenes/UpgradeScene.js
@@ -172,20 +172,11 @@ export class UpgradeScene {
 
         const holdingSlot = this.element.querySelector('#upgrade-holding-slot');
         const cardToAnimate = holdingSlot.querySelector('.hero-card-container');
-        const targetSocket = document.querySelector(`[data-slot="${slotKey}"]`);
 
-        if (!cardToAnimate || !targetSocket) return;
+        if (!cardToAnimate) return;
 
-        const startRect = cardToAnimate.getBoundingClientRect();
-        const endRect = targetSocket.getBoundingClientRect();
-
-        const deltaX = endRect.left - startRect.left;
-        const deltaY = endRect.top - startRect.top;
-        const scaleX = endRect.width / startRect.width;
-        const scaleY = endRect.height / startRect.height;
-
-        cardToAnimate.style.setProperty('--card-equip-transform', `translate(${deltaX}px, ${deltaY}px) scale(${scaleX}, ${scaleY})`);
-        cardToAnimate.style.animation = `card-equip-to-socket 0.6s ease-in-out forwards`;
+        // Play the simple fly-down animation
+        cardToAnimate.style.animation = 'fly-down-and-shrink 0.5s ease-in forwards';
 
         cardToAnimate.addEventListener('animationend', () => {
             this.onComplete(slotKey, this.selectedCardData.id);

--- a/hero-game/style.css
+++ b/hero-game/style.css
@@ -2167,3 +2167,11 @@ button:disabled {
 #upgrade-reveal-area .is-selecting {
     animation: card-select-to-hold 0.5s ease-in-out forwards;
 }
+
+/* --- New Animation for Equipping Card --- */
+@keyframes fly-down-and-shrink {
+    to {
+        transform: translateY(250px) scale(0);
+        opacity: 0;
+    }
+}


### PR DESCRIPTION
## Summary
- add new `fly-down-and-shrink` animation to CSS
- update card equip logic to use the new animation instead of socket pathing

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685484ae0a948327b3e67066cbe3469c