### PR TITLE
Add PvP battles and leaderboard

### DIFF
--- a/discord-bot/commands/leaderboard.js
+++ b/discord-bot/commands/leaderboard.js
@@ -1,0 +1,26 @@
+const { SlashCommandBuilder, EmbedBuilder } = require('discord.js');
+const db = require('../util/database');
+
+module.exports = {
+    data: new SlashCommandBuilder()
+        .setName('leaderboard')
+        .setDescription('Display the top PvP players.'),
+    async execute(interaction) {
+        const [rows] = await db.execute(
+            'SELECT discord_id, pvp_rating FROM users ORDER BY pvp_rating DESC LIMIT 10'
+        );
+        if (rows.length === 0) {
+            return interaction.reply({ content: 'No players found.', ephemeral: true });
+        }
+
+        const description = rows
+            .map((row, idx) => `${idx + 1}. <@${row.discord_id}> - ${row.pvp_rating || 0}`)
+            .join('\n');
+
+        const embed = new EmbedBuilder()
+            .setColor('#f59e0b')
+            .setTitle('🏆 PvP Leaderboard')
+            .setDescription(description);
+        await interaction.reply({ embeds: [embed], ephemeral: true });
+    }
+};

--- a/discord-bot/deploy-commands.js
+++ b/discord-bot/deploy-commands.js
@@ -6,9 +6,13 @@ require('dotenv').config();
 const commands = [];
 const commandsPath = path.join(__dirname, 'commands');
 // Automatically register all command files in the commands directory
-const commandFiles = fs
+let commandFiles = fs
   .readdirSync(commandsPath)
   .filter(file => file.endsWith('.js'));
+
+if (!commandFiles.includes('leaderboard.js')) {
+  commandFiles.push('leaderboard.js');
+}
 
 console.log('Registering slash commands:', commandFiles.join(', '));
 


### PR DESCRIPTION
## Summary
- add PvP enemy selection and rating updates
- create `/leaderboard` command to show top PvP players
- ensure deploy script explicitly handles new command

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6858bb09b9908327bd0e1320621e8675