### PR TITLE
Fix cancel button update

### DIFF
--- a/discord-bot/index.js
+++ b/discord-bot/index.js
@@ -74,7 +74,9 @@ client.on(Events.InteractionCreate, async interaction => {
                 await interaction.update({ embeds: [confirm('Your previous game has been forfeited. Run `/draft` again to start a new one.')], components: [] });
 
             } else if (action === 'cancel') {
-                await interaction.update({ embeds: [confirm('Draft canceled.')], components: [] });
+                // Defer first to avoid InteractionFailed errors if processing takes too long
+                await interaction.deferUpdate();
+                await interaction.editReply({ embeds: [confirm('Draft canceled.')], components: [] });
 
             } else if (action === 'draft') {
                 await interaction.deferUpdate(); // Defer immediately


### PR DESCRIPTION
## Summary
- avoid `Interaction failed` errors for the cancel button by deferring the update

## Testing
- `npm test --prefix discord-bot`

------
https://chatgpt.com/codex/tasks/task_e_6858698b103483279a9fb4c17077d27f