### PR TITLE
Add shared card DM helper

### DIFF
--- a/discord-bot/commands/admin.js
+++ b/discord-bot/commands/admin.js
@@ -1,8 +1,7 @@
 const { SlashCommandBuilder, PermissionFlagsBits } = require('discord.js');
 const db = require('../util/database');
-const { simple } = require('../src/utils/embedBuilder');
+const { simple, sendCardDM } = require('../src/utils/embedBuilder');
 const { allPossibleHeroes } = require('../../backend/game/data');
-const { generateCardImage } = require('../src/utils/cardRenderer');
 
 module.exports = {
     data: new SlashCommandBuilder()
@@ -77,23 +76,8 @@ module.exports = {
                     [targetUser.id]
                 );
 
-                let imageBuffer = null;
-                try {
-                    imageBuffer = await generateCardImage(recruit);
-                } catch (err) {
-                    console.error(`Failed to generate image for ${recruit.name}:`, err);
-                }
                 console.log(`DMing recruit card to user ${targetUser.username} (${targetUser.id})`);
-                const successEmbed = simple(
-                    '🃏 Recruit Granted',
-                    [{ name: 'New Card', value: `${recruit.name} (${recruit.rarity})` }]
-                );
-
-                const files = imageBuffer ? [{ attachment: imageBuffer, name: 'recruit.png' }] : [];
-                await targetUser.send({
-                    embeds: [successEmbed],
-                    files
-                });
+                await sendCardDM(targetUser, recruit);
 
                 await interaction.reply({ content: "Successfully sent the Recruit card to the user's DMs.", ephemeral: true });
             } catch (error) {

--- a/discord-bot/features/marketManager.js
+++ b/discord-bot/features/marketManager.js
@@ -1,8 +1,7 @@
 const { ActionRowBuilder, ButtonBuilder, ButtonStyle, StringSelectMenuBuilder, EmbedBuilder } = require('discord.js');
 const { setTimeout: sleep } = require('node:timers/promises');
 const db = require('../util/database');
-const { simple } = require('../src/utils/embedBuilder');
-const { generateCardImage } = require('../src/utils/cardRenderer');
+const { simple, sendCardDM } = require('../src/utils/embedBuilder');
 const { allPossibleHeroes, allPossibleWeapons, allPossibleArmors, allPossibleAbilities } = require('../../backend/game/data');
 const { getRandomCardsForPack } = require('../util/gameData');
 
@@ -123,21 +122,9 @@ async function handleBoosterPurchase(interaction, userId, packId, page = 0) {
     await interaction.editReply({ embeds: [resultsEmbed], components: [viewInventoryButton] });
 
     for (const card of awardedCards) {
-        let cardBuffer = null;
-        try {
-            cardBuffer = await generateCardImage(card);
-        } catch (err) {
-            console.error(`Failed to generate image for card ${card.name}:`, err);
-        }
         console.log(`DMing card ${card.name} to user ${interaction.user.username} (${interaction.user.id})`);
-        const embed = new EmbedBuilder()
-            .setColor('#FDE047')
-            .setTitle('✨ You pulled a new card! ✨')
-            .addFields({ name: 'Name', value: card.name, inline: true }, { name: 'Rarity', value: card.rarity, inline: true })
-            .setTimestamp();
         try {
-            const files = cardBuffer ? [{ attachment: cardBuffer, name: `${card.name}.png` }] : [];
-            await interaction.user.send({ embeds: [embed], files });
+            await sendCardDM(interaction.user, card);
             console.log(`Sent card DM to ${interaction.user.username} for card ${card.name}`);
         } catch (err) {
             console.error(`Failed to DM card ${card.name} to ${interaction.user.username}:`, err);

--- a/discord-bot/src/utils/embedBuilder.js
+++ b/discord-bot/src/utils/embedBuilder.js
@@ -1,4 +1,5 @@
 const { EmbedBuilder } = require('discord.js');
+const { generateCardImage } = require('./cardRenderer');
 
 /**
  * Build a standard embed with brand styling.
@@ -25,4 +26,32 @@ function simple(title, fields = [], thumbnailUrl) {
   return embed;
 }
 
-module.exports = { simple };
+
+/**
+ * Generate the standard card pull embed and DM it to the given user.
+ *
+ * @param {import('discord.js').User} user
+ * @param {object} card
+ */
+async function sendCardDM(user, card) {
+  let cardBuffer = null;
+  try {
+    cardBuffer = await generateCardImage(card);
+  } catch (err) {
+    console.error(`Failed to generate image for card ${card.name}:`, err);
+  }
+
+  const embed = new EmbedBuilder()
+    .setColor('#FDE047')
+    .setTitle('✨ You pulled a new card! ✨')
+    .addFields(
+      { name: 'Name', value: card.name, inline: true },
+      { name: 'Rarity', value: card.rarity, inline: true }
+    )
+    .setTimestamp();
+
+  const files = cardBuffer ? [{ attachment: cardBuffer, name: `${card.name}.png` }] : [];
+  await user.send({ embeds: [embed], files });
+}
+
+module.exports = { simple, sendCardDM };

--- a/discord-bot/tests/admin.test.js
+++ b/discord-bot/tests/admin.test.js
@@ -1,0 +1,38 @@
+const db = require('../util/database');
+const embedBuilder = require('../src/utils/embedBuilder');
+
+jest.mock('../util/database', () => ({
+  execute: jest.fn(() => Promise.resolve())
+}));
+
+jest.mock('../src/utils/cardRenderer', () => ({
+  generateCardImage: jest.fn(() => Promise.resolve(Buffer.from('img')))
+}));
+
+jest.mock('../../backend/game/data', () => ({
+  allPossibleHeroes: [{ id: 101, name: 'Recruit', rarity: 'Common' }]
+}));
+
+describe('admin grant-recruit', () => {
+  test('uses sendCardDM with pack style embed', async () => {
+    const targetUser = { id: 't1', username: 'Target', send: jest.fn().mockResolvedValue() };
+    const interaction = {
+      options: {
+        getSubcommand: jest.fn(() => 'grant-recruit'),
+        getUser: jest.fn(() => targetUser)
+      },
+      member: { roles: { cache: { some: jest.fn(() => true) } } },
+      user: { id: 'admin' },
+      reply: jest.fn().mockResolvedValue()
+    };
+
+    const spy = jest.spyOn(embedBuilder, 'sendCardDM');
+    const admin = require('../commands/admin');
+    await admin.execute(interaction);
+
+    expect(spy).toHaveBeenCalledWith(targetUser, expect.objectContaining({ id: 101 }));
+    const sent = targetUser.send.mock.calls[0][0];
+    expect(sent.embeds[0].data.title).toBe('✨ You pulled a new card! ✨');
+    expect(sent.embeds[0].data.fields[0].value).toBe('Recruit');
+  });
+});

--- a/discord-bot/tests/marketManager.test.js
+++ b/discord-bot/tests/marketManager.test.js
@@ -2,6 +2,7 @@ const marketManager = require('../features/marketManager');
 const { BOOSTER_PACKS } = require('../src/boosterConfig');
 const db = require('../util/database');
 const gameData = require('../util/gameData');
+const embedBuilder = require('../src/utils/embedBuilder');
 
 jest.mock('../util/database', () => ({
   execute: jest.fn()
@@ -18,8 +19,9 @@ jest.mock('../../backend/game/data', () => ({
   allPossibleAbilities: []
 }));
 
-jest.mock('../src/utils/cardRenderer', () => ({
-  generateCardImage: jest.fn(() => Promise.resolve(Buffer.from('x')))
+jest.mock('../src/utils/embedBuilder', () => ({
+  simple: jest.fn(() => ({ data: {} })),
+  sendCardDM: jest.fn(() => Promise.resolve())
 }));
 
 describe('handleBoosterPurchase', () => {
@@ -47,5 +49,6 @@ describe('handleBoosterPurchase', () => {
 
     expect(interaction.user.send).toHaveBeenCalledWith('💰 Debug: Your new gold balance is 50');
     expect(channelSend).toHaveBeenCalledWith('📣 **Tester** has obtained a new card: **Test Card** (Common)!');
+    expect(embedBuilder.sendCardDM).toHaveBeenCalledWith(interaction.user, expect.objectContaining({ name: 'Test Card' }));
   });
 });


### PR DESCRIPTION
## Summary
- centralize card DM generation logic in `sendCardDM`
- use helper in booster pack flow and admin grant-recruit command
- update unit tests to mock the helper and add new admin test

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_685d8b42edf483279335543ee6f98a60