### PR TITLE
Restore who command and add adventure placeholder

### DIFF
--- a/discord-bot/deploy-commands.js
+++ b/discord-bot/deploy-commands.js
@@ -6,7 +6,8 @@ const commands = [];
 const commandDirs = [
   path.join(__dirname, 'commands/ping.js'),
   path.join(__dirname, 'commands/who.js'),
-  path.join(__dirname, 'src/commands/game.js')
+  path.join(__dirname, 'src/commands/game.js'),
+  path.join(__dirname, 'src/commands/adventure.js')
 ];
 
 console.log('Registering slash commands:', commandDirs.map(f => path.basename(f)).join(', '));

--- a/discord-bot/src/commands/adventure.js
+++ b/discord-bot/src/commands/adventure.js
@@ -1,0 +1,11 @@
+const { SlashCommandBuilder } = require('discord.js');
+
+const data = new SlashCommandBuilder()
+  .setName('adventure')
+  .setDescription('Embark on an adventure');
+
+async function execute(interaction) {
+  await interaction.reply({ content: 'Adventure command not implemented yet.', ephemeral: true });
+}
+
+module.exports = { data, execute };


### PR DESCRIPTION
## Summary
- include `/who` when deploying slash commands
- add placeholder `/adventure` command so deploy succeeds

## Testing
- `npm install`
- `node deploy-commands.js` *(fails: Expected token to be set for this request)*

------
https://chatgpt.com/codex/tasks/task_e_685de99db00c8327a3bf119083ab971e