### PR TITLE
Add pack opening and inventory display

### DIFF
--- a/discord-bot/commands/inventory.js
+++ b/discord-bot/commands/inventory.js
@@ -1,0 +1,95 @@
+const { SlashCommandBuilder } = require('discord.js');
+const { simple } = require('../src/utils/embedBuilder');
+const db = require('../util/database');
+const {
+    allPossibleHeroes,
+    allPossibleWeapons,
+    allPossibleArmors,
+    allPossibleAbilities
+} = require('../../backend/game/data');
+
+module.exports = {
+    data: new SlashCommandBuilder()
+        .setName('inventory')
+        .setDescription('View all cards and items in your collection.'),
+    async execute(interaction) {
+        await interaction.deferReply({ ephemeral: true });
+
+        const userId = interaction.user.id;
+
+        try {
+            const [rows] = await db.execute(
+                `SELECT item_id, quantity, item_type FROM user_inventory WHERE user_id = ?`,
+                [userId]
+            );
+
+            const inventory = {
+                hero: [],
+                ability: [],
+                weapon: [],
+                armor: [],
+                monster: [],
+                other: []
+            };
+
+            for (const row of rows) {
+                let itemName = `Unknown Item (ID: ${row.item_id})`;
+                let itemRarity = '';
+                let itemCategory = row.item_type || 'other';
+
+                let itemData = null;
+                switch (itemCategory) {
+                    case 'hero':
+                        itemData = allPossibleHeroes.find(h => h.id === row.item_id);
+                        if (itemData && itemData.isMonster) itemCategory = 'monster';
+                        break;
+                    case 'ability':
+                        itemData = allPossibleAbilities.find(a => a.id === row.item_id);
+                        break;
+                    case 'weapon':
+                        itemData = allPossibleWeapons.find(w => w.id === row.item_id);
+                        break;
+                    case 'armor':
+                        itemData = allPossibleArmors.find(a => a.id === row.item_id);
+                        break;
+                }
+
+                if (itemData) {
+                    itemName = itemData.name;
+                    itemRarity = itemData.rarity ? ` (${itemData.rarity})` : '';
+                } else if (itemCategory === 'monster') {
+                    itemData = allPossibleHeroes.find(h => h.id === row.item_id && h.isMonster);
+                    if (itemData) {
+                        itemName = itemData.name;
+                        itemRarity = itemData.rarity ? ` (${itemData.rarity})` : '';
+                    }
+                }
+
+                if (inventory[itemCategory]) {
+                    inventory[itemCategory].push(`**${itemName}**${itemRarity} x${row.quantity}`);
+                } else {
+                    inventory.other.push(`**${itemName}**${itemRarity} x${row.quantity}`);
+                }
+            }
+
+            const fields = [];
+            if (inventory.hero.length > 0) fields.push({ name: 'Champions (Base)', value: inventory.hero.join('\n'), inline: true });
+            if (inventory.monster.length > 0) fields.push({ name: 'Monsters', value: inventory.monster.join('\n'), inline: true });
+            if (inventory.ability.length > 0) fields.push({ name: 'Abilities', value: inventory.ability.join('\n'), inline: true });
+            if (inventory.weapon.length > 0) fields.push({ name: 'Weapons', value: inventory.weapon.join('\n'), inline: true });
+            if (inventory.armor.length > 0) fields.push({ name: 'Armor', value: inventory.armor.join('\n'), inline: true });
+            if (inventory.other.length > 0) fields.push({ name: 'Other Items', value: inventory.other.join('\n'), inline: true });
+
+            if (fields.length === 0) {
+                fields.push({ name: 'Your Inventory is Empty!', value: 'Use `/openpack` to acquire new cards!' });
+            }
+
+            const embed = simple('🎒 Your Collection', fields);
+            await interaction.editReply({ embeds: [embed] });
+
+        } catch (error) {
+            console.error('Error fetching inventory:', error);
+            await interaction.editReply({ content: 'Failed to retrieve your inventory.', ephemeral: true });
+        }
+    },
+};

--- a/discord-bot/commands/openpack.js
+++ b/discord-bot/commands/openpack.js
@@ -1,14 +1,112 @@
 const { SlashCommandBuilder } = require('discord.js');
 const { simple } = require('../src/utils/embedBuilder');
 const confirm = require('../src/utils/confirm');
