### PR TITLE
Implement class onboarding flow

### DIFF
--- a/discord-bot/src/commands/game.js
+++ b/discord-bot/src/commands/game.js
@@ -1,39 +1,86 @@
-const { SlashCommandBuilder } = require('discord.js');
+const { SlashCommandBuilder, EmbedBuilder, ActionRowBuilder, StringSelectMenuBuilder, ButtonBuilder, ButtonStyle } = require('discord.js');
+const classes = require('../data/classes');
+const userService = require('../utils/userService');
 
-module.exports = {
-    data: new SlashCommandBuilder()
-        .setName('game')
-        .setDescription('The primary command for playing the game.')
-        .addSubcommand(subcommand =>
-            subcommand
-                .setName('select')
-                .setDescription("Select your champion's class.")
-                .addStringOption(option =>
-                    option.setName('class')
-                        .setDescription('The class you want to select.')
-                        .setRequired(true)
-                        .addChoices(
-                            { name: 'Recruit', value: 'recruit' },
-                        )
-                )
-        ),
-    async execute(interaction) {
-        if (interaction.options.getSubcommand() === 'select') {
-            const selectedClass = interaction.options.getString('class');
+const data = new SlashCommandBuilder()
+  .setName('game')
+  .setDescription('Begin your adventure');
 
-            if (selectedClass === 'recruit') {
-                await interaction.reply({
-                    content: `You have chosen the path of the **Recruit**! Welcome to the adventure.`,
-                    ephemeral: true // Only the user who ran the command can see this
-                });
-            } else {
-                // This case is technically not reachable with the current choices,
-                // but it's good practice for when more classes are added.
-                await interaction.reply({
-                    content: 'That is not a valid class. Please choose from the available options.',
-                    ephemeral: true
-                });
-            }
-        }
-    },
-};
+async function execute(interaction) {
+  let user = await userService.getUser(interaction.user.id);
+  if (!user) {
+    await userService.createUser(interaction.user.id);
+    user = await userService.getUser(interaction.user.id);
+  }
+
+  if (user.class) {
+    await interaction.reply({ content: `You have already chosen the **${user.class}** class and it cannot be changed.`, ephemeral: true });
+    return;
+  }
+
+  const embed = new EmbedBuilder()
+    .setTitle('Welcome to the World')
+    .setDescription('Choose your class to begin your journey.');
+
+  const menu = new StringSelectMenuBuilder()
+    .setCustomId('class-select')
+    .setPlaceholder('Select a class')
+    .addOptions(classes.map(c => ({ label: c.name, value: c.name })));
+
+  const row = new ActionRowBuilder().addComponents(menu);
+
+  await interaction.reply({ embeds: [embed], components: [row], ephemeral: true });
+}
+
+async function handleClassSelect(interaction) {
+  const className = interaction.values[0];
+  const cls = classes.find(c => c.name === className);
+  if (!cls) {
+    await interaction.update({ content: 'Invalid class selected.', components: [], embeds: [], ephemeral: true });
+    return;
+  }
+
+  const embed = new EmbedBuilder()
+    .setTitle(cls.name)
+    .setDescription(cls.description)
+    .addFields({ name: 'Specializations', value: cls.specializations.map(s => `• ${s}`).join('\n') });
+
+  const buttons = new ActionRowBuilder().addComponents(
+    new ButtonBuilder().setCustomId(`class-confirm:${cls.name}`).setLabel('Confirm Class').setStyle(ButtonStyle.Primary),
+    new ButtonBuilder().setCustomId('class-choose-again').setLabel('Choose Another').setStyle(ButtonStyle.Secondary)
+  );
+
+  await interaction.update({ embeds: [embed], components: [buttons], ephemeral: true });
+}
+
+async function handleClassButton(interaction) {
+  if (interaction.customId === 'class-choose-again') {
+    const embed = new EmbedBuilder()
+      .setTitle('Choose your class')
+      .setDescription('Select a class to begin.');
+    const menu = new StringSelectMenuBuilder()
+      .setCustomId('class-select')
+      .setPlaceholder('Select a class')
+      .addOptions(classes.map(c => ({ label: c.name, value: c.name })));
+    const row = new ActionRowBuilder().addComponents(menu);
+    await interaction.update({ embeds: [embed], components: [row], ephemeral: true });
+    return;
+  }
+
+  if (interaction.customId.startsWith('class-confirm:')) {
+    const className = interaction.customId.split(':')[1];
+    let user = await userService.getUser(interaction.user.id);
+    if (!user) {
+      await userService.createUser(interaction.user.id);
+      user = await userService.getUser(interaction.user.id);
+    }
+    if (user.class) {
+      await interaction.reply({ content: 'You have already chosen a class and it cannot be changed.', ephemeral: true });
+      return;
+    }
+    await userService.setUserClass(interaction.user.id, className);
+    await interaction.reply({ content: `Congratulations! You are now a **${className}**.`, ephemeral: true });
+  }
+}
+
+module.exports = { data, execute, handleClassSelect, handleClassButton };

