### PR TITLE
Fix duplicate getRandomCardsForPack function

### DIFF
--- a/discord-bot/commands/openpack.js
+++ b/discord-bot/commands/openpack.js
@@ -8,6 +8,7 @@ const {
     allPossibleArmors,
     allPossibleAbilities
 } = require('../../backend/game/data');
+const { getRandomCardsForPack } = require('../util/gameData');
 
 // Booster pack definitions used for consistent display names
 const BOOSTER_PACKS = {
@@ -24,45 +25,6 @@ const PACK_COLUMN_BASE = {
     armor_pack: 'armor_packs'
 };
 
-// Helper to select cards by rarity tier
-function getRandomCardsForPack(pool, count = 3, packRarity = 'basic') {
-    let allowedRarities;
-    switch (packRarity) {
-        case 'premium':
-            allowedRarities = ['Uncommon', 'Rare', 'Epic'];
-            break;
-        case 'standard':
-            allowedRarities = ['Common', 'Uncommon', 'Rare'];
-            break;
-        case 'basic':
-        default:
-            allowedRarities = ['Common', 'Uncommon'];
-            break;
-    }
-
-    const filteredPool = pool.filter(item => allowedRarities.includes(item.rarity));
-    const shuffled = [...filteredPool].sort(() => 0.5 - Math.random());
-    const uniqueCards = [];
-    const uniqueIds = new Set();
-
-    for (const card of shuffled) {
-        if (!uniqueIds.has(card.id)) {
-            uniqueCards.push(card);
-            uniqueIds.add(card.id);
-            if (uniqueCards.length >= count) break;
-        }
-    }
-
-    while (uniqueCards.length < count) {
-        const fallback = pool[Math.floor(Math.random() * pool.length)];
-        if (!uniqueIds.has(fallback.id)) {
-            uniqueCards.push(fallback);
-            uniqueIds.add(fallback.id);
-        }
-    }
-
-    return uniqueCards;
-}
 
 const command = {
     data: new SlashCommandBuilder()
@@ -123,4 +85,4 @@ const command = {
     },
 };
 
-module.exports = { ...command, getRandomCardsForPack };
+module.exports = command;

--- a/discord-bot/index.js
+++ b/discord-bot/index.js
@@ -8,14 +8,13 @@ const confirmEmbed = require('./src/utils/confirm');
 const { generateCardImage } = require('./src/utils/cardRenderer');
 const { generateAsciiCard } = require('./src/utils/asciiCardRenderer');
 const { setTimeout: sleep } = require('node:timers/promises');
-const { getRandomCardsForPack } = require('./commands/openpack');
 const {
   allPossibleHeroes,
   allPossibleWeapons,
   allPossibleArmors,
   allPossibleAbilities
 } = require('../backend/game/data');
-const { loadAllData, gameData, getHeroes, getHeroById, getMonsters } = require('./util/gameData');
+const { loadAllData, gameData, getHeroes, getHeroById, getMonsters, getRandomCardsForPack } = require('./util/gameData');
 const { createCombatant } = require('../backend/game/utils');
 const GameEngine = require('../backend/game/engine');
 const { getTownMenu } = require('./commands/town.js');
@@ -226,45 +225,6 @@ async function checkAndApplyLevelUp(userId, championId, interaction) {
 }
 // --- END NEW HELPER FUNCTION ---
 
-// Helper for booster packs
-function getRandomCardsForPack(pool, count, packRarity) {
-    let allowedRarities;
-    switch (packRarity) {
-        case 'premium':
-            allowedRarities = ['Uncommon', 'Rare', 'Epic'];
-            break;
-        case 'standard':
-            allowedRarities = ['Common', 'Uncommon', 'Rare'];
-            break;
-        case 'basic':
-        default:
-            allowedRarities = ['Common', 'Uncommon'];
-            break;
-    }
-
-    const filteredPool = pool.filter(item => allowedRarities.includes(item.rarity));
-    const shuffled = [...filteredPool].sort(() => 0.5 - Math.random());
-    const uniqueCards = [];
-    const uniqueIds = new Set();
-
-    for (const card of shuffled) {
-        if (!uniqueIds.has(card.id)) {
-            uniqueCards.push(card);
-            uniqueIds.add(card.id);
-            if (uniqueCards.length >= count) break;
-        }
-    }
-
-    while (uniqueCards.length < count) {
-        const fallback = pool[Math.floor(Math.random() * pool.length)];
-        if (!uniqueIds.has(fallback.id)) {
-            uniqueCards.push(fallback);
-            uniqueIds.add(fallback.id);
-        }
-    }
-
-    return uniqueCards;
-}
 
 async function handleBoosterPurchase(interaction, userId, packId, page = 0) {
     const packInfo = BOOSTER_PACKS[packId];

--- a/discord-bot/util/gameData.js
+++ b/discord-bot/util/gameData.js
@@ -50,10 +50,51 @@ function getMonsters() {
     return getHeroes().filter(h => h.is_monster);
 }
 
+// Helper to select cards by rarity tier for booster packs
+function getRandomCardsForPack(pool, count = 3, packRarity = 'basic') {
+    let allowedRarities;
+    switch (packRarity) {
+        case 'premium':
+            allowedRarities = ['Uncommon', 'Rare', 'Epic'];
+            break;
+        case 'standard':
+            allowedRarities = ['Common', 'Uncommon', 'Rare'];
+            break;
+        case 'basic':
+        default:
+            allowedRarities = ['Common', 'Uncommon'];
+            break;
+    }
+
+    const filteredPool = pool.filter(item => allowedRarities.includes(item.rarity));
+    const shuffled = [...filteredPool].sort(() => 0.5 - Math.random());
+    const uniqueCards = [];
+    const uniqueIds = new Set();
+
+    for (const card of shuffled) {
+        if (!uniqueIds.has(card.id)) {
+            uniqueCards.push(card);
+            uniqueIds.add(card.id);
+            if (uniqueCards.length >= count) break;
+        }
+    }
+
+    while (uniqueCards.length < count) {
+        const fallback = pool[Math.floor(Math.random() * pool.length)];
+        if (!uniqueIds.has(fallback.id)) {
+            uniqueCards.push(fallback);
+            uniqueIds.add(fallback.id);
+        }
+    }
+
+    return uniqueCards;
+}
+
 module.exports = {
     gameData,
     loadAllData,
     getHeroes,
     getHeroById,
     getMonsters,
+    getRandomCardsForPack,
 };


### PR DESCRIPTION
## Summary
- centralize `getRandomCardsForPack` helper into `util/gameData.js`
- remove duplicate implementations from `index.js` and `openpack.js`
- update imports for new location

## Testing
- `npm test` *(fails: TypeError in confirm.test.js)*

------
https://chatgpt.com/codex/tasks/task_e_685c26d434948327b061495ce08b49a7