### PR TITLE
Add View Inventory button after opening packs

### DIFF
--- a/discord-bot/index.js
+++ b/discord-bot/index.js
@@ -930,7 +930,44 @@ client.on(Events.InteractionCreate, async interaction => {
                         .setFooter({ text: 'Your new cards have been added to your collection!' })
                         .setTimestamp();
 
-                    await interaction.editReply({ embeds: [resultsEmbed] });
+                    // --- ADDED 'VIEW INVENTORY' BUTTON ---
+                    const viewInventoryButton = new ActionRowBuilder()
+                        .addComponents(
+                            new ButtonBuilder()
+                                .setCustomId('view_inventory_from_pack')
+                                .setLabel('View Inventory')
+                                .setStyle(ButtonStyle.Secondary)
+                                .setEmoji('🎒')
+                        );
+                    // Build buttons to buy more packs
+                    const packPurchaseButtons = Object.entries(BOOSTER_PACKS).map(([packIdBtn, packInfoBtn]) =>
+                        new ButtonBuilder()
+                            .setCustomId(`buy_pack_${packIdBtn}`)
+                            .setLabel(`${packInfoBtn.name} (${packInfoBtn.cost} ${packInfoBtn.currency === 'soft_currency' ? 'Gold 🪙' : 'Gems 💎'})`)
+                            .setStyle(ButtonStyle.Primary)
+                            .setEmoji('🛒')
+                    );
+                    const packButtonRows = [];
+                    if (packPurchaseButtons.length > 0) {
+                        packButtonRows.push(new ActionRowBuilder().addComponents(packPurchaseButtons));
+                    }
+
+                    const backButton = new ActionRowBuilder()
+                        .addComponents(
+                            new ButtonBuilder().setCustomId('back_to_market').setLabel('Back to Marketplace').setStyle(ButtonStyle.Secondary).setEmoji('⬅️')
+                        );
+
+                    await interaction.editReply({ embeds: [resultsEmbed], components: [viewInventoryButton, ...packButtonRows, backButton] });
+                    break;
+                }
+                case 'view_inventory_from_pack': {
+                    await interaction.deferUpdate();
+                    const inventoryCommand = client.commands.get('inventory');
+                    if (inventoryCommand) {
+                        await inventoryCommand.execute(interaction);
+                    } else {
+                        await interaction.editReply({ content: 'Inventory command not found.', ephemeral: true });
+                    }
                     break;
                 }
                 case 'back_to_market': {


### PR DESCRIPTION
## Summary
- after buying a booster pack, show a `View Inventory` button
- handle new `view_inventory_from_pack` button to call the `/inventory` command

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6859c65a6e788327b19c86adbb5d8966