### PR TITLE
Improve error handling for missing card frames

### DIFF
--- a/discord-bot/commands/admin.js
+++ b/discord-bot/commands/admin.js
@@ -77,16 +77,24 @@ module.exports = {
                     [targetUser.id]
                 );
 
-                const imageBuffer = await generateCardImage(recruit);
+                let imageBuffer;
+                try {
+                    imageBuffer = await generateCardImage(recruit);
+                } catch (err) {
+                    console.error('Failed to generate recruit image:', err);
+                }
                 const successEmbed = simple(
                     '🃏 Recruit Granted',
                     [{ name: 'New Card', value: `${recruit.name} (${recruit.rarity})` }]
                 );
 
-                await targetUser.send({
-                    embeds: [successEmbed],
-                    files: [{ attachment: imageBuffer, name: 'recruit.png' }]
-                });
+                const messageOptions = { embeds: [successEmbed] };
+                if (imageBuffer) {
+                    messageOptions.files = [{ attachment: imageBuffer, name: 'recruit.png' }];
+                } else {
+                    messageOptions.content = 'Card image unavailable.';
+                }
+                await targetUser.send(messageOptions);
 
                 await interaction.reply({ content: "Successfully sent the Recruit card to the user's DMs.", ephemeral: true });
             } catch (error) {

--- a/discord-bot/features/marketManager.js
+++ b/discord-bot/features/marketManager.js
@@ -162,13 +162,24 @@ async function handleBoosterPurchase(interaction, userId, packId, page = 0) {
     await interaction.editReply({ embeds: [resultsEmbed], components: [viewInventoryButton] });
 
     for (const card of awardedCards) {
-        const cardBuffer = await generateCardImage(card);
+        let cardBuffer;
+        try {
+            cardBuffer = await generateCardImage(card);
+        } catch (err) {
+            console.error('Failed to generate card image:', err);
+        }
         const embed = new EmbedBuilder()
             .setColor('#FDE047')
             .setTitle('✨ You pulled a new card! ✨')
             .addFields({ name: 'Name', value: card.name, inline: true }, { name: 'Rarity', value: card.rarity, inline: true })
             .setTimestamp();
-        await interaction.user.send({ embeds: [embed], files: [{ attachment: cardBuffer, name: `${card.name}.png` }] });
+        const messageOptions = { embeds: [embed] };
+        if (cardBuffer) {
+            messageOptions.files = [{ attachment: cardBuffer, name: `${card.name}.png` }];
+        } else {
+            messageOptions.content = 'Card image unavailable.';
+        }
+        await interaction.user.send(messageOptions);
         await sleep(500);
     }
 }

--- a/discord-bot/index.js
+++ b/discord-bot/index.js
@@ -784,9 +784,18 @@ client.on(Events.InteractionCreate, async interaction => {
                         .setTitle('Your New Card!')
                         .setDescription(`You chose **${chosenCard.name}**! You gained **${totalShardsGained}** shards from the other cards.`)
                         .setFooter({ text: 'Auto-Battler Bot' });
-                    const cardBuffer = await generateCardImage(chosenCard);
+                    let cardBuffer;
                     try {
-                        await user.send({ embeds: [dmEmbed], files: [{ attachment: cardBuffer, name: `${chosenCard.name}.png` }] });
+                        cardBuffer = await generateCardImage(chosenCard);
+                    } catch (err) {
+                        console.error('Failed to generate card image:', err);
+                    }
+                    try {
+                        if (cardBuffer) {
+                            await user.send({ embeds: [dmEmbed], files: [{ attachment: cardBuffer, name: `${chosenCard.name}.png` }] });
+                        } else {
+                            await user.send({ embeds: [dmEmbed], content: 'Card image unavailable.' });
+                        }
                     } catch (e) {
                         console.error('Failed to send DM:', e);
                     }

--- a/discord-bot/src/utils/cardRenderer.js
+++ b/discord-bot/src/utils/cardRenderer.js
@@ -16,6 +16,12 @@ async function generateCardImage(card) {
     'frames',
     `frame-${(card.rarity || 'common').toLowerCase()}.png`
   );
+  try {
+    await fs.access(framePath);
+  } catch (err) {
+    console.error(`Missing frame image at ${framePath}`, err);
+    throw new Error('frame-not-found');
+  }
   const heroArtPath = path.join(
     assetsBase,
     'heroes',


### PR DESCRIPTION
## Summary
- validate card frame asset exists in `generateCardImage`
- handle rendering failures in admin command
- handle rendering failures in inventory DM
- handle rendering failures when players open packs

## Testing
- `npm test --prefix discord-bot --silent`

------
https://chatgpt.com/codex/tasks/task_e_685d7a6390e88327adcb7480570b3985