### PR TITLE
Add DM logging around card rewards

### DIFF
--- a/discord-bot/features/marketManager.js
+++ b/discord-bot/features/marketManager.js
@@ -168,7 +168,12 @@ async function handleBoosterPurchase(interaction, userId, packId, page = 0) {
             .setTitle('✨ You pulled a new card! ✨')
             .addFields({ name: 'Name', value: card.name, inline: true }, { name: 'Rarity', value: card.rarity, inline: true })
             .setTimestamp();
-        await interaction.user.send({ embeds: [embed], files: [{ attachment: cardBuffer, name: `${card.name}.png` }] });
+        try {
+            await interaction.user.send({ embeds: [embed], files: [{ attachment: cardBuffer, name: `${card.name}.png` }] });
+            console.log(`Sent card DM to ${interaction.user.username} for card ${card.name}`);
+        } catch (err) {
+            console.error(`Failed to DM card ${card.name} to ${interaction.user.username}:`, err);
+        }
         await sleep(500);
     }
 }


### PR DESCRIPTION
## Summary
- DM success/failure log for card rewards

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685d7a5f109483278746b1111cfd558a