### PR TITLE
Add logging around booster pack card generation

### DIFF
--- a/discord-bot/commands/admin.js
+++ b/discord-bot/commands/admin.js
@@ -78,6 +78,7 @@ module.exports = {
                 );
 
                 const imageBuffer = await generateCardImage(recruit);
+                console.log(`DMing recruit card to user ${targetUser.username} (${targetUser.id})`);
                 const successEmbed = simple(
                     '🃏 Recruit Granted',
                     [{ name: 'New Card', value: `${recruit.name} (${recruit.rarity})` }]

--- a/discord-bot/features/marketManager.js
+++ b/discord-bot/features/marketManager.js
@@ -163,6 +163,7 @@ async function handleBoosterPurchase(interaction, userId, packId, page = 0) {
 
     for (const card of awardedCards) {
         const cardBuffer = await generateCardImage(card);
+        console.log(`DMing card ${card.name} to user ${interaction.user.username} (${interaction.user.id})`);
         const embed = new EmbedBuilder()
             .setColor('#FDE047')
             .setTitle('✨ You pulled a new card! ✨')

--- a/discord-bot/index.js
+++ b/discord-bot/index.js
@@ -785,6 +785,7 @@ client.on(Events.InteractionCreate, async interaction => {
                         .setDescription(`You chose **${chosenCard.name}**! You gained **${totalShardsGained}** shards from the other cards.`)
                         .setFooter({ text: 'Auto-Battler Bot' });
                     const cardBuffer = await generateCardImage(chosenCard);
+                    console.log(`DMing chosen card ${chosenCard.name} to user ${user.username} (${userId})`);
                     try {
                         await user.send({ embeds: [dmEmbed], files: [{ attachment: cardBuffer, name: `${chosenCard.name}.png` }] });
                     } catch (e) {

--- a/discord-bot/src/utils/cardRenderer.js
+++ b/discord-bot/src/utils/cardRenderer.js
@@ -27,18 +27,26 @@ async function generateCardImage(card) {
     `${(card.class || 'generic').toLowerCase().replace(/\s+/g, '-')}.png`
   );
 
+  console.log(
+    `Generating card image for ${card.name} - frame: ${framePath}, hero: ${heroArtPath}, class: ${classIconPath}`
+  );
+
   // Start with the rarity frame as the base image
   let base = sharp(framePath).resize(300, 400);
 
   let artToUse = null;
   try {
     await fs.access(heroArtPath);
+    console.log(`Using hero art for ${card.name}: ${heroArtPath}`);
     artToUse = heroArtPath;
   } catch {
+    console.log(`Hero art not found at ${heroArtPath}`);
     try {
       await fs.access(classIconPath);
+      console.log(`Using class icon for ${card.name}: ${classIconPath}`);
       artToUse = classIconPath;
     } catch {
+      console.log(`Class icon not found at ${classIconPath}`);
       artToUse = null;
     }
   }
@@ -46,6 +54,8 @@ async function generateCardImage(card) {
   if (artToUse) {
     // Place character art above the frame but below the stats text
     base = base.composite([{ input: artToUse, top: 50, left: 25 }]);
+  } else {
+    console.log(`No art asset found for ${card.name}`);
   }
 
   const textSvg = `<svg width="300" height="400" xmlns="http://www.w3.org/2000/svg">


### PR DESCRIPTION
## Summary
- log asset paths used when generating card images
- log when DMs are sent with card images

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685d79153ae48327937e32ee4618bbea