### PR TITLE
Implement paginated marketplace UI

### DIFF
--- a/discord-bot/index.js
+++ b/discord-bot/index.js
@@ -29,6 +29,60 @@ const BOOSTER_PACKS = {
     monster_ability_pack: { name: 'Monster Ability Pack', cost: 100, currency: 'soft_currency', type: 'monster_ability_pack', rarity: 'standard', category: 'altar' }
 };
 
+function getMarketplaceMenu(category = 'tavern', page = 0) {
+    const ITEMS_PER_PAGE = 10;
+    const CATEGORY_INFO = {
+        tavern: { title: '🍻 The Tavern', field: { name: 'Champions & Abilities', value: 'Recruit new heroes and learn new skills.' } },
+        armory: { title: '🛡️ The Armory', field: { name: 'Weapons & Armor', value: 'Outfit your champions with the finest gear.' } },
+        altar: { title: '💀 The Altar', field: { name: 'Monsters & Powers', value: 'Unleash forbidden powers and monstrous allies.' } }
+    };
+
+    const info = CATEGORY_INFO[category] || { title: 'Marketplace', field: { name: 'Packs', value: 'Available booster packs' } };
+    const embed = simple(info.title, [info.field]);
+
+    const packs = Object.entries(BOOSTER_PACKS).filter(([, p]) => p.category === category);
+    const totalPages = Math.ceil(packs.length / ITEMS_PER_PAGE);
+    const start = page * ITEMS_PER_PAGE;
+    const pagePacks = packs.slice(start, start + ITEMS_PER_PAGE);
+
+    const selectMenu = new StringSelectMenuBuilder()
+        .setCustomId(`market_pack_select_${category}_${page}`)
+        .setPlaceholder('Choose a booster pack')
+        .addOptions(pagePacks.map(([id, p]) => ({
+            label: p.name,
+            description: `${p.cost} ${p.currency === 'soft_currency' ? 'Gold 🪙' : 'Gems 💎'}`,
+            value: id
+        })));
+
+    const categoryRow = new ActionRowBuilder().addComponents(
+        new ButtonBuilder().setCustomId('market_tavern').setLabel('The Tavern').setStyle(ButtonStyle.Primary).setEmoji('🍻').setDisabled(category === 'tavern'),
+        new ButtonBuilder().setCustomId('market_armory').setLabel('The Armory').setStyle(ButtonStyle.Secondary).setEmoji('🛡️').setDisabled(category === 'armory'),
+        new ButtonBuilder().setCustomId('market_altar').setLabel('The Altar').setStyle(ButtonStyle.Danger).setEmoji('💀').setDisabled(category === 'altar')
+    );
+
+    const selectRow = new ActionRowBuilder().addComponents(selectMenu);
+    const paginationRow = new ActionRowBuilder().addComponents(
+        new ButtonBuilder()
+            .setCustomId(`market_page_prev_${category}_${page - 1}`)
+            .setLabel('Previous')
+            .setStyle(ButtonStyle.Secondary)
+            .setEmoji('⬅️')
+            .setDisabled(page === 0),
+        new ButtonBuilder()
+            .setCustomId(`market_page_next_${category}_${page + 1}`)
+            .setLabel('Next')
+            .setStyle(ButtonStyle.Secondary)
+            .setEmoji('➡️')
+            .setDisabled(page >= totalPages - 1)
+    );
+
+    const backButton = new ActionRowBuilder().addComponents(
+        new ButtonBuilder().setCustomId('back_to_market').setLabel('Back to Marketplace').setStyle(ButtonStyle.Secondary).setEmoji('⬅️')
+    );
+
+    return { embeds: [embed], components: [categoryRow, selectRow, paginationRow, backButton], ephemeral: true };
+}
+
 const STARTING_GOLD = 400;
 
 // XP needed to reach the NEXT level (Level 10 is max)
@@ -204,6 +258,108 @@ function getRandomCardsForPack(pool, count, packRarity) {
     }
 
     return uniqueCards;
