### PR TITLE
docs: Add Game Design Documents for all projects

### DIFF
--- a/docs/poc2_html_GDD.md
+++ b/docs/poc2_html_GDD.md
@@ -1,0 +1,97 @@
+# Game Design Document: poc2.html - Pack Opening & Draft UI Prototype
+
+## 1. Overview / Introduction
+*   **Project Title:** Character Draft Prototype (poc2.html)
+*   **Core Concept:** A single HTML file prototyping the user interface and interaction flow for opening a virtual booster pack and then drafting two heroes from a selection of four revealed cards.
+*   **Original Goals/Vision:**
+    *   To visualize and test the UX of a pack opening sequence.
+    *   To prototype a simple hero drafting mechanism where players select two heroes for a team.
+    *   To refine compact card visuals suitable for a draft pool and team display.
+
+## 2. Core Features Displayed
+
+*   **Pack Opening Screen:**
+    *   Presents a large, stylized "booster pack" graphic.
+    *   Instructional text prompts the user to click the pack.
+    *   Clicking the pack triggers a transition to the draft screen.
+*   **Drafting Screen:**
+    *   **Team Slots Area:**
+        *   Displays two clearly marked, empty slots for "Hero 1" and "Hero 2".
+        *   When a hero is selected, their compact card representation (art, name, rarity) fills the slot.
+    *   **Draft Pool Area:**
+        *   Shows four hero cards revealed from the "opened pack".
+        *   These cards use a "compact card" design with circular art, name, and rarity.
+        *   "Ultra Rare" cards have a shimmer animation.
+    *   **Selection Interaction:**
+        *   Users click on a hero card from the draft pool to assign it to the next available empty team slot.
+        *   Selected heroes in the pool are visually marked (e.g., dimmed) to indicate they've been chosen.
+        *   Users can click on a hero in a filled team slot to unselect them, making that hero available again in the pool and emptying the slot.
+    *   **Confirmation:**
+        *   A "Confirm Draft" button is present.
+        *   The button becomes active only when both team slots have been filled with selected heroes.
+*   **Card Visuals (Compact Style):**
+    *   Designed for quick identification in a pool or team display.
+    *   Features: Circular hero art, hero name, rarity.
+    *   Rarity is indicated by border color and text (Common, Uncommon, Rare, "Ultra Rare").
+
+## 3. Game Flow / Progression (Simplified)
+
+1.  **Pack Opening:** User is presented with a booster pack and clicks it.
+2.  **Transition:** Screen animates/fades to the draft interface.
+3.  **Hero Selection (Draft Pool):** Four random hero cards are displayed.
+4.  **Team Slot Filling:** User clicks two heroes from the pool to fill the two team slots.
+    *   Can deselect from team slots to change choices.
+5.  **Confirmation:** Once two heroes are selected, the "Confirm Draft" button activates.
+    *   (PoC ends here; no further action on confirmation).
+
+## 4. User Interface (UI) / User Experience (UX)
+
+*   **Clear Visual Flow:** Guides the user from pack opening to team selection.
+*   **Interactive Selection:** Provides immediate visual feedback when cards are selected or deselected.
+*   **Minimalist Design:** Focuses on the core interaction of picking cards.
+*   **Animated Transitions:** Simple opacity fades and card reveal animations enhance the experience.
+
+## 5. Technical Implementation Details
+
+*   **Platform:** Single HTML file (`poc2.html`).
+*   **Technologies:**
+    *   HTML
+    *   CSS (Tailwind CSS via CDN, custom inline CSS for specific elements and animations).
+    *   JavaScript for:
+        *   Handling pack opening transition.
+        *   Randomly selecting 4 heroes from a predefined array to populate the draft pool.
+        *   Managing the selection/deselection of heroes into team slots.
+        *   Updating the UI to reflect selections.
+        *   Activating the confirm button.
+*   **Data:**
+    *   A hardcoded JavaScript array `allPossibleHeroes` (containing 12 sample heroes with `id`, `name`, `rarity`, and `art` URL) serves as the source for cards.
+*   **Dependencies:** Font Awesome for icons, Google Fonts, Tailwind CSS CDN.
+
+## 6. What Was Tried / Prototypes
+
+*   This entire file is a UI/UX prototype for pack opening and a basic 2-hero draft.
+*   It experiments with visual feedback for card selection and slot filling.
+*   It introduces an animated transition between the "pack" state and the "draft" state.
+
+## 7. Lessons Learned (Deduced)
+
+*   **Visual Feedback is Key:** Clearly indicating selected cards and filled slots is important for user understanding in a draft.
+*   **Staged Reveal:** The concept of opening a pack and then seeing a selection of cards is a common and engaging mechanic.
+*   **Simplified Data for Prototyping:** Using a small, hardcoded dataset is effective for quickly prototyping UI interactions.
+
+## 8. Connections to Other Projects
+
+*   **Evolution of Drafting:** This PoC represents an earlier, simpler version of the multi-stage drafting (hero, then ability, then weapon, then armor) found in `hero-game/`.
+*   **Card Visuals:** The compact card style with circular art is distinct from the rectangular art in `poc.html` and `hero-game/`, showing exploration of different visual approaches.
+*   The "Ultra Rare" rarity likely maps to "Epic" in the more developed projects.
+
+## 9. Future Ideas / Potential Improvements (If this PoC were to be expanded)
+
+*   Expand the draft to include other card types (weapons, abilities, armor) per hero.
+*   Allow drafting for more than two hero slots.
+*   Integrate with a more dynamic data source.
+*   Add more sophisticated animations for pack opening (e.g., cards physically flying out).
+*   Implement further actions after "Confirm Draft" (e.g., proceeding to a battle setup screen).
+
+This GDD for `poc2.html` is now created.
+Finally, I will investigate `poc3.html`.

