### PR TITLE
Add starter pack reward when class chosen

### DIFF
--- a/discord-bot/features/beginManager.js
+++ b/discord-bot/features/beginManager.js
@@ -1,6 +1,9 @@
 const { MessageFlags } = require('discord.js');
 const { ActionRowBuilder, StringSelectMenuBuilder, EmbedBuilder } = require('discord.js');
 const db = require('../util/database');
+const { simple } = require('../src/utils/embedBuilder');
+const { allPossibleAbilities } = require('../../backend/game/data');
+const { getRandomCardsForPack } = require('../util/gameData');
 
 // In-memory map storing chosen class keyed by discord_id
 const userClassChoices = new Map();
@@ -39,10 +42,39 @@ async function handleClassSelected(interaction, userId, chosenClass) {
         .setDescription("You'll receive your starter ability cards soon.");
 
     await interaction.editReply({ embeds: [embed], components: [] });
+
+    await openStarterPack(chosenClass, userId, interaction);
+}
+
+async function openStarterPack(chosenClass, userId, interaction) {
+    const abilityPool = allPossibleAbilities.filter(ab => ab.class === chosenClass);
+    const cards = getRandomCardsForPack(abilityPool, 3, 'standard');
+    try {
+        for (const card of cards) {
+            await db.execute(
+                'INSERT INTO user_inventory (user_id, item_id, quantity, item_type) VALUES (?, ?, 1, ?) ON DUPLICATE KEY UPDATE quantity = quantity + 1',
+                [userId, card.id, 'ability']
+            );
+        }
+    } catch (err) {
+        console.error('Failed to insert starter cards:', err);
+        await interaction.followUp({ content: 'Failed to grant starter cards.', flags: [MessageFlags.Ephemeral] }).catch(() => {});
+        return;
+    }
+
+    const fields = cards.map(c => ({ name: c.name, value: c.effect }));
+    try {
+        const embed = simple('🎁 Starter Pack', fields);
+        await interaction.followUp({ embeds: [embed] });
+    } catch (err) {
+        console.error('Failed to send starter pack embed:', err);
+        await interaction.followUp({ content: 'Failed to send starter pack info.', flags: [MessageFlags.Ephemeral] }).catch(() => {});
+    }
 }
 
 module.exports = {
     showClassSelection,
     handleClassSelected,
+    openStarterPack,
     userClassChoices
 };

--- a/discord-bot/tests/begin.test.js
+++ b/discord-bot/tests/begin.test.js
@@ -1,21 +1,42 @@
+const db = require('../util/database');
+const gameData = require('../util/gameData');
+const embedBuilder = require('../src/utils/embedBuilder');
+
+jest.mock('../util/database', () => ({
+  execute: jest.fn()
+}));
+
+jest.mock('../util/gameData', () => ({
+  getRandomCardsForPack: jest.fn()
+}));
+
+jest.mock('../src/utils/embedBuilder', () => ({
+  simple: jest.fn(() => ({ data: {} }))
+}));
+
+jest.mock('../../backend/game/data', () => ({
+  allPossibleAbilities: [
+    { id: 1, name: 'Bolt', class: 'Mage', effect: 'Zap', rarity: 'Common' },
+    { id: 2, name: 'Fireball', class: 'Mage', effect: 'Burn', rarity: 'Uncommon' },
+    { id: 3, name: 'Sneak', class: 'Rogue', effect: 'Hide', rarity: 'Common' }
+  ]
+}));
+
 const beginCommand = require('../commands/begin');
 const selectMenuHandler = require('../handlers/selectMenuHandler');
 const beginManager = require('../features/beginManager');
 
-jest.mock('../features/beginManager', () => ({
-  showClassSelection: jest.fn(),
-  handleClassSelected: jest.fn(),
-  userClassChoices: new Map()
-}));
-
 describe('begin command flow', () => {
   test('executing /begin calls showClassSelection', async () => {
+    const spy = jest.spyOn(beginManager, 'showClassSelection').mockResolvedValue();
     const interaction = {};
     await beginCommand.execute(interaction);
-    expect(beginManager.showClassSelection).toHaveBeenCalledWith(interaction);
+    expect(spy).toHaveBeenCalledWith(interaction);
+    spy.mockRestore();
   });
 
   test('select menu invokes handleClassSelected', async () => {
+    const spy = jest.spyOn(beginManager, 'handleClassSelected').mockResolvedValue();
     const interaction = {
       customId: 'begin_class_select',
       values: ['Mage'],
@@ -23,6 +44,32 @@ describe('begin command flow', () => {
       deferUpdate: jest.fn().mockResolvedValue()
     };
     await selectMenuHandler(interaction);
-    expect(beginManager.handleClassSelected).toHaveBeenCalledWith(interaction, '42', 'Mage');
+    expect(spy).toHaveBeenCalledWith(interaction, '42', 'Mage');
+    spy.mockRestore();
+  });
+
+  test('opening starter pack inserts cards and sends embed', async () => {
+    const interaction = {
+      editReply: jest.fn().mockResolvedValue(),
+      followUp: jest.fn().mockResolvedValue()
+    };
+    gameData.getRandomCardsForPack.mockReturnValue([
+      { id: 1, name: 'Bolt', class: 'Mage', effect: 'Zap' },
+      { id: 2, name: 'Fireball', class: 'Mage', effect: 'Burn' },
+      { id: 4, name: 'Ice', class: 'Mage', effect: 'Freeze' }
+    ]);
+    db.execute.mockResolvedValue([]);
+
+    await beginManager.handleClassSelected(interaction, '99', 'Mage');
+
+    expect(db.execute).toHaveBeenCalledWith(
+      expect.stringContaining('UPDATE users SET class'),
+      ['Mage', '99']
+    );
+    expect(db.execute).toHaveBeenCalledWith(
+      expect.stringContaining('INSERT INTO user_inventory'),
+      ['99', 1, 'ability']
+    );
+    expect(interaction.followUp).toHaveBeenCalledWith(expect.objectContaining({ embeds: [expect.any(Object)] }));
   });
 });


### PR DESCRIPTION
## Summary
- grant starter ability cards once a player chooses a class
- test starter pack insert and embed

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685db0be03fc8327b7d1bb163cf27dcc