### PR TITLE
Fix ephemeral flag deprecation

### DIFF
--- a/discord-bot/commands/addcard.js
+++ b/discord-bot/commands/addcard.js
@@ -1,4 +1,4 @@
-const { InteractionResponseFlags } = require('discord-api-types/v10');
+const { MessageFlags } = require('discord.js');
 const { SlashCommandBuilder } = require('discord.js');
 const embedBuilder = require('../src/utils/embedBuilder');
 const confirm = require('../src/utils/confirm');
@@ -12,10 +12,10 @@ module.exports = {
     const name = interaction.options.getString('name');
     // TODO: add new column in DB
     // TODO: persist card to database
-    await interaction.reply({ embeds: [embedBuilder.simple(`Card ${name} added.`)], flags: [InteractionResponseFlags.EPHEMERAL] });
+    await interaction.reply({ embeds: [embedBuilder.simple(`Card ${name} added.`)], flags: [MessageFlags.Ephemeral] });
     await interaction.followUp({
       embeds: [ confirm('Your card has been added to your collection.') ],
-      flags: [InteractionResponseFlags.EPHEMERAL]
+      flags: [MessageFlags.Ephemeral]
     });
   }
 };

--- a/discord-bot/commands/admin.js
+++ b/discord-bot/commands/admin.js
@@ -1,4 +1,4 @@
-const { InteractionResponseFlags } = require('discord-api-types/v10');
+const { MessageFlags } = require('discord.js');
 const { SlashCommandBuilder, PermissionFlagsBits } = require('discord.js');
 const db = require('../util/database');
 const { simple, sendCardDM } = require('../src/utils/embedBuilder');