--- a/discord-bot/src/data/classes.js
+++ b/discord-bot/src/data/classes.js
@@ -1,0 +1,57 @@
+module.exports = [
+  {
+    name: 'Warrior',
+    description: 'The Warrior is a stalwart combatant, excelling in direct confrontation and battlefield control. They can specialize in defensive stances or powerful offensive maneuvers.',
+    specializations: ['Stun', 'Defense Boost', 'Extra Action']
+  },
+  {
+    name: 'Bard',
+    description: 'The Bard uses music and performance to inspire allies and disrupt foes. They excel in a support role, manipulating turn order and providing buffs.',
+    specializations: ['Attack Boost', 'Speed Boost', 'Evasion Boost', 'Extra Action']
+  },
+  {
+    name: 'Barbarian',
+    description: 'The Barbarian is a ferocious warrior who thrives in the heat of battle, often sacrificing defense for raw power.',
+    specializations: ['Bleed', 'Attack Boost', 'Taunt', 'Vulnerable']
+  },
+  {
+    name: 'Cleric',
+    description: 'The Cleric is a divine agent, focusing on healing allies, providing protection, and smiting evil.',
+    specializations: ['Healing', 'Defense Boost', 'Attack Down', 'Resurrection']
+  },
+  {
+    name: 'Druid',
+    description: 'The Druid channels the power of nature to heal, entangle foes, and shapeshift into powerful beasts.',
+    specializations: ['Poison', 'Root', 'Regeneration', 'Defense Boost']
+  },
+  {
+    name: 'Enchanter',
+    description: 'The Enchanter manipulates minds and arcane energies to control the battlefield and deceive enemies.',
+    specializations: ['Charm / Mind Control', 'Confuse', 'Evasion Boost', 'Attack Down']
+  },
+  {
+    name: 'Paladin',
+    description: 'The Paladin is a holy warrior, combining martial prowess with divine blessings to protect allies and smite foes.',
+    specializations: ['Defense Boost', 'Healing', 'Damage Mitigation / Immunity', 'Anti-Undead Bonus']
+  },
+  {
+    name: 'Rogue',
+    description: 'The Rogue is a master of stealth and subterfuge, striking from the shadows and exploiting enemy weaknesses.',
+    specializations: ['Poison', 'Bleed', 'Evasion Boost', 'Critical Hits']
+  },
+  {
+    name: 'Ranger',
+    description: 'The Ranger is a skilled hunter and tracker, adept with ranged weapons and often accompanied by animal companions.',
+    specializations: ['Evasion Boost', 'Root', 'Summons', 'Multi-Target Damage']
+  },
+  {
+    name: 'Sorcerer',
+    description: 'The Sorcerer wields raw, chaotic magic, often with unpredictable but powerful elemental effects.',
+    specializations: ['Burn', 'Shock', 'Attack Down', 'AoE Damage']
+  },
+  {
+    name: 'Wizard',
+    description: 'The Wizard is a scholarly spellcaster, mastering precise arcane formulas for devastating effects and battlefield manipulation.',
+    specializations: ['Slow', 'Shock', 'Time Manipulation', 'Arcane Buffs']
+  }
+];

--- a/discord-bot/src/utils/userService.js
+++ b/discord-bot/src/utils/userService.js
@@ -1,0 +1,17 @@
+const db = require('../../util/database');
+
+async function getUser(discordId) {
+  const [rows] = await db.query('SELECT * FROM users WHERE discord_id = ?', [discordId]);
+  return rows[0] || null;
+}
+
+async function createUser(discordId) {
+  await db.query('INSERT INTO users (discord_id) VALUES (?)', [discordId]);
+  return getUser(discordId);
+}
+
+async function setUserClass(discordId, className) {
+  await db.query('UPDATE users SET class = ? WHERE discord_id = ?', [className, discordId]);
+}
+
+module.exports = { getUser, createUser, setUserClass };

--- a/discord-bot/tests/game.test.js
+++ b/discord-bot/tests/game.test.js
@@ -1,0 +1,65 @@
+const game = require('../src/commands/game');
+
+jest.mock('../src/utils/userService', () => ({
+  getUser: jest.fn(),
+  createUser: jest.fn(),
+  setUserClass: jest.fn()
+}));
+const userService = require('../src/utils/userService');
+
+describe('game command onboarding', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('new users triggering the onboarding flow', async () => {
+    userService.getUser.mockResolvedValueOnce(null);
+    userService.createUser.mockResolvedValueOnce();
+    userService.getUser.mockResolvedValueOnce({ discord_id: '123', class: null });
+
+    const interaction = {
+      user: { id: '123' },
+      options: {},
+      reply: jest.fn().mockResolvedValue()
+    };
+
+    await game.execute(interaction);
+    expect(userService.createUser).toHaveBeenCalledWith('123');
+    expect(interaction.reply).toHaveBeenCalledWith(expect.objectContaining({ ephemeral: true }));
+  });
+
+  test('class selection persists via userService', async () => {
+    const selectInteraction = {
+      values: ['Warrior'],
+      customId: 'class-select',
+      update: jest.fn().mockResolvedValue()
+    };
+
+    await game.handleClassSelect(selectInteraction);
+    expect(selectInteraction.update).toHaveBeenCalled();
+
+    const buttonInteraction = {
+      customId: 'class-confirm:Warrior',
+      user: { id: '123' },
+      reply: jest.fn().mockResolvedValue()
+    };
+    userService.getUser.mockResolvedValueOnce({ discord_id: '123', class: null });
+    await game.handleClassButton(buttonInteraction);
+    expect(userService.setUserClass).toHaveBeenCalledWith('123', 'Warrior');
+    expect(buttonInteraction.reply).toHaveBeenCalled();
+  });
+
+  test('existing users receive already chosen message', async () => {
+    userService.getUser.mockResolvedValue({ discord_id: '123', class: 'Bard' });
+
+    const interaction = {
+      user: { id: '123' },
+      options: {},
+      reply: jest.fn().mockResolvedValue()
+    };
+
+    await game.execute(interaction);
+    expect(interaction.reply).toHaveBeenCalledWith(expect.objectContaining({ content: expect.stringContaining('cannot be changed') }));
+    expect(userService.createUser).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- add `userService` DB helpers
- provide class data derived from docs
- implement `/game` class onboarding workflow
- route select menus and buttons in index
- test onboarding flow and class persistence

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_685de07b70d08327998a3acbbae79d47