### PR TITLE
Implement reveal and draft state

### DIFF
--- a/auto-battler-react/src/scenes/DraftScene.jsx
+++ b/auto-battler-react/src/scenes/DraftScene.jsx
@@ -1,5 +1,29 @@
 import React from 'react'
+import { useGameStore } from '../store.js'
+import Card from '../components/Card.jsx'
 
 export default function DraftScene() {
-  return <div>Draft Scene</div>
+  const { revealedCards, selectDraftCard, draftStage } = useGameStore(state => ({
+    revealedCards: state.revealedCards,
+    selectDraftCard: state.selectDraftCard,
+    draftStage: state.draftStage,
+  }))
+
+  let instruction = 'Select a card.'
+  if (draftStage.startsWith('HERO')) {
+    instruction = draftStage === 'HERO_1_DRAFT' ? 'Choose your first hero.' : 'Choose your second hero.'
+  } else if (draftStage.startsWith('WEAPON')) {
+    instruction = 'Choose a weapon.'
+  }
+
+  return (
+    <div className="scene">
+      <h2 className="text-2xl font-cinzel mb-4 text-center">{instruction}</h2>
+      <div className="draft-pool">
+        {revealedCards.map(card => (
+          <Card key={card.id} item={card} view="detail" onClick={() => selectDraftCard(card)} />
+        ))}
+      </div>
+    </div>
+  )
 }

--- a/auto-battler-react/src/scenes/PackScene.jsx
+++ b/auto-battler-react/src/scenes/PackScene.jsx
@@ -9,8 +9,8 @@ const boosterPackImages = {
 }
 
 export default function PackScene() {
-  const { advanceGamePhase, draftStage } = useGameStore(state => ({
-    advanceGamePhase: state.advanceGamePhase,
+  const { openPack, draftStage } = useGameStore(state => ({
+    openPack: state.openPack,
     draftStage: state.draftStage,
   }))
 
@@ -20,7 +20,7 @@ export default function PackScene() {
     if (isOpening) return
     setIsOpening(true)
     setTimeout(() => {
-      advanceGamePhase('REVEAL')
+      openPack()
     }, 1000)
   }
 

--- a/auto-battler-react/src/scenes/RevealScene.jsx
+++ b/auto-battler-react/src/scenes/RevealScene.jsx
@@ -1,5 +1,73 @@
-import React from 'react'
+import React, { useEffect, useState } from 'react'
+import { useGameStore } from '../store.js'
+import Card from '../components/Card.jsx'
 
 export default function RevealScene() {
-  return <div>Reveal Scene</div>
+  const { packChoices, finishReveal } = useGameStore(state => ({
+    packChoices: state.packChoices,
+    finishReveal: state.finishReveal,
+  }))
+
+  const [flipped, setFlipped] = useState([])
+  const [dismissed, setDismissed] = useState([])
+
+  useEffect(() => {
+    setFlipped([])
+    setDismissed([])
+  }, [packChoices])
+
+  useEffect(() => {
+    if (packChoices.length && dismissed.length === packChoices.length) {
+      const t = setTimeout(() => finishReveal(), 300)
+      return () => clearTimeout(t)
+    }
+  }, [dismissed, packChoices, finishReveal])
+
+  const handleClick = idx => {
+    if (!flipped.includes(idx)) {
+      setFlipped([...flipped, idx])
+    } else if (!dismissed.includes(idx)) {
+      setDismissed([...dismissed, idx])
+    }
+  }
+
+  const mid = (packChoices.length - 1) / 2
+
+  return (
+    <div className="scene">
+      <div id="reveal-area" className="relative flex justify-center items-center">
+        {packChoices
+          .slice()
+          .reverse()
+          .map((card, rIdx) => {
+            const idx = packChoices.length - 1 - rIdx
+            const rot = (rIdx - mid) * 5
+            const y = Math.abs(rIdx - mid) * 20
+            const style = { transform: `rotate(${rot}deg) translateY(${y}px)`, zIndex: rIdx }
+
+            const isFlipped = flipped.includes(idx)
+            const isDismissed = dismissed.includes(idx)
+
+            let cls = 'revealed-card'
+            if (!isFlipped) {
+              cls += ' card-back-unrevealed'
+              if (card.rarity === 'Rare') cls += ' pre-reveal-rare'
+              if (card.rarity === 'Epic') cls += ' pre-reveal-epic'
+            }
+            if (isFlipped) cls += ' is-flipping'
+            if (isDismissed) cls += ' is-dismissed'
+
+            return (
+              <div key={idx} className={cls} style={style} onClick={() => handleClick(idx)}>
+                {isFlipped && !isDismissed && (
+                  <div className="card-face">
+                    <Card item={card} view="detail" />
+                  </div>
+                )}
+              </div>
+            )
+          })}
+      </div>
+    </div>
+  )
 }


### PR DESCRIPTION
## Summary
- manage pack opening & drafting state with Zustand
- open packs from the Pack scene
- animate card reveal with a fan-out effect
- choose from revealed cards in the Draft scene

## Testing
- `npm run lint`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685594ca01c88327a10cd2c58b9637de