### PR TITLE
Refactor card DMs into reusable helper

### DIFF
--- a/discord-bot/commands/admin.js
+++ b/discord-bot/commands/admin.js
@@ -1,8 +1,7 @@
 const { SlashCommandBuilder, PermissionFlagsBits } = require('discord.js');
 const db = require('../util/database');
-const { simple } = require('../src/utils/embedBuilder');
+const { simple, sendCardDM } = require('../src/utils/embedBuilder');
 const { allPossibleHeroes } = require('../../backend/game/data');
-const { generateCardImage } = require('../src/utils/cardRenderer');
 
 module.exports = {
     data: new SlashCommandBuilder()
@@ -77,17 +76,8 @@ module.exports = {
                     [targetUser.id]
                 );
 
-                const imageBuffer = await generateCardImage(recruit);
                 console.log(`DMing recruit card to user ${targetUser.username} (${targetUser.id})`);
-                const successEmbed = simple(
-                    '🃏 Recruit Granted',
-                    [{ name: 'New Card', value: `${recruit.name} (${recruit.rarity})` }]
-                );
-
-                await targetUser.send({
-                    embeds: [successEmbed],
-                    files: [{ attachment: imageBuffer, name: 'recruit.png' }]
-                });
+                await sendCardDM(targetUser, recruit);
 
                 await interaction.reply({ content: "Successfully sent the Recruit card to the user's DMs.", ephemeral: true });
             } catch (error) {

--- a/discord-bot/features/marketManager.js
+++ b/discord-bot/features/marketManager.js
@@ -1,8 +1,7 @@
 const { ActionRowBuilder, ButtonBuilder, ButtonStyle, StringSelectMenuBuilder, EmbedBuilder } = require('discord.js');
 const { setTimeout: sleep } = require('node:timers/promises');
 const db = require('../util/database');
-const { simple } = require('../src/utils/embedBuilder');
-const { generateCardImage } = require('../src/utils/cardRenderer');
+const { simple, sendCardDM } = require('../src/utils/embedBuilder');
 const { allPossibleHeroes, allPossibleWeapons, allPossibleArmors, allPossibleAbilities } = require('../../backend/game/data');
 const { getRandomCardsForPack } = require('../util/gameData');
 
@@ -162,14 +161,8 @@ async function handleBoosterPurchase(interaction, userId, packId, page = 0) {
     await interaction.editReply({ embeds: [resultsEmbed], components: [viewInventoryButton] });
 
     for (const card of awardedCards) {
-        const cardBuffer = await generateCardImage(card);
         console.log(`DMing card ${card.name} to user ${interaction.user.username} (${interaction.user.id})`);
-        const embed = new EmbedBuilder()
-            .setColor('#FDE047')
-            .setTitle('✨ You pulled a new card! ✨')
-            .addFields({ name: 'Name', value: card.name, inline: true }, { name: 'Rarity', value: card.rarity, inline: true })
-            .setTimestamp();
-        await interaction.user.send({ embeds: [embed], files: [{ attachment: cardBuffer, name: `${card.name}.png` }] });
+        await sendCardDM(interaction.user, card);
         await sleep(500);
     }
 }

--- a/discord-bot/src/utils/embedBuilder.js
+++ b/discord-bot/src/utils/embedBuilder.js
@@ -1,4 +1,5 @@
 const { EmbedBuilder } = require('discord.js');
+const { generateCardImage } = require('./cardRenderer');
 
 /**
  * Build a standard embed with brand styling.
@@ -25,4 +26,22 @@ function simple(title, fields = [], thumbnailUrl) {
   return embed;
 }
 
-module.exports = { simple };
+/**
+ * Send a DM containing a single card image with standardized embed styling.
+ * @param {import('discord.js').User} user
+ * @param {object} card
+ */
+async function sendCardDM(user, card) {
+  const cardBuffer = await generateCardImage(card);
+  const embed = new EmbedBuilder()
+    .setColor('#FDE047')
+    .setTitle('✨ You pulled a new card! ✨')
+    .addFields(
+      { name: 'Name', value: card.name, inline: true },
+      { name: 'Rarity', value: card.rarity, inline: true }
+    )
+    .setTimestamp();
+  await user.send({ embeds: [embed], files: [{ attachment: cardBuffer, name: `${card.name}.png` }] });
+}
+
+module.exports = { simple, sendCardDM };

--- a/discord-bot/tests/admin.test.js
+++ b/discord-bot/tests/admin.test.js
@@ -1,0 +1,40 @@
+const db = require('../util/database');
+const embedBuilder = require('../src/utils/embedBuilder');
+
+jest.mock('../util/database', () => ({
+  execute: jest.fn(() => Promise.resolve([]))
+}));
+
+jest.mock('../src/utils/cardRenderer', () => ({
+  generateCardImage: jest.fn(() => Promise.resolve(Buffer.from('x')))
+}));
+
+jest.mock('../../backend/game/data', () => ({
+  allPossibleHeroes: [{ id: 101, name: 'Recruit', rarity: 'Common' }]
+}));
+
+describe('admin grant-recruit', () => {
+  test('uses sendCardDM helper with pack style embed', async () => {
+    const sendSpy = jest.spyOn(embedBuilder, 'sendCardDM');
+    const admin = require('../commands/admin');
+    const targetUser = { id: '321', username: 'Target', send: jest.fn().mockResolvedValue() };
+    const interaction = {
+      options: {
+        getSubcommand: jest.fn(() => 'grant-recruit'),
+        getUser: jest.fn(() => targetUser)
+      },
+      member: { roles: { cache: { some: jest.fn(() => true) } } },
+      user: { id: '123', username: 'Admin' },
+      reply: jest.fn().mockResolvedValue()
+    };
+
+    await admin.execute(interaction);
+
+    expect(sendSpy).toHaveBeenCalledWith(targetUser, expect.objectContaining({ id: 101 }));
+    const dmPayload = targetUser.send.mock.calls[0][0];
+    expect(dmPayload.embeds[0].data.title).toBe('✨ You pulled a new card! ✨');
+    expect(dmPayload.embeds[0].data.fields[0].name).toBe('Name');
+    expect(dmPayload.embeds[0].data.fields[0].value).toBe('Recruit');
+    expect(interaction.reply).toHaveBeenCalledWith({ content: "Successfully sent the Recruit card to the user's DMs.", ephemeral: true });
+  });
+});


### PR DESCRIPTION
## Summary
- add `sendCardDM` helper in embedBuilder for consistent card embeds
- use `sendCardDM` when granting recruits and when opening packs
- unit test the new helper usage

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685d7a7aafd08327a7075aaa0eba8053