### PR TITLE
Refactor item tooltip positioning

### DIFF
--- a/hero-game/js/scenes/UpgradeScene.js
+++ b/hero-game/js/scenes/UpgradeScene.js
@@ -221,17 +221,15 @@ export class UpgradeScene {
         // === END: FIX FOR DUPLICATE CARD ===
     }
 
-    _updateTooltipPosition(event) {
-        const tooltipElement = document.getElementById('item-tooltip');
-        if (!tooltipElement) return;
-
-        tooltipElement.style.left = `${event.clientX + 15}px`;
-        tooltipElement.style.top = `${event.clientY + 15}px`;
-    }
 
     _showComparisonTooltip(event, slotKey) {
         const tooltipElement = document.getElementById('item-tooltip');
         if (!tooltipElement || !this.selectedCardData) return;
+
+        const championDisplay = event.currentTarget.closest('.champion-display');
+        if (!championDisplay) return;
+
+        championDisplay.appendChild(tooltipElement);
 
         const newStats = this.selectedCardData.statBonuses || {};
 
@@ -259,12 +257,13 @@ export class UpgradeScene {
 
         tooltipElement.innerHTML = comparisonHtml;
         tooltipElement.classList.remove('hidden');
-        this._updateTooltipPosition(event);
+        tooltipElement.classList.add('is-visible');
     }
 
     _hideComparisonTooltip() {
         const tooltipElement = document.getElementById('item-tooltip');
         if (tooltipElement) {
+            tooltipElement.classList.remove('is-visible');
             tooltipElement.classList.add('hidden');
         }
     }
@@ -300,7 +299,6 @@ export class UpgradeScene {
             if (isChampionValid) {
                 championContainer.querySelectorAll('.equipment-socket.targetable').forEach(socket => {
                     socket.addEventListener('mouseover', (e) => this._showComparisonTooltip(e, socket.dataset.slot));
-                    socket.addEventListener('mousemove', (e) => this._updateTooltipPosition(e));
                     socket.addEventListener('mouseout', () => this._hideComparisonTooltip());
                     socket.addEventListener('click', (e) => {
                         e.stopPropagation();

--- a/hero-game/style.css
+++ b/hero-game/style.css
@@ -606,11 +606,21 @@ button:disabled {
 /* Tooltip for equipped items */
 #item-tooltip {
     pointer-events: none;
-    opacity: 0;
+    position: absolute;
+    top: 50px;
+    left: 100%;
+    margin-left: 1rem;
+    z-index: 100;
+    display: none;
+    padding: 0.75rem;
+    border-radius: 0.5rem;
+    background: #1f2937;
+    border: 1px solid #4b5563;
+    max-width: 20rem; /* Matches Tailwind's max-w-xs */
     transition: opacity 0.1s ease;
 }
-#item-tooltip:not(.hidden) {
-    opacity: 1;
+#item-tooltip.is-visible {
+    display: block;
 }
 
 /* --- Evolution Banner Styles --- */


### PR DESCRIPTION
## Summary
- style `.champion-display` has relative positioning already
- move item tooltip positioning logic to CSS
- update tooltip JS to toggle visibility class and attach tooltip to the champion card
- drop mousemove listeners and dead `_updateTooltipPosition` function

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6854949070bc8327aafa4993e11e88dd