### PR TITLE
Refactor booster pack configuration

### DIFF
--- a/discord-bot/features/marketManager.js
+++ b/discord-bot/features/marketManager.js
@@ -6,15 +6,7 @@ const { generateCardImage } = require('../src/utils/cardRenderer');
 const { allPossibleHeroes, allPossibleWeapons, allPossibleArmors, allPossibleAbilities } = require('../../backend/game/data');
 const { getRandomCardsForPack } = require('../util/gameData');
 
-// Booster pack definitions for the marketplace
-const BOOSTER_PACKS = {
-    hero_pack: { name: 'Hero Pack', cost: 100, currency: 'soft_currency', type: 'hero_pack', rarity: 'basic', category: 'tavern' },
-    ability_pack: { name: 'Ability Pack', cost: 100, currency: 'soft_currency', type: 'ability_pack', rarity: 'standard', category: 'tavern' },
-    weapon_pack: { name: 'Weapon Pack', cost: 100, currency: 'soft_currency', type: 'weapon_pack', rarity: 'premium', category: 'armory' },
-    armor_pack: { name: 'Armor Pack', cost: 100, currency: 'soft_currency', type: 'armor_pack', rarity: 'basic', category: 'armory' },
-    monster_pack: { name: 'Monster Pack', cost: 100, currency: 'soft_currency', type: 'monster_pack', rarity: 'basic', category: 'altar' },
-    monster_ability_pack: { name: 'Monster Ability Pack', cost: 100, currency: 'soft_currency', type: 'monster_ability_pack', rarity: 'standard', category: 'altar' }
-};
+const { BOOSTER_PACKS } = require('../src/boosterConfig');
 
 function getMarketplaceMenu(category = 'tavern', page = 0) {
     const ITEMS_PER_PAGE = 10;

--- a/discord-bot/index.js
+++ b/discord-bot/index.js
@@ -20,18 +20,7 @@ const { createCombatant } = require('../backend/game/utils');
 const GameEngine = require('../backend/game/engine');
 const { getTownMenu } = require('./commands/town.js');
 
-// Booster pack definitions for the marketplace
-const BOOSTER_PACKS = {
-    // Tavern Packs
-    hero_pack: { name: 'Hero Pack', cost: 100, currency: 'soft_currency', type: 'hero_pack', rarity: 'basic', category: 'tavern' },
-    ability_pack: { name: 'Ability Pack', cost: 100, currency: 'soft_currency', type: 'ability_pack', rarity: 'standard', category: 'tavern' },
-    // Armory Packs
-    weapon_pack: { name: 'Weapon Pack', cost: 100, currency: 'soft_currency', type: 'weapon_pack', rarity: 'premium', category: 'armory' },
-    armor_pack: { name: 'Armor Pack', cost: 100, currency: 'soft_currency', type: 'armor_pack', rarity: 'basic', category: 'armory' },
-    // Altar Packs
-    monster_pack: { name: 'Monster Pack', cost: 100, currency: 'soft_currency', type: 'monster_pack', rarity: 'basic', category: 'altar' },
-    monster_ability_pack: { name: 'Monster Ability Pack', cost: 100, currency: 'soft_currency', type: 'monster_ability_pack', rarity: 'standard', category: 'altar' }
-};
+const { BOOSTER_PACKS } = require('./src/boosterConfig');
 
 function getMarketplaceMenu(category = 'tavern', page = 0) {
     const ITEMS_PER_PAGE = 10;

--- a/discord-bot/src/boosterConfig.js
+++ b/discord-bot/src/boosterConfig.js
@@ -1,0 +1,58 @@
+// Central configuration for booster pack definitions
+
+const BOOSTER_PACKS = {
+  // Tavern Packs
+  hero_pack: {
+    name: 'Hero Pack',
+    cost: 100,
+    currency: 'soft_currency',
+    type: 'hero_pack',
+    rarity: 'basic',
+    category: 'tavern'
+  },
+  ability_pack: {
+    name: 'Ability Pack',
+    cost: 100,
+    currency: 'soft_currency',
+    type: 'ability_pack',
+    rarity: 'standard',
+    category: 'tavern'
+  },
+  // Armory Packs
+  weapon_pack: {
+    name: 'Weapon Pack',
+    cost: 100,
+    currency: 'soft_currency',
+    type: 'weapon_pack',
+    rarity: 'premium',
+    category: 'armory'
+  },
+  armor_pack: {
+    name: 'Armor Pack',
+    cost: 100,
+    currency: 'soft_currency',
+    type: 'armor_pack',
+    rarity: 'basic',
+    category: 'armory'
+  },
+  // Altar Packs
+  monster_pack: {
+    name: 'Monster Pack',
+    cost: 100,
+    currency: 'soft_currency',
+    type: 'monster_pack',
+    rarity: 'basic',
+    category: 'altar'
+  },
+  monster_ability_pack: {
+    name: 'Monster Ability Pack',
+    cost: 100,
+    currency: 'soft_currency',
+    type: 'monster_ability_pack',
+    rarity: 'standard',
+    category: 'altar'
+  }
+};
+
+module.exports = { BOOSTER_PACKS };
+

--- a/discord-bot/tests/marketManager.test.js
+++ b/discord-bot/tests/marketManager.test.js
@@ -1,4 +1,5 @@
 const marketManager = require('../features/marketManager');
+const { BOOSTER_PACKS } = require('../src/boosterConfig');
 const db = require('../util/database');
 const gameData = require('../util/gameData');
 
@@ -41,7 +42,8 @@ describe('handleBoosterPurchase', () => {
       client: { channels: { cache: { get: jest.fn(() => ({ send: channelSend })) } } }
     };
 
-    await marketManager.handleBoosterPurchase(interaction, '123', 'hero_pack', 0);
+    const firstPack = Object.keys(BOOSTER_PACKS)[0];
+    await marketManager.handleBoosterPurchase(interaction, '123', firstPack, 0);
 
     expect(interaction.user.send).toHaveBeenCalledWith('💰 Debug: Your new gold balance is 50');
     expect(channelSend).toHaveBeenCalledWith('📣 **Tester** has obtained a new card: **Test Card** (Common)!');


### PR DESCRIPTION
## Summary
- centralize BOOSTER_PACKS in `src/boosterConfig.js`
- import the new config in bot entry point and market manager
- adjust unit tests to use the new module

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685d712a30ec83279522f554405a3500