### PR TITLE
Implement champion ability deck management

### DIFF
--- a/discord-bot/commands/team.js
+++ b/discord-bot/commands/team.js
@@ -22,6 +22,10 @@ module.exports = {
                 )
         ),
     async execute(interaction) {
-        // Logic is handled in the interaction listener within index.js
+        // Logic handled in index.js for interaction processing.
+        // The core functionality for 'manage' is now driven by the Barracks UI flow.
+        // You can leave this execute empty or provide a basic ephemeral reply
+        // directing the user to the /town command if they try to use /team manage directly.
+        await interaction.reply({ content: "Please use the `/town` command and then navigate to Barracks to manage your champions. This command is mainly for internal use or specific direct champion selection.", ephemeral: true });
     }
 };


### PR DESCRIPTION
## Summary
- allow champion management to show and edit deck abilities
- support selecting champions from barracks menu
- enable adding an ability card to a champion deck
- clarify `/team manage` command output

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68599008047483278a7276d9489d67f3