### PR TITLE
Fix Discord button timeout

### DIFF
--- a/discord-bot/index.js
+++ b/discord-bot/index.js
@@ -75,7 +75,9 @@ client.on(Events.InteractionCreate, async interaction => {
                 await interaction.update({ content: 'Draft canceled.', components: [] });
 
             } else if (action === 'draft') {
-                const [type, gameId, choiceId] = args;
+            // Acknowledge the interaction immediately
+            await interaction.deferUpdate();
+            const [type, gameId, choiceId] = args;
                 // ... (The rest of your draft handling logic remains here) ...
                 const [gameRows] = await db.execute('SELECT * FROM games WHERE id = ?', [gameId]);
                 if (gameRows.length === 0) {


### PR DESCRIPTION
## Summary
- defer draft button update so the bot acknowledges interaction right away

## Testing
- `npm test` in `discord-bot` (fails: no test specified)
- `npm test` in `backend` (fails: no test specified)
- `npm test` in `auto-battler-react` (fails: missing script)

------
https://chatgpt.com/codex/tasks/task_e_6858619f32e083278f60bbe6b20e5b07