--- a/docs/poc_html_GDD.md
+++ b/docs/poc_html_GDD.md
@@ -1,0 +1,74 @@
+# Game Design Document: poc.html - Card Visual Prototype
+
+## 1. Overview / Introduction
+*   **Project Title:** Hero Card Prototype (poc.html)
+*   **Core Concept:** A single HTML file serving as a visual proof-of-concept for displaying hero cards in various formats, including detailed views with stats and abilities, compact views, and a view showing equippable gear.
+*   **Original Goals/Vision:**
+    *   To explore and demonstrate different visual designs for hero cards.
+    *   To prototype UI elements like rarity indicators, tooltips, card flipping for lore, and visual representation of equipped items.
+    *   To establish a visual style for cards using specific fonts and Tailwind CSS.
+
+## 2. Core Features Displayed
+
+*   **Card Visual Styles:**
+    *   **Detail View:**
+        *   Large card format (320x450px).
+        *   Displays: Hero Art, Name (Cinzel font), HP, Attack stats, XP bar, a list of Abilities.
+        *   Rarity Indication: Different border colors and background frame images (placeholders) for Common, Uncommon, Rare, and "Ultra Rare" (likely equivalent to Epic).
+        *   Ultra Rare cards feature a "shimmer" animation effect.
+        *   Flip Functionality: Cards can be clicked to flip over, revealing lore text on the back. The back also reflects the rarity frame.
+    *   **Compact View:**
+        *   Smaller card format (100x140px).
+        *   Displays: Compact Art, Name, HP bar, and Attack value.
+        *   Rarity borders are also applied.
+    *   **Socketed Gear View:**
+        *   Based on the Detail View.
+        *   Visually attaches smaller "gear cards" (Weapon and Armor sockets) to the sides of the main hero card.
+        *   These gear sockets also have tooltips showing their name and effects (e.g., "+2 Attack, +1 Speed").
+*   **Interactive UI Elements:**
+    *   **Tooltips:** Appear on hover over stats (to show base vs. modified values), abilities (to show effect descriptions and keywords like "Stun"), and gear sockets.
+    *   **Card Flipping:** Clickable button on detail cards to flip them.
+*   **Styling & Presentation:**
+    *   Uses Google Fonts (Cinzel for names/titles, Inter for body text).
+    *   Leverages Tailwind CSS for rapid styling and layout.
+    *   Custom CSS for specific card aesthetics, animations (shimmer), and pseudo-elements for frames/tooltips.
+
+## 3. Game Flow / Progression (Not Applicable)
+*   This PoC is purely visual and does not contain any game flow, progression, or simulation logic. Data is hardcoded.
+
+## 4. User Interface (UI) / User Experience (UX)
+*   Focuses entirely on the visual presentation of cards.
+*   Demonstrates how information hierarchy could be established on a card (name, art, stats, abilities).
+*   Explores interactive elements like hover tooltips and card flipping to reveal more information without cluttering the main view.
+
+## 5. Technical Implementation Details
+*   **Platform:** Single HTML file (`poc.html`).
+*   **Technologies:**
+    *   HTML
+    *   CSS (Tailwind CSS via CDN, custom inline CSS)
+    *   Minimal JavaScript for card flipping interactivity.
+*   **Data:** All hero and item information is hardcoded directly into the HTML structure. No external data files are used for this PoC.
+*   **Dependencies:** Font Awesome for icons (flip button), Google Fonts, Tailwind CSS CDN.
+
+## 6. What Was Tried / Prototypes
+*   This entire file *is* a prototype, specifically for card visuals.
+*   It tests different levels of detail for card presentation (full detail, compact, detail with gear).
+*   It experiments with visual cues for rarity and special card types (shimmer for Ultra Rare).
+
+## 7. Lessons Learned (Deduced)
+*   **Visual Design Exploration:** Useful for quickly iterating on the look and feel of game assets.
+*   **Component Reusability (Conceptual):** While not using a framework, the distinct card views suggest how different card components could be designed for various contexts in a full application.
+*   **Tailwind CSS for Rapid UI Prototyping:** Demonstrates the utility of a utility-first CSS framework for quickly building UI mockups.
+
+## 8. Connections to Other Projects
+*   **Visual Basis:** Provides a potential visual direction for the cards used in `hero-game/`, `auto-battler-react/`, and the `discord-bot/` (especially for `cardRenderer.js`).
+*   **Data Structure Ideas:** The hardcoded data (hero stats, abilities) reflects the kind of information that is structured in `data.js` files in other projects.
+*   The "Ultra Rare" rarity used here likely corresponds to the "Epic" rarity defined in the main game data.
+
+## 9. Future Ideas / Potential Improvements (If this PoC were to be expanded)
+*   Integrate with a JavaScript data source (`data.js`) to dynamically generate cards instead of hardcoding.
+*   Componentize the card designs using a JavaScript framework (like React, as seen in `auto-battler-react`).
+*   Add more card types (abilities, items as separate visual cards).
+
+This GDD for `poc.html` is now created.
+Next, I will investigate `poc2`. I'll first check if it's a file or directory.

