### PR TITLE
Add React UpgradeScene component

### DIFF
--- a/auto-battler-react/src/App.jsx
+++ b/auto-battler-react/src/App.jsx
@@ -1,35 +1,11 @@
-import { useState } from 'react'
-import reactLogo from './assets/react.svg'
-import viteLogo from '/vite.svg'
-import './App.css'
+import UpgradeScene from './scenes/UpgradeScene.jsx';
+import './App.css';
 
-function App() {
-  const [count, setCount] = useState(0)
-
+export default function App() {
   return (
-    <>
-      <div>
-        <a href="https://vite.dev" target="_blank">
-          <img src={viteLogo} className="logo" alt="Vite logo" />
-        </a>
-        <a href="https://react.dev" target="_blank">
-          <img src={reactLogo} className="logo react" alt="React logo" />
-        </a>
-      </div>
-      <h1>Vite + React</h1>
-      <div className="card">
-        <button onClick={() => setCount((count) => count + 1)}>
-          count is {count}
-        </button>
-        <p>
-          Edit <code>src/App.jsx</code> and save to test HMR
-        </p>
-      </div>
-      <p className="read-the-docs">
-        Click on the Vite and React logos to learn more
-      </p>
-    </>
-  )
+    <div className="app">
+      <h1>Upgrade Scene Demo</h1>
+      <UpgradeScene />
+    </div>
+  );
 }
-
-export default App

--- a/auto-battler-react/src/components/Card.jsx
+++ b/auto-battler-react/src/components/Card.jsx
@@ -1,0 +1,13 @@
+import React from 'react';
+
+export default function Card({ item, view = 'detail' }) {
+  if (!item) return null;
+  return (
+    <div className={`card ${view}`} style={{ border: '1px solid white', padding: '0.5rem', margin: '0.5rem' }}>
+      <h3>{item.name}</h3>
+      <p>Type: {item.type}</p>
+      {item.class && <p>Class: {item.class}</p>}
+      <p>Rarity: {item.rarity}</p>
+    </div>
+  );
+}

--- a/auto-battler-react/src/components/ChampionDisplay.jsx
+++ b/auto-battler-react/src/components/ChampionDisplay.jsx
@@ -1,0 +1,33 @@
+import React from 'react';
+import {
+  allPossibleHeroes,
+  allPossibleAbilities,
+  allPossibleWeapons,
+  allPossibleArmors,
+} from '../data/data.js';
+
+export default function ChampionDisplay({ number, champion, validSlots = [], onSelectSlot }) {
+  const hero = allPossibleHeroes.find((h) => h.id === champion.hero);
+  const ability = allPossibleAbilities.find((a) => a.id === champion.ability);
+  const weapon = allPossibleWeapons.find((w) => w.id === champion.weapon);
+  const armor = allPossibleArmors.find((a) => a.id === champion.armor);
+
+  const slotButton = (slotKey, label, item) => (
+    <button
+      onClick={() => onSelectSlot(slotKey)}
+      disabled={!validSlots.includes(slotKey)}
+      style={{ marginRight: '0.5rem', opacity: validSlots.includes(slotKey) ? 1 : 0.5 }}
+    >
+      {item ? item.name : `Empty ${label}`}
+    </button>
+  );
+
+  return (
+    <div style={{ border: '1px dashed gray', padding: '0.5rem', marginBottom: '0.5rem' }}>
+      <div>{hero ? hero.name : 'Unknown Hero'}</div>
+      {slotButton(`ability${number}`, 'Ability', ability)}
+      {slotButton(`weapon${number}`, 'Weapon', weapon)}
+      {slotButton(`armor${number}`, 'Armor', armor)}
+    </div>
+  );
+}

