### PR TITLE
Refactor buy pack interaction

### DIFF
--- a/discord-bot/tests/buttonHandler.test.js
+++ b/discord-bot/tests/buttonHandler.test.js
@@ -1,0 +1,35 @@
+const marketManager = require('../features/marketManager');
+
+jest.mock('../features/marketManager', () => ({
+  handleBoosterPurchase: jest.fn(),
+  getMarketplaceMenu: jest.fn(),
+}));
+
+jest.mock('../features/tutorialManager', () => ({
+  handleTutorialButton: jest.fn(),
+}));
+
+jest.mock('../commands/town', () => ({
+  getTownMenu: jest.fn(),
+}));
+
+const buttonHandler = require('../handlers/buttonHandler');
+
+describe('buttonHandler', () => {
+  test('delegates buy_pack button to handleBoosterPurchase', async () => {
+    const interaction = {
+      customId: 'buy_pack_hero_pack',
+      deferUpdate: jest.fn().mockResolvedValue(),
+      user: { id: '123' },
+    };
+
+    await buttonHandler(interaction);
+
+    expect(marketManager.handleBoosterPurchase).toHaveBeenCalledWith(
+      interaction,
+      '123',
+      'hero_pack',
+      0
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- delegate pack purchase logic in `index.js` to the shared `marketManager.handleBoosterPurchase`
- add unit tests for the button handler

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685d7128aae08327bee8b062ea7864ca