### PR TITLE
Implement goblin cave adventure command

### DIFF
--- a/discord-bot/src/commands/adventure.js
+++ b/discord-bot/src/commands/adventure.js
@@ -1,11 +1,63 @@
-const { SlashCommandBuilder } = require('discord.js');
+const { SlashCommandBuilder, EmbedBuilder } = require('discord.js');
+const path = require('node:path');
+const userService = require('../utils/userService');
+
+const GameEngine = require(path.join(__dirname, '../../..', 'backend/game/engine'));
+const { createCombatant } = require(path.join(__dirname, '../../..', 'backend/game/utils'));
+const { allPossibleHeroes, allPossibleAbilities } = require(path.join(__dirname, '../../..', 'backend/game/data'));
 
 const data = new SlashCommandBuilder()
   .setName('adventure')
-  .setDescription('Embark on an adventure');
+  .setDescription('Embark on a practice battle in the goblin cave');
+
+function getBaseHeroByClass(cls) {
+  return allPossibleHeroes.find(h => h.class === cls && h.isBase);
+}
+
+function pickRandomBaseHero() {
+  const bases = allPossibleHeroes.filter(h => h.isBase);
+  return bases[Math.floor(Math.random() * bases.length)];
+}
 
 async function execute(interaction) {
-  await interaction.reply({ content: 'Adventure command not implemented yet.', ephemeral: true });
+  const user = await userService.getUser(interaction.user.id);
+
+  if (!user || !user.class) {
+    await interaction.reply({
+      content: 'You must select a class before you can go on an adventure! Use the /game select command to get started.',
+      ephemeral: true
+    });
+    return;
+  }
+
+  const playerBase = getBaseHeroByClass(user.class);
+  if (!playerBase) {
+    await interaction.reply({ content: 'Your selected class data could not be found.', ephemeral: true });
+    return;
+  }
+
+  const player = createCombatant({ hero_id: playerBase.id, weapon_id: null, armor_id: null, ability_id: null, deck: [] }, 'player', 0);
+
+  const randomBase = pickRandomBaseHero();
+  const abilityPool = allPossibleAbilities.filter(a => a.class === randomBase.class && a.rarity === 'Common');
+  const goblinDeck = abilityPool.map(a => a.id);
+  const goblin = createCombatant({ hero_id: randomBase.id, weapon_id: null, armor_id: null, ability_id: null, deck: goblinDeck }, 'enemy', 0);
+  goblin.heroData = { ...goblin.heroData, name: `Goblin ${randomBase.class}` };
+
+  await interaction.reply(`${interaction.user.username} delves into the goblin cave and encounters a ferocious ${goblin.heroData.name}! The battle begins!`);
+
+  const engine = new GameEngine([player, goblin]);
+  const log = engine.runFullGame();
+  const resultText = engine.winner === 'player' ? 'Victory!' : 'Defeat!';
+  log.push(resultText);
+
+  const embed = new EmbedBuilder()
+    .setColor(engine.winner === 'player' ? 0x4caf50 : 0xf44336)
+    .setTitle('Battle Log')
+    .setDescription(log.join('\n'))
+    .setTimestamp();
+
+  await interaction.followUp({ embeds: [embed] });
 }
 
 module.exports = { data, execute };

--- a/discord-bot/tests/adventure.test.js
+++ b/discord-bot/tests/adventure.test.js
@@ -1,0 +1,28 @@
+const adventure = require('../src/commands/adventure');
+
+jest.mock('../src/utils/userService', () => ({
+  getUser: jest.fn()
+}));
+
+const userService = require('../src/utils/userService');
+
+describe('adventure command', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('requires class selection', async () => {
+    userService.getUser.mockResolvedValue(null);
+    const interaction = { user: { id: '1' }, reply: jest.fn().mockResolvedValue() };
+    await adventure.execute(interaction);
+    expect(interaction.reply).toHaveBeenCalledWith(expect.objectContaining({ ephemeral: true }));
+  });
+
+  test('runs battle when class selected', async () => {
+    userService.getUser.mockResolvedValue({ discord_id: '1', class: 'Warrior' });
+    const interaction = { user: { id: '1', username: 'Tester' }, reply: jest.fn().mockResolvedValue(), followUp: jest.fn().mockResolvedValue() };
+    await adventure.execute(interaction);
+    expect(interaction.reply).toHaveBeenCalledWith(expect.stringContaining('goblin cave'));
+    expect(interaction.followUp).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- implement `/adventure` command
- add tests for the adventure command

## Testing
- `npm test --prefix backend`
- `npm test --prefix discord-bot`


------
https://chatgpt.com/codex/tasks/task_e_685dedd015148327ba541b0a6077d8dd