+}
+
+async function handleBoosterPurchase(interaction, userId, packId, page = 0) {
+    const packInfo = BOOSTER_PACKS[packId];
+    if (!packInfo) {
+        await interaction.editReply({ content: 'Invalid pack selected.', ephemeral: true });
+        return;
+    }
+
+    const [userRows] = await db.execute(`SELECT ${packInfo.currency} FROM users WHERE discord_id = ?`, [userId]);
+    const user = userRows[0];
+
+    if (!user || user[packInfo.currency] < packInfo.cost) {
+        await interaction.editReply({
+            content: `You don't have enough ${packInfo.currency === 'soft_currency' ? 'Gold 🪙' : 'Gems 💎'} to buy the ${packInfo.name}! You need ${packInfo.cost}.`,
+            ephemeral: true
+        });
+        return;
+    }
+
+    await db.execute(
+        `UPDATE users SET ${packInfo.currency} = ${packInfo.currency} - ? WHERE discord_id = ?`,
+        [packInfo.cost, userId]
+    );
+
+    let cardPool = [];
+    let awardedCardsCount = 0;
+    let actualItemType = '';
+
+    switch (packInfo.type) {
+        case 'hero_pack':
+            cardPool = allPossibleHeroes.filter(h => !h.is_monster);
+            awardedCardsCount = 1;
+            actualItemType = 'hero';
+            break;
+        case 'ability_pack':
+            cardPool = allPossibleAbilities;
+            awardedCardsCount = 3;
+            actualItemType = 'ability';
+            break;
+        case 'weapon_pack':
+            cardPool = allPossibleWeapons;
+            awardedCardsCount = 2;
+            actualItemType = 'weapon';
+            break;
+        case 'armor_pack':
+            cardPool = allPossibleArmors;
+            awardedCardsCount = 2;
+            actualItemType = 'armor';
+            break;
+        case 'monster_pack':
+            cardPool = allPossibleHeroes.filter(h => h.is_monster);
+            awardedCardsCount = 1;
+            actualItemType = 'monster';
+            break;
+        case 'monster_ability_pack':
+            cardPool = allPossibleAbilities.filter(ab => ab.class && ab.class.includes('Monster'));
+            awardedCardsCount = 2;
+            actualItemType = 'monster_ability';
+            break;
+        default:
+            await interaction.editReply({ content: 'Internal error: Unknown pack content type.', ephemeral: true });
+            return;
+    }
+
+    const awardedCards = getRandomCardsForPack(cardPool, awardedCardsCount, packInfo.rarity);
+
+    const cardNames = [];
+    for (const card of awardedCards) {
+        cardNames.push(`**${card.name}** (${card.rarity})`);
+        try {
+            await db.execute(
+                `INSERT INTO user_inventory (user_id, item_id, quantity, item_type)
+                 VALUES (?, ?, 1, ?)
+                 ON DUPLICATE KEY UPDATE quantity = quantity + 1`,
+                [userId, card.id, actualItemType]
+            );
+        } catch (error) {
+            console.error(`Error adding card ${card.id} to inventory for user ${userId} during purchase:`, error);
+        }
+    }
+
+    const resultsEmbed = new EmbedBuilder()
+        .setColor('#FDE047')
+        .setTitle(`✨ ${packInfo.name} Opened! ✨`)
+        .setDescription(`You spent ${packInfo.cost} ${packInfo.currency === 'soft_currency' ? 'Gold 🪙' : 'Gems 💎'}.`)
+        .addFields({ name: 'Cards Received:', value: cardNames.join('\n') || 'No cards received.', inline: false })
+        .setFooter({ text: 'Your new cards have been added to your collection!' })
+        .setTimestamp();
+
+    const viewInventoryButton = new ActionRowBuilder()
+        .addComponents(
+            new ButtonBuilder()
+                .setCustomId('view_inventory_from_pack')
+                .setLabel('View Inventory')
+                .setStyle(ButtonStyle.Secondary)
+                .setEmoji('🎒')
+        );
+
+    await interaction.editReply({ embeds: [resultsEmbed], components: [viewInventoryButton] });
+
+    await interaction.followUp(getMarketplaceMenu(packInfo.category, page));
 }
 
 
