### PR TITLE
Fix undefined stats in summon confirmation

### DIFF
--- a/discord-bot/util/gameData.js
+++ b/discord-bot/util/gameData.js
@@ -10,7 +10,7 @@ const gameData = {
 async function loadAllData() {
     try {
         // Corrected SQL query with snake_case
-        const [heroes] = await db.execute('SELECT id, name, rarity, class, is_monster, trait FROM heroes');
+        const [heroes] = await db.execute('SELECT id, name, rarity, class, is_monster, trait, hp, attack, speed FROM heroes');
         for (const hero of heroes) {
             gameData.heroes.set(hero.id, hero);
         }


### PR DESCRIPTION
## Summary
- include HP, attack and speed columns when loading heroes into cache

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68596b1787d88327ac55fdcb24687e15