### PR TITLE
Add fight command

### DIFF
--- a/backend/game/utils.js
+++ b/backend/game/utils.js
@@ -32,4 +32,25 @@ function createCombatant(playerData, team, position) {
     };
 }
 
-module.exports = { createCombatant };
+function generateRandomChampion() {
+    const commonHeroes = allPossibleHeroes.filter(h => h.rarity === 'Common');
+    const hero = commonHeroes[Math.floor(Math.random() * commonHeroes.length)];
+
+    const abilityPool = allPossibleAbilities.filter(a => a.class === hero.class && a.rarity === 'Common');
+    const ability = abilityPool.length ? abilityPool[Math.floor(Math.random() * abilityPool.length)] : null;
+
+    const commonWeapons = allPossibleWeapons.filter(w => w.rarity === 'Common');
+    const weapon = commonWeapons[Math.floor(Math.random() * commonWeapons.length)];
+
+    const commonArmors = allPossibleArmors.filter(a => a.rarity === 'Common');
+    const armor = commonArmors[Math.floor(Math.random() * commonArmors.length)];
+
+    return {
+        hero_id: hero.id,
+        ability_id: ability ? ability.id : null,
+        weapon_id: weapon.id,
+        armor_id: armor.id,
+    };
+}
+
+module.exports = { createCombatant, generateRandomChampion };

--- a/discord-bot/commands/fight.js
+++ b/discord-bot/commands/fight.js
@@ -1,0 +1,7 @@
+const { SlashCommandBuilder } = require('discord.js');
+
+module.exports = {
+    data: new SlashCommandBuilder()
+        .setName('fight')
+        .setDescription('Choose champions from your roster to enter a dungeon fight!'),
+};

--- a/discord-bot/deploy-commands.js
+++ b/discord-bot/deploy-commands.js
@@ -7,7 +7,7 @@ const commands = [];
 const commandsPath = path.join(__dirname, 'commands');
 const commandFiles = fs
   .readdirSync(commandsPath)
-  .filter(file => file.endsWith('.js') && file !== 'draft.js');
+  .filter(file => file.endsWith('.js'));
 
 console.log('Registering slash commands:', commandFiles.join(', '));
 

--- a/discord-bot/index.js
+++ b/discord-bot/index.js
@@ -1,10 +1,12 @@
 const fs = require('node:fs');
 const path = require('node:path');
-const { Client, Collection, GatewayIntentBits, Events } = require('discord.js');
+const { Client, Collection, GatewayIntentBits, Events, ActionRowBuilder, StringSelectMenuBuilder } = require('discord.js');
 require('dotenv').config();
 const db = require('./util/database');
 const { simple } = require('./src/utils/embedBuilder');
 const { allPossibleHeroes } = require('../backend/game/data');
+const { createCombatant, generateRandomChampion } = require('../backend/game/utils');
+const GameEngine = require('../backend/game/engine');
 
 const client = new Client({ intents: [GatewayIntentBits.Guilds] });
 
