### PR TITLE
Implement booster pack store in bot

### DIFF
--- a/discord-bot/commands/town.js
+++ b/discord-bot/commands/town.js
@@ -16,7 +16,7 @@ function getTownMenu() {
     const row2 = new ActionRowBuilder()
         .addComponents(
             new ButtonBuilder().setCustomId('town_forge').setLabel('The Forge').setStyle(ButtonStyle.Secondary).setEmoji('🔥').setDisabled(true),
-            new ButtonBuilder().setCustomId('town_market').setLabel('Marketplace').setStyle(ButtonStyle.Secondary).setEmoji('💰').setDisabled(true)
+            new ButtonBuilder().setCustomId('town_market').setLabel('Marketplace').setStyle(ButtonStyle.Secondary).setEmoji('💰').setDisabled(false)
         );
 
     const row3 = new ActionRowBuilder()


### PR DESCRIPTION
## Summary
- enable Marketplace button in town menu
- define booster packs and helper for pulling random cards
- add store UI and purchase logic in interaction handler

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6859bb6d0404832788127ce5dae1eaad