### PR TITLE
Add PvP defense team selection

### DIFF
--- a/discord-bot/commands/team.js
+++ b/discord-bot/commands/team.js
@@ -1,0 +1,15 @@
+const { SlashCommandBuilder } = require('discord.js');
+
+module.exports = {
+    data: new SlashCommandBuilder()
+        .setName('team')
+        .setDescription('Manage your champion teams.')
+        .addSubcommand(subcommand =>
+            subcommand
+                .setName('set-defense')
+                .setDescription('Set your persistent team for PvP defense.')
+        ),
+    async execute(interaction) {
+        // Logic is handled in the interaction listener within index.js
+    }
+};

--- a/docs/database_migrations.sql
+++ b/docs/database_migrations.sql
@@ -1,0 +1,8 @@
+-- Step 5: Create the 'defense_teams' table to store player-designated PvP teams.
+CREATE TABLE IF NOT EXISTS `defense_teams` (
+    `user_id` VARCHAR(255) PRIMARY KEY,
+    `champion_1_id` INT NOT NULL COMMENT 'This is the ID from the user_champions table.',
+    `champion_2_id` INT NULL COMMENT 'Can be NULL if a monster is used.',
+    `updated_at` TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    FOREIGN KEY (`user_id`) REFERENCES `users`(`discord_id`)
+);


### PR DESCRIPTION
## Summary
- create `defense_teams` table for PvP defense rosters
- add `/team set-defense` command
- handle defense team selection and saving in the bot

## Testing
- `npm install --silent`
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6858a8b69af88327b0bdba5c61fcbff5