### PR TITLE
Fix follow-up confirmation for openpack command

### DIFF
--- a/discord-bot/commands/openpack.js
+++ b/discord-bot/commands/openpack.js
@@ -82,6 +82,11 @@ const command = {
         );
 
         await interaction.editReply({ embeds: [resultsEmbed] });
+
+        await interaction.followUp({
+            embeds: [confirm('Pack successfully added to your account.')],
+            ephemeral: true
+        });
     },
 };
 


### PR DESCRIPTION
## Summary
- ensure `/openpack` command sends a confirmation embed after editing the reply
- all Jest tests pass

## Testing
- `npm install --prefix discord-bot`
- `npm test --prefix discord-bot`

------
https://chatgpt.com/codex/tasks/task_e_685c44e9c5108327b11c2844b0e721c4