### PR TITLE
Fix champion deck insert parameters

### DIFF
--- a/discord-bot/features/tutorialManager.js
+++ b/discord-bot/features/tutorialManager.js
@@ -199,7 +199,7 @@ async function insertAndDeckChampion(userId, champData) {
         if (champData.abilityId) {
             await connection.execute(
                 `INSERT INTO champion_decks (user_champion_id, ability_id, order_index) VALUES (?, ?, 0)`,
-                [newChampionId, champData.abilityId, 0]
+                [newChampionId, champData.abilityId]
             );
         }
         await connection.commit();

--- a/discord-bot/index.js
+++ b/discord-bot/index.js
@@ -1642,7 +1642,7 @@ async function insertAndDeckChampion(userId, champData) {
             try {
                 await connection.execute(
                     `INSERT INTO champion_decks (user_champion_id, ability_id, order_index) VALUES (?, ?, 0)`,
-                    [newChampionId, champData.abilityId, 0]
+                    [newChampionId, champData.abilityId]
                 );
                 console.log(`[DEBUG] Successfully inserted champion_decks entry for champion ID: ${newChampionId}`);
             } catch (deckInsertError) {


### PR DESCRIPTION
## Summary
- remove extra placeholder parameter for `INSERT INTO champion_decks`
- update tutorialManager with the same fix

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685da35462688327bf2cbf3f1099458e