### PR TITLE
Add ability equip flow

### DIFF
--- a/discord-bot/features/beginManager.js
+++ b/discord-bot/features/beginManager.js
@@ -1,6 +1,7 @@
 const { MessageFlags } = require('discord.js');
 const { ActionRowBuilder, StringSelectMenuBuilder, EmbedBuilder } = require('discord.js');
 const db = require('../util/database');
+const { startEquipFlow } = require('./equipManager');
 
 // In-memory map storing chosen class keyed by discord_id
 const userClassChoices = new Map();
@@ -39,6 +40,12 @@ async function handleClassSelected(interaction, userId, chosenClass) {
         .setDescription("You'll receive your starter ability cards soon.");
 
     await interaction.editReply({ embeds: [embed], components: [] });
+
+    try {
+        await startEquipFlow(interaction, userId);
+    } catch (err) {
+        console.error('Failed to start equip flow:', err);
+    }
 }
 
 module.exports = {

--- a/discord-bot/features/equipManager.js
+++ b/discord-bot/features/equipManager.js
@@ -1,0 +1,84 @@
+const { MessageFlags } = require('discord.js');
+const { ActionRowBuilder, StringSelectMenuBuilder, EmbedBuilder } = require('discord.js');
+const db = require('../util/database');
+
+async function startEquipFlow(interaction, userId) {
+    const [[userRow]] = await db.execute('SELECT starter_class FROM users WHERE discord_id = ?', [userId]);
+    const userClass = userRow?.starter_class;
+    if (!userClass) {
+        await interaction.followUp({ content: 'No class found for your user.', flags: [MessageFlags.Ephemeral] });
+        return;
+    }
+
+    const [abilityRows] = await db.execute(
+        `SELECT ui.item_id, a.name, a.effect
+         FROM user_inventory ui JOIN abilities a ON ui.item_id = a.id
+         WHERE ui.user_id = ? AND a.class = ? AND ui.quantity > 0`,
+        [userId, userClass]
+    );
+
+    if (abilityRows.length === 0) {
+        await interaction.followUp({ content: 'You have no ability cards for your class.', flags: [MessageFlags.Ephemeral] });
+        return;
+    }
+
+    const options = abilityRows.slice(0, 4).map(ab => ({
+        label: ab.name,
+        description: ab.effect,
+        value: String(ab.item_id)
+    }));
+
+    const menu = new StringSelectMenuBuilder()
+        .setCustomId('equip_select')
+        .setPlaceholder('Select abilities to equip')
+        .setMinValues(1)
+        .setMaxValues(options.length)
+        .addOptions(options);
+
+    const row = new ActionRowBuilder().addComponents(menu);
+    const promptEmbed = new EmbedBuilder()
+        .setColor('#0ea5e9')
+        .setTitle('Equip Abilities')
+        .setDescription('Choose up to 4 abilities to equip to your champion.');
+
+    const msg = await interaction.followUp({ embeds: [promptEmbed], components: [row], flags: [MessageFlags.Ephemeral], fetchReply: true });
+
+    let selectInteraction;
+    try {
+        selectInteraction = await msg.awaitMessageComponent({ time: 60000 });
+    } catch {
+        await msg.edit({ content: 'Equip timed out.', components: [] });
+        return;
+    }
+
+    const selectedIds = selectInteraction.values.map(v => parseInt(v));
+
+    const [[champRow]] = await db.execute('SELECT id FROM user_champions WHERE user_id = ? ORDER BY id ASC LIMIT 1', [userId]);
+    const championId = champRow?.id;
+    if (!championId) {
+        await selectInteraction.update({ content: 'No champion found to equip.', components: [] });
+        return;
+    }
+
+    await db.execute('DELETE FROM champion_decks WHERE user_champion_id = ?', [championId]);
+    for (let i = 0; i < selectedIds.length; i++) {
+        await db.execute(
+            'INSERT INTO champion_decks (user_champion_id, ability_id, order_index) VALUES (?, ?, ?)',
+            [championId, selectedIds[i], i]
+        );
+    }
+
+    const selectedNames = abilityRows
+        .filter(ab => selectedIds.includes(ab.item_id))
+        .map(ab => ab.name)
+        .join(', ');
+
+    const resultEmbed = new EmbedBuilder()
+        .setColor('#84cc16')
+        .setTitle('Abilities Equipped')
+        .setDescription(`Equipped: ${selectedNames}`);
+
+    await selectInteraction.update({ embeds: [resultEmbed], components: [] });
+}
+
+module.exports = { startEquipFlow };

--- a/discord-bot/tests/equipManager.test.js
+++ b/discord-bot/tests/equipManager.test.js
@@ -1,0 +1,31 @@
+const { MessageFlags } = require('discord.js');
+const equipManager = require('../features/equipManager');
+const db = require('../util/database');
+
+jest.mock('../util/database', () => ({
+  execute: jest.fn()
+}));
+
+describe('startEquipFlow', () => {
+  test('persists selections and sends confirmation embed', async () => {
+    db.execute
+      .mockResolvedValueOnce([[{ starter_class: 'Warrior' }]])
+      .mockResolvedValueOnce([[{ item_id: 10, name: 'Slash', effect: 'Hit' }, { item_id: 11, name: 'Block', effect: 'Defend' }]])
+      .mockResolvedValueOnce([[{ id: 1 }]])
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([]);
+
+    const update = jest.fn().mockResolvedValue();
+    const message = { awaitMessageComponent: jest.fn(() => Promise.resolve({ values: ['10','11'], update })) };
+    const interaction = { followUp: jest.fn(() => Promise.resolve(message)), user: { id: '123' } };
+
+    await equipManager.startEquipFlow(interaction, '123');
+
+    expect(db.execute).toHaveBeenCalledWith('DELETE FROM champion_decks WHERE user_champion_id = ?', [1]);
+    expect(db.execute).toHaveBeenCalledWith('INSERT INTO champion_decks (user_champion_id, ability_id, order_index) VALUES (?, ?, ?)', [1, 10, 0]);
+    expect(db.execute).toHaveBeenCalledWith('INSERT INTO champion_decks (user_champion_id, ability_id, order_index) VALUES (?, ?, ?)', [1, 11, 1]);
+    const embed = update.mock.calls[0][0].embeds[0];
+    expect(embed.data.title).toBe('Abilities Equipped');
+  });
+});


### PR DESCRIPTION
## Summary
- create `equipManager.js` to guide players through equipping abilities
- call the equip flow when a player chooses a class
- test persistence of selected ability IDs

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685db02a9eb08327a820de4e719892a1