### PR TITLE
Remove unused marketplace menu function

### DIFF
--- a/discord-bot/features/marketManager.js
+++ b/discord-bot/features/marketManager.js
@@ -1,54 +1,12 @@
-const { ActionRowBuilder, ButtonBuilder, ButtonStyle, StringSelectMenuBuilder, EmbedBuilder } = require('discord.js');
+const { ActionRowBuilder, ButtonBuilder, ButtonStyle, EmbedBuilder } = require('discord.js');
 const { setTimeout: sleep } = require('node:timers/promises');
 const db = require('../util/database');
-const { simple } = require('../src/utils/embedBuilder');
 const { generateCardImage } = require('../src/utils/cardRenderer');
 const { allPossibleHeroes, allPossibleWeapons, allPossibleArmors, allPossibleAbilities } = require('../../backend/game/data');
 const { getRandomCardsForPack } = require('../util/gameData');
 
 const { BOOSTER_PACKS } = require('../src/boosterConfig');
 
-function getMarketplaceMenu(category = 'tavern', page = 0) {
-    const ITEMS_PER_PAGE = 10;
-    const CATEGORY_INFO = {
-        tavern: { title: '🍻 The Tavern', field: { name: 'Champions & Abilities', value: 'Recruit new heroes and learn new skills.' } },
-        armory: { title: '🛡️ The Armory', field: { name: 'Weapons & Armor', value: 'Outfit your champions with the finest gear.' } },
-        altar: { title: '💀 The Altar', field: { name: 'Monsters & Powers', value: 'Unleash forbidden powers and monstrous allies.' } }
-    };
-    const info = CATEGORY_INFO[category] || { title: 'Marketplace', field: { name: 'Packs', value: 'Available booster packs' } };
-    const embed = simple(info.title, [info.field]);
-    const packs = Object.entries(BOOSTER_PACKS).filter(([, p]) => p.category === category);
-    const totalPages = Math.ceil(packs.length / ITEMS_PER_PAGE);
-    const start = page * ITEMS_PER_PAGE;
-    const pagePacks = packs.slice(start, start + ITEMS_PER_PAGE);
-
-    const selectMenu = new StringSelectMenuBuilder()
-        .setCustomId(`market_pack_select_${category}_${page}`)
-        .setPlaceholder('Choose a booster pack')
-        .addOptions(pagePacks.map(([id, p]) => ({
-            label: p.name,
-            description: `${p.cost} ${p.currency === 'soft_currency' ? 'Gold 🪙' : 'Gems 💎'}`,
-            value: id
-        })));
-
-    const categoryRow = new ActionRowBuilder().addComponents(
-        new ButtonBuilder().setCustomId('market_tavern').setLabel('The Tavern').setStyle(ButtonStyle.Primary).setEmoji('🍻').setDisabled(category === 'tavern'),
-        new ButtonBuilder().setCustomId('market_armory').setLabel('The Armory').setStyle(ButtonStyle.Secondary).setEmoji('🛡️').setDisabled(category === 'armory'),
-        new ButtonBuilder().setCustomId('market_altar').setLabel('The Altar').setStyle(ButtonStyle.Danger).setEmoji('💀').setDisabled(category === 'altar')
-    );
-
-    const selectRow = new ActionRowBuilder().addComponents(selectMenu);
-    const paginationRow = new ActionRowBuilder().addComponents(
-        new ButtonBuilder().setCustomId(`market_page_prev_${category}_${page - 1}`).setLabel('Previous').setStyle(ButtonStyle.Secondary).setEmoji('⬅️').setDisabled(page === 0),
-        new ButtonBuilder().setCustomId(`market_page_next_${category}_${page + 1}`).setLabel('Next').setStyle(ButtonStyle.Secondary).setEmoji('➡️').setDisabled(page >= totalPages - 1)
-    );
-
-    const backButton = new ActionRowBuilder().addComponents(
-        new ButtonBuilder().setCustomId('back_to_market').setLabel('Back to Marketplace').setStyle(ButtonStyle.Secondary).setEmoji('⬅️')
-    );
-
-    return { embeds: [embed], components: [categoryRow, selectRow, paginationRow, backButton], ephemeral: true };
-}
 
 async function handleBoosterPurchase(interaction, userId, packId, page = 0) {
     const packInfo = BOOSTER_PACKS[packId];
@@ -174,4 +132,4 @@ async function handleBoosterPurchase(interaction, userId, packId, page = 0) {
     }
 }
 
-module.exports = { BOOSTER_PACKS, getMarketplaceMenu, handleBoosterPurchase };
+module.exports = { BOOSTER_PACKS, handleBoosterPurchase };

--- a/discord-bot/tests/buttonHandler.test.js
+++ b/discord-bot/tests/buttonHandler.test.js
@@ -2,7 +2,6 @@ const marketManager = require('../features/marketManager');
 
 jest.mock('../features/marketManager', () => ({
   handleBoosterPurchase: jest.fn(),
-  getMarketplaceMenu: jest.fn(),
 }));
 
 jest.mock('../features/tutorialManager', () => ({


### PR DESCRIPTION
## Summary
- delete `getMarketplaceMenu` from `marketManager`
- drop export and update tests accordingly

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685d7a748c788327ab38df2103a52287