### PR TITLE
Implement status effect visuals

### DIFF
--- a/auto-battler-react/src/components/Card.jsx
+++ b/auto-battler-react/src/components/Card.jsx
@@ -1,4 +1,49 @@
 import React from 'react'
+import { STATUS_DATA } from '../data/statusEffects.js'
+
+function getAuraClasses(effects = []) {
+  const classes = []
+  effects.forEach(e => {
+    switch (e.name) {
+      case 'Stun':
+        classes.push('aura-stun')
+        break
+      case 'Poison':
+        classes.push('aura-poison')
+        break
+      case 'Bleed':
+        classes.push('aura-bleed')
+        break
+      case 'Burn':
+        classes.push('aura-burn')
+        break
+      case 'Slow':
+        classes.push('aura-slow')
+        break
+      case 'Confuse':
+        classes.push('aura-confuse')
+        break
+      case 'Root':
+        classes.push('aura-root')
+        break
+      case 'Shock':
+        classes.push('aura-shock')
+        break
+      case 'Vulnerable':
+        classes.push('aura-vulnerable')
+        break
+      case 'Defense Down':
+        classes.push('aura-defense-down')
+        break
+      case 'Attack Up':
+      case 'Fortify':
+        classes.push('aura-buff')
+        break
+      default:
+    }
+  })
+  return classes
+}
 
 function getRarityClass(rarity = 'common') {
   return rarity.toLowerCase().replace(/\s+/g, '-')
@@ -8,6 +53,8 @@ export default function Card({
   item,
   view = 'detail',
   onClick,
+  onStatusHover,
+  onStatusOut,
   isDefeated = false,
   isActive = false,
   isTakingDamage = false,
@@ -26,9 +73,12 @@ export default function Card({
     const hpPercent = maxHp ? (currentHp / maxHp) * 100 : 100
     const hpColor = hpPercent > 50 ? '#48bb78' : hpPercent > 20 ? '#f59e0b' : '#ef4444'
 
+    const auraClasses = getAuraClasses(item.statusEffects)
+    const hasAura = auraClasses.length > 0
+
     return (
       <div
-        className={`compact-card ${rarityClass} ${isDefeated ? 'is-defeated' : ''} ${isActive ? 'is-active-turn' : ''} ${isTakingDamage ? 'is-taking-damage' : ''}`}
+        className={`compact-card ${rarityClass} ${isDefeated ? 'is-defeated' : ''} ${isActive ? 'is-active-turn' : ''} ${isTakingDamage ? 'is-taking-damage' : ''} ${hasAura ? 'has-aura' : ''} ${auraClasses.join(' ')}`}
         onClick={onClick ? handleClick : undefined}
       >
         <div className="shockwave" />
@@ -46,11 +96,31 @@ export default function Card({
           </div>
         </div>
         <div className="status-icon-container">
-          {item.statusEffects?.map((effect) => (
-            <div key={effect.id || effect.name} className="status-icon" title={effect.name}>
-              {effect.icon ? <i className={effect.icon} /> : effect.label}
-            </div>
-          ))}
+          {item.statusEffects?.map((effect) => {
+            const data = STATUS_DATA[effect.name] || {}
+            const Icon = () => (data.icon ? <i className={data.icon} /> : data.label)
+            const handleEnter = (e) => {
+              if (onStatusHover)
+                onStatusHover(e, {
+                  name: effect.name,
+                  turns: effect.turnsRemaining,
+                  description: data.description || effect.description || ''
+                })
+            }
+            const handleLeave = () => {
+              if (onStatusOut) onStatusOut()
+            }
+            return (
+              <div
+                key={effect.id || effect.name}
+                className="status-icon"
+                onMouseEnter={handleEnter}
+                onMouseLeave={handleLeave}
+              >
+                <Icon />
+              </div>
+            )
+          })}
         </div>
       </div>
     )

--- a/auto-battler-react/src/data/statusEffects.js
+++ b/auto-battler-react/src/data/statusEffects.js
@@ -1,0 +1,14 @@
+export const STATUS_DATA = {
+  Stun: { icon: 'fas fa-star', description: 'Skips the next action.' },
+  Poison: { icon: 'fas fa-skull-crossbones', description: 'Takes 2 damage per turn.' },
+  Bleed: { icon: 'fas fa-droplet', description: 'Takes 1 damage per turn and healing is halved.' },
+  Burn: { icon: 'fas fa-fire-alt', description: 'Takes 3 damage per turn and suffers -1 defense.' },
+  Slow: { icon: 'fas fa-hourglass-half', description: 'Speed reduced by 1.' },
+  Confuse: { icon: 'fas fa-question', description: '50% chance to miss actions.' },
+  Root: { icon: 'fas fa-tree', description: 'Cannot act next turn.' },
+  Shock: { icon: 'fas fa-bolt', description: '50% chance to fail casting abilities.' },
+  Vulnerable: { icon: 'fas fa-crosshairs', description: 'Takes +1 damage from all sources.' },
+  'Defense Down': { icon: 'fas fa-shield-slash', description: 'Defense is reduced by 1.' },
+  'Attack Up': { icon: 'fas fa-arrow-up', description: 'Attack power increased.' },
+  Fortify: { icon: 'fas fa-arrow-up', description: 'Defense increased.' }
+};

--- a/auto-battler-react/src/scenes/BattleScene.jsx
+++ b/auto-battler-react/src/scenes/BattleScene.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react'
+import React, { useEffect, useState } from 'react'
 import Card from '../components/Card.jsx'
 import useBattleLogic from '../hooks/useBattleLogic.js'
 import { useGameStore } from '../store.js'
@@ -16,6 +16,19 @@ export default function BattleScene() {
 
   const { battleState, battleLog, isBattleOver, winner, processTurn } =
     useBattleLogic(combatants)
+
+  const [tooltip, setTooltip] = useState(null)
+
+  const showTooltip = (e, data) => {
+    const rect = e.currentTarget.getBoundingClientRect()
+    setTooltip({
+      x: rect.left + rect.width / 2,
+      y: rect.top,
+      ...data
+    })
+  }
+
+  const hideTooltip = () => setTooltip(null)
 
   useEffect(() => {
     if (!isBattleOver) {
@@ -38,12 +51,24 @@ export default function BattleScene() {
       <div className="teams flex justify-between mb-4">
         <div className="player-team flex gap-2">
           {playerCards.map(c => (
-            <Card key={c.id} item={c} view="compact" />
+            <Card
+              key={c.id}
+              item={c}
+              view="compact"
+              onStatusHover={showTooltip}
+              onStatusOut={hideTooltip}
+            />
           ))}
         </div>
         <div className="enemy-team flex gap-2">
           {enemyCards.map(c => (
-            <Card key={c.id} item={c} view="compact" />
+            <Card
+              key={c.id}
+              item={c}
+              view="compact"
+              onStatusHover={showTooltip}
+              onStatusOut={hideTooltip}
+            />
           ))}
         </div>
       </div>
@@ -57,6 +82,22 @@ export default function BattleScene() {
           {winner === 'player' ? 'Victory!' : 'Defeat!'}
         </div>
       )}
+      <div
+        className={`status-tooltip ${tooltip ? 'visible' : ''}`}
+        style={tooltip ? { left: tooltip.x + 10, top: tooltip.y + 10 } : {}}
+      >
+        {tooltip && (
+          <>
+            <h4 className="status-tooltip-name">{tooltip.name}</h4>
+            <p className="status-tooltip-duration">
+              Turns remaining: {tooltip.turns}
+            </p>
+            {tooltip.description && (
+              <p className="status-tooltip-description">{tooltip.description}</p>
+            )}
+          </>
+        )}
+      </div>
     </div>
   )
 }


### PR DESCRIPTION
## Summary
- show aura classes and icons for combatant status effects
- add tooltip component to BattleScene for status info
- centralize status effect metadata

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_685702a3797083279983ad4933f6ae5c