### PR TITLE
Implement ability announcements on special moves

### DIFF
--- a/hero-game/js/scenes/BattleScene.js
+++ b/hero-game/js/scenes/BattleScene.js
@@ -470,6 +470,9 @@ export class BattleScene {
 
             this._showAbilityCard(ability);
             this._triggerArenaEffect('ability-zoom');
+            // Display a central announcement for high-impact abilities
+            const announcerStyle = (ability.rarity === 'Epic') ? 'critical' : '';
+            this._showBattleAnnouncement(ability.name, announcerStyle, ability.effect || '');
             this._logToBattle(`${attacker.heroData.name} unleashes ${ability.name}!`, 'ability-cast', attacker, 2);
 
             // This is now redundant with the main _showBattleAnnouncement call.
@@ -1236,6 +1239,7 @@ export class BattleScene {
         const style = didPlayerWin ? 'victory-text' : 'defeat-text';
         const anim = didPlayerWin ? 'animate-forge' : 'animate-crumble';
         this._triggerWordEffect(word, style, anim);
+        this._showBattleAnnouncement(word, didPlayerWin ? 'victory' : 'defeat');
 
         this.state.forEach(combatant => {
             if (combatant.team === winningTeam && combatant.currentHp > 0) {


### PR DESCRIPTION
## Summary
- show central announcer text when abilities are used
- display victory/defeat text using announcer overlay

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_685702b0021c83279a4d3d36454a4f7a