### PR TITLE
Add team manage command

### DIFF
--- a/discord-bot/commands/team.js
+++ b/discord-bot/commands/team.js
@@ -8,6 +8,18 @@ module.exports = {
             subcommand
                 .setName('set-defense')
                 .setDescription('Set your persistent team for PvP defense.')
+        )
+        .addSubcommand(subcommand =>
+            subcommand
+                .setName('manage')
+                .setDescription('Equip items on one of your champions.')
+                .addStringOption(opt =>
+                    opt
+                        .setName('champion')
+                        .setDescription('Champion to manage')
+                        .setRequired(true)
+                        .setAutocomplete(true)
+                )
         ),
     async execute(interaction) {
         // Logic is handled in the interaction listener within index.js


### PR DESCRIPTION
## Summary
- add `/team manage` subcommand with champion autocomplete
- implement autocomplete handler to fetch champion list
- show champion details and equipment menus for weapon, armor, ability
- update equipped gear when selections are made

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6858baea52e88327bfcb33eda38cdc1c