### PR TITLE
Implement ASCII pack opening flow

### DIFF
--- a/discord-bot/src/utils/asciiCardRenderer.js
+++ b/discord-bot/src/utils/asciiCardRenderer.js
@@ -1,0 +1,21 @@
+const CARD_BORDER = "╔═════════════════════╗\n";
+const CARD_MIDDLE = "║                     ║\n";
+const CARD_BOTTOM = "╚═════════════════════╝\n";
+
+function generateAsciiCard(cardName, rarity) {
+    const paddedName = cardName.padEnd(21, ' ').substring(0, 21);
+    const paddedRarity = `Rarity: ${rarity}`.padEnd(21, ' ').substring(0, 21);
+
+    return "```\n" +
+        CARD_BORDER +
+        CARD_MIDDLE.replace(' ', '█') +
+        `║ ${paddedName} ║\n` +
+        `║                     ║\n` +
+        `║                     ║\n` +
+        `║   ${paddedRarity}   ║\n` +
+        CARD_MIDDLE.replace(' ', '▓') +
+        CARD_BOTTOM +
+        "```";
+}
+
+module.exports = { generateAsciiCard };


### PR DESCRIPTION
## Summary
- add ASCII card renderer
- refactor `/openpack` to give unopened packs instead of cards
- allow pack opening in Barracks with animated ASCII steps
- let users pick one of three cards and receive shards for the rest

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c2195f55883278d911bce7870efdd