### PR TITLE
Add auto user registration for Discord bot

### DIFF
--- a/discord-bot/index.js
+++ b/discord-bot/index.js
@@ -37,13 +37,24 @@ client.on(Events.InteractionCreate, async interaction => {
     if (!interaction.isChatInputCommand()) return;
 
     const command = client.commands.get(interaction.commandName);
-
     if (!command) return;
 
     try {
+        // Find or create user in the database
+        const userId = interaction.user.id;
+        const [rows] = await db.execute('SELECT * FROM users WHERE discord_id = ?', [userId]);
+
+        if (rows.length === 0) {
+            // User does not exist, so insert them
+            await db.execute('INSERT INTO users (discord_id) VALUES (?)', [userId]);
+            console.log(`New user added: ${interaction.user.tag}`);
+        }
+
+        // Now, execute the command
         await command.execute(interaction);
+
     } catch (error) {
-        console.error(error);
+        console.error('Error during interaction or database operation:', error);
         await interaction.reply({ content: 'There was an error while executing this command!', ephemeral: true });
     }
 });


### PR DESCRIPTION
## Summary
- add user auto-registration on command use

## Testing
- `npm test` in `discord-bot`
- `npm test` in `backend`
- `npm test` (fails: missing script) and `npm run lint` in `auto-battler-react` (fails: missing package)

------
https://chatgpt.com/codex/tasks/task_e_6857575780048327891874c1cc12e5e6