### PR TITLE
Improve navigation with Back to Town buttons

### DIFF
--- a/discord-bot/commands/inventory.js
+++ b/discord-bot/commands/inventory.js
@@ -1,4 +1,4 @@
-const { SlashCommandBuilder, EmbedBuilder } = require('discord.js');
+const { SlashCommandBuilder, EmbedBuilder, ActionRowBuilder, ButtonBuilder, ButtonStyle } = require('discord.js');
 const { simple } = require('../src/utils/embedBuilder');
 const db = require('../util/database');
 const {
@@ -109,7 +109,11 @@ module.exports = {
 
             const embed = simple('🎒 Your Collection', fields);
             console.log('[INVENTORY DEBUG] Attempting to editReply.');
-            await interaction.editReply({ embeds: [embed], components: [] });
+            const navigationRow = new ActionRowBuilder()
+                .addComponents(
+                    new ButtonBuilder().setCustomId('back_to_town').setLabel('Back to Town').setStyle(ButtonStyle.Secondary).setEmoji('🏠')
+                );
+            await interaction.editReply({ embeds: [embed], components: [navigationRow] });
             console.log('[INVENTORY DEBUG] editReply successful.');
 
         } catch (error) {

--- a/discord-bot/index.js
+++ b/discord-bot/index.js
@@ -723,15 +723,15 @@ client.on(Events.InteractionCreate, async interaction => {
                         .addOptions(championOptions.slice(0, 25));
 
                     const row = new ActionRowBuilder().addComponents(selectMenu);
-                    const backButton = new ActionRowBuilder()
+                    const navigationRow = new ActionRowBuilder()
                         .addComponents(
-                            new ButtonBuilder().setCustomId('back_to_barracks').setLabel('Back to Barracks').setStyle(ButtonStyle.Secondary).setEmoji('⬅️')
+                            new ButtonBuilder().setCustomId('back_to_barracks').setLabel('Back to Barracks').setStyle(ButtonStyle.Secondary).setEmoji('⬅️'),
+                            new ButtonBuilder().setCustomId('back_to_town').setLabel('Back to Town').setStyle(ButtonStyle.Secondary).setEmoji('🏠')
                         );
-
 
                     await interaction.editReply({
                         embeds: [simple('Manage Your Champions', [{ name: 'Choose a Champion', value: 'Select a champion to view their details and modify their deck.' }])],
-                        components: [row, backButton]
+                        components: [row, navigationRow]
                     });
                     break;
                 }
@@ -815,7 +815,11 @@ client.on(Events.InteractionCreate, async interaction => {
                         .setMaxValues(2)
                         .addOptions(options);
                     const row = new ActionRowBuilder().addComponents(selectMenu);
-                    await interaction.reply({ content: 'Choose your team for the dungeon fight!', components: [row], ephemeral: true });
+                    const backToTownRow = new ActionRowBuilder()
+                        .addComponents(
+                            new ButtonBuilder().setCustomId('back_to_town').setLabel('Back to Town').setStyle(ButtonStyle.Secondary).setEmoji('⬅️')
+                        );
+                    await interaction.reply({ content: 'Choose your team for the dungeon fight!', components: [row, backToTownRow], ephemeral: true });
                     break;
                 }
                 case 'town_forge': {
@@ -1166,7 +1170,8 @@ client.on(Events.InteractionCreate, async interaction => {
 
             const navigationRow = new ActionRowBuilder()
                 .addComponents(
-                    new ButtonBuilder().setCustomId('back_to_barracks_from_champ').setLabel('Back to Roster').setStyle(ButtonStyle.Secondary).setEmoji('⬅️')
+                    new ButtonBuilder().setCustomId('back_to_barracks_from_champ').setLabel('Back to Roster').setStyle(ButtonStyle.Secondary).setEmoji('⬅️'),
+                    new ButtonBuilder().setCustomId('back_to_town').setLabel('Back to Town').setStyle(ButtonStyle.Secondary).setEmoji('🏠')
                 );
             components.push(navigationRow);
 


### PR DESCRIPTION
## Summary
- ensure manage champions menus include Back to Town
- add Back to Town option on champion detail screen
- provide Back to Town button when choosing dungeon team
- include Back to Town navigation in inventory command

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6859da6ff794832784b6934d3b05f744