### PR TITLE
Implement DM card rewards with images

### DIFF
--- a/discord-bot/commands/admin.js
+++ b/discord-bot/commands/admin.js
@@ -80,14 +80,15 @@ module.exports = {
                 const imageBuffer = await generateCardImage(recruit);
                 const successEmbed = simple(
                     '🃏 Recruit Granted',
-                    [{ name: 'Success!', value: `Successfully granted a Recruit card to ${targetUser.username}.` }]
+                    [{ name: 'New Card', value: `${recruit.name} (${recruit.rarity})` }]
                 );
 
-                await interaction.reply({
+                await targetUser.send({
                     embeds: [successEmbed],
-                    files: [{ attachment: imageBuffer, name: 'card.png' }],
-                    ephemeral: true
+                    files: [{ attachment: imageBuffer, name: 'recruit.png' }]
                 });
+
+                await interaction.reply({ content: "Successfully sent the Recruit card to the user's DMs.", ephemeral: true });
             } catch (error) {
                 console.error('Error granting recruit:', error);
                 await interaction.reply({ content: 'An error occurred while granting the Recruit card.', ephemeral: true });

--- a/discord-bot/src/utils/cardRenderer.js
+++ b/discord-bot/src/utils/cardRenderer.js
@@ -1,17 +1,62 @@
+const fs = require('fs/promises');
+const path = require('path');
 const sharp = require('sharp');
 
 /**
- * Generates a simple card image for a hero.
- * Currently creates an SVG placeholder with the hero's name.
- * @param {{ name: string }} hero
+ * Generate a card image buffer using rarity frames and art assets.
+ * @param {object} card The card object containing name, class, rarity and stats.
  * @returns {Promise<Buffer>}
  */
-async function generateCardImage(hero) {
-  const svg = `<svg width="300" height="400" xmlns="http://www.w3.org/2000/svg">
-    <rect width="300" height="400" fill="#1e293b"/>
-    <text x="150" y="200" font-size="32" fill="white" text-anchor="middle" font-family="Arial, Helvetica, sans-serif">${hero.name}</text>
-  </svg>`;
-  return sharp(Buffer.from(svg)).png().toBuffer();
+async function generateCardImage(card) {
+  const assetsBase = path.join(__dirname, '..', '..', 'assets');
+  const framePath = path.join(
+    assetsBase,
+    'frames',
+    `frame-${(card.rarity || 'common').toLowerCase()}.png`
+  );
+  const heroArtPath = path.join(
+    assetsBase,
+    'heroes',
+    `${card.name.toLowerCase().replace(/\s+/g, '_')}_card.png`
+  );
+  const classIconPath = path.join(
+    assetsBase,
+    'classes',
+    `${(card.class || 'generic').toLowerCase().replace(/\s+/g, '-')}.png`
+  );
+
+  const base = sharp(framePath).resize(300, 400);
+  const composites = [];
+
+  let artToUse = null;
+  try {
+    await fs.access(heroArtPath);
+    artToUse = heroArtPath;
+  } catch {
+    try {
+      await fs.access(classIconPath);
+      artToUse = classIconPath;
+    } catch {
+      artToUse = null;
+    }
+  }
+
+  if (artToUse) {
+    composites.push({ input: artToUse });
+  }
+
+  const textSvg = `<svg width="300" height="400" xmlns="http://www.w3.org/2000/svg">
+  <style>
+    .name { fill: white; font-size: 24px; font-weight: bold; font-family: Arial, Helvetica, sans-serif; text-anchor: middle; }
+    .stats { fill: white; font-size: 16px; font-family: Arial, Helvetica, sans-serif; text-anchor: middle; }
+  </style>
+  <text x="150" y="340" class="name">${card.name}</text>
+  <text x="150" y="365" class="stats">HP: ${card.hp}  ATK: ${card.attack}  SPD: ${card.speed}</text>
+</svg>`;
+
+  composites.push({ input: Buffer.from(textSvg) });
+
+  return base.composite(composites).png().toBuffer();
 }
 
 module.exports = { generateCardImage };


### PR DESCRIPTION
## Summary
- generate card images with `sharp` using frames, art, and stat overlays
- refactor admin `/grant-recruit` to DM the card image to the target user
- refactor booster pack purchase button to DM each pulled card image

## Testing
- `npm test --prefix discord-bot`

------
https://chatgpt.com/codex/tasks/task_e_685b5489ddc88327b76b44fe68042f59