### PR TITLE
Add town hub command

### DIFF
--- a/discord-bot/commands/town.js
+++ b/discord-bot/commands/town.js
@@ -1,0 +1,27 @@
+const { SlashCommandBuilder, ActionRowBuilder, ButtonBuilder, ButtonStyle } = require('discord.js');
+const { simple } = require('../src/utils/embedBuilder');
+
+module.exports = {
+  data: new SlashCommandBuilder()
+    .setName('town')
+    .setDescription('Visit the Town Square and access all game features.'),
+  async execute(interaction) {
+    const embed = simple('Welcome to the Town Square');
+
+    const row1 = new ActionRowBuilder().addComponents(
+      new ButtonBuilder().setCustomId('town_summon').setLabel('Summoning Circle').setStyle(ButtonStyle.Secondary),
+      new ButtonBuilder().setCustomId('town_roster').setLabel('Barracks').setStyle(ButtonStyle.Secondary)
+    );
+
+    const row2 = new ActionRowBuilder().addComponents(
+      new ButtonBuilder().setCustomId('town_craft').setLabel('The Forge').setStyle(ButtonStyle.Secondary),
+      new ButtonBuilder().setCustomId('town_market').setLabel('Marketplace').setStyle(ButtonStyle.Secondary)
+    );
+
+    const row3 = new ActionRowBuilder().addComponents(
+      new ButtonBuilder().setCustomId('town_dungeon').setLabel('Enter the Dungeon Portal').setStyle(ButtonStyle.Primary)
+    );
+
+    await interaction.reply({ embeds: [embed], components: [row1, row2, row3], ephemeral: true });
+  }
+};

--- a/discord-bot/deploy-commands.js
+++ b/discord-bot/deploy-commands.js
@@ -5,10 +5,11 @@ require('dotenv').config();
 
 const commands = [];
 const commandsPath = path.join(__dirname, 'commands');
-// Automatically register all command files, including the new /unleash command
+// Automatically register command files, excluding deprecated ones
+const deprecated = ['summon.js', 'roster.js', 'profile.js', 'fight.js'];
 const commandFiles = fs
   .readdirSync(commandsPath)
-  .filter(file => file.endsWith('.js'));
+  .filter(file => file.endsWith('.js') && !deprecated.includes(file));
 
 console.log('Registering slash commands:', commandFiles.join(', '));
 


### PR DESCRIPTION
## Summary
- exclude deprecated commands from registration
- create new `/town` command as the main hub
- handle new town button interactions for summoning, roster, dungeon and placeholders

## Testing
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6858a352d39883278bb16bb3f8a2233c