### PR TITLE
Enable decks in combat and champion leveling

### DIFF
--- a/backend/game/utils.js
+++ b/backend/game/utils.js
@@ -6,6 +6,7 @@ function createCombatant(playerData, team, position) {
     const weapon = allPossibleWeapons.find(w => w.id === playerData.weapon_id);
     const armor = allPossibleArmors.find(a => a.id === playerData.armor_id);
     const ability = allPossibleAbilities.find(a => a.id === playerData.ability_id);
+    const deckAbilities = (playerData.deck || []).map(id => allPossibleAbilities.find(a => a.id === id));
 
     if (!hero) return null;
 
@@ -22,6 +23,7 @@ function createCombatant(playerData, team, position) {
         weaponData: weapon,
         armorData: armor,
         abilityData: ability,
+        deck: deckAbilities,
         team: team,
         position: position,
         currentHp: finalStats.hp,


### PR DESCRIPTION
## Summary
- pass each champion's deck when creating combatants
- expose deck info inside createCombatant
- teach the game engine to choose abilities from the deck
- add XP thresholds and helper to level up champions
- apply level-ups after PvE victories

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_685ad31282ec8327904693add1099df0