### PR TITLE
Add adventure command

### DIFF
--- a/discord-bot/src/commands/adventure.js
+++ b/discord-bot/src/commands/adventure.js
@@ -1,11 +1,43 @@
 const { SlashCommandBuilder } = require('discord.js');
+const { simple } = require('../utils/embedBuilder');
+const userService = require('../utils/userService');
+const GameEngine = require('../../../backend/game/engine');
+const { createCombatant } = require('../../../backend/game/utils');
+const { allPossibleHeroes } = require('../../../backend/game/data');
 
 const data = new SlashCommandBuilder()
   .setName('adventure')
-  .setDescription('Embark on an adventure');
+  .setDescription('Fight a practice battle against a goblin');
 
 async function execute(interaction) {
-  await interaction.reply({ content: 'Adventure command not implemented yet.', ephemeral: true });
+  const user = await userService.getUser(interaction.user.id);
+
+  if (!user || !user.class) {
+    await interaction.reply({ content: 'You must choose a class before adventuring. Use `/game` to pick one!', ephemeral: true });
+    return;
+  }
+
+  const playerHero = allPossibleHeroes.find(h => (h.class === user.class || h.name === user.class) && h.isBase);
+  const goblinHero = allPossibleHeroes.find(h => h.name === 'Goblin');
+
+  if (!playerHero || !goblinHero) {
+    await interaction.reply({ content: 'Required hero data missing.', ephemeral: true });
+    return;
+  }
+
+  const player = createCombatant({ hero_id: playerHero.id }, 'player', 0);
+  const goblin = createCombatant({ hero_id: goblinHero.id }, 'enemy', 0);
+
+  await interaction.reply({ content: `⚔️ ${playerHero.name} engages a Goblin!` });
+
+  const engine = new GameEngine([player, goblin]);
+  const log = engine.runFullGame();
+
+  const outcome = engine.winner === 'player' ? 'Victory!' : 'Defeat!';
+  const logText = log.concat(outcome).join('\n');
+  const embed = simple(outcome, [{ name: 'Battle Log', value: logText }]);
+
+  await interaction.followUp({ embeds: [embed] });
 }
 
 module.exports = { data, execute };

--- a/discord-bot/tests/adventure.test.js
+++ b/discord-bot/tests/adventure.test.js
@@ -1,0 +1,27 @@
+const adventure = require('../src/commands/adventure');
+
+jest.mock('../src/utils/userService', () => ({
+  getUser: jest.fn()
+}));
+const userService = require('../src/utils/userService');
+
+describe('adventure command', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('ephemeral reply when user lacks a class', async () => {
+    userService.getUser.mockResolvedValue({ discord_id: '123', class: null });
+    const interaction = { user: { id: '123' }, reply: jest.fn().mockResolvedValue() };
+    await adventure.execute(interaction);
+    expect(interaction.reply).toHaveBeenCalledWith(expect.objectContaining({ ephemeral: true }));
+  });
+
+  test('battle runs when user has a class', async () => {
+    userService.getUser.mockResolvedValue({ discord_id: '123', class: 'Warrior' });
+    const interaction = { user: { id: '123' }, reply: jest.fn().mockResolvedValue(), followUp: jest.fn().mockResolvedValue() };
+    await adventure.execute(interaction);
+    expect(interaction.reply).toHaveBeenCalledWith(expect.objectContaining({ content: expect.stringContaining('Goblin') }));
+    expect(interaction.followUp).toHaveBeenCalledWith(expect.objectContaining({ embeds: expect.any(Array) }));
+  });
+});


### PR DESCRIPTION
## Summary
- expand `adventure` command into a working battle simulator
- add tests covering the new command

## Testing
- `npm test` in `backend`
- `npm test` in `discord-bot`


------
https://chatgpt.com/codex/tasks/task_e_685dec0427fc83279689fd37c1ca6ea8