### PR TITLE
Refactor tutorial handling

### DIFF
--- a/discord-bot/commands/town.js
+++ b/discord-bot/commands/town.js
@@ -19,12 +19,12 @@ function getTownMenu(showTutorialButton = true) {
 
     const components = [];
 
-    // Conditionally add the tutorial button at the very top if needed.
+    // Conditionally add the onboarding button at the very top if needed.
     if (showTutorialButton) {
         const tutorialRow = new ActionRowBuilder().addComponents(
             new ButtonBuilder()
-                .setCustomId('tutorial_start_new_flow')
-                .setLabel('Begin Your Training')
+                .setCustomId('begin_show_class_selection')
+                .setLabel('Begin Your Adventure')
                 .setStyle(ButtonStyle.Success)
                 .setEmoji('🎓')
         );

--- a/discord-bot/features/tutorialManager.js
+++ b/discord-bot/features/tutorialManager.js
@@ -1,3 +1,4 @@
+// TODO: Legacy tutorial manager. Remove once new onboarding flow is stable.
 const { MessageFlags } = require('discord.js');
 const { ActionRowBuilder, ButtonBuilder, ButtonStyle, StringSelectMenuBuilder, EmbedBuilder } = require('discord.js');
 const confirmEmbed = require('../src/utils/confirm');
@@ -339,28 +340,10 @@ async function finalizeTutorialCompletion(interaction, userId) {
         await interaction.editReply({ content: 'Failed to mark tutorial as complete due to an error. Please try again.', components: [] });
     }
 }
-
-module.exports = {
-    STARTING_GOLD,
-    activeTutorialDrafts,
-    sendHeroSelectionStep,
-    sendAbilitySelectionStep,
-    sendWeaponSelectionStep,
-    sendArmorSelectionStep,
-    sendChampionRecapStep,
-    insertAndDeckChampion,
-    finalizeChampionTeam,
-    generateRandomChampion,
-    generateRandomChampionKit,
-    sendWelcomePackStep,
-    openWelcomePackAndGrantGold,
-    sendInitialGoldAndBoosterStore,
-    finalizeTutorialCompletion
-};
-
 function handleTutorialButton(interaction) {
     const userId = interaction.user.id;
     let userDraftState = activeTutorialDrafts.get(userId);
+
     switch (interaction.customId) {
         case 'tutorial_start_new_flow':
             if (!userDraftState) {

--- a/discord-bot/handlers/buttonHandler.js
+++ b/discord-bot/handlers/buttonHandler.js
@@ -1,4 +1,5 @@
 const tutorialManager = require('../features/tutorialManager');
+const beginManager = require('../features/beginManager');
 const { getTownMenu } = require('../commands/town');
 
 module.exports = async (interaction) => {
@@ -10,6 +11,9 @@ module.exports = async (interaction) => {
         return;
     }
     switch (customId) {
+        case 'begin_show_class_selection':
+            await beginManager.showClassSelection(interaction);
+            break;
         case 'back_to_town':
             await interaction.update(getTownMenu());
             break;

--- a/discord-bot/index.js
+++ b/discord-bot/index.js
@@ -21,10 +21,9 @@ const { createCombatant } = require('../backend/game/utils');
 const GameEngine = require('../backend/game/engine');
 const { getTownMenu } = require('./commands/town.js');
 const marketManager = require('./features/marketManager');
+const tutorialManager = require('./features/tutorialManager');
 
 const { BOOSTER_PACKS } = require('./src/boosterConfig');
-
-const STARTING_GOLD = 400;
 
 // XP needed to reach the NEXT level (Level 10 is max)
 const LEVEL_UP_THRESHOLDS = {
@@ -37,9 +36,6 @@ const client = new Client({ intents: [GatewayIntentBits.Guilds] });
 
 client.commands = new Collection();
 
-// In-memory map to track active tutorial drafts
-// Key: userId, Value: { currentChampNum: 1, stage: 'hero_selection', champion1: {}, champion2: {} }
-const activeTutorialDrafts = new Map();
 // In-memory map to track active deck edits
 // Key: userId, Value: { championId: number, deck: number[] }
 const activeDeckEdits = new Map();
@@ -357,7 +353,7 @@ client.on(Events.InteractionCreate, async interaction => {
     // --- Button Interaction Handler ---
     if (interaction.isButton()) {
         const userId = interaction.user.id;
-        let userDraftState = activeTutorialDrafts.get(userId);
+        let userDraftState = tutorialManager.activeTutorialDrafts.get(userId);
         if (interaction.customId.startsWith('tutorial_') || userDraftState) {
             try {
                 await interaction.deferUpdate();
@@ -372,20 +368,20 @@ client.on(Events.InteractionCreate, async interaction => {
                                 initialGoldGranted: false,
                                 currentChampNum: 1
                             };
-                            activeTutorialDrafts.set(userId, userDraftState);
+                            tutorialManager.activeTutorialDrafts.set(userId, userDraftState);
                         }
 
                         if (!userDraftState.receivedWelcomePack) {
-                            await sendWelcomePackStep(interaction, userId);
+                            await tutorialManager.sendWelcomePackStep(interaction, userId);
                             userDraftState.receivedWelcomePack = true;
                             userDraftState.stage = 'WELCOME_PACK_OPENED';
                         } else {
-                            await sendInitialGoldAndBoosterStore(interaction, userId);
+                            await tutorialManager.sendInitialGoldAndBoosterStore(interaction, userId);
                         }
                         break;
                     case 'tutorial_open_welcome_pack':
                         if (userDraftState.stage === 'WELCOME_PACK_OPENED') {
-                            await openWelcomePackAndGrantGold(interaction, userId);
+                            await tutorialManager.openWelcomePackAndGrantGold(interaction, userId);
                             userDraftState.stage = 'GOLD_GRANTED_AND_STORE_OPENED';
                             userDraftState.initialGoldGranted = true;
                         } else {
@@ -393,22 +389,22 @@ client.on(Events.InteractionCreate, async interaction => {
                         }
                         break;
                     case 'tutorial_confirm_tutorial_completion':
-                        await finalizeTutorialCompletion(interaction, userId);
+                        await tutorialManager.finalizeTutorialCompletion(interaction, userId);
                         break;
                     case 'tutorial_start_draft': // Initial button to start Champion 1 draft
                         userDraftState.stage = 'HERO_SELECTION';
-                        await sendHeroSelectionStep(interaction, userId, userDraftState.currentChampNum);
+                        await tutorialManager.sendHeroSelectionStep(interaction, userId, userDraftState.currentChampNum);
                         break;
                     case 'tutorial_recap_1_continue':
                         userDraftState.currentChampNum = 2;
                         userDraftState.stage = 'HERO_SELECTION';
-                        await sendHeroSelectionStep(interaction, userId, userDraftState.currentChampNum);
+                        await tutorialManager.sendHeroSelectionStep(interaction, userId, userDraftState.currentChampNum);
                         break;
                     case 'tutorial_recap_2_finalize':
-                        await finalizeChampionTeam(interaction, userId);
+                        await tutorialManager.finalizeChampionTeam(interaction, userId);
                         break;
                     case 'tutorial_start_over':
-                        activeTutorialDrafts.delete(userId);
+                        tutorialManager.activeTutorialDrafts.delete(userId);
                         await interaction.editReply({
                             embeds: [simple('Draft Reset', [{ name: 'Starting Over!', value: 'Your champion draft has been reset. Use `/start` to begin again.' }])],
                             components: []
@@ -417,12 +413,12 @@ client.on(Events.InteractionCreate, async interaction => {
                     default:
                         console.log(`Unhandled tutorial interaction: ${interaction.customId}`);
                         await interaction.editReply({ content: 'Something went wrong with the tutorial step. Please try `/start` again.', components: [] });
-                        activeTutorialDrafts.delete(userId);
+                        tutorialManager.activeTutorialDrafts.delete(userId);
                 }
             } catch (error) {
                 console.error(`Error handling tutorial step ${interaction.customId}:`, error);
                 await interaction.editReply({ content: 'An error occurred during the tutorial. Please try `/start` again.', components: [] });
-                activeTutorialDrafts.delete(userId);
+                tutorialManager.activeTutorialDrafts.delete(userId);
             }
             return;
         }
@@ -827,7 +823,7 @@ client.on(Events.InteractionCreate, async interaction => {
     // --- Selection Menu Handler ---
     if (interaction.isStringSelectMenu()) {
         const userId = interaction.user.id;
-        const userDraftState = activeTutorialDrafts.get(userId);
+        const userDraftState = tutorialManager.activeTutorialDrafts.get(userId);
         if (interaction.customId.startsWith('market_pack_select_')) {
             await interaction.deferUpdate();
             const parts = interaction.customId.split('_');
@@ -855,37 +851,37 @@ client.on(Events.InteractionCreate, async interaction => {
                     case `tutorial_select_hero_${champNum}`:
                         currentChampionData.heroId = parseInt(interaction.values[0]);
                         userDraftState.stage = 'ABILITY_SELECTION';
-                        await sendAbilitySelectionStep(interaction, userId, champNum);
+                        await tutorialManager.sendAbilitySelectionStep(interaction, userId, champNum);
                         break;
                     case `tutorial_select_ability_${champNum}`:
                         currentChampionData.abilityId = parseInt(interaction.values[0]);
                         userDraftState.stage = 'WEAPON_SELECTION';
-                        await sendWeaponSelectionStep(interaction, userId, champNum);
+                        await tutorialManager.sendWeaponSelectionStep(interaction, userId, champNum);
                         break;
                     case `tutorial_select_weapon_${champNum}`:
                         currentChampionData.weaponId = parseInt(interaction.values[0]);
                         userDraftState.stage = 'ARMOR_SELECTION';
-                        await sendArmorSelectionStep(interaction, userId, champNum);
+                        await tutorialManager.sendArmorSelectionStep(interaction, userId, champNum);
                         break;
                     case `tutorial_select_armor_${champNum}`:
                         currentChampionData.armorId = parseInt(interaction.values[0]);
                         if (userDraftState.currentChampNum === 1) {
                             userDraftState.stage = 'RECAP_1';
-                            await sendChampionRecapStep(interaction, userId, userDraftState.currentChampNum);
+                            await tutorialManager.sendChampionRecapStep(interaction, userId, userDraftState.currentChampNum);
                         } else {
                             userDraftState.stage = 'RECAP_2';
-                            await sendChampionRecapStep(interaction, userId, userDraftState.currentChampNum);
+                            await tutorialManager.sendChampionRecapStep(interaction, userId, userDraftState.currentChampNum);
                         }
                         break;
                     default:
                         console.log(`Unhandled tutorial interaction (select menu): ${interaction.customId}`);
                         await interaction.editReply({ content: 'Something went wrong with the tutorial step. Please try `/start` again.', components: [] });
-                        activeTutorialDrafts.delete(userId);
+                        tutorialManager.activeTutorialDrafts.delete(userId);
                 }
             } catch (error) {
                 console.error(`Error handling tutorial select menu ${interaction.customId}:`, error);
                 await interaction.editReply({ content: 'An error occurred during the tutorial. Please try `/start` again.', components: [] });
-                activeTutorialDrafts.delete(userId);
+                tutorialManager.activeTutorialDrafts.delete(userId);
             }
             return;
         }
@@ -1407,664 +1403,6 @@ client.on(Events.InteractionCreate, async interaction => {
     }
 });
 
-// --- Tutorial Helper Functions ---
-/**
- * Sends the hero selection step for the given champion number.
- * @param {Interaction} interaction
- * @param {string} userId
- * @param {number} champNum - 1 or 2
- */
-async function sendHeroSelectionStep(interaction, userId, champNum) {
-    const commonHeroes = allPossibleHeroes.filter(h => h.rarity === 'Common');
-    const heroOptions = commonHeroes.map(hero => ({
-        label: hero.name,
-        description: `${hero.class} | HP: ${hero.hp}, ATK: ${hero.attack}`,
-        value: hero.id.toString(),
-    }));
-
-    const selectMenu = new StringSelectMenuBuilder()
-        .setCustomId(`tutorial_select_hero_${champNum}`)
-        .setPlaceholder(`Choose your Hero for Champion ${champNum}`)
-        .addOptions(heroOptions.slice(0, 5));
-
-    const row = new ActionRowBuilder().addComponents(selectMenu);
-
-    await interaction.editReply({
-        embeds: [simple(
-            `Step 1: Choose Your Champion ${champNum}'s Hero`,
-            [{ name: 'Select Your Core Hero', value: 'Heroes define your champion\'s class and base stats. Choose one to begin shaping your champion!' }]
-        )],
-        components: [row]
-    });
-    activeTutorialDrafts.get(userId).stage = 'HERO_SELECTION';
-}
-
-/**
- * Sends the ability selection step for the given champion number.
- * @param {Interaction} interaction
- * @param {string} userId
- * @param {number} champNum - 1 or 2
- */
-async function sendAbilitySelectionStep(interaction, userId, champNum) {
-    const userDraftState = activeTutorialDrafts.get(userId);
-    const championData = champNum === 1 ? userDraftState.champion1 : userDraftState.champion2;
-    const selectedHero = allPossibleHeroes.find(h => h.id === championData.heroId);
-    if (!selectedHero) {
-        throw new Error('Selected hero not found for ability step.');
-    }
-
-    const commonAbilities = allPossibleAbilities.filter(ab => ab.class === selectedHero.class && ab.rarity === 'Common');
-    const abilityOptions = commonAbilities.map(ability => ({
-        label: ability.name,
-        description: `⚡ ${ability.energyCost} Energy | ${ability.effect}`,
-        value: ability.id.toString(),
-    }));
-
-    const selectMenu = new StringSelectMenuBuilder()
-        .setCustomId(`tutorial_select_ability_${champNum}`)
-        .setPlaceholder(`Choose a Basic Ability for Champion ${champNum}`)
-        .addOptions(abilityOptions.slice(0, 5));
-
-    const row = new ActionRowBuilder().addComponents(selectMenu);
-
-    await interaction.editReply({
-        embeds: [simple(
-            `Step 2: Choose a Basic Ability for Champion ${champNum}`,
-            [{ name: 'Equip a Skill', value: 'Abilities are powerful skills your champion can use in battle. Pick one that complements your hero!' }]
-        )],
-        components: [row]
-    });
-    userDraftState.stage = 'ABILITY_SELECTION';
-}
-
-/**
- * Sends the weapon selection step for the given champion number.
- * @param {Interaction} interaction
- * @param {string} userId
- * @param {number} champNum - 1 or 2
- */
-async function sendWeaponSelectionStep(interaction, userId, champNum) {
-    const commonWeapons = allPossibleWeapons.filter(w => w.rarity === 'Common');
-    const weaponOptions = commonWeapons.map(weapon => ({
-        label: weapon.name,
-        description: `ATK: +${weapon.statBonuses.ATK || 0} ${weapon.ability ? '| ' + weapon.ability.name : ''}`,
-        value: weapon.id.toString(),
-    }));
-
-    const selectMenu = new StringSelectMenuBuilder()
-        .setCustomId(`tutorial_select_weapon_${champNum}`)
-        .setPlaceholder(`Choose a Basic Weapon for Champion ${champNum}`)
-        .addOptions(weaponOptions.slice(0, 5));
-
-    const row = new ActionRowBuilder().addComponents(selectMenu);
-
-    await interaction.editReply({
-        embeds: [simple(
-            `Step 3: Choose a Basic Weapon for Champion ${champNum}`,
-            [{ name: 'Arm Your Champion', value: 'Weapons augment your champion\'s attacks and can provide unique effects.' }]
-        )],
-        components: [row]
-    });
-    activeTutorialDrafts.get(userId).stage = 'WEAPON_SELECTION';
-}
-
-/**
- * Sends the armor selection step for the given champion number.
- * @param {Interaction} interaction
- * @param {string} userId
- * @param {number} champNum - 1 or 2
- */
-async function sendArmorSelectionStep(interaction, userId, champNum) {
-    const commonArmors = allPossibleArmors.filter(a => a.rarity === 'Common');
-    const armorOptions = commonArmors.map(armor => ({
-        label: armor.name,
-        description: `HP: +${armor.statBonuses.HP || 0} | Block: +${armor.statBonuses.Block || 0} ${armor.ability ? '| ' + armor.ability.name : ''}`,
-        value: armor.id.toString(),
-    }));
-
-    const selectMenu = new StringSelectMenuBuilder()
-        .setCustomId(`tutorial_select_armor_${champNum}`)
-        .setPlaceholder(`Choose a Basic Armor for Champion ${champNum}`)
-        .addOptions(armorOptions.slice(0, 5));
-
-    const row = new ActionRowBuilder().addComponents(selectMenu);
-
-    await interaction.editReply({
-        embeds: [simple(
-            `Step 4: Choose a Basic Armor for Champion ${champNum}`,
-            [{ name: 'Protect Your Champion', value: 'Armor provides crucial defense, mitigating incoming damage.' }]
-        )],
-        components: [row]
-    });
-    activeTutorialDrafts.get(userId).stage = 'ARMOR_SELECTION';
-}
-
-/**
- * Displays the recap for a single champion during the tutorial.
- * @param {Interaction} interaction
- * @param {string} userId
- * @param {number} champNum - The champion number being recapped (1 or 2)
- */
-async function sendChampionRecapStep(interaction, userId, champNum) {
-    const userDraftState = activeTutorialDrafts.get(userId);
-    const championData = champNum === 1 ? userDraftState.champion1 : userDraftState.champion2;
-
-    const hero = allPossibleHeroes.find(h => h.id === championData.heroId);
-    const ability = allPossibleAbilities.find(ab => ab.id === championData.abilityId);
-    const weapon = allPossibleWeapons.find(w => w.id === championData.weaponId);
-    const armor = allPossibleArmors.find(a => a.id === championData.armorId);
-
-    const detailedInfo = await getDetailedChampionInfo({
-        id: 'temp',
-        base_hero_id: hero.id,
-        equipped_weapon_id: weapon.id,
-        equipped_armor_id: armor.id,
-        equipped_ability_id: ability.id,
-        level: 1
-    });
-
-    const embed = new EmbedBuilder()
-        .setColor('#29b6f6')
-        .setTitle(`Champion ${champNum} Assembled!`)
-        .setDescription(`**${detailedInfo.name}** - the **${detailedInfo.class}**`)
-        .setThumbnail(detailedInfo.imageUrl || 'https://placehold.co/100x100')
-        .addFields(
-            { name: 'Core Stats', value: `HP: **${detailedInfo.hp}** | ATK: **${detailedInfo.attack}** | SPD: **${detailedInfo.speed}**`, inline: false },
-            { name: 'Defense', value: `Block: **${detailedInfo.block}** | Magic Resist: **${detailedInfo.magicResist}**`, inline: false },
-            { name: 'Equipped Ability', value: `${ability.name} (⚡${ability.energyCost})`, inline: true },
-            { name: 'Equipped Weapon', value: weapon.name, inline: true },
-            { name: 'Equipped Armor', value: armor.name, inline: true },
-            { name: 'Ability Effect', value: ability.effect, inline: false },
-            { name: 'Weapon Bonus', value: weapon.ability ? weapon.ability.description : 'None', inline: false },
-            { name: 'Armor Bonus', value: armor.ability ? armor.ability.description : 'None', inline: false }
-        )
-        .setTimestamp();
-
-    let buttonLabel = '';
-    let customId = '';
-    let buttonStyle = ButtonStyle.Primary;
-
-    if (champNum === 1) {
-        buttonLabel = 'Draft Second Champion';
-        customId = 'tutorial_recap_1_continue';
-        embed.setFooter({ text: 'Next, you will draft your second champion.' });
-    } else {
-        buttonLabel = 'Finalize Team & Begin Adventure!';
-        customId = 'tutorial_recap_2_finalize';
-        buttonStyle = ButtonStyle.Success;
-        embed.setFooter({ text: 'Your team is complete! Confirm to save them to your roster.' });
-    }
-
-    const actionRow = new ActionRowBuilder()
-        .addComponents(
-            new ButtonBuilder()
-                .setCustomId(customId)
-                .setLabel(buttonLabel)
-                .setStyle(buttonStyle)
-        );
-
-    const startOverButton = new ActionRowBuilder()
-        .addComponents(
-            new ButtonBuilder()
-                .setCustomId('tutorial_start_over')
-                .setLabel('Start Over')
-                .setStyle(ButtonStyle.Danger)
-        );
-
-    await interaction.editReply({ embeds: [embed], components: [actionRow, startOverButton] });
-}
-
-/**
- * Helper function to insert a single champion into the database and its equipped ability into champion_decks.
- * This function is designed to ensure the champion is created before its deck.
- * @param {string} userId - The Discord ID of the user.
- * @param {object} champData - Object containing heroId, abilityId, weaponId, armorId.
- * @returns {Promise<number>} The ID of the newly created user_champion.
- */
-async function insertAndDeckChampion(userId, champData) {
-    let connection;
-    try {
-        console.log(`[DEBUG] Attempting to insert champion for user ${userId} with data:`, champData);
-
-        connection = await db.getConnection();
-        await connection.beginTransaction();
-
-        const [insertResult] = await connection.execute(
-            `INSERT INTO user_champions (user_id, base_hero_id, equipped_ability_id, equipped_weapon_id, equipped_armor_id, level, xp)
-             VALUES (?, ?, ?, ?, ?, ?, ?)`,
-            [
-                userId,
-                champData.heroId,
-                champData.abilityId,
-                champData.weaponId,
-                champData.armorId,
-                1,
-                0
-            ]
-        );
-        const newChampionId = insertResult.insertId;
-        console.log(`[DEBUG] Inserted user_champion, new ID: ${newChampionId} for user ${userId}`);
-
-        if (champData.abilityId) {
-            try {
-                await connection.execute(
-                    `INSERT INTO champion_decks (user_champion_id, ability_id, order_index) VALUES (?, ?, 0)`,
-                    [newChampionId, champData.abilityId]
-                );
-                console.log(`[DEBUG] Successfully inserted champion_decks entry for champion ID: ${newChampionId}`);
-            } catch (deckInsertError) {
-                console.error(`[ERROR] Failed to insert into champion_decks for champ ID ${newChampionId}:`, deckInsertError.message);
-                throw deckInsertError;
-            }
-        } else {
-            console.log(`[DEBUG] No ability selected for champion ID: ${newChampionId}, skipping champion_decks insert.`);
-        }
-
-        await connection.commit();
-        return newChampionId;
-
-    } catch (error) {
-        if (connection) {
-            console.log(`[DEBUG] Rolling back transaction for user ${userId} due to error.`);
-            await connection.rollback();
-        }
-        throw error;
-    } finally {
-        if (connection) {
-            connection.release();
-        }
-    }
-}
-
-/**
- * Finalizes both champions and saves them to the database.
- * @param {Interaction} interaction
- * @param {string} userId
- */
-async function finalizeChampionTeam(interaction, userId) {
-    const userDraftState = activeTutorialDrafts.get(userId);
-    const champion1Data = userDraftState.champion1;
-    const champion2Data = userDraftState.champion2;
-
-    try {
-        await insertAndDeckChampion(userId, champion1Data);
-        await insertAndDeckChampion(userId, champion2Data);
-
-        await db.execute(
-            'UPDATE users SET tutorial_completed = TRUE WHERE discord_id = ?',
-            [userId]
-        );
-
-        activeTutorialDrafts.delete(userId);
-
-        const hero1 = allPossibleHeroes.find(h => h.id === champion1Data.heroId);
-        const hero2 = allPossibleHeroes.find(h => h.id === champion2Data.heroId);
-
-        const embed = confirmEmbed(
-            `Your team of **${hero1.name}** and **${hero2.name}** has been created and added to your roster!`
-        );
-        embed.setDescription('You\'re all set! Now you can manage your champions or jump into the Dungeon!');
-
-        const nextStepsRow = new ActionRowBuilder()
-            .addComponents(
-                new ButtonBuilder()
-                    .setCustomId('town_barracks')
-                    .setLabel('View Barracks')
-                    .setStyle(ButtonStyle.Secondary)
-                    .setEmoji('⚔️'),
-                new ButtonBuilder()
-                    .setCustomId('town_dungeon')
-                    .setLabel('Enter Dungeon')
-                    .setStyle(ButtonStyle.Primary)
-                    .setEmoji('🌀')
-            );
-
-        await interaction.editReply({ embeds: [embed], components: [nextStepsRow] });
-
-    } catch (error) {
-        console.error('Error finalizing champion team:', error);
-        await interaction.editReply({
-            embeds: [simple('Error!', [{ name: 'Failed to create team', value: 'There was an issue saving your champions. Please try again.' }])],
-            components: []
-        });
-        activeTutorialDrafts.delete(userId);
-    }
-}
-
-/**
- * Displays the dedicated deck edit screen for a champion.
- * @param {Interaction} interaction
- * @param {string} userId
- * @param {number} championId - The ID of the champion whose deck is being edited.
- */
-async function sendDeckEditScreen(interaction, userId, championId, isUpdate = false) {
-    try {
-        // 1. Fetch Champion's Full Details
-        const [champRows] = await db.execute(
-            `SELECT uc.*, h.name, h.class FROM user_champions uc JOIN heroes h ON uc.base_hero_id = h.id WHERE uc.id = ? AND uc.user_id = ?`,
-            [championId, userId]
-        );
-        if (champRows.length === 0) {
-            await interaction.editReply({ content: 'Champion not found or does not belong to you.', components: [] });
-            return;
-        }
-        const champion = champRows[0];
-        const heroData = getHeroById(champion.base_hero_id);
-
-        // 2. Determine current deck state (from memory or database)
-        let state = activeDeckEdits.get(userId);
-        if (!state || state.championId !== championId) {
-            const [currentDeckRaw] = await db.execute(
-                `SELECT ability_id FROM champion_decks WHERE user_champion_id = ? ORDER BY order_index ASC`,
-                [championId]
-            );
-            state = { championId, deck: currentDeckRaw.map(r => r.ability_id) };
-            activeDeckEdits.set(userId, state);
-        }
-
-        const deckCounts = {};
-        for (const id of state.deck) {
-            deckCounts[id] = (deckCounts[id] || 0) + 1;
-        }
-        const currentDeckSize = state.deck.length;
-        const currentDeckDisplay = Object.entries(deckCounts).map(([id, c]) => {
-            const ability = allPossibleAbilities.find(a => a.id === parseInt(id));
-            return `${ability ? ability.name : `ID ${id}`} (x${c})`;
-        });
-        const currentDeckString = currentDeckDisplay.join('\n') || 'None (Deck empty)';
-
-        // 3. Fetch Available Abilities from Inventory (matching champion's class)
-        const [availableAbilitiesRaw] = await db.execute(
-            `SELECT ui.item_id, ui.quantity, a.name, a.energy_cost, a.effect, a.rarity
-             FROM user_inventory ui JOIN abilities a ON ui.item_id = a.id
-             WHERE ui.user_id = ? AND a.class = ? AND ui.quantity > 0`,
-            [userId, champion.class]
-        );
-
-        const availableAbilityOptions = [];
-        availableAbilitiesRaw.forEach(ab => {
-            const currentCountInDeck = deckCounts[ab.item_id] || 0;
-            if (currentCountInDeck < 2) {
-                availableAbilityOptions.push({
-                    label: ab.name,
-                    description: `⚡ ${ab.energy_cost} | ${ab.effect} (Owned: ${ab.quantity} | In Deck: ${currentCountInDeck})`,
-                    value: String(ab.item_id),
-                });
-            }
-        });
-
-        // 4. Build the Embed
-        const embed = new EmbedBuilder()
-            .setColor('#0099ff')
-            .setTitle(`📚 Edit Deck: ${champion.name} (${champion.class})`)
-            .setThumbnail(heroData?.imageUrl || null)
-            .addFields(
-                { name: 'Current Deck (Max 20 cards)', value: currentDeckString, inline: false },
-                { name: 'Deck Size', value: `${currentDeckSize}/20 cards`, inline: true },
-                { name: 'Rules', value: 'Max 2 copies of any single card.', inline: true }
-            );
-
-        // 5. Build Components
-        const components = [];
-
-        if (currentDeckSize < 20 && availableAbilityOptions.length > 0) {
-            const addCardSelect = new StringSelectMenuBuilder()
-                .setCustomId(`deck_add_${championId}`)
-                .setPlaceholder('Add Ability to Deck')
-                .addOptions(availableAbilityOptions.slice(0, 25));
-            components.push(new ActionRowBuilder().addComponents(addCardSelect));
-        } else if (currentDeckSize >= 20) {
-            components.push(new ActionRowBuilder().addComponents(
-                new ButtonBuilder().setCustomId('deck_full').setLabel('Deck is Full (20/20)').setStyle(ButtonStyle.Secondary).setDisabled(true)
-            ));
-        } else {
-            components.push(new ActionRowBuilder().addComponents(
-                new ButtonBuilder().setCustomId('no_abilities_to_add').setLabel('No Abilities to Add').setStyle(ButtonStyle.Secondary).setDisabled(true)
-            ));
-        }
-
-        if (currentDeckSize > 0) {
-            const removeCardOptions = Object.keys(deckCounts).map(id => {
-                const ability = allPossibleAbilities.find(a => a.id === parseInt(id));
-                return {
-                    label: ability ? ability.name : `ID ${id}`,
-                    description: `Remove ${ability ? ability.name : id}`,
-                    value: String(id)
-                };
-            });
-
-            const removeCardSelect = new StringSelectMenuBuilder()
-                .setCustomId(`deck_remove_${championId}`)
-                .setPlaceholder('Remove Ability from Deck')
-                .addOptions(removeCardOptions.slice(0, 25));
-            components.push(new ActionRowBuilder().addComponents(removeCardSelect));
-        }
-
-        const actionButtons = new ActionRowBuilder()
-            .addComponents(
-                new ButtonBuilder().setCustomId(`deck_save_${championId}`).setLabel('Save Deck').setStyle(ButtonStyle.Success).setEmoji('💾'),
-                new ButtonBuilder().setCustomId(`deck_cancel_${championId}`).setLabel('Cancel').setStyle(ButtonStyle.Danger).setEmoji('❌')
-            );
-        components.push(actionButtons);
-
-        // 6. Send the reply
-        await interaction.editReply({ embeds: [embed], components });
-    } catch (error) {
-        console.error(`[CRITICAL ERROR] sendDeckEditScreen failed for championId ${championId}:`, error);
-        if (!interaction.replied && !interaction.deferred) {
-            await interaction.reply({ content: 'Failed to open deck editor due to an unexpected error.', flags: [MessageFlags.Ephemeral] });
-        } else {
-            await interaction.editReply({ content: 'Failed to open deck editor due to an unexpected error. Check bot console for details.', components: [] });
-        }
-    }
-}
-
-function buildDeckEditEmbed(champion, deck) {
-    const counts = {};
-    for (const id of deck) {
-        counts[id] = (counts[id] || 0) + 1;
-    }
-    const deckList = Object.entries(counts).map(([id, c]) => {
-        const name = allPossibleAbilities.find(ab => ab.id === parseInt(id))?.name || `ID ${id}`;
-        return `${name} (x${c})`;
-    }).join(', ');
-    return new EmbedBuilder()
-        .setColor('#29b6f6')
-        .setTitle(`Editing Deck: ${champion.name}`)
-        .addFields(
-            { name: 'Deck', value: deckList || 'Empty', inline: false },
-            { name: 'Deck Size', value: `${deck.length}/20 cards`, inline: true },
-            { name: 'Rules', value: 'Max 20 cards, 2x per card', inline: true }
-        );
-}
-
-
-function generateRandomChampion() {
-    const commonHeroes = getHeroes().filter(h => h.rarity === 'Common' && !h.is_monster);
-    const hero = commonHeroes[Math.floor(Math.random() * commonHeroes.length)];
-    const abilityPool = allPossibleAbilities.filter(a => a.class === hero.class && a.rarity === 'Common');
-    const ability = abilityPool.length > 0 ? abilityPool[Math.floor(Math.random() * abilityPool.length)] : null;
-    const weapon = allPossibleWeapons[Math.floor(Math.random() * allPossibleWeapons.length)];
-    const armor = allPossibleArmors[Math.floor(Math.random() * allPossibleArmors.length)];
-    return { id: hero.id, ability: ability?.id, weapon: weapon.id, armor: armor.id };
-}
-
-// --- NEW TUTORIAL HELPER: Generate a random champion kit (hero + gear) ---
-async function generateRandomChampionKit() {
-    const commonHeroes = allPossibleHeroes.filter(h => h.rarity === 'Common' && !h.is_monster);
-    const hero = commonHeroes[Math.floor(Math.random() * commonHeroes.length)];
-
-    const abilityPool = allPossibleAbilities.filter(a => a.class === hero.class && a.rarity === 'Common');
-    const ability = abilityPool.length ? abilityPool[Math.floor(Math.random() * abilityPool.length)] : null;
-
-    const commonWeapons = allPossibleWeapons.filter(w => w.rarity === 'Common');
-    const weapon = commonWeapons[Math.floor(Math.random() * commonWeapons.length)];
-
-    const commonArmors = allPossibleArmors.filter(a => a.rarity === 'Common');
-    const armor = commonArmors[Math.floor(Math.random() * commonArmors.length)];
-
-    return {
-        heroId: hero.id,
-        abilityId: ability ? ability.id : null,
-        weaponId: weapon.id,
-        armorId: armor.id,
-        heroData: hero,
-        abilityData: ability,
-        weaponData: weapon,
-        armorData: armor
-    };
-}
-
-/**
- * Sends the initial welcome pack embed.
- */
-async function sendWelcomePackStep(interaction, userId) {
-    const embed = simple(
-        '📦 Your Welcome Pack Awaits!',
-        [
-            { name: 'Special Delivery!', value: 'As a new adventurer, you receive a complimentary "Heroic Beginnings" Booster Pack. It contains two common champions, ready for battle!' }
-        ]
-    );
-
-    const row = new ActionRowBuilder()
-        .addComponents(
-            new ButtonBuilder()
-                .setCustomId('tutorial_open_welcome_pack')
-                .setLabel('Open "Heroic Beginnings" Pack')
-                .setStyle(ButtonStyle.Primary)
-                .setEmoji('✨')
-        );
-
-    await interaction.editReply({ embeds: [embed], components: [row] });
-}
-
-/**
- * Opens the welcome pack, grants starting gold, and transitions to the store.
- */
-async function openWelcomePackAndGrantGold(interaction, userId) {
-    const userDraftState = activeTutorialDrafts.get(userId);
-
-    const champion1Kit = await generateRandomChampionKit();
-    let champion2Kit = await generateRandomChampionKit();
-    while (champion2Kit.heroId === champion1Kit.heroId && allPossibleHeroes.length > 1) {
-        champion2Kit = await generateRandomChampionKit();
-    }
-
-    userDraftState.champion1 = champion1Kit;
-    userDraftState.champion2 = champion2Kit;
-
-    const names = [];
-
-    try {
-        await insertAndDeckChampion(userId, champion1Kit);
-        await insertAndDeckChampion(userId, champion2Kit);
-        names.push(`**${champion1Kit.heroData.name}** (Common) - Equipped`);
-        names.push(`**${champion2Kit.heroData.name}** (Common) - Equipped`);
-    } catch (error) {
-        console.error('Error inserting welcome pack champions:', error);
-        await interaction.editReply({ content: 'Failed to create your starting champions due to a database error. Please try `/start` again.', components: [] });
-        activeTutorialDrafts.delete(userId);
-        return;
-    }
-
-    try {
-        await db.execute(
-            'UPDATE users SET soft_currency = soft_currency + ? WHERE discord_id = ?',
-            [STARTING_GOLD, userId]
-        );
-    } catch (error) {
-        console.error('Error granting initial gold:', error);
-    }
-
-    const resultsEmbed = new EmbedBuilder()
-        .setColor('#84cc16')
-        .setTitle('🎉 Heroic Beginnings Pack Opened! 🎉')
-        .setDescription(`You received two powerful champions and ${STARTING_GOLD} Gold to get started!`)
-        .addFields(
-            { name: 'New Champions:', value: names.join('\n'), inline: false },
-            { name: 'Starting Gold:', value: `🪙 ${STARTING_GOLD}`, inline: true }
-        )
-        .setFooter({ text: 'Time to expand your collection!' })
-        .setTimestamp();
-
-    await interaction.editReply({ embeds: [resultsEmbed] });
-    await sendInitialGoldAndBoosterStore(interaction, userId);
-}
-
-/**
- * Displays the booster store after granting gold.
- */
-async function sendInitialGoldAndBoosterStore(interaction, userId) {
-    const storeEmbed = simple(
-        '🛍️ Your First Shopping Spree!',
-        [{ name: 'Available Packs', value: `Use your ${STARTING_GOLD} Gold to buy more packs and strengthen your roster!` }]
-    );
-
-    // Build pack purchase buttons grouped into rows of up to 5 to satisfy
-    // Discord's component limits
-    const packButtons = Object.entries(BOOSTER_PACKS).map(([packId, packInfo]) =>
-        new ButtonBuilder()
-            .setCustomId(`buy_pack_${packId}`)
-            .setLabel(`${packInfo.name} (${packInfo.cost} Gold 🪙)`)
-            .setStyle(ButtonStyle.Primary)
-            .setEmoji('🛒')
-    );
-
-    const components = [];
-    for (let i = 0; i < packButtons.length; i += 5) {
-        components.push(new ActionRowBuilder().addComponents(packButtons.slice(i, i + 5)));
-    }
-
-    const finalizeTutorialRow = new ActionRowBuilder()
-        .addComponents(
-            new ButtonBuilder()
-                .setCustomId('tutorial_confirm_tutorial_completion')
-                .setLabel('Done Training - Begin Dungeon!')
-                .setStyle(ButtonStyle.Success)
-                .setEmoji('✅')
-        );
-
-    components.push(finalizeTutorialRow);
-
-    await interaction.followUp({ embeds: [storeEmbed], components, flags: [MessageFlags.Ephemeral] });
-}
-
-/**
- * Marks the tutorial as completed.
- */
-async function finalizeTutorialCompletion(interaction, userId) {
-    try {
-        await db.execute(
-            'UPDATE users SET tutorial_completed = TRUE WHERE discord_id = ?',
-            [userId]
-        );
-        activeTutorialDrafts.delete(userId);
-
-        const embed = confirmEmbed(
-            'Training Complete!'
-        );
-        embed.addFields({ name: 'Your Adventure Awaits!', value: 'You are now ready to face the dangers of the dungeon. Good luck, adventurer!' });
-
-        const nextStepsRow = new ActionRowBuilder()
-            .addComponents(
-                new ButtonBuilder()
-                    .setCustomId('town_barracks')
-                    .setLabel('View Barracks')
-                    .setStyle(ButtonStyle.Secondary)
-                    .setEmoji('⚔️'),
-                new ButtonBuilder()
-                    .setCustomId('town_dungeon')
-                    .setLabel('Enter Dungeon')
-                    .setStyle(ButtonStyle.Primary)
-                    .setEmoji('🌀')
-            );
-
-        await interaction.editReply({ embeds: [embed], components: [nextStepsRow] });
-    } catch (error) {
-        console.error('Error finalizing tutorial completion:', error);
-        await interaction.editReply({ content: 'Failed to mark tutorial as complete due to an error. Please try again.', components: [] });
-    }
-}
 
 function chunkBattleLog(log, chunkSize = 1980) {
     const chunks = [];


### PR DESCRIPTION
## Summary
- move tutorial helpers out of `index.js`
- mark legacy tutorial manager for removal
- update town button to use new onboarding
- route new button through button handler

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685daec774b08327b43a463358c137fe