### PR TITLE
Fix multiline string in Discord bot

### DIFF
--- a/discord-bot/index.js
+++ b/discord-bot/index.js
@@ -845,17 +845,17 @@ client.on(Events.InteractionCreate, async interaction => {
                     const cards = getRandomCardsForPack(cardPool, 3, columnName.split('_')[0]);
                     userTemporaryPacks.set(userId, cards);
 
-                    await interaction.editReply({ content: '```
+                    await interaction.editReply({ content: `\`\`\`
 📦 Pack is sealed...
-```', components: [] });
+\`\`\``, components: [] });
                     await sleep(800);
-                    await interaction.editReply({ content: '```
+                    await interaction.editReply({ content: `\`\`\`
 💥 Ripping open the pack!
-```' });
+\`\`\`` });
                     await sleep(800);
-                    await interaction.editReply({ content: '```
+                    await interaction.editReply({ content: `\`\`\`
 ✨ Cards are revealing...
-```' });
+\`\`\`` });
                     await sleep(800);
 
                     const asciiCards = cards.map(c => generateAsciiCard(c.name, c.rarity)).join('\n');


### PR DESCRIPTION
## Summary
- fix SyntaxError by using backtick template strings for pack opening animations in `discord-bot/index.js`

## Testing
- `npm test` *(fails: TypeError in confirm.test.js)*

------
https://chatgpt.com/codex/tasks/task_e_685c44dda2e08327bfb278b29621e583