### PR TITLE
Add who command tests

### DIFF
--- a/discord-bot/commands/who.js
+++ b/discord-bot/commands/who.js
@@ -1,0 +1,25 @@
+const { SlashCommandBuilder } = require('discord.js');
+const userService = require('../src/utils/userService');
+
+const data = new SlashCommandBuilder()
+  .setName('who')
+  .setDescription('Display your current class');
+
+async function execute(interaction) {
+  try {
+    const user = await userService.getUser(interaction.user.id);
+    if (!user) {
+      await interaction.reply({ content: 'User not found. Try /game to get started.', ephemeral: true });
+      return;
+    }
+    if (!user.class) {
+      await interaction.reply({ content: 'You have not chosen a class yet.', ephemeral: true });
+      return;
+    }
+    await interaction.reply({ content: `You are a **${user.class}**.` });
+  } catch (err) {
+    await interaction.reply({ content: 'Failed to look up user.', ephemeral: true });
+  }
+}
+
+module.exports = { data, execute };

--- a/discord-bot/deploy-commands.js
+++ b/discord-bot/deploy-commands.js
@@ -5,6 +5,7 @@ require('dotenv').config();
 const commands = [];
 const commandDirs = [
   path.join(__dirname, 'commands/ping.js'),
+  path.join(__dirname, 'commands/who.js'),
   path.join(__dirname, 'src/commands/game.js')
 ];
 

--- a/discord-bot/tests/who.test.js
+++ b/discord-bot/tests/who.test.js
@@ -1,0 +1,34 @@
+const who = require('../commands/who');
+
+jest.mock('../src/utils/userService', () => ({
+  getUser: jest.fn()
+}));
+const userService = require('../src/utils/userService');
+
+describe('who command', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('public reply when user has a class', async () => {
+    userService.getUser.mockResolvedValue({ discord_id: '123', class: 'Mage' });
+    const interaction = { user: { id: '123' }, reply: jest.fn().mockResolvedValue() };
+    await who.execute(interaction);
+    expect(interaction.reply).toHaveBeenCalledWith(expect.objectContaining({ content: expect.stringContaining('Mage') }));
+    expect(interaction.reply.mock.calls[0][0].ephemeral).toBeUndefined();
+  });
+
+  test('ephemeral reply when user lacks a class', async () => {
+    userService.getUser.mockResolvedValue({ discord_id: '123', class: null });
+    const interaction = { user: { id: '123' }, reply: jest.fn().mockResolvedValue() };
+    await who.execute(interaction);
+    expect(interaction.reply).toHaveBeenCalledWith(expect.objectContaining({ ephemeral: true }));
+  });
+
+  test('ephemeral reply on lookup failure', async () => {
+    userService.getUser.mockRejectedValue(new Error('fail'));
+    const interaction = { user: { id: '123' }, reply: jest.fn().mockResolvedValue() };
+    await who.execute(interaction);
+    expect(interaction.reply).toHaveBeenCalledWith(expect.objectContaining({ ephemeral: true }));
+  });
+});


### PR DESCRIPTION
## Summary
- add a `who` command that fetches player data
- include the new command when deploying slash commands
- test `who` command responses with mocked `userService`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685de7de64e08327804832619ad4047f