### PR TITLE
Add /play command and DB schema

### DIFF
--- a/discord-bot/commands/play.js
+++ b/discord-bot/commands/play.js
@@ -1,0 +1,44 @@
+const { SlashCommandBuilder } = require('discord.js');
+const db = require('../util/database');
+
+module.exports = {
+    data: new SlashCommandBuilder()
+        .setName('play')
+        .setDescription('Starts a new game or joins an existing one.'),
+    async execute(interaction) {
+        const userId = interaction.user.id;
+
+        // 1. Check if the user is already in an active game
+        const [userRows] = await db.execute('SELECT current_game_id FROM users WHERE discord_id = ?', [userId]);
+        if (userRows[0] && userRows[0].current_game_id) {
+            return interaction.reply({ content: 'You are already in a game! Finish that one before starting a new one.', ephemeral: true });
+        }
+
+        // 2. Find a pending game with only one player
+        const [gameRows] = await db.execute("SELECT * FROM games WHERE status = 'pending' AND player2_id IS NULL");
+
+        if (gameRows.length > 0) {
+            // 3. Join an existing game
+            const game = gameRows[0];
+            if (game.player1_id === userId) {
+                 return interaction.reply({ content: "You can't play against yourself! Waiting for another player.", ephemeral: true });
+            }
+
+            await db.execute("UPDATE games SET player2_id = ?, status = 'active' WHERE id = ?", [userId, game.id]);
+            await db.execute("UPDATE users SET current_game_id = ? WHERE discord_id IN (?, ?)", [game.id, userId, game.player1_id]);
+
+            await interaction.reply({ content: `You have joined a game against another player! The battle will begin shortly.`, ephemeral: true });
+            // We can notify the other player as well
+            const otherPlayer = await interaction.client.users.fetch(game.player1_id);
+            otherPlayer.send(`Your game is starting! You are playing against ${interaction.user.tag}.`);
+
+        } else {
+            // 4. Create a new game
+            const [newGame] = await db.execute('INSERT INTO games (player1_id) VALUES (?)', [userId]);
+            const gameId = newGame.insertId;
+            await db.execute('UPDATE users SET current_game_id = ? WHERE discord_id = ?', [gameId, userId]);
+
+            await interaction.reply({ content: 'You have started a new game! Waiting for another player to join...', ephemeral: true });
+        }
+    },
+};

--- a/discord-bot/db-schema.sql
+++ b/discord-bot/db-schema.sql
@@ -1,0 +1,18 @@
+-- Schema for the Discord bot database
+
+-- Games table
+CREATE TABLE IF NOT EXISTS games (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    player1_id VARCHAR(255) NOT NULL,
+    player2_id VARCHAR(255) DEFAULT NULL,
+    status ENUM('pending', 'active') DEFAULT 'pending',
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+
+-- Users table
+CREATE TABLE IF NOT EXISTS users (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    discord_id VARCHAR(255) NOT NULL UNIQUE,
+    current_game_id INT DEFAULT NULL,
+    FOREIGN KEY (current_game_id) REFERENCES games(id) ON DELETE SET NULL
+);

--- a/docs/database_changes.sql
+++ b/docs/database_changes.sql
@@ -1,0 +1,11 @@
+-- Add current_game_id column to users table
+ALTER TABLE users ADD COLUMN IF NOT EXISTS current_game_id INT DEFAULT NULL;
+
+-- Create games table
+CREATE TABLE IF NOT EXISTS games (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    player1_id VARCHAR(255) NOT NULL,
+    player2_id VARCHAR(255) DEFAULT NULL,
+    status ENUM('pending', 'active') DEFAULT 'pending',
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);


### PR DESCRIPTION
## Summary
- add `/play` command to manage joining or creating games
- include SQL schema defining `games` table and `current_game_id` on `users`
- document DB changes in `docs/database_changes.sql`

## Testing
- `npm test --silent`
- `node deploy-commands.js` *(fails: Expected token to be set)*
- `node index.js` *(fails: TokenInvalid)*

------
https://chatgpt.com/codex/tasks/task_e_685758ce707c8327a762aa0c603cc9f4