### PR TITLE
Update town button logic

### DIFF
--- a/discord-bot/commands/town.js
+++ b/discord-bot/commands/town.js
@@ -1,24 +1,32 @@
 const { SlashCommandBuilder, ActionRowBuilder, ButtonBuilder, ButtonStyle, EmbedBuilder } = require('discord.js');
 const db = require('../util/database');
 
+/**
+ * Generates the town menu, conditionally adding a tutorial button.
+ * @param {boolean} showTutorialButton - Whether to show the "Begin Your Training" button.
+ * @returns {object} The message payload for Discord's reply function.
+ */
+
 function getTownMenu(showTutorialButton = false) {
     const embed = new EmbedBuilder()
         .setColor('#29b6f6')
         .setTitle('Welcome to the Town Square')
-        .setDescription('This is your central hub for all activities. Where would you like to go?')
+        .setDescription(
+            'This is your central hub for all activities. Where would you like to go?'
+        )
         .setImage('https://placehold.co/600x200/1e293b/ffffff?text=Town+Square');
 
     const components = [];
 
+    // Conditionally add the tutorial button at the very top if needed.
     if (showTutorialButton) {
-        const tutorialRow = new ActionRowBuilder()
-            .addComponents(
-                new ButtonBuilder()
-                    .setCustomId('tutorial_start_new_flow')
-                    .setLabel('Begin Your Training')
-                    .setStyle(ButtonStyle.Success)
-                    .setEmoji('🎓')
-            );
+        const tutorialRow = new ActionRowBuilder().addComponents(
+            new ButtonBuilder()
+                .setCustomId('tutorial_start_new_flow')
+                .setLabel('Begin Your Training')
+                .setStyle(ButtonStyle.Success)
+                .setEmoji('🎓')
+        );
         components.push(tutorialRow);
     }
 
@@ -40,7 +48,7 @@ function getTownMenu(showTutorialButton = false) {
 
     components.push(row1, row2, row3);
 
-    return { embeds: [embed], components, ephemeral: true };
+    return { embeds: [embed], components: components, ephemeral: true };
 }
 
 module.exports = {
@@ -51,12 +59,31 @@ module.exports = {
         const userId = interaction.user.id;
         let showTutorial = false;
         try {
-            const [[user]] = await db.execute('SELECT tutorial_completed FROM users WHERE discord_id = ?', [userId]);
-            if (!user || !user.tutorial_completed) {
+            // Check if the user exists in the database.
+            let [[user]] = await db.execute(
+                'SELECT tutorial_completed FROM users WHERE discord_id = ?',
+                [userId]
+            );
+
+            // If the user doesn't exist, create a new entry for them.
+            if (!user) {
+                await db.execute(
+                    'INSERT INTO users (discord_id) VALUES (?) ON DUPLICATE KEY UPDATE discord_id=discord_id',
+                    [userId]
+                );
+                user = { tutorial_completed: 0 };
+            }
+
+            // If the tutorial_completed flag is 0 (or false), we should show the button.
+            if (!user.tutorial_completed) {
                 showTutorial = true;
             }
         } catch (error) {
-            console.error(`Error checking tutorial status for ${userId}:`, error);
+            console.error(
+                `[ERROR] Could not check tutorial status for user ${userId}:`,
+                error
+            );
+            // As a fallback, we won't show the tutorial button if the database check fails.
         }
         await interaction.reply(getTownMenu(showTutorial));
     },


### PR DESCRIPTION
## Summary
- show the training button for new players in `/town`
- insert a user record when first calling the command if needed

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685adcc3e13c8327b32ea94f986a1c1d