@@ -36,7 +36,7 @@ module.exports = {
         if (!interaction.member.roles.cache.some(role => role.name === requiredRoleName)) {
             return interaction.reply({
                 embeds: [simple('🚫 Access Denied', [{ name: 'Error', value: 'You do not have permission to use this command.' }])],
-                flags: [InteractionResponseFlags.EPHEMERAL]
+                flags: [MessageFlags.Ephemeral]
             });
         }
 
@@ -45,7 +45,7 @@ module.exports = {
             const amount = interaction.options.getInteger('amount');
 
             if (amount <= 0) {
-                return interaction.reply({ content: 'Please provide a positive amount of gold.', flags: [InteractionResponseFlags.EPHEMERAL] });
+                return interaction.reply({ content: 'Please provide a positive amount of gold.', flags: [MessageFlags.Ephemeral] });
             }
 
             try {
@@ -56,17 +56,17 @@ module.exports = {
                     '💰 Gold Granted',
                     [{ name: 'Success!', value: `Successfully granted ${amount} gold to ${targetUser.username}.` }]
                 );
-                await interaction.reply({ embeds: [successEmbed], flags: [InteractionResponseFlags.EPHEMERAL] });
+                await interaction.reply({ embeds: [successEmbed], flags: [MessageFlags.Ephemeral] });
             } catch (error) {
                 console.error('Error granting gold:', error);
-                await interaction.reply({ content: 'An error occurred while granting gold.', flags: [InteractionResponseFlags.EPHEMERAL] });
+                await interaction.reply({ content: 'An error occurred while granting gold.', flags: [MessageFlags.Ephemeral] });
             }
         } else if (interaction.options.getSubcommand() === 'grant-recruit') {
             const targetUser = interaction.options.getUser('target') || interaction.user;
             const recruit = allPossibleHeroes.find(h => h.id === 101);
 
             if (!recruit) {
-                return interaction.reply({ content: 'Recruit card data not found.', flags: [InteractionResponseFlags.EPHEMERAL] });
+                return interaction.reply({ content: 'Recruit card data not found.', flags: [MessageFlags.Ephemeral] });
             }
 
             try {
@@ -80,10 +80,10 @@ module.exports = {
                 console.log(`DMing recruit card to user ${targetUser.username} (${targetUser.id})`);
                 await sendCardDM(targetUser, recruit);
 
-                await interaction.reply({ content: "Successfully sent the Recruit card to the user's DMs.", flags: [InteractionResponseFlags.EPHEMERAL] });
+                await interaction.reply({ content: "Successfully sent the Recruit card to the user's DMs.", flags: [MessageFlags.Ephemeral] });
             } catch (error) {
                 console.error('Error granting recruit:', error);
-                await interaction.reply({ content: 'An error occurred while granting the Recruit card.', flags: [InteractionResponseFlags.EPHEMERAL] });
+                await interaction.reply({ content: 'An error occurred while granting the Recruit card.', flags: [MessageFlags.Ephemeral] });
             }
         }
     },

--- a/discord-bot/commands/inventory.js
+++ b/discord-bot/commands/inventory.js
@@ -1,4 +1,4 @@
-const { InteractionResponseFlags } = require('discord-api-types/v10');
+const { MessageFlags } = require('discord.js');
 const { SlashCommandBuilder, EmbedBuilder, ActionRowBuilder, ButtonBuilder, ButtonStyle } = require('discord.js');
 const { simple } = require('../src/utils/embedBuilder');
 const db = require('../util/database');
@@ -24,7 +24,7 @@ module.exports = {
         if (interaction.isChatInputCommand()) {
             try {
                 console.log('[INVENTORY DEBUG] Attempting to deferReply for slash command.');
-                await interaction.deferReply({ flags: [InteractionResponseFlags.EPHEMERAL] });
+                await interaction.deferReply({ flags: [MessageFlags.Ephemeral] });
                 interactionHandledByThisCommand = true;
                 console.log(`[INVENTORY DEBUG] deferReply successful. interactionHandledByThisCommand: ${interactionHandledByThisCommand}`);
             } catch (deferError) {

--- a/discord-bot/commands/leaderboard.js
+++ b/discord-bot/commands/leaderboard.js
@@ -1,4 +1,4 @@
-const { InteractionResponseFlags } = require('discord-api-types/v10');
+const { MessageFlags } = require('discord.js');
 const { SlashCommandBuilder } = require('discord.js');
 const db = require('../util/database');
 const { simple } = require('../src/utils/embedBuilder');
@@ -25,10 +25,10 @@ module.exports = {
             const embed = simple('🏆 PvP Leaderboard', [
                 { name: 'Top Players', value: lines.join('\n') || 'No data' }
             ]);
-            await interaction.reply({ embeds: [embed], flags: [InteractionResponseFlags.EPHEMERAL] });
+            await interaction.reply({ embeds: [embed], flags: [MessageFlags.Ephemeral] });
         } catch (err) {
             console.error('Error fetching leaderboard:', err);
-            await interaction.reply({ content: 'Failed to fetch leaderboard.', flags: [InteractionResponseFlags.EPHEMERAL] });
+            await interaction.reply({ content: 'Failed to fetch leaderboard.', flags: [MessageFlags.Ephemeral] });
         }
     }
 };

--- a/discord-bot/commands/openpack.js
+++ b/discord-bot/commands/openpack.js
@@ -1,4 +1,4 @@
-const { InteractionResponseFlags } = require('discord-api-types/v10');
+const { MessageFlags } = require('discord.js');
 const { SlashCommandBuilder } = require('discord.js');
 const { simple } = require('../src/utils/embedBuilder');
 const confirm = require('../src/utils/confirm');
@@ -51,7 +51,7 @@ const command = {
                     { name: 'Premium', value: 'premium' }
                 )),
     async execute(interaction) {
-        await interaction.deferReply({ flags: [InteractionResponseFlags.EPHEMERAL] });
+        await interaction.deferReply({ flags: [MessageFlags.Ephemeral] });
 
         const userId = interaction.user.id;
         const packTypeRaw = interaction.options.getString('type');
@@ -59,7 +59,7 @@ const command = {
 
         const columnBase = PACK_COLUMN_BASE[packTypeRaw];
         if (!columnBase) {
-            await interaction.editReply({ content: 'Invalid pack type selected.', flags: [InteractionResponseFlags.EPHEMERAL] });
+            await interaction.editReply({ content: 'Invalid pack type selected.', flags: [MessageFlags.Ephemeral] });
             return;
         }
 
@@ -71,7 +71,7 @@ const command = {
             );
         } catch (err) {
             console.error('Error updating pack count:', err);
-            await interaction.editReply({ content: 'Failed to add pack to your account.', flags: [InteractionResponseFlags.EPHEMERAL] });
+            await interaction.editReply({ content: 'Failed to add pack to your account.', flags: [MessageFlags.Ephemeral] });
             return;
         }
 
@@ -86,7 +86,7 @@ const command = {
 
         await interaction.followUp({
             embeds: [confirm('Pack successfully added to your account.')],
-            flags: [InteractionResponseFlags.EPHEMERAL]
+            flags: [MessageFlags.Ephemeral]
         });
     },
 };

--- a/discord-bot/commands/ping.js
+++ b/discord-bot/commands/ping.js
@@ -1,4 +1,4 @@
-const { InteractionResponseFlags } = require('discord-api-types/v10');
+const { MessageFlags } = require('discord.js');
 const { SlashCommandBuilder } = require('discord.js');
 const { simple } = require('../src/utils/embedBuilder');
 
@@ -8,6 +8,6 @@ module.exports = {
         .setDescription('Replies with Pong!'),
     async execute(interaction) {
         const embed = simple('Pong!');
-        await interaction.reply({ embeds: [embed], flags: [InteractionResponseFlags.EPHEMERAL] });
+        await interaction.reply({ embeds: [embed], flags: [MessageFlags.Ephemeral] });
     },
 };

--- a/discord-bot/commands/start.js
+++ b/discord-bot/commands/start.js
@@ -1,4 +1,4 @@
-const { InteractionResponseFlags } = require('discord-api-types/v10');
+const { MessageFlags } = require('discord.js');
 const { SlashCommandBuilder } = require('discord.js');
 const { simple } = require('../src/utils/embedBuilder');
 
@@ -11,6 +11,6 @@ module.exports = {
             'Welcome to the Grand Adventure!',
             [{ name: 'Your Journey Begins!', value: 'Use the `/town` command to get started. If you are a new player, a "Begin Your Training" button will appear to guide you!' }]
         );
-        await interaction.reply({ embeds: [embed], flags: [InteractionResponseFlags.EPHEMERAL] });
+        await interaction.reply({ embeds: [embed], flags: [MessageFlags.Ephemeral] });
     },
 };

