### PR TITLE
Add back navigation for empty champion roster

### DIFF
--- a/discord-bot/index.js
+++ b/discord-bot/index.js
@@ -617,7 +617,20 @@ client.on(Events.InteractionCreate, async interaction => {
                     );
 
                     if (ownedChampions.length === 0) {
-                        await interaction.editReply({ content: 'You have no champions to manage!', components: [] });
+                        // Create a button to allow the user to go back
+                        const backButton = new ButtonBuilder()
+                            .setCustomId('back_to_barracks')
+                            .setLabel('Back to Barracks')
+                            .setStyle(ButtonStyle.Secondary)
+                            .setEmoji('⬅️');
+
+                        const row = new ActionRowBuilder().addComponents(backButton);
+
+                        // Update the reply to include the button
+                        await interaction.editReply({
+                            content: 'You have no champions to manage!',
+                            components: [row]
+                        });
                         return;
                     }
 


### PR DESCRIPTION
## Summary
- include a **Back to Barracks** button when Manage Champions menu finds no champions

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685ad9cdfc788327908dc3ad91c6053c