### PR TITLE
Implement champion recap flow

### DIFF
--- a/auto-battler-react/src/App.jsx
+++ b/auto-battler-react/src/App.jsx
@@ -26,7 +26,7 @@ export default function App() {
       return <WeaponScene />
     case 'BATTLE':
       return <BattleScene />
-    case 'RECAP':
+    case 'RECAP_1':
       return <RecapScene />
     case 'UPGRADE':
       return <UpgradeScene />

--- a/auto-battler-react/src/components/ChampionDisplay.jsx
+++ b/auto-battler-react/src/components/ChampionDisplay.jsx
@@ -8,18 +8,19 @@ import {
 } from '../data/data.js'
 
 export default function ChampionDisplay({
-  slotData,
-  championNum,
+  championData,
+  championNum = 1,
   targetType = null,
   valid = true,
   onSelectSlot,
   onHoverSlot
 }) {
-  const hero = allPossibleHeroes.find(h => h.id === slotData.hero)
+  const data = championData || {}
+  const hero = allPossibleHeroes.find(h => h.id === data.hero)
   if (!hero) return null
-  const ability = allPossibleAbilities.find(a => a.id === slotData.ability)
-  const weapon = allPossibleWeapons.find(w => w.id === slotData.weapon)
-  const armor = allPossibleArmors.find(a => a.id === slotData.armor)
+  const ability = allPossibleAbilities.find(a => a.id === data.ability)
+  const weapon = allPossibleWeapons.find(w => w.id === data.weapon)
+  const armor = allPossibleArmors.find(a => a.id === data.armor)
 
   const renderSocket = (item, className, slotKey) => {
     const type = slotKey.replace(/\d+$/, '')

--- a/auto-battler-react/src/scenes/RecapScene.jsx
+++ b/auto-battler-react/src/scenes/RecapScene.jsx
@@ -1,5 +1,27 @@
 import React from 'react'
+import { useGameStore } from '../store.js'
+import ChampionDisplay from '../components/ChampionDisplay.jsx'
 
 export default function RecapScene() {
-  return <div>Recap Scene</div>
+  const { playerTeam, startSecondChampionDraft } = useGameStore(state => ({
+    playerTeam: state.playerTeam,
+    startSecondChampionDraft: state.startSecondChampionDraft
+  }))
+
+  const championData = {
+    hero: playerTeam.hero1,
+    ability: playerTeam.ability1,
+    weapon: playerTeam.weapon1,
+    armor: playerTeam.armor1
+  }
+
+  return (
+    <div className="scene flex flex-col items-center gap-6">
+      <h2 className="text-2xl font-cinzel">Champion Recap</h2>
+      <ChampionDisplay championData={championData} championNum={1} />
+      <button className="mt-4" onClick={startSecondChampionDraft}>
+        Continue to Next Draft
+      </button>
+    </div>
+  )
 }

--- a/auto-battler-react/src/scenes/UpgradeScene.jsx
+++ b/auto-battler-react/src/scenes/UpgradeScene.jsx
@@ -141,7 +141,7 @@ export default function UpgradeScene() {
           return (
             <ChampionDisplay
               key={idx}
-              slotData={data}
+              championData={data}
               championNum={idx + 1}
               targetType={current.type}
               valid={valid}

--- a/auto-battler-react/src/store.js
+++ b/auto-battler-react/src/store.js
@@ -149,6 +149,9 @@ export const useGameStore = createWithEqualityFn(
       gamePhase: 'DRAFT'
     })),
 
+  startSecondChampionDraft: () =>
+    set({ draftStage: 'HERO_2_PACK', gamePhase: 'PACK' }),
+
   selectDraftCard: card =>
     set(state => {
       const team = { ...state.playerTeam }
@@ -158,11 +161,20 @@ export const useGameStore = createWithEqualityFn(
       switch (stage) {
         case 'HERO_1_DRAFT':
           team.hero1 = card.id
+          stage = 'ABILITY_1_PACK'
+          break
+        case 'ABILITY_1_DRAFT':
+          team.ability1 = card.id
           stage = 'WEAPON_1_PACK'
           break
         case 'WEAPON_1_DRAFT':
           team.weapon1 = card.id
-          stage = 'HERO_2_PACK'
+          stage = 'ARMOR_1_PACK'
+          break
+        case 'ARMOR_1_DRAFT':
+          team.armor1 = card.id
+          stage = 'CHAMPION_1_COMPLETE'
+          phase = 'RECAP_1'
           break
         case 'HERO_2_DRAFT':
           team.hero2 = card.id


### PR DESCRIPTION
## Summary
- add recap scene routing
- expand ChampionDisplay to use champion data prop
- show assembled champion in RecapScene
- update upgrade scene to call new component prop
- support multi-stage draft and recap in store

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6855d197390c8327b963709aac2e7f29