### PR TITLE
Improve /who command embed

### DIFF
--- a/discord-bot/README.md
+++ b/discord-bot/README.md
@@ -46,10 +46,11 @@ After confirmation the champion is saved to your roster and you can explore the 
 /who @SomePlayer
 ```
 
-The command replies with that player's class. If they have not started the game you will see `@SomePlayer has not started their adventure yet.`
+The command replies with a styled embed showing the player's name and class. If the player has not started the game or has not chosen a class, the embed will display that message instead.
 
 Example output:
 
 ```
-@SomePlayer – Level 3 Barbarian
+Player Details
+Player: SomePlayer - Bard
 ```

--- a/discord-bot/commands/who.js
+++ b/discord-bot/commands/who.js
@@ -1,4 +1,5 @@
 const { SlashCommandBuilder } = require('discord.js');
+const { simple } = require('../src/utils/embedBuilder');
 const userService = require('../src/utils/userService');
 
 const data = new SlashCommandBuilder()
@@ -15,16 +16,28 @@ async function execute(interaction) {
   const user = await userService.getUser(mentionedUser.id);
 
   if (!user) {
-    await interaction.reply({ content: `@${mentionedUser.username} has not started their adventure yet.`, ephemeral: true });
+    const embed = simple('Player Details', [{
+      name: 'Player',
+      value: `@${mentionedUser.username} has not started their adventure yet.`
+    }], mentionedUser.displayAvatarURL());
+    await interaction.reply({ embeds: [embed], ephemeral: true });
     return;
   }
 
   if (!user.class) {
-    await interaction.reply({ content: `${user.name} has not yet chosen a class.` });
+    const embed = simple('Player Details', [{
+      name: 'Player',
+      value: `${user.name} has not yet chosen a class.`
+    }], mentionedUser.displayAvatarURL());
+    await interaction.reply({ embeds: [embed] });
     return;
   }
 
-  await interaction.reply({ content: `${user.name} - ${user.class}` });
+  const embed = simple('Player Details', [{
+    name: 'Player',
+    value: `${user.name} - ${user.class}`
+  }], mentionedUser.displayAvatarURL());
+  await interaction.reply({ embeds: [embed] });
 }
 
 module.exports = { data, execute };

--- a/discord-bot/tests/who.test.js
+++ b/discord-bot/tests/who.test.js
@@ -13,32 +13,32 @@ describe('who command', () => {
   test('public reply when user has a class', async () => {
     userService.getUser.mockResolvedValue({ name: 'Tester', class: 'Mage' });
     const interaction = {
-      options: { getUser: jest.fn().mockReturnValue({ id: '123', username: 'Tester' }) },
+      options: { getUser: jest.fn().mockReturnValue({ id: '123', username: 'Tester', displayAvatarURL: jest.fn().mockReturnValue('https://example.com/avatar.png') }) },
       reply: jest.fn().mockResolvedValue()
     };
     await who.execute(interaction);
-    expect(interaction.reply).toHaveBeenCalledWith(expect.objectContaining({ content: 'Tester - Mage' }));
+    expect(interaction.reply).toHaveBeenCalledWith(expect.objectContaining({ embeds: expect.any(Array) }));
     expect(interaction.reply.mock.calls[0][0].ephemeral).toBeUndefined();
   });
 
   test('public reply when user lacks a class', async () => {
     userService.getUser.mockResolvedValue({ name: 'Tester', class: null });
     const interaction = {
-      options: { getUser: jest.fn().mockReturnValue({ id: '123', username: 'Tester' }) },
+      options: { getUser: jest.fn().mockReturnValue({ id: '123', username: 'Tester', displayAvatarURL: jest.fn().mockReturnValue('https://example.com/avatar.png') }) },
       reply: jest.fn().mockResolvedValue()
     };
     await who.execute(interaction);
-    expect(interaction.reply).toHaveBeenCalledWith(expect.objectContaining({ content: 'Tester has not yet chosen a class.' }));
+    expect(interaction.reply).toHaveBeenCalledWith(expect.objectContaining({ embeds: expect.any(Array) }));
     expect(interaction.reply.mock.calls[0][0].ephemeral).toBeUndefined();
   });
 
   test('ephemeral reply on lookup failure', async () => {
     userService.getUser.mockResolvedValue(null);
     const interaction = {
-      options: { getUser: jest.fn().mockReturnValue({ id: '123', username: 'Tester' }) },
+      options: { getUser: jest.fn().mockReturnValue({ id: '123', username: 'Tester', displayAvatarURL: jest.fn().mockReturnValue('https://example.com/avatar.png') }) },
       reply: jest.fn().mockResolvedValue()
     };
     await who.execute(interaction);
-    expect(interaction.reply).toHaveBeenCalledWith(expect.objectContaining({ ephemeral: true }));
+    expect(interaction.reply).toHaveBeenCalledWith(expect.objectContaining({ ephemeral: true, embeds: expect.any(Array) }));
   });
 });


### PR DESCRIPTION
## Summary
- enhance `/who` command to use embed with avatar
- update who command tests for embed response
- document `/who` embed output in README

## Testing
- `npm install` within `discord-bot`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685deebae2f48327843dc38f6198d1d4