### PR TITLE
Add status effect visuals

### DIFF
--- a/auto-battler-react/index.html
+++ b/auto-battler-react/index.html
@@ -11,6 +11,11 @@
   <body>
     <canvas id="background-canvas"></canvas>
     <div id="root"></div>
+    <div id="status-tooltip" class="status-tooltip">
+      <h4 class="status-tooltip-name"></h4>
+      <p class="status-tooltip-duration"></p>
+      <p class="status-tooltip-description"></p>
+    </div>
     <script type="module" src="/src/main.jsx"></script>
   </body>
 </html>

--- a/auto-battler-react/src/statusTooltip.js
+++ b/auto-battler-react/src/statusTooltip.js
@@ -1,0 +1,37 @@
+let tooltipEl
+
+function ensureElement() {
+  if (!tooltipEl) {
+    tooltipEl = document.getElementById('status-tooltip')
+    if (!tooltipEl) {
+      tooltipEl = document.createElement('div')
+      tooltipEl.id = 'status-tooltip'
+      tooltipEl.className = 'status-tooltip'
+      tooltipEl.innerHTML = `
+        <h4 class="status-tooltip-name"></h4>
+        <p class="status-tooltip-duration"></p>
+        <p class="status-tooltip-description"></p>
+      `
+      document.body.appendChild(tooltipEl)
+    }
+  }
+  return tooltipEl
+}
+
+export function showStatusTooltip(effect, x, y) {
+  const el = ensureElement()
+  const nameEl = el.querySelector('.status-tooltip-name')
+  const durEl = el.querySelector('.status-tooltip-duration')
+  const descEl = el.querySelector('.status-tooltip-description')
+  if (nameEl) nameEl.textContent = effect.name
+  if (durEl) durEl.textContent = `Turns remaining: ${effect.turnsRemaining}`
+  if (descEl) descEl.textContent = effect.description || ''
+  el.style.left = `${x + 10}px`
+  el.style.top = `${y + 10}px`
+  el.classList.add('visible')
+}
+
+export function hideStatusTooltip() {
+  const el = ensureElement()
+  el.classList.remove('visible')
+}


### PR DESCRIPTION
## Summary
- show tooltip container in `index.html`
- handle aura icons and tooltips in `Card` component
- provide DOM helpers for tooltip display

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6857075b3f2483278238c3bba5c3752b