### PR TITLE
Refactor tutorial entry via town command

### DIFF
--- a/discord-bot/commands/start.js
+++ b/discord-bot/commands/start.js
@@ -1,26 +1,15 @@
-const { SlashCommandBuilder, ActionRowBuilder, ButtonBuilder, ButtonStyle } = require('discord.js');
+const { SlashCommandBuilder } = require('discord.js');
 const { simple } = require('../src/utils/embedBuilder');
 
 module.exports = {
     data: new SlashCommandBuilder()
         .setName('start')
-        .setDescription('Begin your adventure and create your first champions!'),
+        .setDescription('Learn how to begin your adventure!'),
     async execute(interaction) {
         const embed = simple(
             'Welcome to the Grand Adventure!',
-            [
-                { name: 'Your Journey Begins!', value: 'Prepare to forge your path in a world of mighty heroes and formidable monsters. To begin, let\'s get you equipped with your first champions and some starting resources!' }
-            ]
+            [{ name: 'Your Journey Begins!', value: 'Use the `/town` command to get started. If you are a new player, a "Begin Your Training" button will appear to guide you!' }]
         );
-
-        const row = new ActionRowBuilder()
-            .addComponents(
-                new ButtonBuilder()
-                    .setCustomId('tutorial_start_new_flow')
-                    .setLabel('Begin Your Training')
-                    .setStyle(ButtonStyle.Primary)
-            );
-
-        await interaction.reply({ embeds: [embed], components: [row], ephemeral: true });
+        await interaction.reply({ embeds: [embed], ephemeral: true });
     },
 };


### PR DESCRIPTION
## Summary
- move tutorial onboarding button to `/town`
- make `/start` informational
- remove special handling of `/start` in bot logic
- initialize tutorial state when the training button is pressed

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685ad7dab7948327bc8494508020561f