@@ -776,174 +932,34 @@ client.on(Events.InteractionCreate, async interaction => {
                 }
                 case 'market_tavern': {
                     await interaction.deferUpdate();
-                    const tavernEmbed = simple('🍻 The Tavern', [{ name: 'Champions & Abilities', value: 'Recruit new heroes and learn new skills.' }]);
-                    const tavernButtons = new ActionRowBuilder();
-                    Object.entries(BOOSTER_PACKS).filter(([, pack]) => pack.category === 'tavern').forEach(([packId, packInfo]) => {
-                        tavernButtons.addComponents(
-                            new ButtonBuilder()
-                                .setCustomId(`buy_pack_${packId}`)
-                                .setLabel(`${packInfo.name} (${packInfo.cost} Gold 🪙)`)
-                                .setStyle(ButtonStyle.Primary)
-                                .setEmoji('🛒')
-                        );
-                    });
-                    const backButton = new ActionRowBuilder().addComponents(new ButtonBuilder().setCustomId('back_to_market').setLabel('Back to Marketplace').setStyle(ButtonStyle.Secondary).setEmoji('⬅️'));
-                    await interaction.editReply({ embeds: [tavernEmbed], components: [tavernButtons, backButton] });
+                    await interaction.editReply(getMarketplaceMenu('tavern'));
                     break;
                 }
                 case 'market_armory': {
                     await interaction.deferUpdate();
-                    const armoryEmbed = simple('🛡️ The Armory', [{ name: 'Weapons & Armor', value: 'Outfit your champions with the finest gear.' }]);
-                    const armoryButtons = new ActionRowBuilder();
-                    Object.entries(BOOSTER_PACKS).filter(([, pack]) => pack.category === 'armory').forEach(([packId, packInfo]) => {
-                        armoryButtons.addComponents(
-                            new ButtonBuilder()
-                                .setCustomId(`buy_pack_${packId}`)
-                                .setLabel(`${packInfo.name} (${packInfo.cost} Gold 🪙)`)
-                                .setStyle(ButtonStyle.Primary)
-                                .setEmoji('🛒')
-                        );
-                    });
-                    const backButton = new ActionRowBuilder().addComponents(new ButtonBuilder().setCustomId('back_to_market').setLabel('Back to Marketplace').setStyle(ButtonStyle.Secondary).setEmoji('⬅️'));
-                    await interaction.editReply({ embeds: [armoryEmbed], components: [armoryButtons, backButton] });
+                    await interaction.editReply(getMarketplaceMenu('armory'));
                     break;
                 }
                 case 'market_altar': {
                     await interaction.deferUpdate();
-                    const altarEmbed = simple('💀 The Altar', [{ name: 'Monsters & Powers', value: 'Unleash forbidden powers and monstrous allies.' }]);
-                    const altarButtons = new ActionRowBuilder();
-                    Object.entries(BOOSTER_PACKS).filter(([, pack]) => pack.category === 'altar').forEach(([packId, packInfo]) => {
-                        altarButtons.addComponents(
-                            new ButtonBuilder()
-                                .setCustomId(`buy_pack_${packId}`)
-                                .setLabel(`${packInfo.name} (${packInfo.cost} Gold 🪙)`)
-                                .setStyle(ButtonStyle.Primary)
-                                .setEmoji('🛒')
-                        );
-                    });
-                    const backButton = new ActionRowBuilder().addComponents(new ButtonBuilder().setCustomId('back_to_market').setLabel('Back to Marketplace').setStyle(ButtonStyle.Secondary).setEmoji('⬅️'));
-                    await interaction.editReply({ embeds: [altarEmbed], components: [altarButtons, backButton] });
+                    await interaction.editReply(getMarketplaceMenu('altar'));
+                    break;
+                }
+                case (interaction.customId.startsWith('market_page_prev_') ? interaction.customId : (interaction.customId.startsWith('market_page_next_') ? interaction.customId : '')): {
+                    await interaction.deferUpdate();
+                    const parts = interaction.customId.split('_');
+                    const category = parts[3];
+                    const page = parseInt(parts[4], 10) || 0;
+                    await interaction.editReply(getMarketplaceMenu(category, page));
                     break;
                 }
                 case (interaction.customId.startsWith('buy_pack_') ? interaction.customId : ''): {
                     await interaction.deferUpdate();
                     const packId = interaction.customId.replace('buy_pack_', '');
-                    const packInfo = BOOSTER_PACKS[packId];
-
-                    if (!packInfo) {
-                        await interaction.editReply({ content: 'Invalid pack selected.', ephemeral: true });
-                        return;
-                    }
-
-                    const [userRows] = await db.execute(`SELECT ${packInfo.currency} FROM users WHERE discord_id = ?`, [userId]);
-                    const user = userRows[0];
-
-                    if (!user || user[packInfo.currency] < packInfo.cost) {
-                        await interaction.editReply({
-                            content: `You don't have enough ${packInfo.currency === 'soft_currency' ? 'Gold 🪙' : 'Gems 💎'} to buy the ${packInfo.name}! You need ${packInfo.cost}.`,
-                            ephemeral: true
-                        });
-                        return;
-                    }
-
-                    await db.execute(
-                        `UPDATE users SET ${packInfo.currency} = ${packInfo.currency} - ? WHERE discord_id = ?`,
-                        [packInfo.cost, userId]
-                    );
-
-                    let cardPool = [];
-                    let awardedCardsCount = 0;
-                    let actualItemType = '';
-
-                    switch (packInfo.type) {
-                        case 'hero_pack':
-                            cardPool = allPossibleHeroes.filter(h => !h.isMonster);
-                            awardedCardsCount = 1;
-                            actualItemType = 'hero';
-                            break;
-                        case 'ability_pack':
-                            cardPool = allPossibleAbilities;
-                            awardedCardsCount = 3;
-                            actualItemType = 'ability';
-                            break;
-                        case 'weapon_pack':
-                            cardPool = allPossibleWeapons;
-                            awardedCardsCount = 2;
-                            actualItemType = 'weapon';
-                            break;
-                        case 'armor_pack':
-                            cardPool = allPossibleArmors;
-                            awardedCardsCount = 2;
-                            actualItemType = 'armor';
-                            break;
-                        case 'monster_pack':
-                            cardPool = allPossibleHeroes.filter(h => h.is_monster);
-                            awardedCardsCount = 1;
-                            actualItemType = 'monster';
-                            break;
-                        case 'monster_ability_pack':
-                            cardPool = allPossibleAbilities.filter(ab => ab.class && ab.class.includes('Monster'));
-                            awardedCardsCount = 2;
-                            actualItemType = 'monster_ability';
-                            break;
-                        default:
-                            await interaction.editReply({ content: 'Internal error: Unknown pack content type.', ephemeral: true });
-                            return;
-                    }
-                    const awardedCards = getRandomCardsForPack(cardPool, awardedCardsCount, packInfo.rarity);
-
-                    const cardNames = [];
-                    for (const card of awardedCards) {
-                        cardNames.push(`**${card.name}** (${card.rarity})`);
-                        try {
-                            await db.execute(
-                                `INSERT INTO user_inventory (user_id, item_id, quantity, item_type)
-                                 VALUES (?, ?, 1, ?)
-                                 ON DUPLICATE KEY UPDATE quantity = quantity + 1`,
-                                [userId, card.id, actualItemType]
-                            );
-                        } catch (error) {
-                            console.error(`Error adding card ${card.id} to inventory for user ${userId} during purchase:`, error);
-                        }
-                    }
-
-                    const resultsEmbed = new EmbedBuilder()
-                        .setColor('#FDE047')
-                        .setTitle(`✨ ${packInfo.name} Opened! ✨`)
-                        .setDescription(`You spent ${packInfo.cost} ${packInfo.currency === 'soft_currency' ? 'Gold 🪙' : 'Gems 💎'}.`)
-                        .addFields({ name: 'Cards Received:', value: cardNames.join('\n') || 'No cards received.', inline: false })
-                        .setFooter({ text: 'Your new cards have been added to your collection!' })
-                        .setTimestamp();
-
-                    // --- ADDED 'VIEW INVENTORY' BUTTON ---
-                    const viewInventoryButton = new ActionRowBuilder()
-                        .addComponents(
-                            new ButtonBuilder()
-                                .setCustomId('view_inventory_from_pack')
-                                .setLabel('View Inventory')
-                                .setStyle(ButtonStyle.Secondary)
-                                .setEmoji('🎒')
-                        );
-                    // Build buttons to buy more packs in a single row
-                    const packPurchaseButtons = new ActionRowBuilder();
-                    Object.entries(BOOSTER_PACKS).forEach(([packIdBtn, packInfoBtn]) =>
-                        packPurchaseButtons.addComponents(
-                            new ButtonBuilder()
-                                .setCustomId(`buy_pack_${packIdBtn}`)
-                                .setLabel(`${packInfoBtn.name} (${packInfoBtn.cost} ${packInfoBtn.currency === 'soft_currency' ? 'Gold 🪙' : 'Gems 💎'})`)
-                                .setStyle(ButtonStyle.Primary)
-                                .setEmoji('🛒')
-                        )
-                    );
-
-                    const backButton = new ActionRowBuilder()
-                        .addComponents(
-                            new ButtonBuilder().setCustomId('back_to_market').setLabel('Back to Marketplace').setStyle(ButtonStyle.Secondary).setEmoji('⬅️')
-                        );
-
-                    await interaction.editReply({ embeds: [resultsEmbed], components: [viewInventoryButton, packPurchaseButtons, backButton] });
+                    await handleBoosterPurchase(interaction, userId, packId);
                     break;
                 }
+
                 case 'view_inventory_from_pack': {
                     await interaction.deferUpdate();
                     const inventoryCommand = client.commands.get('inventory');
@@ -997,6 +1013,15 @@ client.on(Events.InteractionCreate, async interaction => {
     if (interaction.isStringSelectMenu()) {
         const userId = interaction.user.id;
         const userDraftState = activeTutorialDrafts.get(userId);
+        if (interaction.customId.startsWith('market_pack_select_')) {
+            await interaction.deferUpdate();
+            const parts = interaction.customId.split('_');
+            const category = parts[3];
+            const page = parseInt(parts[4], 10) || 0;
+            const packId = interaction.values[0];
+            await handleBoosterPurchase(interaction, userId, packId, page);
+            return;
+        }
         if (interaction.customId.startsWith('tutorial_') || userDraftState) {
             try {
                 await interaction.deferUpdate();


### PR DESCRIPTION
## Summary
- add `getMarketplaceMenu` for paginated booster pack browsing
- factor pack purchase logic into `handleBoosterPurchase`
- refactor marketplace button handlers to use paginated menu
- add pagination and select menu handlers for marketplace
- show marketplace after purchases

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685b3856b9d883279cd635b2d17ef559