### PR TITLE
Add recruit grant admin command

### DIFF
--- a/discord-bot/src/utils/cardRenderer.js
+++ b/discord-bot/src/utils/cardRenderer.js
@@ -1,0 +1,17 @@
+const sharp = require('sharp');
+
+/**
+ * Generates a simple card image for a hero.
+ * Currently creates an SVG placeholder with the hero's name.
+ * @param {{ name: string }} hero
+ * @returns {Promise<Buffer>}
+ */
+async function generateCardImage(hero) {
+  const svg = `<svg width="300" height="400" xmlns="http://www.w3.org/2000/svg">
+    <rect width="300" height="400" fill="#1e293b"/>
+    <text x="150" y="200" font-size="32" fill="white" text-anchor="middle" font-family="Arial, Helvetica, sans-serif">${hero.name}</text>
+  </svg>`;
+  return sharp(Buffer.from(svg)).png().toBuffer();
+}
+
+module.exports = { generateCardImage };


### PR DESCRIPTION
## Summary
- add `grant-recruit` admin subcommand
- create `generateCardImage` helper for placeholder hero card rendering

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685b4d1fa94c8327b4f36aa317ecd546