### PR TITLE
Add random hero draft option

### DIFF
--- a/auto-battler-react/src/scenes/PackScene.jsx
+++ b/auto-battler-react/src/scenes/PackScene.jsx
@@ -9,9 +9,12 @@ const boosterPackImages = {
 }
 
 export default function PackScene() {
-  const { openPack, draftStage } = useGameStore(state => ({
+  const { openPack, draftStage, addRandomHero, hero1, hero2 } = useGameStore(state => ({
     openPack: state.openPack,
     draftStage: state.draftStage,
+    addRandomHero: state.addRandomHero,
+    hero1: state.playerTeam.hero1,
+    hero2: state.playerTeam.hero2,
   }))
 
   const [isTearing, setIsTearing] = useState(false)
@@ -108,6 +111,14 @@ export default function PackScene() {
       <p id="pack-scene-instructions" className="text-lg text-gray-400 mt-8">
         Click anywhere on the pack to tear it open.
       </p>
+      <button
+        id="random-hero-button"
+        className="mt-6 text-gray-400 border border-gray-600 rounded-lg px-4 py-2 hover:bg-gray-700 hover:text-white transition-colors"
+        onClick={addRandomHero}
+        disabled={hero1 && hero2}
+      >
+        ... or add a Random Hero
+      </button>
     </div>
   )
 }

--- a/auto-battler-react/src/store.js
+++ b/auto-battler-react/src/store.js
@@ -139,6 +139,35 @@ export const useGameStore = createWithEqualityFn(
     return { playerTeam: team }
   }),
 
+  addRandomHero: () =>
+    set(state => {
+      const team = { ...state.playerTeam }
+      let stage = state.draftStage
+      let phase = state.gamePhase
+
+      if (!team.hero1) {
+        const champ = generateRandomChampion()
+        team.hero1 = champ.hero
+        team.ability1 = champ.ability
+        team.weapon1 = champ.weapon
+        team.armor1 = champ.armor
+        stage = 'CHAMPION_1_COMPLETE'
+        phase = 'RECAP_1'
+      } else if (!team.hero2) {
+        const champ = generateRandomChampion()
+        team.hero2 = champ.hero
+        team.ability2 = champ.ability
+        team.weapon2 = champ.weapon
+        team.armor2 = champ.armor
+        stage = 'CHAMPION_2_COMPLETE'
+        phase = 'RECAP_2'
+      } else {
+        return {}
+      }
+
+      return { playerTeam: team, draftStage: stage, gamePhase: phase }
+    }),
+
   debugSkipToBattle: () => {
     const champion1 = generateRandomChampion()
     let champion2 = generateRandomChampion()


### PR DESCRIPTION
## Summary
- add `addRandomHero` action to generate and insert a full champion
- render a `... or add a Random Hero` button in `PackScene`
- hook the button to the new action and disable it when both hero slots are full

## Testing
- `npm run lint` *(fails: cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68570ecabbc0832780e1c395e21e1387