### PR TITLE
Apply recap styling

### DIFF
--- a/auto-battler-react/src/components/ChampionDisplay.jsx
+++ b/auto-battler-react/src/components/ChampionDisplay.jsx
@@ -40,7 +40,7 @@ export default function ChampionDisplay({
         className={`equipment-socket ${className} ${item ? '' : 'empty-socket'} ${isTargetable ? 'targetable' : ''} ${disabled ? 'disabled' : ''}`}
         data-slot={slotKey}
         data-type={type}
-        style={item ? { backgroundImage: `url('${item.art}')` } : undefined}
+        style={item ? { backgroundImage: `url(${item.art})` } : undefined}
         title={item ? `${item.name} - ${item.rarity}` : undefined}
         onClick={handleClick}
         onMouseOver={handleMouseOver}

--- a/auto-battler-react/src/scenes/RecapScene.jsx
+++ b/auto-battler-react/src/scenes/RecapScene.jsx
@@ -19,7 +19,7 @@ export default function RecapScene() {
     <div className="scene flex flex-col items-center gap-6">
       <h2 className="text-2xl font-cinzel">Champion Recap</h2>
       <ChampionDisplay championData={championData} championNum={1} />
-      <button className="mt-4" onClick={startSecondChampionDraft}>
+      <button className="confirm-button mt-4" onClick={startSecondChampionDraft}>
         Continue to Next Draft
       </button>
     </div>


### PR DESCRIPTION
## Summary
- style RecapScene continue button
- improve backgroundImage logic in ChampionDisplay socket rendering

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6855ea76208883279347c183e20687bb