### PR TITLE
Add draft manager and button handling for hero draft

### DIFF
--- a/discord-bot/commands/draft.js
+++ b/discord-bot/commands/draft.js
@@ -1,6 +1,6 @@
-const { SlashCommandBuilder, ActionRowBuilder, ButtonBuilder, ButtonStyle, EmbedBuilder } = require('discord.js');
+const { SlashCommandBuilder } = require('discord.js');
 const db = require('../util/database');
-const { allPossibleHeroes } = require('../../backend/game/data');
+const { sendHeroSelection } = require('../managers/DraftManager');
 
 module.exports = {
     data: new SlashCommandBuilder()
@@ -9,7 +9,6 @@ module.exports = {
     async execute(interaction) {
         const userId = interaction.user.id;
 
-        // 1. Check if the user is already in a game
         const [userRows] = await db.execute('SELECT current_game_id FROM users WHERE discord_id = ?', [userId]);
         if (userRows[0] && userRows[0].current_game_id) {
             return interaction.reply({ content: 'You are already in a game! Finish or forfeit that one first.', ephemeral: true });
@@ -17,16 +16,7 @@ module.exports = {
 
         await interaction.reply({ content: 'Your draft is starting! Please check your Direct Messages.', ephemeral: true });
 
-        // 2. Create a new game and draft record
-        const initialDraftState = {
-            stage: 'HERO_SELECTION',
-            team: {
-                hero: null,
-                weapon: null,
-                ability: null
-            }
-        };
-
+        const initialDraftState = { stage: 'HERO_SELECTION', team: {} };
         const [newGame] = await db.execute(
             "INSERT INTO games (player1_id, status, draft_state) VALUES (?, 'drafting', ?)",
             [userId, JSON.stringify(initialDraftState)]
@@ -35,39 +25,13 @@ module.exports = {
 
         await db.execute('UPDATE users SET current_game_id = ? WHERE discord_id = ?', [gameId, userId]);
 
-        // 3. Generate Hero Choices
-        const shuffledHeroes = [...allPossibleHeroes].sort(() => 0.5 - Math.random());
-        const heroChoices = shuffledHeroes.slice(0, 4);
-
-        // 4. Build the Interactive Message (Embed + Buttons)
-        const embed = new EmbedBuilder()
-            .setColor('#0099ff')
-            .setTitle('Hero Selection')
-            .setDescription('Choose the first hero for your team.')
-            .setTimestamp();
-
-        const buttons = heroChoices.map(hero => {
-            return new ButtonBuilder()
-                .setCustomId(`draft_hero_${gameId}_${hero.id}`)
-                .setLabel(hero.name)
-                .setStyle(ButtonStyle.Secondary)
-                .setEmoji('👤');
-        });
-
-        const actionRow = new ActionRowBuilder().addComponents(buttons);
-
-        // 5. Send the choices to the user's DMs
         try {
-            await interaction.user.send({
-                content: `Game #${gameId}: It's time to draft!`,
-                embeds: [embed],
-                components: [actionRow]
-            });
+            await sendHeroSelection(interaction, gameId);
         } catch (error) {
-            console.error(`Could not send DM to ${interaction.user.tag}.`);
+            console.error(`Could not send DM to ${interaction.user.tag}.`, error);
             await db.execute('DELETE FROM games WHERE id = ?', [gameId]);
             await db.execute('UPDATE users SET current_game_id = NULL WHERE discord_id = ?', [userId]);
-            await interaction.followUp({ content: "I couldn't send you a DM! Please check your privacy settings to allow DMs from this server.", ephemeral: true });
+            await interaction.followUp({ content: "I couldn't send you a DM! Please check your privacy settings.", ephemeral: true });
         }
-    }
+    },
 };

--- a/discord-bot/index.js
+++ b/discord-bot/index.js
@@ -3,6 +3,10 @@ const path = require('node:path');
 const { Client, Collection, GatewayIntentBits, Events } = require('discord.js');
 require('dotenv').config();
 const db = require('./util/database');
+const { sendAbilitySelection, sendWeaponSelection } = require('./managers/DraftManager');
+const GameEngine = require('../backend/game/engine');
+const { createCombatant } = require('../backend/game/utils');
+const { allPossibleHeroes } = require('../backend/game/data');
 
 const client = new Client({ intents: [GatewayIntentBits.Guilds] });
 
@@ -34,28 +38,84 @@ client.once(Events.ClientReady, async () => {
 });
 
 client.on(Events.InteractionCreate, async interaction => {
-    if (!interaction.isChatInputCommand()) return;
+    // Handle Slash Commands
+    if (interaction.isChatInputCommand()) {
+        const command = client.commands.get(interaction.commandName);
+        if (!command) return;
 
-    const command = client.commands.get(interaction.commandName);
-    if (!command) return;
-
-    try {
-        // Find or create user in the database
-        const userId = interaction.user.id;
-        const [rows] = await db.execute('SELECT * FROM users WHERE discord_id = ?', [userId]);
-
-        if (rows.length === 0) {
-            // User does not exist, so insert them
-            await db.execute('INSERT INTO users (discord_id) VALUES (?)', [userId]);
-            console.log(`New user added: ${interaction.user.tag}`);
+        try {
+            const userId = interaction.user.id;
+            const [rows] = await db.execute('SELECT * FROM users WHERE discord_id = ?', [userId]);
+            if (rows.length === 0) {
+                await db.execute('INSERT INTO users (discord_id) VALUES (?)', [userId]);
+                console.log(`New user added: ${interaction.user.tag}`);
+            }
+            await command.execute(interaction);
+        } catch (error) {
+            console.error(error);
+            await interaction.reply({ content: 'There was an error executing this command!', ephemeral: true });
         }
+        return;
+    }
 
-        // Now, execute the command
-        await command.execute(interaction);
+    // Handle Button Clicks
+    if (interaction.isButton()) {
+        const [action, type, gameId, choiceId] = interaction.customId.split('_');
 
-    } catch (error) {
-        console.error('Error during interaction or database operation:', error);
-        await interaction.reply({ content: 'There was an error while executing this command!', ephemeral: true });
+        if (action !== 'draft') return;
+
+        try {
+            const [gameRows] = await db.execute('SELECT * FROM games WHERE id = ?', [gameId]);
+            if (gameRows.length === 0) {
+                return interaction.update({ content: 'This game no longer exists.', components: [] });
+            }
+            const game = gameRows[0];
+            const draftState = JSON.parse(game.draft_state);
+
+            if (type === 'hero' && draftState.stage === 'HERO_SELECTION') {
+                draftState.team.hero = parseInt(choiceId, 10);
+                draftState.stage = 'ABILITY_SELECTION';
+                await db.execute('UPDATE games SET draft_state = ? WHERE id = ?', [JSON.stringify(draftState), gameId]);
+
+                await sendAbilitySelection(interaction, gameId, draftState.team.hero);
+
+            } else if (type === 'ability' && draftState.stage === 'ABILITY_SELECTION') {
+                draftState.team.ability = parseInt(choiceId, 10);
+                draftState.stage = 'WEAPON_SELECTION';
+                await db.execute('UPDATE games SET draft_state = ? WHERE id = ?', [JSON.stringify(draftState), gameId]);
+
+                const hero = allPossibleHeroes.find(h => h.id === draftState.team.hero);
+                await sendWeaponSelection(interaction, gameId, hero.name);
+
+            } else if (type === 'weapon' && draftState.stage === 'WEAPON_SELECTION') {
+                draftState.team.weapon = parseInt(choiceId, 10);
+                draftState.stage = 'DRAFT_COMPLETE';
+                await db.execute('UPDATE games SET draft_state = ? WHERE id = ?', [JSON.stringify(draftState), gameId]);
+
+                await interaction.update({ content: 'Draft complete! Simulating battle...', components: [] });
+
+                const playerData = { discord_id: game.player1_id, hero_id: draftState.team.hero, weapon_id: draftState.team.weapon, ability_id: draftState.team.ability };
+                const aiData = { discord_id: 'AI', hero_id: 301, weapon_id: 1201, armor_id: null, ability_id: null };
+
+                const playerCombatant = createCombatant(playerData, 'player', 0);
+                const aiCombatant = createCombatant(aiData, 'enemy', 0);
+
+                const gameInstance = new GameEngine([playerCombatant, aiCombatant]);
+                const battleLog = gameInstance.runFullGame();
+                const winnerId = gameInstance.winner === 'player' ? game.player1_id : 'AI';
+
+                await db.execute("UPDATE games SET status = 'complete', winner_id = ? WHERE id = ?", [winnerId, gameId]);
+                await db.execute("UPDATE users SET current_game_id = NULL WHERE discord_id = ?", [game.player1_id]);
+
+                const logText = battleLog.join('\n');
+                const resultMessage = `**Battle Complete!**\n**Winner:** ${winnerId === 'AI' ? 'AI Opponent' : `<@${game.player1_id}>`}\n\n**Final Roster:**\n<@${game.player1_id}>: ${gameInstance.combatants[0].currentHp}/${gameInstance.combatants[0].maxHp} HP\nAI Opponent: ${gameInstance.combatants[1].currentHp}/${gameInstance.combatants[1].maxHp} HP\n\n**Battle Log:**\n\`\`\`\n${logText}\n\`\`\``;
+
+                await interaction.followUp({ content: resultMessage });
+            }
+        } catch (error) {
+            console.error('Error handling button interaction:', error);
+            await interaction.update({ content: 'An error occurred while processing your selection.', components: [] });
+        }
     }
 });
 

--- a/discord-bot/managers/DraftManager.js
+++ b/discord-bot/managers/DraftManager.js
@@ -1,0 +1,55 @@
+const { ActionRowBuilder, ButtonBuilder, ButtonStyle, EmbedBuilder } = require('discord.js');
+const { allPossibleHeroes, allPossibleAbilities, allPossibleWeapons } = require('../../backend/game/data');
+
+async function sendHeroSelection(interaction, gameId) {
+    const shuffledHeroes = [...allPossibleHeroes].sort(() => 0.5 - Math.random());
+    const heroChoices = shuffledHeroes.slice(0, 4);
+
+    const embed = new EmbedBuilder().setColor('#0099ff').setTitle('Hero Selection').setDescription('Choose the first hero for your team.');
+    const buttons = heroChoices.map(hero =>
+        new ButtonBuilder()
+            .setCustomId(`draft_hero_${gameId}_${hero.id}`)
+            .setLabel(hero.name)
+            .setStyle(ButtonStyle.Secondary)
+            .setEmoji('👤')
+    );
+    const actionRow = new ActionRowBuilder().addComponents(buttons);
+
+    await interaction.user.send({ content: `Game #${gameId}: It's time to draft!`, embeds: [embed], components: [actionRow] });
+}
+
+async function sendAbilitySelection(interaction, gameId, chosenHeroId) {
+    const hero = allPossibleHeroes.find(h => h.id === chosenHeroId);
+    const abilityPool = allPossibleAbilities.filter(a => a.class === hero.class);
+    const abilityChoices = [...abilityPool].sort(() => 0.5 - Math.random()).slice(0, 4);
+
+    const embed = new EmbedBuilder().setColor('#22c55e').setTitle('Ability Selection').setDescription(`Choose an ability for your ${hero.name}.`);
+    const buttons = abilityChoices.map(ability =>
+        new ButtonBuilder()
+            .setCustomId(`draft_ability_${gameId}_${ability.id}`)
+            .setLabel(ability.name)
+            .setStyle(ButtonStyle.Secondary)
+            .setEmoji('✨')
+    );
+    const actionRow = new ActionRowBuilder().addComponents(buttons);
+
+    await interaction.editReply({ content: 'Next up, choose an ability.', embeds: [embed], components: [actionRow] });
+}
+
+async function sendWeaponSelection(interaction, gameId, chosenHeroName) {
+    const weaponChoices = [...allPossibleWeapons].sort(() => 0.5 - Math.random()).slice(0, 4);
+
+    const embed = new EmbedBuilder().setColor('#ef4444').setTitle('Weapon Selection').setDescription(`Choose a weapon for your ${chosenHeroName}.`);
+    const buttons = weaponChoices.map(weapon =>
+        new ButtonBuilder()
+            .setCustomId(`draft_weapon_${gameId}_${weapon.id}`)
+            .setLabel(weapon.name)
+            .setStyle(ButtonStyle.Secondary)
+            .setEmoji('⚔️')
+    );
+    const actionRow = new ActionRowBuilder().addComponents(buttons);
+
+    await interaction.editReply({ content: 'Finally, choose a weapon.', embeds: [embed], components: [actionRow] });
+}
+
+module.exports = { sendHeroSelection, sendAbilitySelection, sendWeaponSelection };


### PR DESCRIPTION
## Summary
- add `DraftManager.js` with functions for sending hero/ability/weapon selections
- rewrite `/draft` command to use `DraftManager`
- extend `index.js` to handle draft button interactions and run battles

## Testing
- `npm test` in `discord-bot` *(fails: no test specified)*
- `npm test` in `backend` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68585b99ae388327b2f4aeaa4703b340