--- a/discord-bot/commands/team.js
+++ b/discord-bot/commands/team.js
@@ -1,4 +1,4 @@
-const { InteractionResponseFlags } = require('discord-api-types/v10');
+const { MessageFlags } = require('discord.js');
 const { SlashCommandBuilder } = require('discord.js');
 
 module.exports = {
@@ -27,6 +27,6 @@ module.exports = {
         // The core functionality for 'manage' is now driven by the Barracks UI flow.
         // You can leave this execute empty or provide a basic ephemeral reply
         // directing the user to the /town command if they try to use /team manage directly.
-        await interaction.reply({ content: "Please use the `/town` command and then navigate to Barracks to manage your champions. This command is mainly for internal use or specific direct champion selection.", flags: [InteractionResponseFlags.EPHEMERAL] });
+        await interaction.reply({ content: "Please use the `/town` command and then navigate to Barracks to manage your champions. This command is mainly for internal use or specific direct champion selection.", flags: [MessageFlags.Ephemeral] });
     }
 };

--- a/discord-bot/commands/town.js
+++ b/discord-bot/commands/town.js
@@ -1,4 +1,4 @@
-const { InteractionResponseFlags } = require('discord-api-types/v10');
+const { MessageFlags } = require('discord.js');
 const { SlashCommandBuilder, ActionRowBuilder, ButtonBuilder, ButtonStyle, EmbedBuilder } = require('discord.js');
 const db = require('../util/database');
 
@@ -42,7 +42,7 @@ function getTownMenu(showTutorialButton = true) {
 
     components.push(row);
 
-    return { embeds: [embed], components: components, flags: [InteractionResponseFlags.EPHEMERAL] };
+    return { embeds: [embed], components: components, flags: [MessageFlags.Ephemeral] };
 }
 
 module.exports = {
@@ -79,7 +79,7 @@ module.exports = {
             );
             // As a fallback, we won't show the tutorial button if the database check fails.
         }
-        await interaction.reply(getTownMenu());
+        await interaction.reply(getTownMenu(showTutorial));
     },
     getTownMenu,
 };

--- a/discord-bot/commands/unleash.js
+++ b/discord-bot/commands/unleash.js
@@ -1,4 +1,4 @@
-const { InteractionResponseFlags } = require('discord-api-types/v10');
+const { MessageFlags } = require('discord.js');
 const { SlashCommandBuilder } = require('discord.js');
 const db = require('../util/database');
 const { simple } = require('../src/utils/embedBuilder');
