### PR TITLE
Handle missing frame assets

### DIFF
--- a/discord-bot/commands/admin.js
+++ b/discord-bot/commands/admin.js
@@ -77,16 +77,22 @@ module.exports = {
                     [targetUser.id]
                 );
 
-                const imageBuffer = await generateCardImage(recruit);
+                let imageBuffer = null;
+                try {
+                    imageBuffer = await generateCardImage(recruit);
+                } catch (err) {
+                    console.error(`Failed to generate image for ${recruit.name}:`, err);
+                }
                 console.log(`DMing recruit card to user ${targetUser.username} (${targetUser.id})`);
                 const successEmbed = simple(
                     '🃏 Recruit Granted',
                     [{ name: 'New Card', value: `${recruit.name} (${recruit.rarity})` }]
                 );
 
+                const files = imageBuffer ? [{ attachment: imageBuffer, name: 'recruit.png' }] : [];
                 await targetUser.send({
                     embeds: [successEmbed],
-                    files: [{ attachment: imageBuffer, name: 'recruit.png' }]
+                    files
                 });
 
                 await interaction.reply({ content: "Successfully sent the Recruit card to the user's DMs.", ephemeral: true });

--- a/discord-bot/features/marketManager.js
+++ b/discord-bot/features/marketManager.js
@@ -124,7 +124,12 @@ async function handleBoosterPurchase(interaction, userId, packId, page = 0) {
     await interaction.editReply({ embeds: [resultsEmbed], components: [viewInventoryButton] });
 
     for (const card of awardedCards) {
-        const cardBuffer = await generateCardImage(card);
+        let cardBuffer = null;
+        try {
+            cardBuffer = await generateCardImage(card);
+        } catch (err) {
+            console.error(`Failed to generate image for card ${card.name}:`, err);
+        }
         console.log(`DMing card ${card.name} to user ${interaction.user.username} (${interaction.user.id})`);
         const embed = new EmbedBuilder()
             .setColor('#FDE047')
@@ -132,7 +137,8 @@ async function handleBoosterPurchase(interaction, userId, packId, page = 0) {
             .addFields({ name: 'Name', value: card.name, inline: true }, { name: 'Rarity', value: card.rarity, inline: true })
             .setTimestamp();
         try {
-            await interaction.user.send({ embeds: [embed], files: [{ attachment: cardBuffer, name: `${card.name}.png` }] });
+            const files = cardBuffer ? [{ attachment: cardBuffer, name: `${card.name}.png` }] : [];
+            await interaction.user.send({ embeds: [embed], files });
             console.log(`Sent card DM to ${interaction.user.username} for card ${card.name}`);
         } catch (err) {
             console.error(`Failed to DM card ${card.name} to ${interaction.user.username}:`, err);

--- a/discord-bot/index.js
+++ b/discord-bot/index.js
@@ -658,10 +658,16 @@ client.on(Events.InteractionCreate, async interaction => {
                         .setTitle('Your New Card!')
                         .setDescription(`You chose **${chosenCard.name}**! You gained **${totalShardsGained}** shards from the other cards.`)
                         .setFooter({ text: 'Auto-Battler Bot' });
-                    const cardBuffer = await generateCardImage(chosenCard);
+                    let cardBuffer = null;
+                    try {
+                        cardBuffer = await generateCardImage(chosenCard);
+                    } catch (err) {
+                        console.error(`Failed to generate image for ${chosenCard.name}:`, err);
+                    }
                     console.log(`DMing chosen card ${chosenCard.name} to user ${user.username} (${userId})`);
                     try {
-                        await user.send({ embeds: [dmEmbed], files: [{ attachment: cardBuffer, name: `${chosenCard.name}.png` }] });
+                        const files = cardBuffer ? [{ attachment: cardBuffer, name: `${chosenCard.name}.png` }] : [];
+                        await user.send({ embeds: [dmEmbed], files });
                     } catch (e) {
                         console.error('Failed to send DM:', e);
                     }

--- a/discord-bot/src/utils/cardRenderer.js
+++ b/discord-bot/src/utils/cardRenderer.js
@@ -31,6 +31,15 @@ async function generateCardImage(card) {
     `Generating card image for ${card.name} - frame: ${framePath}, hero: ${heroArtPath}, class: ${classIconPath}`
   );
 
+  // Verify the rarity frame exists
+  try {
+    await fs.access(framePath);
+  } catch {
+    const errMsg = `Frame image not found at ${framePath}`;
+    console.error(errMsg);
+    throw new Error(errMsg);
+  }
+
   // Start with the rarity frame as the base image
   let base = sharp(framePath).resize(300, 400);
 


### PR DESCRIPTION
## Summary
- verify card frame exists in `cardRenderer`
- catch frame errors in callers and skip attachments when rendering fails

## Testing
- `npm test` in `backend`
- `npm test` in `discord-bot`

------
https://chatgpt.com/codex/tasks/task_e_685d8310f894832782a2ee4e0a5be30e