### PR TITLE
Add debug menu for quick scene navigation

### DIFF
--- a/hero-game/index.html
+++ b/hero-game/index.html
@@ -287,6 +287,15 @@
         </div>
     </div>
 
+    <!-- ======== DEBUG MENU START ======== -->
+    <div id="debug-menu">
+        <h4 class="debug-title">Debug Menu</h4>
+        <button id="debug-skip-to-battle" class="debug-btn">Skip to Battle</button>
+        <button id="debug-skip-to-upgrade-win" class="debug-btn">Simulate Win</button>
+        <button id="debug-skip-to-upgrade-loss" class="debug-btn">Simulate Loss</button>
+    </div>
+    <!-- ======== DEBUG MENU END ======== -->
+
     <script type="module" src="js/main.js"></script>
 
 </body>

--- a/hero-game/js/main.js
+++ b/hero-game/js/main.js
@@ -726,6 +726,60 @@ if (randomHeroButton) {
     randomHeroButton.addEventListener('click', generateSingleRandomHero);
 }
 
+// --- DEBUG MENU LOGIC ---
+const debugSkipToBattleBtn = document.getElementById('debug-skip-to-battle');
+const debugSkipToUpgradeWinBtn = document.getElementById('debug-skip-to-upgrade-win');
+const debugSkipToUpgradeLossBtn = document.getElementById('debug-skip-to-upgrade-loss');
+
+/**
+ * Ensures a random team exists for debugging purposes. If the player hasn't
+ * drafted a team, this function will generate one.
+ */
+function ensurePlayerTeamExists() {
+    if (!gameState.draft.playerTeam.hero1 || !gameState.draft.playerTeam.hero2) {
+        console.log("Debug: No team found. Generating a random team to proceed.");
+        const champion1 = generateRandomChampion();
+        let champion2 = generateRandomChampion();
+        while (champion2.hero === champion1.hero) {
+            champion2 = generateRandomChampion();
+        }
+
+        gameState.draft.playerTeam.hero1 = champion1.hero;
+        gameState.draft.playerTeam.ability1 = champion1.ability;
+        gameState.draft.playerTeam.weapon1 = champion1.weapon;
+        gameState.draft.playerTeam.armor1 = champion1.armor;
+
+        gameState.draft.playerTeam.hero2 = champion2.hero;
+        gameState.draft.playerTeam.ability2 = champion2.ability;
+        gameState.draft.playerTeam.weapon2 = champion2.weapon;
+        gameState.draft.playerTeam.armor2 = champion2.armor;
+    }
+}
+
+if (debugSkipToBattleBtn) {
+    debugSkipToBattleBtn.addEventListener('click', () => {
+        console.log("Debug: Skipping to battle...");
+        generateRandomTeamAndStartBattle();
+    });
+}
+
+if (debugSkipToUpgradeWinBtn) {
+    debugSkipToUpgradeWinBtn.addEventListener('click', () => {
+        console.log("Debug: Simulating battle win...");
+        ensurePlayerTeamExists();
+        handleBattleComplete(true);
+    });
+}
+
+if (debugSkipToUpgradeLossBtn) {
+    debugSkipToUpgradeLossBtn.addEventListener('click', () => {
+        console.log("Debug: Simulating battle loss...");
+        ensurePlayerTeamExists();
+        handleBattleComplete(false);
+    });
+}
+// --- END DEBUG MENU LOGIC ---
+
 // --- INITIALIZE ---
 // Set up the initial scene on page load
 initBackgroundAnimation();

--- a/hero-game/style.css
+++ b/hero-game/style.css
@@ -6,6 +6,7 @@ body {
     overflow-x: hidden;
 }
 
+
 #background-canvas {
     position: fixed;
     top: 0;
@@ -2188,4 +2189,45 @@ button:disabled {
         transform: translateY(250px) scale(0);
         opacity: 0;
     }
+}
+
+/* --- Debug Menu Styles --- */
+#debug-menu {
+    position: fixed;
+    bottom: 1rem;
+    left: 1rem;
+    background-color: rgba(0, 0, 0, 0.7);
+    backdrop-filter: blur(4px);
+    border: 1px solid rgba(255, 255, 255, 0.2);
+    border-radius: 0.5rem;
+    padding: 0.75rem;
+    z-index: 9999;
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+}
+
+.debug-title {
+    color: #fde047;
+    font-family: 'Cinzel', serif;
+    text-align: center;
+    font-size: 1rem;
+    margin-bottom: 0.25rem;
+    border-bottom: 1px solid #4b5563;
+    padding-bottom: 0.25rem;
+}
+
+.debug-btn {
+    background-color: #4b5563;
+    color: white;
+    border: 1px solid #6b7280;
+    padding: 0.25rem 0.5rem;
+    border-radius: 0.25rem;
+    font-size: 0.8rem;
+    cursor: pointer;
+    transition: background-color 0.2s;
+}
+
+.debug-btn:hover {
+    background-color: #6b7280;
 }


### PR DESCRIPTION
## Summary
- add debug menu panel to the HTML
- style the debug panel
- implement skip-to-battle and simulate victory/defeat logic

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68548fb9dafc83279cf8ee57db459c19