### PR TITLE
Implement upgrade flow

### DIFF
--- a/auto-battler-react/src/components/ChampionDisplay.jsx
+++ b/auto-battler-react/src/components/ChampionDisplay.jsx
@@ -1,0 +1,41 @@
+import React from 'react'
+import Card from './Card.jsx'
+import { allPossibleHeroes, allPossibleAbilities, allPossibleWeapons, allPossibleArmors } from '../data/data.js'
+
+export default function ChampionDisplay({ slotData, championNum, targetType = null, valid = true, onSelectSlot }) {
+  const hero = allPossibleHeroes.find(h => h.id === slotData.hero)
+  if (!hero) return null
+  const ability = allPossibleAbilities.find(a => a.id === slotData.ability)
+  const weapon = allPossibleWeapons.find(w => w.id === slotData.weapon)
+  const armor = allPossibleArmors.find(a => a.id === slotData.armor)
+
+  const renderSocket = (item, className, slotKey) => {
+    const type = slotKey.replace(/\d+$/, '')
+    const isTargetable = targetType === type && valid
+    const disabled = targetType && !isTargetable
+    const handleClick = () => {
+      if (isTargetable && onSelectSlot) onSelectSlot(slotKey)
+    }
+    return (
+      <div
+        className={`equipment-socket ${className} ${item ? '' : 'empty-socket'} ${isTargetable ? 'targetable' : ''} ${disabled ? 'disabled' : ''}`}
+        style={item ? { backgroundImage: `url('${item.art}')` } : undefined}
+        onClick={handleClick}
+      >
+        {!item && <i className="fas fa-plus" />}
+      </div>
+    )
+  }
+
+  const heroData = { ...hero }
+  if (ability) heroData.abilities = [ability]
+
+  return (
+    <div className={`champion-display ${!valid ? 'is-invalid' : ''}`}>
+      <Card item={heroData} view="detail" />
+      {renderSocket(ability, 'ability-socket', `ability${championNum}`)}
+      {renderSocket(weapon, 'weapon-socket', `weapon${championNum}`)}
+      {renderSocket(armor, 'armor-socket', `armor${championNum}`)}
+    </div>
+  )
+}

