### PR TITLE
Polish upgrade scene UI

### DIFF
--- a/auto-battler-react/index.html
+++ b/auto-battler-react/index.html
@@ -11,6 +11,7 @@
   <body>
     <canvas id="background-canvas"></canvas>
     <div id="root"></div>
+    <div id="item-tooltip" class="hidden absolute z-50 p-3 rounded-lg bg-gray-900 border border-gray-500 max-w-xs text-sm"></div>
     <script type="module" src="/src/main.jsx"></script>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- improve UpgradeScene with card counter pips and hover tooltip
- style upgrade buttons using the confirm-button class
- mount item-tooltip container in the page for comparison hover

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_685702bc608c83278014993a5fdaea64