### PR TITLE
Add booster pack cases

### DIFF
--- a/discord-bot/index.js
+++ b/discord-bot/index.js
@@ -904,6 +904,9 @@ client.on(Events.InteractionCreate, async interaction => {
                             awardedCardsCount = 2;
                             actualItemType = 'armor';
                             break;
+                        default:
+                            await interaction.editReply({ content: 'Internal error: Unknown pack content type.', ephemeral: true });
+                            return;
                     }
                     const awardedCards = getRandomCardsForPack(cardPool, awardedCardsCount, packInfo.rarity);
 


### PR DESCRIPTION
## Summary
- support ability, weapon, and armor booster packs in the marketplace

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6859d49898d88327920e2989495db71b