### PR TITLE
Fix monster column query

### DIFF
--- a/discord-bot/index.js
+++ b/discord-bot/index.js
@@ -604,7 +604,7 @@ client.on(Events.InteractionCreate, async interaction => {
 
                 if (!isPvP) {
                     const [monsterRows] = await db.execute(
-                        'SELECT id FROM heroes WHERE isMonster = TRUE'
+                        'SELECT id FROM heroes WHERE is_monster = TRUE'
                     );
                     const monsterIds = monsterRows.map(r => r.id);
                     const randIndex1 = Math.floor(Math.random() * monsterIds.length);


### PR DESCRIPTION
## Summary
- fix dungeon query to use new `is_monster` column

## Testing
- `npm test` *(fails: jest not found)*
- `mysql -e "ALTER TABLE heroes ADD COLUMN is_monster BOOLEAN DEFAULT FALSE;"` *(fails: can't connect to local MySQL server)*

------
https://chatgpt.com/codex/tasks/task_e_68598333d6788327999768e2571c2160