+const db = require('../util/database');
+const {
+    allPossibleHeroes,
+    allPossibleWeapons,
+    allPossibleArmors,
+    allPossibleAbilities
+} = require('../../backend/game/data');
+
+function getRandomCards(pool, count = 3, allowedRarities = ['Common', 'Uncommon']) {
+    const filteredPool = pool.filter(item => allowedRarities.includes(item.rarity));
+    const shuffled = [...filteredPool].sort(() => 0.5 - Math.random());
+    const uniqueCards = [];
+    const uniqueIds = new Set();
+    for (const card of shuffled) {
+        if (!uniqueIds.has(card.id)) {
+            uniqueCards.push(card);
+            uniqueIds.add(card.id);
+            if (uniqueCards.length >= count) break;
+        }
+    }
+    while (uniqueCards.length < count) {
+        const fallback = pool[Math.floor(Math.random() * pool.length)];
+        if (!uniqueIds.has(fallback.id)) {
+            uniqueCards.push(fallback);
+            uniqueIds.add(fallback.id);
+        }
+    }
+    return uniqueCards;
+}
 
 module.exports = {
-  data: new SlashCommandBuilder()
-    .setName('openpack')
-    .setDescription('Open a card pack'),
-  async execute(interaction) {
-    const results = simple('Pack Opened', [{ name: 'Cards', value: 'Ace, King' }]);
-    await interaction.reply({ embeds: [results], ephemeral: true });
-    await interaction.followUp({ embeds: [confirm('Cards added to your collection.')], ephemeral: true });
-  }
+    data: new SlashCommandBuilder()
+        .setName('openpack')
+        .setDescription('Open a booster pack of a specific type.')
+        .addStringOption(option =>
+            option.setName('type')
+                .setDescription('The type of booster pack to open.')
+                .setRequired(true)
+                .addChoices(
+                    { name: 'Hero Pack', value: 'hero' },
+                    { name: 'Ability Pack', value: 'ability' },
+                    { name: 'Weapon Pack', value: 'weapon' },
+                    { name: 'Armor Pack', value: 'armor' }
+                )),
+    async execute(interaction) {
+        await interaction.deferReply({ ephemeral: true });
+
+        const userId = interaction.user.id;
+        const packType = interaction.options.getString('type');
+
+        let cardPool = [];
+        let packName = '';
+        let awardedCards = [];
+
+        switch (packType) {
+            case 'hero':
+                cardPool = allPossibleHeroes;
+                packName = 'Hero Pack';
+                awardedCards = getRandomCards(cardPool.filter(h => !h.isMonster), 1, ['Common', 'Uncommon', 'Rare']);
+                break;
+            case 'ability':
+                cardPool = allPossibleAbilities;
+                packName = 'Ability Pack';
+                awardedCards = getRandomCards(cardPool, 3, ['Common', 'Uncommon', 'Rare']);
+                break;
+            case 'weapon':
+                cardPool = allPossibleWeapons;
+                packName = 'Weapon Pack';
+                awardedCards = getRandomCards(cardPool, 2, ['Common', 'Uncommon']);
+                break;
+            case 'armor':
+                cardPool = allPossibleArmors;
+                packName = 'Armor Pack';
+                awardedCards = getRandomCards(cardPool, 2, ['Common', 'Uncommon']);
+                break;
+            default:
+                await interaction.editReply({ content: 'Invalid pack type selected.', ephemeral: true });
+                return;
+        }
+
+        if (awardedCards.length === 0) {
+            await interaction.editReply({ content: `Could not generate cards for ${packName}.`, ephemeral: true });
+            return;
+        }
+
+        const cardNames = [];
+        for (const card of awardedCards) {
+            cardNames.push(`**${card.name}** (${card.rarity})`);
+            try {
+                await db.execute(
+                    `INSERT INTO user_inventory (user_id, item_id, quantity, item_type)
+                     VALUES (?, ?, 1, ?)
+                     ON DUPLICATE KEY UPDATE quantity = quantity + 1`,
+                    [userId, card.id, card.type || packType]
+                );
+            } catch (error) {
+                console.error(`Error adding card ${card.id} to inventory for user ${userId}:`, error);
+            }
+        }
+
+        const resultsEmbed = simple(
+            `📦 ${packName} Opened!`,
+            [{ name: 'Cards Received', value: cardNames.join('\n') }]
+        );
+
+        await interaction.editReply({ embeds: [resultsEmbed] });
+        await interaction.followUp({ embeds: [confirm('Your new cards have been added to your collection!')], ephemeral: true });
+    },
 };

--- a/discord-bot/tests/confirm.test.js
+++ b/discord-bot/tests/confirm.test.js
@@ -1,4 +1,9 @@
 const addcard = require('../commands/addcard');
+
+jest.mock('../util/database', () => ({
+  execute: jest.fn(() => Promise.resolve([]))
+}));
+
 const openpack = require('../commands/openpack');
 
 describe('confirm embed', () => {
@@ -16,11 +21,14 @@ describe('confirm embed', () => {
 
   test('/openpack sequential confirmation', async () => {
     const interaction = {
-      reply: jest.fn().mockResolvedValue(),
-      followUp: jest.fn().mockResolvedValue()
+      deferReply: jest.fn().mockResolvedValue(),
+      editReply: jest.fn().mockResolvedValue(),
+      followUp: jest.fn().mockResolvedValue(),
+      user: { id: '123' },
+      options: { getString: jest.fn(() => 'hero') }
     };
     await openpack.execute(interaction);
-    expect(interaction.reply).toHaveBeenCalled();
+    expect(interaction.deferReply).toHaveBeenCalled();
     const follow = interaction.followUp.mock.calls[0][0];
     expect(follow.embeds[0].data.title).toBe('✅ Success');
   });

--- a/docs/database_migrations.sql
+++ b/docs/database_migrations.sql
@@ -6,3 +6,7 @@ CREATE TABLE IF NOT EXISTS `defense_teams` (
     `updated_at` TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
     FOREIGN KEY (`user_id`) REFERENCES `users`(`discord_id`)
 );
+
+-- Step 6: Add item_type column for categorizing inventory items
+ALTER TABLE `user_inventory`
+    ADD COLUMN `item_type` VARCHAR(20) DEFAULT NULL AFTER `quantity`;


### PR DESCRIPTION
## Summary
- implement booster pack opening logic
- show categorized inventory
- track item type in database migrations
- adjust test to mock db and handle new command

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6859aab5d66c83279ef7dc5c831ef50b