### PR TITLE
Add /who command

### DIFF
--- a/discord-bot/commands/who.js
+++ b/discord-bot/commands/who.js
@@ -1,0 +1,24 @@
+const { SlashCommandBuilder } = require('discord.js');
+const userService = require('../src/utils/userService');
+
+module.exports = {
+  data: new SlashCommandBuilder()
+    .setName('who')
+    .setDescription('Look up a player\'s class')
+    .addStringOption(option =>
+      option.setName('player').setDescription('Player name').setRequired(true)
+    ),
+  async execute(interaction) {
+    const playerName = interaction.options.getString('player');
+    const user = await userService.getUserByName(playerName);
+    if (!user) {
+      await interaction.reply({ content: `Could not find a player named ${playerName}.`, ephemeral: true });
+      return;
+    }
+    if (user.class) {
+      await interaction.reply({ content: `${user.name} - ${user.class}` });
+    } else {
+      await interaction.reply({ content: `${user.name} has not yet chosen a class.` });
+    }
+  }
+};

--- a/discord-bot/deploy-commands.js
+++ b/discord-bot/deploy-commands.js
@@ -5,6 +5,7 @@ require('dotenv').config();
 const commands = [];
 const commandDirs = [
   path.join(__dirname, 'commands/ping.js'),
+  path.join(__dirname, 'commands/who.js'),
   path.join(__dirname, 'src/commands/game.js')
 ];
 

--- a/discord-bot/src/utils/userService.js
+++ b/discord-bot/src/utils/userService.js
@@ -14,4 +14,9 @@ async function setUserClass(discordId, className) {
   await db.query('UPDATE users SET class = ? WHERE discord_id = ?', [className, discordId]);
 }
 
-module.exports = { getUser, createUser, setUserClass };
+async function getUserByName(name) {
+  const [rows] = await db.query('SELECT * FROM users WHERE LOWER(name) = LOWER(?)', [name]);
+  return rows[0] || null;
+}
+
+module.exports = { getUser, createUser, setUserClass, getUserByName };

--- a/discord-bot/tests/game.test.js
+++ b/discord-bot/tests/game.test.js
@@ -3,7 +3,8 @@ const game = require('../src/commands/game');
 jest.mock('../src/utils/userService', () => ({
   getUser: jest.fn(),
   createUser: jest.fn(),
-  setUserClass: jest.fn()
+  setUserClass: jest.fn(),
+  getUserByName: jest.fn()
 }));
 const userService = require('../src/utils/userService');
 

--- a/discord-bot/tests/who.test.js
+++ b/discord-bot/tests/who.test.js
@@ -1,0 +1,43 @@
+const who = require('../commands/who');
+
+jest.mock('../src/utils/userService', () => ({
+  getUserByName: jest.fn()
+}));
+const userService = require('../src/utils/userService');
+
+describe('who command', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('replies with class when user has class', async () => {
+    userService.getUserByName.mockResolvedValue({ name: 'Alice', class: 'Bard' });
+    const interaction = {
+      options: { getString: jest.fn().mockReturnValue('Alice') },
+      reply: jest.fn().mockResolvedValue()
+    };
+    await who.execute(interaction);
+    expect(userService.getUserByName).toHaveBeenCalledWith('Alice');
+    expect(interaction.reply).toHaveBeenCalledWith({ content: 'Alice - Bard' });
+  });
+
+  test('replies when user has no class', async () => {
+    userService.getUserByName.mockResolvedValue({ name: 'Bob', class: null });
+    const interaction = {
+      options: { getString: jest.fn().mockReturnValue('Bob') },
+      reply: jest.fn().mockResolvedValue()
+    };
+    await who.execute(interaction);
+    expect(interaction.reply).toHaveBeenCalledWith({ content: 'Bob has not yet chosen a class.' });
+  });
+
+  test('ephemeral reply when user not found', async () => {
+    userService.getUserByName.mockResolvedValue(null);
+    const interaction = {
+      options: { getString: jest.fn().mockReturnValue('Eve') },
+      reply: jest.fn().mockResolvedValue()
+    };
+    await who.execute(interaction);
+    expect(interaction.reply).toHaveBeenCalledWith({ content: 'Could not find a player named Eve.', ephemeral: true });
+  });
+});


### PR DESCRIPTION
## Summary
- implement `/who` command to find a player's class
- extend user service with `getUserByName`
- load command for slash registration
- update game tests for new mock and test new command

## Testing
- `npm test --silent` in discord-bot
- `npm test --silent` in backend

------
https://chatgpt.com/codex/tasks/task_e_685de735bfcc83279fed0740f43d5727