--- a/auto-battler-react/src/scenes/UpgradeScene.jsx
+++ b/auto-battler-react/src/scenes/UpgradeScene.jsx
@@ -1,0 +1,113 @@
+import React, { useEffect, useState } from 'react';
+import Card from '../components/Card.jsx';
+import ChampionDisplay from '../components/ChampionDisplay.jsx';
+import { allPossibleHeroes } from '../data/data.js';
+import { useGameStore } from '../store/gameStore.js';
+
+export default function UpgradeScene() {
+  const {
+    playerTeam,
+    inventory,
+    dismantleCard,
+    equipItem,
+    startNextBattle,
+    generateBonusPack,
+  } = useGameStore();
+
+  const [phase, setPhase] = useState('REVEAL');
+  const [pack, setPack] = useState([]);
+  const [index, setIndex] = useState(0);
+
+  useEffect(() => {
+    const bonus = generateBonusPack();
+    setPack(bonus);
+    setIndex(0);
+    setPhase('REVEAL');
+  }, [generateBonusPack]);
+
+  const currentCard = pack[index];
+
+  const nextCard = () => {
+    setIndex((i) => i + 1);
+    setPhase('REVEAL');
+  };
+
+  const handleDismantle = () => {
+    if (!currentCard) return;
+    dismantleCard(currentCard.rarity);
+    nextCard();
+  };
+
+  const handleTake = () => {
+    if (!currentCard) return;
+    setPhase('EQUIP');
+  };
+
+  const computeValidSlots = () => {
+    if (!currentCard) return [];
+    const slots = [];
+    if (currentCard.type === 'weapon' || currentCard.type === 'armor') {
+      slots.push(`${currentCard.type}1`, `${currentCard.type}2`);
+    } else if (currentCard.type === 'ability') {
+      const hero1 = allPossibleHeroes.find((h) => h.id === playerTeam.hero1);
+      const hero2 = allPossibleHeroes.find((h) => h.id === playerTeam.hero2);
+      if (hero1 && hero1.class === currentCard.class) slots.push('ability1');
+      if (hero2 && hero2.class === currentCard.class) slots.push('ability2');
+    }
+    return slots;
+  };
+
+  const validSlots = computeValidSlots();
+
+  const handleEquip = (slotKey) => {
+    equipItem(slotKey, currentCard.id);
+    nextCard();
+    startNextBattle();
+  };
+
+  if (!currentCard) {
+    startNextBattle();
+    return null;
+  }
+
+  return (
+    <div>
+      <div style={{ marginBottom: '0.5rem' }}>
+        <span>Shards: {inventory.shards}</span>{' '}
+        <span>Reroll Tokens: {inventory.rerollTokens}</span>
+      </div>
+      <Card item={currentCard} view="detail" />
+      {phase === 'REVEAL' && (
+        <div>
+          <button onClick={handleTake} style={{ marginRight: '0.5rem' }}>
+            Take
+          </button>
+          <button onClick={handleDismantle}>Dismantle</button>
+        </div>
+      )}
+      {phase === 'EQUIP' && (
+        <div>
+          <p>Choose a slot for this item:</p>
+          {validSlots.length === 0 && (
+            <p>No champion can equip this item. Dismantle instead.</p>
+          )}
+          {[1, 2].map((num) => (
+            <ChampionDisplay
+              key={num}
+              number={num}
+              champion={{
+                hero: playerTeam[`hero${num}`],
+                ability: playerTeam[`ability${num}`],
+                weapon: playerTeam[`weapon${num}`],
+                armor: playerTeam[`armor${num}`],
+              }}
+              validSlots={validSlots.filter((s) => s.endsWith(num))}
+              onSelectSlot={handleEquip}
+            />
+          ))}
+          <button onClick={handleDismantle}>Dismantle</button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/auto-battler-react/src/store/gameStore.js
+++ b/auto-battler-react/src/store/gameStore.js
@@ -1,0 +1,81 @@
+import { create } from 'zustand';
+import {
+  allPossibleHeroes,
+  allPossibleAbilities,
+  allPossibleWeapons,
+  allPossibleArmors,
+} from '../data/data.js';
+
+function getRandom(arr) {
+  return arr[Math.floor(Math.random() * arr.length)];
+}
+
+// Simplified bonus pack generator
+function generateBonusPack(playerHeroes = []) {
+  const heroClasses = playerHeroes
+    .map((id) => allPossibleHeroes.find((h) => h.id === id)?.class)
+    .filter(Boolean);
+
+  const abilityPool = allPossibleAbilities.filter((a) =>
+    heroClasses.includes(a.class)
+  );
+
+  const pack = [];
+  if (abilityPool.length) pack.push(getRandom(abilityPool));
+  pack.push(getRandom(allPossibleWeapons));
+  pack.push(getRandom(allPossibleArmors));
+
+  // Fill remaining slots randomly
+  const generalPool = [
+    ...allPossibleWeapons,
+    ...allPossibleArmors,
+    ...abilityPool,
+  ];
+  while (pack.length < 5) pack.push(getRandom(generalPool));
+
+  return pack;
+}
+
+export const useGameStore = create((set, get) => ({
+  playerTeam: {
+    hero1: null,
+    ability1: null,
+    weapon1: null,
+    armor1: null,
+    hero2: null,
+    ability2: null,
+    weapon2: null,
+    armor2: null,
+  },
+  inventory: { shards: 0, rerollTokens: 0 },
+
+  dismantleCard: (rarity) =>
+    set((state) => {
+      const shardValues = { Common: 1, Uncommon: 3, Rare: 5, Epic: 10 };
+      const gain = shardValues[rarity] ?? 1;
+      return {
+        inventory: {
+          ...state.inventory,
+          shards: state.inventory.shards + gain,
+        },
+      };
+    }),
+
+  equipItem: (slot, itemId) =>
+    set((state) => {
+      const team = { ...state.playerTeam, [slot]: itemId };
+      if (slot.startsWith('hero')) {
+        const idx = slot.endsWith('1') ? '1' : '2';
+        team[`ability${idx}`] = null;
+        team[`weapon${idx}`] = null;
+        team[`armor${idx}`] = null;
+      }
+      return { playerTeam: team };
+    }),
+
+  startNextBattle: () => {
+    console.log('Starting next battle');
+  },
+
+  generateBonusPack: () => generateBonusPack([get().playerTeam.hero1, get().playerTeam.hero2]),
+}));


### PR DESCRIPTION
## Summary
- replace the default App with a simple UpgradeScene demo
- add Zustand-based game store with equip/dismantle logic
- create Card and ChampionDisplay components
- implement UpgradeScene React component to manage item reveal/equip flow

## Testing
- `npm install`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68556f2dea40832785cadbe69c80beb6