### PR TITLE
Add confirmation embeds and tests

### DIFF
--- a/discord-bot/commands/addcard.js
+++ b/discord-bot/commands/addcard.js
@@ -1,4 +1,5 @@
 const { SlashCommandBuilder } = require('discord.js');
+const embedBuilder = require('../src/utils/embedBuilder');
 const confirm = require('../src/utils/confirm');
 
 module.exports = {
@@ -9,6 +10,11 @@ module.exports = {
   async execute(interaction) {
     const name = interaction.options.getString('name');
     // TODO: add new column in DB
-    await interaction.reply({ embeds: [confirm(`Card ${name} added.`)], ephemeral: true });
+    // TODO: persist card to database
+    await interaction.reply({ embeds: [embedBuilder.simple(`Card ${name} added.`)], ephemeral: true });
+    await interaction.followUp({
+      embeds: [ confirm('Your card has been added to your collection.') ],
+      ephemeral: true
+    });
   }
 };

--- a/discord-bot/src/utils/confirm.js
+++ b/discord-bot/src/utils/confirm.js
@@ -1,5 +1,13 @@
-const embedBuilder = require('./embedBuilder');
+const { simple } = require('./embedBuilder');
 
-const confirm = msg => embedBuilder.simple('✅ Success', [{ name: 'Result', value: msg }]);
+/**
+ * Returns a success embed with a standardized checkmark
+ * @param {string} message
+ */
+function confirm(message) {
+  return simple('✅ Success', [
+    { name: 'Result', value: message }
+  ]);
+}
 
 module.exports = confirm;

--- a/discord-bot/tests/confirm.test.js
+++ b/discord-bot/tests/confirm.test.js
@@ -2,15 +2,15 @@ const addcard = require('../commands/addcard');
 const confirm = require('../src/utils/confirm');
 
 describe('confirm embed', () => {
-  test('/addcard uses success embed', async () => {
+  test('/addcard confirmation follow up', async () => {
     const interaction = {
       options: { getString: jest.fn(() => 'Ace') },
-      reply: jest.fn().mockResolvedValue()
+      reply: jest.fn().mockResolvedValue(),
+      followUp: jest.fn().mockResolvedValue()
     };
     await addcard.execute(interaction);
-    const expected = confirm('Card Ace added.');
-    const call = interaction.reply.mock.calls[0][0];
+    const call = interaction.followUp.mock.calls[0][0];
     expect(call.ephemeral).toBe(true);
-    expect(call.embeds[0].data.title).toBe(expected.data.title);
+    expect(call.embeds[0].data.title).toBe('✅ Success');
   });
 });


### PR DESCRIPTION
## Summary
- create helper for confirming actions
- reply then follow up in `/addcard`
- test confirmation follow-up after executing `/addcard`

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68586970aa5c8327a2f9f85be4e65604