### PR TITLE
Update /who command to use user mentions

### DIFF
--- a/discord-bot/README.md
+++ b/discord-bot/README.md
@@ -40,13 +40,13 @@ After confirmation the champion is saved to your roster and you can explore the 
 
 ## Using `/who`
 
-`/who` displays the champion bound to a Discord user. The command is case‑insensitive and accepts an optional user mention:
+`/who` displays the champion bound to a Discord user. You must mention the target player:
 
 ```bash
 /who @SomePlayer
 ```
 
-If no user is provided, the bot looks up your own champion. A successful lookup replies with a short embed summarizing that player's class and level. When the target has not created a character yet you will see `That player has no champion.`
+The command replies with that player's class. If they have not started the game you will see `@SomePlayer has not started their adventure yet.`
 
 Example output:
 

--- a/discord-bot/commands/who.js
+++ b/discord-bot/commands/who.js
@@ -3,19 +3,19 @@ const userService = require('../src/utils/userService');
 
 const data = new SlashCommandBuilder()
   .setName('who')
-  .setDescription('Look up a player by name')
-  .addStringOption(option =>
-    option.setName('player')
-      .setDescription('Player name')
+  .setDescription('Look up a player by mention')
+  .addUserOption(option =>
+    option.setName('user')
+      .setDescription('Discord user to look up')
       .setRequired(true)
   );
 
 async function execute(interaction) {
-  const searchName = interaction.options.getString('player');
-  const user = await userService.getUserByName(searchName);
+  const mentionedUser = interaction.options.getUser('user');
+  const user = await userService.getUser(mentionedUser.id);
 
   if (!user) {
-    await interaction.reply({ content: `Could not find a player named ${searchName}.`, ephemeral: true });
+    await interaction.reply({ content: `@${mentionedUser.username} has not started their adventure yet.`, ephemeral: true });
     return;
   }
 

--- a/discord-bot/tests/who.test.js
+++ b/discord-bot/tests/who.test.js
@@ -1,7 +1,7 @@
 const who = require('../commands/who');
 
 jest.mock('../src/utils/userService', () => ({
-  getUserByName: jest.fn()
+  getUser: jest.fn()
 }));
 const userService = require('../src/utils/userService');
 
@@ -11,9 +11,9 @@ describe('who command', () => {
   });
 
   test('public reply when user has a class', async () => {
-    userService.getUserByName.mockResolvedValue({ name: 'Tester', class: 'Mage' });
+    userService.getUser.mockResolvedValue({ name: 'Tester', class: 'Mage' });
     const interaction = {
-      options: { getString: jest.fn().mockReturnValue('tester') },
+      options: { getUser: jest.fn().mockReturnValue({ id: '123', username: 'Tester' }) },
       reply: jest.fn().mockResolvedValue()
     };
     await who.execute(interaction);
@@ -22,9 +22,9 @@ describe('who command', () => {
   });
 
   test('public reply when user lacks a class', async () => {
-    userService.getUserByName.mockResolvedValue({ name: 'Tester', class: null });
+    userService.getUser.mockResolvedValue({ name: 'Tester', class: null });
     const interaction = {
-      options: { getString: jest.fn().mockReturnValue('tester') },
+      options: { getUser: jest.fn().mockReturnValue({ id: '123', username: 'Tester' }) },
       reply: jest.fn().mockResolvedValue()
     };
     await who.execute(interaction);
@@ -33,9 +33,9 @@ describe('who command', () => {
   });
 
   test('ephemeral reply on lookup failure', async () => {
-    userService.getUserByName.mockResolvedValue(null);
+    userService.getUser.mockResolvedValue(null);
     const interaction = {
-      options: { getString: jest.fn().mockReturnValue('tester') },
+      options: { getUser: jest.fn().mockReturnValue({ id: '123', username: 'Tester' }) },
       reply: jest.fn().mockResolvedValue()
     };
     await who.execute(interaction);


### PR DESCRIPTION
## Summary
- look up players via user mention instead of by string
- update tests to mock `getUser`
- document `/who` mention requirement in README

## Testing
- `npm test --silent` in `discord-bot`
- `npm test --silent` in `backend`

------
https://chatgpt.com/codex/tasks/task_e_685dec77cb50832793439565d514386c