### PR TITLE
Fix champion management query

### DIFF
--- a/discord-bot/index.js
+++ b/discord-bot/index.js
@@ -534,7 +534,7 @@ client.on(Events.InteractionCreate, async interaction => {
 
                     const userId = interaction.user.id;
                     const [ownedChampions] = await db.execute(
-                        'SELECT uc.id, h.name, h.level, h.class, h.rarity FROM user_champions uc JOIN heroes h ON uc.base_hero_id = h.id WHERE uc.user_id = ?',
+                        'SELECT uc.id, h.name, uc.level, h.class, h.rarity FROM user_champions uc JOIN heroes h ON uc.base_hero_id = h.id WHERE uc.user_id = ?',
                         [userId]
                     );
 


### PR DESCRIPTION
## Summary
- query champion data using `uc.level` instead of nonexistent `h.level`

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68599252805883279f43701739d78cb8