### PR TITLE
Implement database-backed booster pack store

### DIFF
--- a/discord-bot/package.json
+++ b/discord-bot/package.json
@@ -4,6 +4,7 @@
   "description": "Auto battler discord bot",
   "main": "index.js",
   "dependencies": {
-    "discord.js": "^14.13.0"
+    "discord.js": "^14.13.0",
+    "mysql2": "^3.6.0"
   }
 }


### PR DESCRIPTION
## Summary
- enable MySQL pool for persistent data
- add database logic for buying booster packs
- add mysql2 dependency

## Testing
- `npm --prefix discord-bot install`


------
https://chatgpt.com/codex/tasks/task_e_6859afa23c588327824eeb47696d5d6a