### PR TITLE
Refactor Discord bot to pull hero data from DB

### DIFF
--- a/discord-bot/commands/unleash.js
+++ b/discord-bot/commands/unleash.js
@@ -1,7 +1,7 @@
 const { SlashCommandBuilder } = require('discord.js');
 const db = require('../util/database');
 const { simple } = require('../src/utils/embedBuilder');
-const { allPossibleHeroes } = require('../../backend/game/data');
+const { getMonsters } = require('../util/gameData');
 
 module.exports = {
     data: new SlashCommandBuilder()
@@ -17,7 +17,7 @@ module.exports = {
             return interaction.reply({ content: 'You do not have a Corrupted Lodestone to unleash a monster.', ephemeral: true });
         }
 
-        const monsters = allPossibleHeroes.filter(h => h.isMonster);
+        const monsters = getMonsters();
         const summonedMonster = monsters[Math.floor(Math.random() * monsters.length)];
 
         await db.execute('INSERT INTO user_champions (user_id, base_hero_id) VALUES (?, ?)', [userId, summonedMonster.id]);

--- a/discord-bot/util/gameData.js
+++ b/discord-bot/util/gameData.js
@@ -1,0 +1,25 @@
+const db = require('./database');
+
+let heroes = [];
+
+async function loadHeroes() {
+  const [rows] = await db.execute(
+    'SELECT id, name, rarity, class, is_monster, trait FROM heroes'
+  );
+  heroes = rows;
+  console.log(`✅ Loaded ${heroes.length} heroes from database.`);
+}
+
+function getHeroes() {
+  return heroes;
+}
+
+function getHeroById(id) {
+  return heroes.find(h => h.id === id);
+}
+
+function getMonsters() {
+  return heroes.filter(h => h.is_monster);
+}
+
+module.exports = { loadHeroes, getHeroes, getHeroById, getMonsters };


### PR DESCRIPTION
## Summary
- cache hero & monster data using new `gameData` utility
- load hero data from MySQL when bot starts
- update all handlers to use DB-backed hero data

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6858baa77a2c8327a4113b23fa97e088