--- a/auto-battler-react/src/scenes/UpgradeScene.jsx
+++ b/auto-battler-react/src/scenes/UpgradeScene.jsx
@@ -1,5 +1,155 @@
-import React from 'react'
+import React, { useEffect, useState } from 'react'
+import Card from '../components/Card.jsx'
+import ChampionDisplay from '../components/ChampionDisplay.jsx'
+import { useGameStore } from '../store.js'
+import {
+  allPossibleWeapons,
+  allPossibleArmors,
+  allPossibleAbilities,
+  allPossibleHeroes
+} from '../data/data.js'
+
+function generateBonusPack(team, wins, didPlayerWin = true) {
+  let allowed
+  if (didPlayerWin) {
+    if (wins <= 1) allowed = ['Common']
+    else if (wins <= 3) allowed = ['Common', 'Uncommon']
+    else if (wins <= 5) allowed = ['Common', 'Uncommon', 'Rare']
+    else allowed = ['Common', 'Uncommon', 'Rare', 'Epic']
+  } else {
+    allowed = ['Common', 'Uncommon']
+  }
+
+  const weaponPool = allPossibleWeapons.filter(w => allowed.includes(w.rarity))
+  const armorPool = allPossibleArmors.filter(a => allowed.includes(a.rarity))
+
+  const hero1 = allPossibleHeroes.find(h => h.id === team.hero1)
+  const hero2 = allPossibleHeroes.find(h => h.id === team.hero2)
+  const classes = [hero1?.class, hero2?.class]
+  const abilityPool = allPossibleAbilities.filter(
+    ab => allowed.includes(ab.rarity) && classes.includes(ab.class)
+  )
+
+  const pack = []
+  if (weaponPool.length) {
+    const i = Math.floor(Math.random() * weaponPool.length)
+    pack.push(weaponPool.splice(i, 1)[0])
+  }
+  if (armorPool.length) {
+    const i = Math.floor(Math.random() * armorPool.length)
+    pack.push(armorPool.splice(i, 1)[0])
+  }
+  if (abilityPool.length) {
+    const i = Math.floor(Math.random() * abilityPool.length)
+    pack.push(abilityPool.splice(i, 1)[0])
+  }
+  if (didPlayerWin) {
+    const general = [...weaponPool, ...armorPool, ...abilityPool].sort(
+      () => 0.5 - Math.random()
+    )
+    while (pack.length < 6 && general.length) pack.push(general.shift())
+  }
+  return [...pack].sort(() => 0.5 - Math.random())
+}
 
 export default function UpgradeScene() {
-  return <div>Upgrade Scene</div>
+  const {
+    playerTeam,
+    tournament,
+    inventory,
+    dismantleCard,
+    advanceGamePhase,
+    equipItem
+  } = useGameStore(state => ({
+    playerTeam: state.playerTeam,
+    tournament: state.tournament,
+    inventory: state.inventory,
+    dismantleCard: state.dismantleCard,
+    advanceGamePhase: state.advanceGamePhase,
+    equipItem: state.equipItem
+  }))
+
+  const [pack, setPack] = useState([])
+  const [index, setIndex] = useState(0)
+  const [phase, setPhase] = useState('REVEAL')
+  const current = pack[index]
+
+  useEffect(() => {
+    setPack(generateBonusPack(playerTeam, tournament.wins, true))
+    setIndex(0)
+    setPhase('REVEAL')
+  }, [playerTeam, tournament.wins])
+
+  const nextCard = () => {
+    const newIndex = index + 1
+    if (newIndex >= pack.length) {
+      advanceGamePhase('BATTLE')
+    } else {
+      setIndex(newIndex)
+      setPhase('REVEAL')
+    }
+  }
+
+  const handleDismantle = () => {
+    if (!current) return
+    dismantleCard(current)
+    nextCard()
+  }
+
+  const handleTake = () => {
+    if (!current) return
+    setPhase('EQUIP')
+  }
+
+  const handleEquip = slotKey => {
+    equipItem(slotKey, current.id)
+    nextCard()
+  }
+
+  if (!current) return null
+
+  if (phase === 'REVEAL') {
+    return (
+      <div className="scene">
+        <Card item={current} view="detail" />
+        <p className="mt-2">Shards: {inventory.shards}</p>
+        <div className="flex gap-4 mt-4">
+          <button onClick={handleDismantle}>Dismantle</button>
+          <button onClick={handleTake}>Take</button>
+        </div>
+      </div>
+    )
+  }
+
+  // EQUIP phase
+  const champions = [1, 2].map(num => ({
+    hero: playerTeam[`hero${num}`],
+    ability: playerTeam[`ability${num}`],
+    weapon: playerTeam[`weapon${num}`],
+    armor: playerTeam[`armor${num}`]
+  }))
+
+  return (
+    <div className="scene">
+      <div className="flex flex-col lg:flex-row gap-8 mt-8" id="upgrade-team-roster">
+        {champions.map((data, idx) => {
+          const hero = allPossibleHeroes.find(h => h.id === data.hero)
+          let valid = true
+          if (current.type === 'ability' && hero && hero.class !== current.class) {
+            valid = false
+          }
+          return (
+            <ChampionDisplay
+              key={idx}
+              slotData={data}
+              championNum={idx + 1}
+              targetType={current.type}
+              valid={valid}
+              onSelectSlot={handleEquip}
+            />
+          )
+        })}
+      </div>
+    </div>
+  )
 }

--- a/auto-battler-react/src/store.js
+++ b/auto-battler-react/src/store.js
@@ -88,5 +88,17 @@ export const useGameStore = create(set => ({
     const shardValues = { Uncommon: 3, Rare: 5, Epic: 10, Common: 1 }
     const gained = shardValues[card.rarity] || 1
     return { inventory: { ...state.inventory, shards: state.inventory.shards + gained } }
+  }),
+
+  equipItem: (slotKey, newId) => set(state => {
+    const team = { ...state.playerTeam }
+    team[slotKey] = newId
+    if (slotKey.startsWith('hero')) {
+      const idx = slotKey.endsWith('1') ? '1' : '2'
+      team[`ability${idx}`] = null
+      team[`weapon${idx}`] = null
+      team[`armor${idx}`] = null
+    }
+    return { playerTeam: team }
   })
 }))


### PR DESCRIPTION
## Summary
- add new `ChampionDisplay` component for rendering heroes with equipment slots
- store: add `equipItem` action for upgrade flow
- implement bonus pack logic and upgrade scene

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68558c8188a48327af2310c42258fb54