### PR TITLE
Simplify town menu

### DIFF
--- a/discord-bot/commands/town.js
+++ b/discord-bot/commands/town.js
@@ -1,22 +1,34 @@
 const { SlashCommandBuilder, ActionRowBuilder, ButtonBuilder, ButtonStyle, EmbedBuilder } = require('discord.js');
 
-function getTownMenu() {
+function getTownMenu(showTutorialButton = true) {
     const embed = new EmbedBuilder()
         .setColor('#29b6f6')
         .setTitle('Welcome to the Town Square')
         .setDescription('This is your central hub for all activities. Where would you like to go?')
         .setImage('https://placehold.co/600x200/1e293b/ffffff?text=Town+Square');
 
+    const components = [];
+
+    // Conditionally add the tutorial button at the top of the menu
+    if (showTutorialButton) {
+        const tutorialRow = new ActionRowBuilder().addComponents(
+            new ButtonBuilder()
+                .setCustomId('tutorial_start_new_flow')
+                .setLabel('Begin Your Training')
+                .setStyle(ButtonStyle.Success)
+                .setEmoji('⚔️')
+        );
+        components.push(tutorialRow);
+    }
+
     const row1 = new ActionRowBuilder()
         .addComponents(
-            new ButtonBuilder().setCustomId('town_summon').setLabel('Acquire Units').setStyle(ButtonStyle.Success).setEmoji('✨'),
-            new ButtonBuilder().setCustomId('town_barracks').setLabel('Barracks').setStyle(ButtonStyle.Secondary).setEmoji('⚔️')
+            new ButtonBuilder().setCustomId('town_barracks').setLabel('Barracks').setStyle(ButtonStyle.Secondary).setEmoji('⚔️').setDisabled(false)
         );
 
     const row2 = new ActionRowBuilder()
         .addComponents(
-            new ButtonBuilder().setCustomId('town_forge').setLabel('The Forge').setStyle(ButtonStyle.Secondary).setEmoji('🔥').setDisabled(true),
-            new ButtonBuilder().setCustomId('town_market').setLabel('Marketplace').setStyle(ButtonStyle.Secondary).setEmoji('💰').setDisabled(false)
+            new ButtonBuilder().setCustomId('town_forge').setLabel('The Forge').setStyle(ButtonStyle.Secondary).setEmoji('🔥').setDisabled(true)
         );
 
     const row3 = new ActionRowBuilder()
@@ -24,7 +36,9 @@ function getTownMenu() {
             new ButtonBuilder().setCustomId('town_dungeon').setLabel('Enter the Dungeon Portal').setStyle(ButtonStyle.Primary).setEmoji('🌀')
         );
 
-    return { embeds: [embed], components: [row1, row2, row3], ephemeral: true };
+    components.push(row1, row2, row3);
+
+    return { embeds: [embed], components: components, ephemeral: true };
 }
 
 module.exports = {


### PR DESCRIPTION
## Summary
- streamline the town menu to show only Barracks, The Forge (disabled), Dungeon and tutorial button
- always display tutorial button by default

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685d933d030c8327870c86f2ad7b58b4