### PR TITLE
Implement basic combat VFX in React prototype

### DIFF
--- a/auto-battler-react/src/components/Card.jsx
+++ b/auto-battler-react/src/components/Card.jsx
@@ -1,17 +1,18 @@
-import React from 'react'
+import React, { forwardRef } from 'react'
 
 function getRarityClass(rarity = 'common') {
   return rarity.toLowerCase().replace(/\s+/g, '-')
 }
 
-export default function Card({
+const Card = forwardRef(function Card({
   item,
   view = 'detail',
   onClick,
   isDefeated = false,
   isActive = false,
   isTakingDamage = false,
-}) {
+  isAttacking = false,
+}, ref) {
   const rarityClass = getRarityClass(item?.rarity)
   const handleClick = () => {
     if (onClick) onClick(item)
@@ -28,7 +29,8 @@ export default function Card({
 
     return (
       <div
-        className={`compact-card ${rarityClass} ${isDefeated ? 'is-defeated' : ''} ${isActive ? 'is-active-turn' : ''} ${isTakingDamage ? 'is-taking-damage' : ''}`}
+        ref={ref}
+        className={`compact-card ${rarityClass} ${isDefeated ? 'is-defeated' : ''} ${isActive ? 'is-active-turn' : ''} ${isTakingDamage ? 'is-taking-damage' : ''} ${isAttacking ? 'is-attacking' : ''}`}
         onClick={onClick ? handleClick : undefined}
       >
         <div className="shockwave" />
@@ -150,3 +152,5 @@ export default function Card({
     </div>
   )
 }
+
+export default Card

--- a/auto-battler-react/src/hooks/useBattleLogic.js
+++ b/auto-battler-react/src/hooks/useBattleLogic.js
@@ -28,7 +28,8 @@ function calculateDamage(attacker, target, baseDamage) {
   return dmg;
 }
 
-export default function useBattleLogic(initialCombatants = []) {
+export default function useBattleLogic(initialCombatants = [], eventHandlers = {}) {
+  const { onAttack } = eventHandlers
   const [battleState, setBattleState] = useState(() =>
     initialCombatants.map(c => ({ ...c }))
   );
@@ -47,15 +48,20 @@ export default function useBattleLogic(initialCombatants = []) {
   const removeFromQueue = (id, queue) => queue.filter((q) => q !== id);
 
   const applyDamage = (attacker, target, baseDamage, queue) => {
-    const dmg = calculateDamage(attacker, target, baseDamage);
-    target.currentHp = Math.max(0, target.currentHp - dmg);
-    log(`${attacker.name} hits ${target.name} for ${dmg} damage.`);
+    const dmg = calculateDamage(attacker, target, baseDamage)
+
+    if (onAttack) onAttack(attacker.id, target.id, dmg)
+
+    target.currentHp = Math.max(0, target.currentHp - dmg)
+    const aName = attacker.heroData?.name || attacker.name
+    const tName = target.heroData?.name || target.name
+    log(`${aName} hits ${tName} for ${dmg} damage.`)
     if (target.currentHp <= 0) {
-      log(`${target.name} is defeated.`);
-      queue = removeFromQueue(target.id, queue);
+      log(`${tName} is defeated.`)
+      queue = removeFromQueue(target.id, queue)
     }
-    return queue;
-  };
+    return queue
+  }
 
   const processStatuses = (combatant) => {
     let skip = false;

--- a/auto-battler-react/src/scenes/BattleScene.jsx
+++ b/auto-battler-react/src/scenes/BattleScene.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react'
+import React, { useEffect, useRef } from 'react'
 import Card from '../components/Card.jsx'
 import useBattleLogic from '../hooks/useBattleLogic.js'
 import { useGameStore } from '../store.js'
@@ -14,8 +14,66 @@ export default function BattleScene() {
     if (!combatants.length) startBattle()
   }, [combatants, startBattle])
 
+  const sceneRef = useRef(null)
+  const cardRefs = useRef({})
+
+  const handleAttack = (attackerId, targetId, dmg) => {
+    const attackerEl = cardRefs.current[attackerId]
+    const targetEl = cardRefs.current[targetId]
+    if (!attackerEl || !targetEl) return
+
+    attackerEl.classList.add('is-attacking')
+    setTimeout(() => attackerEl.classList.remove('is-attacking'), 400)
+
+    targetEl.classList.add('is-taking-damage')
+    setTimeout(() => targetEl.classList.remove('is-taking-damage'), 400)
+
+    spawnProjectile(attackerEl, targetEl)
+    createHitSpark(targetEl)
+    showCombatText(targetEl, `-${dmg}`, 'damage')
+  }
+
+  const spawnProjectile = (startEl, endEl) => {
+    if (!sceneRef.current) return
+    const projectile = document.createElement('div')
+    projectile.className = 'battle-projectile'
+    sceneRef.current.appendChild(projectile)
+
+    const s = startEl.getBoundingClientRect()
+    const e = endEl.getBoundingClientRect()
+    const startX = s.left + s.width / 2
+    const startY = s.top + s.height / 2
+    const endX = e.left + e.width / 2
+    const endY = e.top + e.height / 2
+    projectile.style.left = `${startX}px`
+    projectile.style.top = `${startY}px`
+    requestAnimationFrame(() => {
+      projectile.style.transform = `translate(${endX - startX}px, ${endY - startY}px)`
+    })
+    projectile.addEventListener('transitionend', () => projectile.remove())
+  }
+
+  const createHitSpark = (targetEl) => {
+    if (!sceneRef.current) return
+    const rect = targetEl.getBoundingClientRect()
+    const spark = document.createElement('div')
+    spark.className = 'hit-spark'
+    spark.style.left = `${rect.left + rect.width / 2}px`
+    spark.style.top = `${rect.top + rect.height / 2}px`
+    sceneRef.current.appendChild(spark)
+    setTimeout(() => spark.remove(), 300)
+  }
+
+  const showCombatText = (targetEl, text, type) => {
+    const popup = document.createElement('div')
+    popup.className = `combat-text-popup ${type}`
+    popup.textContent = text
+    targetEl.appendChild(popup)
+    setTimeout(() => popup.remove(), 1200)
+  }
+
   const { battleState, battleLog, isBattleOver, winner, processTurn } =
-    useBattleLogic(combatants)
+    useBattleLogic(combatants, { onAttack: handleAttack })
 
   useEffect(() => {
     if (!isBattleOver) {
@@ -34,16 +92,26 @@ export default function BattleScene() {
   const enemyCards = battleState.filter(c => c.team === 'enemy')
 
   return (
-    <div className="battle-scene">
+    <div className="battle-scene" ref={sceneRef}>
       <div className="teams flex justify-between mb-4">
         <div className="player-team flex gap-2">
           {playerCards.map(c => (
-            <Card key={c.id} item={c} view="compact" />
+            <Card
+              key={c.id}
+              ref={el => { cardRefs.current[c.id] = el }}
+              item={c}
+              view="compact"
+            />
           ))}
         </div>
         <div className="enemy-team flex gap-2">
           {enemyCards.map(c => (
-            <Card key={c.id} item={c} view="compact" />
+            <Card
+              key={c.id}
+              ref={el => { cardRefs.current[c.id] = el }}
+              item={c}
+              view="compact"
+            />
           ))}
         </div>
       </div>

--- a/auto-battler-react/src/style.css
+++ b/auto-battler-react/src/style.css
@@ -1161,6 +1161,11 @@ button:disabled {
 /* Battle Scene Enhancements                                                  */
 /* -------------------------------------------------------------------------- */
 
+.battle-scene {
+    position: relative;
+    overflow: hidden;
+}
+
 .battle-projectile {
     position: fixed; /* Use fixed positioning for screen-space travel */
     width: 15px;


### PR DESCRIPTION
## Summary
- add ref forwarding to `Card` component so scenes can manipulate card DOM
- expose combat event hook in `useBattleLogic`
- trigger attack animations and VFX from `BattleScene`
- style battle scene container to allow floating effects

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6857029b4cac8327b82dfe0679fd12e0