@@ -38,43 +40,104 @@ client.once(Events.ClientReady, async () => {
 
 // Handle slash commands
 client.on(Events.InteractionCreate, async interaction => {
-    if (!interaction.isChatInputCommand()) return;
-
     try {
-        const userId = interaction.user.id;
-        const [rows] = await db.execute('SELECT * FROM users WHERE discord_id = ?', [userId]);
-        if (rows.length === 0) {
-            await db.execute('INSERT INTO users (discord_id, summoning_shards) VALUES (?, 0)', [userId]);
-        }
-
-        if (interaction.commandName === 'summon') {
-            const SHARD_COST = 10;
-            const userShards = rows[0] ? rows[0].summoning_shards : 0;
-            if (userShards < SHARD_COST) {
-                return interaction.reply({ content: `You don't have enough summoning shards! You need ${SHARD_COST}.`, ephemeral: true });
+        if (interaction.isChatInputCommand()) {
+            const userId = interaction.user.id;
+            const [rows] = await db.execute('SELECT * FROM users WHERE discord_id = ?', [userId]);
+            if (rows.length === 0) {
+                await db.execute('INSERT INTO users (discord_id, summoning_shards) VALUES (?, 0)', [userId]);
             }
 
-            await db.execute('UPDATE users SET summoning_shards = summoning_shards - ? WHERE discord_id = ?', [SHARD_COST, userId]);
+            if (interaction.commandName === 'summon') {
+                const SHARD_COST = 10;
+                const userShards = rows[0] ? rows[0].summoning_shards : 0;
+                if (userShards < SHARD_COST) {
+                    return interaction.reply({ content: `You don't have enough summoning shards! You need ${SHARD_COST}.`, ephemeral: true });
+                }
 
-            const roll = Math.random();
-            let rarity = 'Common';
-            if (roll < 0.005) rarity = 'Epic';
-            else if (roll < 0.05) rarity = 'Rare';
-            else if (roll < 0.30) rarity = 'Uncommon';
+                await db.execute('UPDATE users SET summoning_shards = summoning_shards - ? WHERE discord_id = ?', [SHARD_COST, userId]);
 
-            const possibleHeroes = allPossibleHeroes.filter(h => h.rarity === rarity);
-            const summonedHero = possibleHeroes[Math.floor(Math.random() * possibleHeroes.length)];
+                const roll = Math.random();
+                let rarity = 'Common';
+                if (roll < 0.005) rarity = 'Epic';
+                else if (roll < 0.05) rarity = 'Rare';
+                else if (roll < 0.30) rarity = 'Uncommon';
 
-            await db.execute('INSERT INTO user_champions (user_id, base_hero_id) VALUES (?, ?)', [userId, summonedHero.id]);
+                const possibleHeroes = allPossibleHeroes.filter(h => h.rarity === rarity);
+                const summonedHero = possibleHeroes[Math.floor(Math.random() * possibleHeroes.length)];
 
-            const embed = simple(`✨ You Summoned a Champion! ✨`, [
-                { name: summonedHero.name, value: `Rarity: ${summonedHero.rarity}\nClass: ${summonedHero.class}` }
-            ]);
-            await interaction.reply({ embeds: [embed] });
-        } else {
-            const command = client.commands.get(interaction.commandName);
-            if (!command) return;
-            await command.execute(interaction);
+                await db.execute('INSERT INTO user_champions (user_id, base_hero_id) VALUES (?, ?)', [userId, summonedHero.id]);
+
+                const embed = simple(`✨ You Summoned a Champion! ✨`, [
+                    { name: summonedHero.name, value: `Rarity: ${summonedHero.rarity}\nClass: ${summonedHero.class}` }
+                ]);
+                await interaction.reply({ embeds: [embed] });
+            } else if (interaction.commandName === 'fight') {
+                const [roster] = await db.execute(
+                    'SELECT uc.id, uc.level, h.name, h.rarity FROM user_champions uc JOIN heroes h ON uc.base_hero_id = h.id WHERE uc.user_id = ?',
+                    [userId]
+                );
+
+                if (roster.length < 2) {
+                    return interaction.reply({ content: 'You need at least 2 champions in your roster to fight! Use `/summon` to recruit more.', ephemeral: true });
+                }
+
+                const options = roster.map(champion => ({
+                    label: `${champion.name} (Lvl ${champion.level})`,
+                    description: `Rarity: ${champion.rarity}`,
+                    value: champion.id.toString(),
+                }));
+
+                const selectMenu = new StringSelectMenuBuilder()
+                    .setCustomId('fight_team_select')
+                    .setPlaceholder('Select 2 champions for your team')
+                    .setMinValues(2)
+                    .setMaxValues(2)
+                    .addOptions(options);
+
+                const row = new ActionRowBuilder().addComponents(selectMenu);
+
+                await interaction.reply({
+                    content: 'Choose your team for the dungeon fight!',
+                    components: [row],
+                    ephemeral: true,
+                });
+                return;
+            } else {
+                const command = client.commands.get(interaction.commandName);
+                if (!command) return;
+                await command.execute(interaction);
+            }
+        } else if (interaction.isStringSelectMenu()) {
+            if (interaction.customId === 'fight_team_select') {
+                await interaction.update({ content: 'Team selected! Preparing the battle...', components: [] });
+
+                const [champion1_id, champion2_id] = interaction.values;
+
+                const [p1_rows] = await db.execute('SELECT * FROM user_champions WHERE id = ?', [champion1_id]);
+                const [p2_rows] = await db.execute('SELECT * FROM user_champions WHERE id = ?', [champion2_id]);
+                const playerChampion1 = p1_rows[0];
+                const playerChampion2 = p2_rows[0];
+
+                const aiChampion1 = generateRandomChampion();
+                const aiChampion2 = generateRandomChampion();
+
+                const combatants = [
+                    createCombatant({ hero_id: playerChampion1.base_hero_id, weapon_id: playerChampion1.weapon_id, armor_id: playerChampion1.armor_id, ability_id: playerChampion1.ability_id }, 'player', 0),
+                    createCombatant({ hero_id: playerChampion2.base_hero_id, weapon_id: playerChampion2.weapon_id, armor_id: playerChampion2.armor_id, ability_id: playerChampion2.ability_id }, 'player', 1),
+                    createCombatant({ hero_id: aiChampion1.hero_id, weapon_id: aiChampion1.weapon_id, armor_id: aiChampion1.armor_id, ability_id: aiChampion1.ability_id }, 'enemy', 0),
+                    createCombatant({ hero_id: aiChampion2.hero_id, weapon_id: aiChampion2.weapon_id, armor_id: aiChampion2.armor_id, ability_id: aiChampion2.ability_id }, 'enemy', 1)
+                ];
+
+                const gameInstance = new GameEngine(combatants);
+                const battleLog = gameInstance.runFullGame();
+                const winner = gameInstance.winner;
+
+                await interaction.followUp({ embeds: [simple(`Battle Complete! Winner: ${winner}`)], ephemeral: true });
+                for (const line of battleLog) {
+                    await interaction.followUp({ content: line, ephemeral: true });
+                }
+            }
         }
     } catch (error) {
         console.error(error);


### PR DESCRIPTION
## Summary
- create `/fight` slash command
- register new command and load all command modules
- add fight handler with roster selection and battle logic
- add random champion generator for AI opponents

## Testing
- `npm test --prefix discord-bot`
- `node discord-bot/deploy-commands.js` *(fails: Expected token to be set)*

------
https://chatgpt.com/codex/tasks/task_e_685886cd18888327865c07982342a045