### PR TITLE
Add tutorial flags to DB schema

### DIFF
--- a/discord-bot/db-schema.sql
+++ b/discord-bot/db-schema.sql
@@ -15,5 +15,7 @@ CREATE TABLE IF NOT EXISTS users (
     id INT AUTO_INCREMENT PRIMARY KEY,
     discord_id VARCHAR(255) NOT NULL UNIQUE,
     current_game_id INT DEFAULT NULL,
+    tutorial_completed BOOL DEFAULT FALSE,
+    starter_class VARCHAR(50),
     FOREIGN KEY (current_game_id) REFERENCES games(id) ON DELETE SET NULL
 );

--- a/docs/database_migrations.sql
+++ b/docs/database_migrations.sql
@@ -10,3 +10,8 @@ CREATE TABLE IF NOT EXISTS `defense_teams` (
 -- Step 6: Add item_type column for categorizing inventory items
 ALTER TABLE `user_inventory`
     ADD COLUMN `item_type` VARCHAR(20) DEFAULT NULL AFTER `quantity`;
+
+-- Step 7: Track tutorial completion and starter class for each user
+ALTER TABLE `users`
+    ADD COLUMN `tutorial_completed` BOOL DEFAULT FALSE AFTER `current_game_id`,
+    ADD COLUMN `starter_class` VARCHAR(50) DEFAULT NULL AFTER `tutorial_completed`;


### PR DESCRIPTION
## Summary
- extend bot schema with `tutorial_completed` and `starter_class`
- document new user columns in migrations file

## Testing
- `npm test` in `discord-bot`
- `npm test` in `backend`


------
https://chatgpt.com/codex/tasks/task_e_685dab2673788327b12b2c563d192f23