### PR TITLE
Implement session-based draft flow

### DIFF
--- a/discord-bot/managers/DraftManager.js
+++ b/discord-bot/managers/DraftManager.js
@@ -2,24 +2,24 @@ const { ActionRowBuilder, ButtonBuilder, ButtonStyle } = require('discord.js');
 const { simple } = require('../src/utils/embedBuilder');
 const { allPossibleHeroes, allPossibleAbilities, allPossibleWeapons } = require('../../backend/game/data');
 
-async function sendHeroSelection(interaction, gameId) {
+async function sendHeroSelection(interaction, session) {
     const shuffledHeroes = [...allPossibleHeroes].sort(() => 0.5 - Math.random());
     const heroChoices = shuffledHeroes.slice(0, 4);
 
     const embed = simple('Hero Selection', [{ name: 'Instructions', value: 'Choose the first hero for your team.' }]);
     const buttons = heroChoices.map(hero =>
         new ButtonBuilder()
-            .setCustomId(`draft_hero_${gameId}_${hero.id}`)
+            .setCustomId(`${session.id}:pickHero:${hero.id}`)
             .setLabel(hero.name)
             .setStyle(ButtonStyle.Secondary)
             .setEmoji('👤')
     );
     const actionRow = new ActionRowBuilder().addComponents(buttons);
 
-    await interaction.user.send({ content: `Game #${gameId}: It's time to draft!`, embeds: [embed], components: [actionRow] });
+    await interaction.editReply({ content: 'Choose your hero.', embeds: [embed], components: [actionRow] });
 }
 
-async function sendAbilitySelection(interaction, gameId, chosenHeroId) {
+async function sendAbilitySelection(interaction, session, chosenHeroId) {
     const hero = allPossibleHeroes.find(h => h.id === chosenHeroId);
     const abilityPool = allPossibleAbilities.filter(a => a.class === hero.class);
     const abilityChoices = [...abilityPool].sort(() => 0.5 - Math.random()).slice(0, 4);
@@ -27,7 +27,7 @@ async function sendAbilitySelection(interaction, gameId, chosenHeroId) {
     const embed = simple('Ability Selection', [{ name: 'Instructions', value: `Choose an ability for your ${hero.name}.` }]);
     const buttons = abilityChoices.map(ability =>
         new ButtonBuilder()
-            .setCustomId(`draft_ability_${gameId}_${ability.id}`)
+            .setCustomId(`${session.id}:pickAbility:${ability.id}`)
             .setLabel(ability.name)
             .setStyle(ButtonStyle.Secondary)
             .setEmoji('✨')
@@ -37,13 +37,13 @@ async function sendAbilitySelection(interaction, gameId, chosenHeroId) {
     await interaction.editReply({ content: 'Next up, choose an ability.', embeds: [embed], components: [actionRow] });
 }
 
-async function sendWeaponSelection(interaction, gameId, chosenHeroName) {
+async function sendWeaponSelection(interaction, session, chosenHeroName) {
     const weaponChoices = [...allPossibleWeapons].sort(() => 0.5 - Math.random()).slice(0, 4);
 
     const embed = simple('Weapon Selection', [{ name: 'Instructions', value: `Choose a weapon for your ${chosenHeroName}.` }]);
     const buttons = weaponChoices.map(weapon =>
         new ButtonBuilder()
-            .setCustomId(`draft_weapon_${gameId}_${weapon.id}`)
+            .setCustomId(`${session.id}:pickWeapon:${weapon.id}`)
             .setLabel(weapon.name)
             .setStyle(ButtonStyle.Secondary)
             .setEmoji('⚔️')

--- a/discord-bot/sessionManager.js
+++ b/discord-bot/sessionManager.js
@@ -1,0 +1,33 @@
+const crypto = require('crypto');
+
+const sessions = new Map();
+
+function createSession(userId, data = {}) {
+  const id = crypto.randomUUID();
+  const session = Object.assign(
+    {
+      id,
+      userId,
+      step: 'choose-hero',
+      choices: {},
+      messageId: null,
+    },
+    data,
+  );
+  sessions.set(id, session);
+  return session;
+}
+
+function getSession(id) {
+  return sessions.get(id);
+}
+
+function deleteSession(id) {
+  sessions.delete(id);
+}
+
+module.exports = {
+  createSession,
+  getSession,
+  deleteSession,
+};


### PR DESCRIPTION
## Summary
- refactor draft manager to use session IDs for button customIds
- add simple in-memory session manager
- update `/draft` command to create a session and start hero selection in a single reply
- handle button interactions using the session state machine

## Testing
- `npm install --prefix discord-bot`
- `npm test --prefix discord-bot`

------
https://chatgpt.com/codex/tasks/task_e_685873e9db1083279864704089de4ca4