### PR TITLE
Implement scene manager for React app

### DIFF
--- a/auto-battler-react/src/App.jsx
+++ b/auto-battler-react/src/App.jsx
@@ -1,35 +1,20 @@
-import { useState } from 'react'
-import reactLogo from './assets/react.svg'
-import viteLogo from '/vite.svg'
-import './App.css'
+import React from 'react';
+import PackScene from './PackScene';
+import DraftScene from './DraftScene';
+import BattleScene from './BattleScene';
+import { useGameStore } from './store';
+import './style.css';
 
-function App() {
-  const [count, setCount] = useState(0)
+export default function App() {
+  const gamePhase = useGameStore((state) => state.gamePhase);
 
-  return (
-    <>
-      <div>
-        <a href="https://vite.dev" target="_blank">
-          <img src={viteLogo} className="logo" alt="Vite logo" />
-        </a>
-        <a href="https://react.dev" target="_blank">
-          <img src={reactLogo} className="logo react" alt="React logo" />
-        </a>
-      </div>
-      <h1>Vite + React</h1>
-      <div className="card">
-        <button onClick={() => setCount((count) => count + 1)}>
-          count is {count}
-        </button>
-        <p>
-          Edit <code>src/App.jsx</code> and save to test HMR
-        </p>
-      </div>
-      <p className="read-the-docs">
-        Click on the Vite and React logos to learn more
-      </p>
-    </>
-  )
+  switch (gamePhase) {
+    case 'BATTLE':
+      return <BattleScene />;
+    case 'DRAFT':
+      return <DraftScene />;
+    case 'PACK':
+    default:
+      return <PackScene />;
+  }
 }
-
-export default App

--- a/auto-battler-react/src/BattleScene.jsx
+++ b/auto-battler-react/src/BattleScene.jsx
@@ -1,0 +1,9 @@
+import React from 'react';
+
+export default function BattleScene() {
+  return (
+    <div className="scene">
+      <h2>Battle Scene</h2>
+    </div>
+  );
+}

--- a/auto-battler-react/src/DraftScene.jsx
+++ b/auto-battler-react/src/DraftScene.jsx
@@ -1,0 +1,9 @@
+import React from 'react';
+
+export default function DraftScene() {
+  return (
+    <div className="scene">
+      <h2>Draft Scene</h2>
+    </div>
+  );
+}

--- a/auto-battler-react/src/PackScene.jsx
+++ b/auto-battler-react/src/PackScene.jsx
@@ -1,0 +1,9 @@
+import React from 'react';
+
+export default function PackScene() {
+  return (
+    <div className="scene">
+      <h2>Pack Scene</h2>
+    </div>
+  );
+}

--- a/auto-battler-react/src/store.js
+++ b/auto-battler-react/src/store.js
@@ -1,0 +1,6 @@
+import { create } from 'zustand';
+
+export const useGameStore = create((set) => ({
+  gamePhase: 'PACK',
+  setGamePhase: (phase) => set({ gamePhase: phase }),
+}));


### PR DESCRIPTION
## Summary
- implement `App` component as scene manager
- add zustand store for game phase
- create placeholder Pack, Draft, and Battle scenes

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68556eed6f548327b2039960a544c0a8