### PR TITLE
Fix missing optional peer dep

### DIFF
--- a/auto-battler-react/package-lock.json
+++ b/auto-battler-react/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
+        "use-sync-external-store": "^1.5.0",
         "zustand": "^5.0.5"
       },
       "devDependencies": {
@@ -2679,6 +2680,15 @@
       "license": "BSD-2-Clause",
       "dependencies": {
         "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/use-sync-external-store": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.5.0.tgz",
+      "integrity": "sha512-Rb46I4cGGVBmjamjphe8L/UnvJD+uPPtTkNvX5mZgqdbavhI4EbgIWJiIHXJ8bc/i9EQGPRh4DwEURJ552Do0A==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/vite": {

--- a/auto-battler-react/package.json
+++ b/auto-battler-react/package.json
@@ -12,6 +12,7 @@
   "dependencies": {
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
+    "use-sync-external-store": "^1.5.0",
     "zustand": "^5.0.5"
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary
- add `use-sync-external-store` so zustand can find the shim

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6855cae342708327bc8765e625180c51