--- a/hero-game/docs/GDD.md
+++ b/hero-game/docs/GDD.md
@@ -1,0 +1,116 @@
+# Game Design Document: hero-game (JavaScript Prototype)
+
+## 1. Overview / Introduction
+*   **Project Title:** Hero Game Prototype
+*   **Core Concept:** A client-side, session-based auto-battler where the player drafts a team of two heroes, along with their abilities, weapons, and armor, and then engages in a series of automated battles against randomly generated enemy teams. The player progresses through a tournament, upgrading their team between battles.
+*   **Original Goals/Vision (deduced from `docs/technical_overview.md` and its functionality):**
+    *   To create a playable prototype of an auto-battler with a drafting phase and automated combat.
+    *   To test core gameplay mechanics like hero stats, abilities, items, status effects, and a tournament progression loop.
+    *   Entirely client-side for ease of development and iteration.
+
+## 2. Core Gameplay Mechanics
+
+*   **Drafting Phase (`PackScene`, `RevealScene`, `DraftScene` in `js/main.js`):**
+    *   Players draft a team of two heroes.
+    *   For each hero, they draft:
+        1.  A Hero card (defines base stats, class).
+        2.  An Ability card (active skill used in combat, specific to hero's class).
+        3.  A Weapon card (provides stat bonuses and sometimes passive effects).
+        4.  An Armor card (provides stat bonuses and sometimes passive effects).
+    *   Packs are generated with card rarity influenced by the player's current number of tournament wins (more wins = better chance at rarer cards).
+*   **Combat System (`js/scenes/BattleScene.js`):**
+    *   **Team Composition:** 2v2 battles.
+    *   **Automated & Turn-Based:** Combat resolves automatically once started.
+    *   **Turn Order:** Determined by each combatant's `speed` stat (higher speed acts first). Status effects like `Slow` can modify speed.
+    *   **Actions:**
+        *   On a combatant's turn, they gain 1 Energy (up to a cap of 10).
+        *   If they have an equipped ability (`abilityData`) and enough energy, they will use the ability. Some abilities are followed by a basic attack.
+        *   Otherwise, they perform a basic attack.
+    *   **Targeting:** Combatants primarily target the first available enemy in the opponent's lineup (typically the front-most active unit).
+    *   **Damage Calculation:**
+        *   Basic Attack Damage: `attacker.attack - target.block` (minimum 1).
+        *   Ability Damage: Often defined by the ability's effect string (e.g., "Deal X damage"), or defaults to attacker's attack.
+        *   Critical Hits: 10% chance for 1.5x damage.
+        *   Stat Bonuses: Weapon and Armor stat bonuses are factored into a combatant's effective stats at the start of the battle.
+    *   **Status Effects:** Implemented with descriptions and visual indicators. Includes: Stun, Poison, Bleed, Burn, Slow, Confuse, Root, Shock, Vulnerable, Defense Down, Attack Up, Fortify.
+    *   **Summoning:** Certain abilities can summon minions (defined in `js/data.js`) which join the battle.
+    *   **Note on Specific GDD Ability Triggers:** The `docs/gdd.md` ("Auto-Battle Scene" section) describes specific conditional logic for some passive hero abilities (e.g., Warrior's Fortify) and weapon effects (e.g., Iron Sword's Cleave). This highly specific conditional logic is **not explicitly observed** in `BattleScene.js`'s main turn execution, which primarily focuses on the active equipped ability. This suggests a simplification in the prototype or that these passives are intended to be represented by the stat bonuses or the nature of the active ability chosen.
+*   **Tournament Loop (`js/main.js`):**
+    *   Players fight successive battles.
+    *   Wins and losses are tracked.
+    *   The tournament ends if the player achieves 10 wins or accumulates 2 losses.
+*   **Upgrade Phase (`js/scenes/UpgradeScene.js`):**
+    *   After each battle (if the tournament is not over), the player enters an upgrade phase.
+    *   They are presented with a "bonus pack" of cards (quality influenced by the previous battle's outcome and total wins).
+    *   Players can choose one card to replace an existing hero, weapon, armor, or ability on one of their champions.
+    *   **Hero Evolution:** At certain win thresholds (1, 2, 5 wins), if the player won the last battle, their heroes may automatically evolve to the next rarity tier within their class (e.g., Common Recruit to Uncommon Soldier).
+    *   **Shards & Reroll Tokens:** A simple inventory system tracks `shards` (gained from not picking cards in upgrade phase) and `rerollTokens` (gained from winning, allows rerolling upgrade pack).
+
+## 3. Game Flow / Progression
+
+1.  **Initial Draft (Hero 1):**
+    *   Open Hero Pack -> Reveal -> Draft Hero.
+    *   Open Ability Pack (class-specific) -> Reveal -> Draft Ability.
+    *   Open Weapon Pack -> Reveal -> Draft Weapon.
+    *   Open Armor Pack -> Reveal -> Draft Armor.
+    *   Recap Champion 1.
+2.  **Second Draft (Hero 2):** Same sequence as Hero 1.
+3.  **Recap Champion 2.**
+4.  **Start Tournament Battle.**
+5.  **Battle Scene:** Combat resolves.
+6.  **Post-Battle:**
+    *   If tournament ends (10 wins / 2 losses): Show end screen.
+    *   Else:
+        *   Check for hero evolution if player won.
+        *   Proceed to Upgrade Scene.
+7.  **Upgrade Scene:** Player picks one card from a bonus pack to upgrade their team or takes shards. Can use a reroll token.
+8.  **Loop back to Step 4 (Start Next Battle).**
+
+## 4. User Interface (UI) / User Experience (UX)
+
+*   **Visual Style:** Simple HTML and CSS.
+*   **Card Display:** `CardRenderer.js` handles creating visual representations of cards (compact for battle, detailed for draft/recap).
+*   **Battle Interface (`BattleScene.js`):**
+    *   Player team on one side, enemy on the other.
+    *   Health bars and energy display for each combatant.
+    *   Battle log panel showing turn-by-turn actions, filterable by event type.
+    *   Status effect icons displayed on cards with tooltips.
+    *   Ability announcer for major actions.
+    *   Visual effects for attacks, damage, status applications (e.g., "muzzle-flash", "physical-hit", "combat-text-popup").
+*   **Scene Transitions:** Basic transitions between game phases (pack opening, drafting, battle, recap, upgrade).
+
+## 5. Technical Implementation Details
+
+*   **Platform:** Client-side JavaScript, HTML, CSS. Runs in a web browser.
+*   **Structure:** ES modules. `js/main.js` is the main coordinator.
+    *   `js/data.js`: Contains static arrays for `allPossibleHeroes`, `allPossibleMinions`, `allPossibleWeapons`, `allPossibleAbilities`, `allPossibleArmors`. Data is very similar to `auto-battler-react/src/data/data.js`.
+    *   `js/scenes/`: Separate modules for each game state (Pack, Draft, Battle, etc.).
+    *   `js/ui/`: UI helper modules like `CardRenderer.js`.
+    *   `js/systems/`: Contains `EffectProcessor.js` (though its direct usage wasn't deeply explored in this pass, `BattleScene.js` handles most status logic directly).
+*   **State Management:** A global `gameState` object in `js/main.js`.
+*   **No Backend:** All logic and data are handled client-side. No persistent storage beyond the current session.
+
+## 6. What Was Tried / Prototypes
+*   This entire `hero-game/` project is a functional prototype demonstrating a complete game loop.
+*   It explores drafting, automated combat with abilities and status effects, and a simple meta-progression (tournament with upgrades and evolution).
+*   The fixed turn order described in an early GDD section was likely an even earlier concept, as the current `BattleScene.js` uses a speed-based turn queue.
+
+## 7. Lessons Learned (Deduced)
+*   **Rapid Prototyping:** Client-side JS allows for quick iteration of game mechanics without backend complexities.
+*   **Core Loop Validation:** The prototype successfully validates a draft-battle-upgrade loop.
+*   **Complexity Management:** Even in a client-side prototype, managing state (`gameState` in `main.js`) and the interactions between numerous scenes and game systems requires careful organization.
+*   **Data Consistency:** While self-contained, the data structures in `js/data.js` show an early version of what's used in the more complex `auto-battler-react` and `backend` projects.
+
+## 8. Connections to Other Projects
+*   **Foundation for `auto-battler-react` and `backend`:** `hero-game/` likely served as an initial proof-of-concept. Many of its data structures (heroes, items, abilities) and core mechanics (energy, status effects) are mirrored or expanded upon in the other projects.
+*   **Distinct Battle Logic Details:** While sharing concepts, the specific implementation of turn order and ability triggers in `hero-game/js/BattleScene.js` differs in some details from `auto-battler-react/src/hooks/useBattleLogic.js` and `backend/game/engine.js`.
+
+## 9. Future Ideas / Potential Improvements (from `docs/technical_overview.md`)
+*   Introduce a backend for persistent storage or matchmaking.
+*   Break large modules into smaller units.
+*   Add tests for combat logic.
+*   Consider using a framework (React, Vue) for more complex UI if expanding this specific codebase (though `auto-battler-react` already does this).
+*   Implement the more specific conditional ability/weapon triggers detailed in `docs/gdd.md` if desired for more tactical depth.
+
+This GDD for `hero-game/` is now created.
+I will now proceed to the Proof of Concept files: `poc.html`, `poc2`, and `poc3.html`.


### PR DESCRIPTION
Created GDDs to document the implementation, design decisions, and lessons learned for:
- auto-battler-react, backend, and discord-bot (combined)
- hero-game (JS prototype)
- poc.html (card visual PoC)
- poc2.html (pack opening & draft UI PoC)
- poc3.html (draft & battle loop PoC)

These documents are intended to preserve design history and provide an overview of each component's purpose and current state.