@@ -15,7 +15,7 @@ module.exports = {
         // Placeholder currency check - replace with real query when available
         const userHasStones = true;
         if (!userHasStones) {
-            return interaction.reply({ content: 'You do not have a Corrupted Lodestone to unleash a monster.', flags: [InteractionResponseFlags.EPHEMERAL] });
+            return interaction.reply({ content: 'You do not have a Corrupted Lodestone to unleash a monster.', flags: [MessageFlags.Ephemeral] });
         }
 
         const monsters = getMonsters();

--- a/discord-bot/features/deckManager.js
+++ b/discord-bot/features/deckManager.js
@@ -1,4 +1,4 @@
-const { InteractionResponseFlags } = require('discord-api-types/v10');
+const { MessageFlags } = require('discord.js');
 const { ActionRowBuilder, ButtonBuilder, ButtonStyle, EmbedBuilder, StringSelectMenuBuilder } = require('discord.js');
 const db = require('../util/database');
 const { allPossibleAbilities } = require('../../backend/game/data');
@@ -112,7 +112,7 @@ async function sendDeckEditScreen(interaction, userId, championId, isUpdate = fa
     } catch (error) {
         console.error(`[CRITICAL ERROR] sendDeckEditScreen failed for championId ${championId}:`, error);
         if (!interaction.replied && !interaction.deferred) {
-            await interaction.reply({ content: 'Failed to open deck editor due to an unexpected error.', flags: [InteractionResponseFlags.EPHEMERAL] });
+            await interaction.reply({ content: 'Failed to open deck editor due to an unexpected error.', flags: [MessageFlags.Ephemeral] });
         } else {
             await interaction.editReply({ content: 'Failed to open deck editor due to an unexpected error. Check bot console for details.', components: [] });
         }

--- a/discord-bot/features/marketManager.js
+++ b/discord-bot/features/marketManager.js
@@ -1,4 +1,4 @@
-const { InteractionResponseFlags } = require('discord-api-types/v10');
+const { MessageFlags } = require('discord.js');
 const { ActionRowBuilder, ButtonBuilder, ButtonStyle, StringSelectMenuBuilder, EmbedBuilder } = require('discord.js');
 const { setTimeout: sleep } = require('node:timers/promises');
 const db = require('../util/database');
@@ -11,7 +11,7 @@ const { BOOSTER_PACKS } = require('../src/boosterConfig');
 async function handleBoosterPurchase(interaction, userId, packId, page = 0) {
     const packInfo = BOOSTER_PACKS[packId];
     if (!packInfo) {
-        await interaction.editReply({ content: 'Invalid pack selected.', flags: [InteractionResponseFlags.EPHEMERAL] });
+        await interaction.editReply({ content: 'Invalid pack selected.', flags: [MessageFlags.Ephemeral] });
         return;
     }
     const [userRows] = await db.execute(`SELECT ${packInfo.currency} FROM users WHERE discord_id = ?`, [userId]);
@@ -19,7 +19,7 @@ async function handleBoosterPurchase(interaction, userId, packId, page = 0) {
     if (!user || user[packInfo.currency] < packInfo.cost) {
         await interaction.editReply({
             content: `You don't have enough ${packInfo.currency === 'soft_currency' ? 'Gold 🪙' : 'Gems 💎'} to buy the ${packInfo.name}! You need ${packInfo.cost}.`,
-            flags: [InteractionResponseFlags.EPHEMERAL]
+            flags: [MessageFlags.Ephemeral]
         });
         return;
     }
@@ -75,7 +75,7 @@ async function handleBoosterPurchase(interaction, userId, packId, page = 0) {
             actualItemType = 'monster_ability';
             break;
         default:
-            await interaction.editReply({ content: 'Internal error: Unknown pack content type.', flags: [InteractionResponseFlags.EPHEMERAL] });
+            await interaction.editReply({ content: 'Internal error: Unknown pack content type.', flags: [MessageFlags.Ephemeral] });
             return;
     }
     const awardedCards = getRandomCardsForPack(cardPool, awardedCardsCount, packInfo.rarity);

--- a/discord-bot/features/tutorialManager.js
+++ b/discord-bot/features/tutorialManager.js
@@ -1,4 +1,4 @@
-const { InteractionResponseFlags } = require('discord-api-types/v10');
+const { MessageFlags } = require('discord.js');
 const { ActionRowBuilder, ButtonBuilder, ButtonStyle, StringSelectMenuBuilder, EmbedBuilder } = require('discord.js');
 const confirmEmbed = require('../src/utils/confirm');
 const { simple } = require('../src/utils/embedBuilder');
@@ -320,7 +320,7 @@ async function sendInitialGoldAndBoosterStore(interaction, userId) {
         new ButtonBuilder().setCustomId('tutorial_confirm_tutorial_completion').setLabel('Done Training - Begin Dungeon!').setStyle(ButtonStyle.Success).setEmoji('✅')
     );
     components.push(finalizeTutorialRow);
-    await interaction.followUp({ embeds: [storeEmbed], components, flags: [InteractionResponseFlags.EPHEMERAL] });
+    await interaction.followUp({ embeds: [storeEmbed], components, flags: [MessageFlags.Ephemeral] });
 }
 
 async function finalizeTutorialCompletion(interaction, userId) {

--- a/discord-bot/index.js
+++ b/discord-bot/index.js
@@ -1,4 +1,4 @@
-const { InteractionResponseFlags } = require('discord-api-types/v10');
+const { MessageFlags } = require('discord.js');
 const fs = require('node:fs');
 const path = require('node:path');
 const { Client, Collection, GatewayIntentBits, Events, ActionRowBuilder, ButtonBuilder, ButtonStyle, StringSelectMenuBuilder, EmbedBuilder } = require('discord.js');
@@ -159,7 +159,7 @@ async function checkAndApplyLevelUp(userId, championId, interaction) {
         const hero = getHeroById(heroRow.base_hero_id);
         await interaction.followUp({
             embeds: [simple('🌟 Level Up! 🌟', [{ name: hero.name, value: `has reached Level ${newLevel}!` }])],
-            flags: [InteractionResponseFlags.EPHEMERAL]
+            flags: [MessageFlags.Ephemeral]
         });
     }
 }
@@ -222,7 +222,7 @@ client.on(Events.InteractionCreate, async interaction => {
                     [userId]
                 );
                 if (ownedChampions.length < 1) {
-                    await interaction.reply({ content: 'You need at least one champion in your roster to set a defense team.', flags: [InteractionResponseFlags.EPHEMERAL] });
+                    await interaction.reply({ content: 'You need at least one champion in your roster to set a defense team.', flags: [MessageFlags.Ephemeral] });
                     return;
                 }
 
@@ -245,11 +245,11 @@ client.on(Events.InteractionCreate, async interaction => {
                     .setMaxValues(2)
                     .addOptions(options);
                 const row = new ActionRowBuilder().addComponents(selectMenu);
-                await interaction.reply({ content: 'Choose your defense team!', components: [row], flags: [InteractionResponseFlags.EPHEMERAL] });
+                await interaction.reply({ content: 'Choose your defense team!', components: [row], flags: [MessageFlags.Ephemeral] });
             } catch (error) {
                 console.error('Error preparing defense team selection:', error);
                 if (!interaction.replied) {
-                    await interaction.reply({ content: 'An error occurred while preparing your defense team.', flags: [InteractionResponseFlags.EPHEMERAL] });
+                    await interaction.reply({ content: 'An error occurred while preparing your defense team.', flags: [MessageFlags.Ephemeral] });
                 }
             }
             return;
@@ -263,7 +263,7 @@ client.on(Events.InteractionCreate, async interaction => {
                         [championId, userId]
                     );
                     if (rows.length === 0) {
-                        await interaction.reply({ content: 'Champion not found.', flags: [InteractionResponseFlags.EPHEMERAL] });
+                        await interaction.reply({ content: 'Champion not found.', flags: [MessageFlags.Ephemeral] });
                         return;
                     }
                     const champ = rows[0];
@@ -325,12 +325,12 @@ client.on(Events.InteractionCreate, async interaction => {
                         );
                     components.push(navigationRow);
 
-                    await interaction.reply({ embeds: [embed], components, flags: [InteractionResponseFlags.EPHEMERAL] });
+                    await interaction.reply({ embeds: [embed], components, flags: [MessageFlags.Ephemeral] });
 
                 } catch (err) {
                     console.error('Error preparing champion management:', err);
                     if (!interaction.replied) {
-                        await interaction.reply({ content: 'An error occurred while preparing this menu.', flags: [InteractionResponseFlags.EPHEMERAL] });
+                        await interaction.reply({ content: 'An error occurred while preparing this menu.', flags: [MessageFlags.Ephemeral] });
                     }
                 }
                 return;
@@ -344,7 +344,7 @@ client.on(Events.InteractionCreate, async interaction => {
             await command.execute(interaction);
         } catch (error) {
             console.error(`Error executing ${interaction.commandName}`, error);
-            const replyOptions = { content: 'There was an error executing this command!', flags: [InteractionResponseFlags.EPHEMERAL] };
+            const replyOptions = { content: 'There was an error executing this command!', flags: [MessageFlags.Ephemeral] };
             if (interaction.replied || interaction.deferred) {
                 await interaction.followUp(replyOptions);
             } else {
@@ -735,7 +735,7 @@ client.on(Events.InteractionCreate, async interaction => {
                         [userId]
                     );
                     if (ownedChampions.length < 2) {
-                        await interaction.reply({ content: 'You need at least 2 champions in your roster to fight! Use `/summon` to recruit more.', flags: [InteractionResponseFlags.EPHEMERAL] });
+                        await interaction.reply({ content: 'You need at least 2 champions in your roster to fight! Use `/summon` to recruit more.', flags: [MessageFlags.Ephemeral] });
                         break;
                     }
                     const options = ownedChampions.map(champion => {
@@ -760,15 +760,15 @@ client.on(Events.InteractionCreate, async interaction => {
                         .addComponents(
                             new ButtonBuilder().setCustomId('back_to_town').setLabel('Back to Town').setStyle(ButtonStyle.Secondary).setEmoji('⬅️')
                         );
-                    await interaction.reply({ content: 'Choose your team for the dungeon fight!', components: [row, backToTownRow], flags: [InteractionResponseFlags.EPHEMERAL] });
+                    await interaction.reply({ content: 'Choose your team for the dungeon fight!', components: [row, backToTownRow], flags: [MessageFlags.Ephemeral] });
                     break;
                 }
                 case 'town_forge': {
-                    await interaction.reply({ content: "The Forge is not yet open. Check back later!", flags: [InteractionResponseFlags.EPHEMERAL] });
+                    await interaction.reply({ content: "The Forge is not yet open. Check back later!", flags: [MessageFlags.Ephemeral] });
                     break;
                 }
                 case 'town_craft':
-                    await interaction.reply({ content: 'This feature is coming soon!', flags: [InteractionResponseFlags.EPHEMERAL] });
+                    await interaction.reply({ content: 'This feature is coming soon!', flags: [MessageFlags.Ephemeral] });
                     break;
                 case 'town_market': {
                     await interaction.deferUpdate();
@@ -800,7 +800,7 @@ client.on(Events.InteractionCreate, async interaction => {
                     if (inventoryCommand) {
                         await inventoryCommand.execute(interaction);
                     } else {
-                        await interaction.editReply({ content: 'Inventory command not found.', flags: [InteractionResponseFlags.EPHEMERAL] });
+                        await interaction.editReply({ content: 'Inventory command not found.', flags: [MessageFlags.Ephemeral] });
                     }
                     break;
                 }
@@ -809,7 +809,7 @@ client.on(Events.InteractionCreate, async interaction => {
                     break;
                 }
                 case 'manage_champions': {
-                    await interaction.reply({ content: 'Champion management is coming soon!', flags: [InteractionResponseFlags.EPHEMERAL] });
+                    await interaction.reply({ content: 'Champion management is coming soon!', flags: [MessageFlags.Ephemeral] });
                     break;
                 }
                 default:
@@ -818,7 +818,7 @@ client.on(Events.InteractionCreate, async interaction => {
         } catch (err) {
             console.error('Error handling button interaction:', err);
             if (!interaction.replied) {
-                await interaction.reply({ content: 'An error occurred while processing this interaction.', flags: [InteractionResponseFlags.EPHEMERAL] });
+                await interaction.reply({ content: 'An error occurred while processing this interaction.', flags: [MessageFlags.Ephemeral] });
             }
         }
         return;
@@ -1065,11 +1065,11 @@ client.on(Events.InteractionCreate, async interaction => {
             const countInDeck = state.deck.filter(id => id === abilityId).length;
 
             if (state.deck.length >= 20) {
-                await interaction.followUp({ content: 'Your deck is full (20/20 cards). Remove a card to add another.', flags: [InteractionResponseFlags.EPHEMERAL] });
+                await interaction.followUp({ content: 'Your deck is full (20/20 cards). Remove a card to add another.', flags: [MessageFlags.Ephemeral] });
                 return;
             }
             if (countInDeck >= 2) {
-                await interaction.followUp({ content: 'You can only have a maximum of 2 copies of the same card.', flags: [InteractionResponseFlags.EPHEMERAL] });
+                await interaction.followUp({ content: 'You can only have a maximum of 2 copies of the same card.', flags: [MessageFlags.Ephemeral] });
                 return;
             }
 
@@ -1289,16 +1289,16 @@ client.on(Events.InteractionCreate, async interaction => {
                     resultFields.push({ name: 'Defeat', value: 'You were vanquished by the dungeon foes.' });
                 }
 
-                await interaction.followUp({ embeds: [simple('⚔️ Battle Complete! ⚔️', resultFields)], flags: [InteractionResponseFlags.EPHEMERAL] });
+                await interaction.followUp({ embeds: [simple('⚔️ Battle Complete! ⚔️', resultFields)], flags: [MessageFlags.Ephemeral] });
 
                 const logChunks = chunkBattleLog(battleLog);
                 for (const chunk of logChunks) {
-                    await interaction.followUp({ content: `\`\`\`${chunk}\`\`\``, flags: [InteractionResponseFlags.EPHEMERAL] });
+                    await interaction.followUp({ content: `\`\`\`${chunk}\`\`\``, flags: [MessageFlags.Ephemeral] });
                 }
 
             } catch (error) {
                 console.error('Error handling fight selection:', error);
-                await interaction.followUp({ content: 'An error occurred while starting the battle.', flags: [InteractionResponseFlags.EPHEMERAL] }).catch(() => {});
+                await interaction.followUp({ content: 'An error occurred while starting the battle.', flags: [MessageFlags.Ephemeral] }).catch(() => {});
             }
         } else if (interaction.customId === 'defense_team_select') {
             try {
@@ -1846,7 +1846,7 @@ async function sendDeckEditScreen(interaction, userId, championId, isUpdate = fa
     } catch (error) {
         console.error(`[CRITICAL ERROR] sendDeckEditScreen failed for championId ${championId}:`, error);
         if (!interaction.replied && !interaction.deferred) {
-            await interaction.reply({ content: 'Failed to open deck editor due to an unexpected error.', flags: [InteractionResponseFlags.EPHEMERAL] });
+            await interaction.reply({ content: 'Failed to open deck editor due to an unexpected error.', flags: [MessageFlags.Ephemeral] });
         } else {
             await interaction.editReply({ content: 'Failed to open deck editor due to an unexpected error. Check bot console for details.', components: [] });
         }
@@ -2020,7 +2020,7 @@ async function sendInitialGoldAndBoosterStore(interaction, userId) {
 
     components.push(finalizeTutorialRow);
 
-    await interaction.followUp({ embeds: [storeEmbed], components, flags: [InteractionResponseFlags.EPHEMERAL] });
+    await interaction.followUp({ embeds: [storeEmbed], components, flags: [MessageFlags.Ephemeral] });
 }
 
 /**

--- a/discord-bot/tests/confirm.test.js
+++ b/discord-bot/tests/confirm.test.js
@@ -1,3 +1,4 @@
+const { MessageFlags } = require('discord.js');
 const addcard = require('../commands/addcard');
 
 jest.mock('../util/database', () => ({
@@ -15,7 +16,7 @@ describe('confirm embed', () => {
     };
     await addcard.execute(interaction);
     const call = interaction.followUp.mock.calls[0][0];
-    expect(call.ephemeral).toBe(true);
+    expect(call.flags).toContain(MessageFlags.Ephemeral);
     expect(call.embeds[0].data.title).toBe('✅ Success');
   });
 


### PR DESCRIPTION
## Summary
- remove deprecated `InteractionResponseFlags` usage
- use `MessageFlags.Ephemeral` when sending ephemeral responses
- update `town` command to pass the tutorial flag correctly
- update tests to reflect new message flag API

## Testing
- `npm test --silent`
- `node index.js` *(fails: TokenInvalid)*

------
https://chatgpt.com/codex/tasks/task_e_685da811efbc8327ab6e62c98b17a7ae