### PR TITLE
Add ability equip flow

### DIFF
--- a/discord-bot/features/beginManager.js
+++ b/discord-bot/features/beginManager.js
@@ -2,6 +2,7 @@ const { MessageFlags } = require('discord.js');
 const { ActionRowBuilder, StringSelectMenuBuilder, EmbedBuilder } = require('discord.js');
 const db = require('../util/database');
 const { simple } = require('../src/utils/embedBuilder');
+const { startEquipFlow } = require('./equipManager');
 const { allPossibleAbilities } = require('../../backend/game/data');
 const { getRandomCardsForPack } = require('../util/gameData');
 
@@ -65,7 +66,8 @@ async function openStarterPack(chosenClass, userId, interaction) {
     const fields = cards.map(c => ({ name: c.name, value: c.effect }));
     try {
         const embed = simple('🎁 Starter Pack', fields);
-        await interaction.followUp({ embeds: [embed] });
+        const msg = await interaction.followUp({ embeds: [embed] });
+        await startEquipFlow(interaction, userId);
     } catch (err) {
         console.error('Failed to send starter pack embed:', err);
         await interaction.followUp({ content: 'Failed to send starter pack info.', flags: [MessageFlags.Ephemeral] }).catch(() => {});

--- a/discord-bot/features/equipManager.js
+++ b/discord-bot/features/equipManager.js
@@ -1,0 +1,81 @@
+const { MessageFlags } = require('discord.js');
+const { ActionRowBuilder, StringSelectMenuBuilder, ButtonBuilder, ButtonStyle } = require('discord.js');
+const db = require('../util/database');
+const { simple } = require('../src/utils/embedBuilder');
+
+async function startEquipFlow(interaction, userId) {
+    let userClass;
+    try {
+        const [rows] = await db.execute('SELECT class FROM users WHERE discord_id = ?', [userId]);
+        userClass = rows[0]?.class;
+    } catch (err) {
+        console.error('Failed to fetch user class:', err);
+        return;
+    }
+    if (!userClass) return;
+
+    const [abilities] = await db.execute(
+        `SELECT ui.item_id, a.name, a.effect
+         FROM user_inventory ui JOIN abilities a ON ui.item_id = a.id
+         WHERE ui.user_id = ? AND a.class = ? AND ui.quantity > 0`,
+        [userId, userClass]
+    );
+
+    if (!abilities.length) {
+        await interaction.followUp({ content: 'No abilities available to equip.', flags: [MessageFlags.Ephemeral] });
+        return;
+    }
+
+    const options = abilities.slice(0, 4).map(ab => ({
+        label: ab.name,
+        description: ab.effect,
+        value: String(ab.item_id)
+    }));
+
+    const select = new StringSelectMenuBuilder()
+        .setCustomId('equip_select')
+        .setPlaceholder('Select abilities')
+        .setMinValues(1)
+        .setMaxValues(options.length)
+        .addOptions(options);
+    const confirmButton = new ButtonBuilder()
+        .setCustomId('equip_confirm')
+        .setLabel('Confirm')
+        .setStyle(ButtonStyle.Primary);
+
+    const msg = await interaction.followUp({
+        content: 'Choose abilities to equip:',
+        components: [
+            new ActionRowBuilder().addComponents(select),
+            new ActionRowBuilder().addComponents(confirmButton)
+        ],
+        fetchReply: true,
+        flags: [MessageFlags.Ephemeral]
+    });
+
+    try {
+        const selectInteraction = await msg.awaitMessageComponent({ time: 30000 });
+        const chosenIds = selectInteraction.values.map(v => parseInt(v));
+        await selectInteraction.deferUpdate();
+        const confirmInteraction = await msg.awaitMessageComponent({ time: 30000 });
+        if (confirmInteraction.customId !== 'equip_confirm') return;
+        await confirmInteraction.deferUpdate?.();
+        const [champRows] = await db.execute('SELECT id FROM user_champions WHERE user_id = ? LIMIT 1', [userId]);
+        const championId = champRows[0]?.id;
+        if (championId) {
+            for (let i = 0; i < chosenIds.length; i++) {
+                await db.execute(
+                    'INSERT INTO champion_decks (user_champion_id, ability_id, order_index) VALUES (?, ?, ?)',
+                    [championId, chosenIds[i], i]
+                );
+            }
+        }
+        const names = abilities.filter(ab => chosenIds.includes(ab.item_id)).map(ab => ab.name);
+        const embed = simple('Abilities Equipped', [{ name: 'Equipped', value: names.join(', ') }]);
+        await confirmInteraction.update({ embeds: [embed], components: [], flags: [MessageFlags.Ephemeral] });
+    } catch (err) {
+        console.error('Equip flow failed:', err);
+    }
+}
+
+module.exports = { startEquipFlow };

--- a/discord-bot/tests/begin.test.js
+++ b/discord-bot/tests/begin.test.js
@@ -22,9 +22,14 @@ jest.mock('../../backend/game/data', () => ({
   ]
 }));
 
+jest.mock('../features/equipManager', () => ({
+  startEquipFlow: jest.fn()
+}));
+
 const beginCommand = require('../commands/begin');
 const selectMenuHandler = require('../handlers/selectMenuHandler');
 const beginManager = require('../features/beginManager');
+const equipManager = require('../features/equipManager');
 
 describe('begin command flow', () => {
   test('executing /begin calls showClassSelection', async () => {
@@ -53,6 +58,7 @@ describe('begin command flow', () => {
       editReply: jest.fn().mockResolvedValue(),
       followUp: jest.fn().mockResolvedValue()
     };
+    equipManager.startEquipFlow.mockResolvedValue();
     gameData.getRandomCardsForPack.mockReturnValue([
       { id: 1, name: 'Bolt', class: 'Mage', effect: 'Zap' },
       { id: 2, name: 'Fireball', class: 'Mage', effect: 'Burn' },
@@ -71,5 +77,6 @@ describe('begin command flow', () => {
       ['99', 1, 'ability']
     );
     expect(interaction.followUp).toHaveBeenCalledWith(expect.objectContaining({ embeds: [expect.any(Object)] }));
+    expect(equipManager.startEquipFlow).toHaveBeenCalledWith(interaction, '99');
   });
 });

--- a/discord-bot/tests/equipManager.test.js
+++ b/discord-bot/tests/equipManager.test.js
@@ -1,0 +1,36 @@
+const equipManager = require('../features/equipManager');
+const db = require('../util/database');
+const embedBuilder = require('../src/utils/embedBuilder');
+
+jest.mock('../util/database', () => ({
+  execute: jest.fn()
+}));
+
+jest.mock('../src/utils/embedBuilder', () => ({
+  simple: jest.fn(() => ({ data: {} }))
+}));
+
+describe('startEquipFlow', () => {
+  test('persists selected ability IDs and sends confirmation embed', async () => {
+    const selectInteraction = { customId: 'equip_select', values: ['1', '2'], deferUpdate: jest.fn().mockResolvedValue() };
+    const confirmInteraction = { customId: 'equip_confirm', update: jest.fn().mockResolvedValue(), deferUpdate: jest.fn().mockResolvedValue() };
+
+    const message = { awaitMessageComponent: jest.fn()
+      .mockResolvedValueOnce(selectInteraction)
+      .mockResolvedValueOnce(confirmInteraction) };
+    const interaction = { followUp: jest.fn(() => Promise.resolve(message)) };
+
+    db.execute
+      .mockResolvedValueOnce([[{ class: 'Mage' }]])
+      .mockResolvedValueOnce([[{ item_id: 1, name: 'Bolt', effect: 'Zap' }, { item_id: 2, name: 'Fireball', effect: 'Burn' }]])
+      .mockResolvedValueOnce([[{ id: 42 }]])
+      .mockResolvedValue([]);
+
+    await equipManager.startEquipFlow(interaction, 'user');
+
+    expect(db.execute).toHaveBeenCalledWith(expect.stringContaining('INSERT INTO champion_decks'), [42, 1, 0]);
+    expect(db.execute).toHaveBeenCalledWith(expect.stringContaining('INSERT INTO champion_decks'), [42, 2, 1]);
+    expect(embedBuilder.simple).toHaveBeenCalledWith('Abilities Equipped', expect.any(Array));
+    expect(confirmInteraction.update).toHaveBeenCalledWith(expect.objectContaining({ embeds: [expect.any(Object)] }));
+  });
+});


### PR DESCRIPTION
## Summary
- add EquipManager with ability selection flow
- trigger equip flow after starter pack arrives
- cover EquipManager with Jest tests
- adjust begin tests for new logic

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_685db860261883278b898ceac2b29d15