### PR TITLE
Fix second champion draft flow

### DIFF
--- a/auto-battler-react/src/App.jsx
+++ b/auto-battler-react/src/App.jsx
@@ -36,6 +36,9 @@ export default function App() {
     case 'RECAP_1':
       scene = <RecapScene />
       break
+    case 'RECAP_2':
+      scene = <RecapScene />
+      break
     case 'UPGRADE':
       scene = <UpgradeScene />
       break

--- a/auto-battler-react/src/scenes/RecapScene.jsx
+++ b/auto-battler-react/src/scenes/RecapScene.jsx
@@ -3,24 +3,33 @@ import { useGameStore } from '../store.js'
 import ChampionDisplay from '../components/ChampionDisplay.jsx'
 
 export default function RecapScene() {
-  const { playerTeam, startSecondChampionDraft } = useGameStore(state => ({
-    playerTeam: state.playerTeam,
-    startSecondChampionDraft: state.startSecondChampionDraft
-  }))
+  const { playerTeam, draftStage, startSecondChampionDraft, startBattle } =
+    useGameStore(state => ({
+      playerTeam: state.playerTeam,
+      draftStage: state.draftStage,
+      startSecondChampionDraft: state.startSecondChampionDraft,
+      startBattle: state.startBattle
+    }))
+
+  const isFirst = draftStage === 'CHAMPION_1_COMPLETE'
+  const champNum = isFirst ? 1 : 2
 
   const championData = {
-    hero: playerTeam.hero1,
-    ability: playerTeam.ability1,
-    weapon: playerTeam.weapon1,
-    armor: playerTeam.armor1
+    hero: playerTeam[`hero${champNum}`],
+    ability: playerTeam[`ability${champNum}`],
+    weapon: playerTeam[`weapon${champNum}`],
+    armor: playerTeam[`armor${champNum}`]
   }
+
+  const handleContinue = isFirst ? startSecondChampionDraft : startBattle
+  const buttonText = isFirst ? 'Continue to Next Draft' : 'Start Battle'
 
   return (
     <div className="scene flex flex-col items-center gap-6">
       <h2 className="text-2xl font-cinzel">Champion Recap</h2>
-      <ChampionDisplay championData={championData} championNum={1} />
-      <button className="confirm-button mt-4" onClick={startSecondChampionDraft}>
-        Continue to Next Draft
+      <ChampionDisplay championData={championData} championNum={champNum} />
+      <button className="confirm-button mt-4" onClick={handleContinue}>
+        {buttonText}
       </button>
     </div>
   )

--- a/auto-battler-react/src/store.js
+++ b/auto-battler-react/src/store.js
@@ -318,12 +318,21 @@ export const useGameStore = createWithEqualityFn(
         break
       case 'HERO_2_DRAFT':
         team.hero2 = card.id
+        stage = 'ABILITY_2_PACK'
+        break
+      case 'ABILITY_2_DRAFT':
+        team.ability2 = card.id
         stage = 'WEAPON_2_PACK'
         break
       case 'WEAPON_2_DRAFT':
         team.weapon2 = card.id
-        stage = 'COMPLETE'
-        phase = 'BATTLE'
+        stage = 'ARMOR_2_PACK'
+        phase = 'PACK'
+        break
+      case 'ARMOR_2_DRAFT':
+        team.armor2 = card.id
+        stage = 'CHAMPION_2_COMPLETE'
+        phase = 'RECAP_2'
         break
       default:
         break


### PR DESCRIPTION
## Summary
- fix drafting logic for second champion so ability and armor are selected
- show second recap screen before battle
- make RecapScene handle both champions

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68570b28e0808327aeb63c4d42d70c1a