### PR TITLE
Implement battle initialization and logic hook

### DIFF
--- a/auto-battler-react/src/scenes/BattleScene.jsx
+++ b/auto-battler-react/src/scenes/BattleScene.jsx
@@ -1,28 +1,28 @@
 import React, { useEffect } from 'react'
-import { allPossibleHeroes } from '../data/data.js'
 import Card from '../components/Card.jsx'
 import useBattleLogic from '../hooks/useBattleLogic.js'
 import { useGameStore } from '../store.js'
 
 export default function BattleScene() {
-  const { playerTeam, handleBattleComplete } = useGameStore(state => ({
-    playerTeam: state.playerTeam,
+  const { combatants, startBattle, handleBattleComplete } = useGameStore(state => ({
+    combatants: state.combatants,
+    startBattle: state.startBattle,
     handleBattleComplete: state.handleBattleComplete,
   }))
 
-  const playerHeroes = [playerTeam.hero1, playerTeam.hero2]
-    .map(id => allPossibleHeroes.find(h => h.id === id))
-    .filter(Boolean)
+  useEffect(() => {
+    if (!combatants.length) startBattle()
+  }, [combatants, startBattle])
 
-  const { battleState, battleLog, isBattleOver, winner, nextTurn } =
-    useBattleLogic(playerHeroes)
+  const { battleState, battleLog, isBattleOver, winner, processTurn } =
+    useBattleLogic(combatants)
 
   useEffect(() => {
     if (!isBattleOver) {
-      const timer = setTimeout(nextTurn, 1000)
+      const timer = setTimeout(processTurn, 1000)
       return () => clearTimeout(timer)
     }
-  }, [battleLog, isBattleOver, nextTurn])
+  }, [battleLog, isBattleOver, processTurn])
 
   useEffect(() => {
     if (isBattleOver) {

--- a/auto-battler-react/src/scenes/UpgradeScene.jsx
+++ b/auto-battler-react/src/scenes/UpgradeScene.jsx
@@ -58,14 +58,14 @@ export default function UpgradeScene() {
     tournament,
     inventory,
     dismantleCard,
-    advanceGamePhase,
+    startBattle,
     equipItem
   } = useGameStore(state => ({
     playerTeam: state.playerTeam,
     tournament: state.tournament,
     inventory: state.inventory,
     dismantleCard: state.dismantleCard,
-    advanceGamePhase: state.advanceGamePhase,
+    startBattle: state.startBattle,
     equipItem: state.equipItem
   }))
 
@@ -83,7 +83,7 @@ export default function UpgradeScene() {
   const nextCard = () => {
     const newIndex = index + 1
     if (newIndex >= pack.length) {
-      advanceGamePhase('BATTLE')
+      startBattle()
     } else {
       setIndex(newIndex)
       setPhase('REVEAL')


### PR DESCRIPTION
## Summary
- create `startBattle` action in store to assemble player and enemy combatants
- use new action when drafting is complete and when leaving upgrade screen
- update BattleScene to load combatants from the store and run the logic hook
- modify battle logic hook to accept prepared combatants

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6855dd94ccec83279d5504354084dceb