### PR TITLE
Implement /inventory command

### DIFF
--- a/discord-bot/commands/inventory.js
+++ b/discord-bot/commands/inventory.js
@@ -1,0 +1,32 @@
+const { SlashCommandBuilder } = require('discord.js');
+const { simple } = require('../src/utils/embedBuilder');
+const userService = require('../src/utils/userService');
+
+const data = new SlashCommandBuilder()
+  .setName('inventory')
+  .setDescription("Display your current status and backpack");
+
+async function execute(interaction) {
+  const user = await userService.getUser(interaction.user.id);
+
+  if (!user || !user.class) {
+    await interaction.reply({
+      content: 'You must select a class first! Use /game select to begin your adventure.',
+      ephemeral: true
+    });
+    return;
+  }
+
+  const embed = simple(
+    'Player Inventory',
+    [
+      { name: 'Player', value: `${user.name} - ${user.class}` },
+      { name: 'Backpack', value: 'Your backpack is empty.' }
+    ],
+    interaction.user.displayAvatarURL()
+  );
+
+  await interaction.reply({ embeds: [embed] });
+}
+
+module.exports = { data, execute };

--- a/discord-bot/deploy-commands.js
+++ b/discord-bot/deploy-commands.js
@@ -6,6 +6,7 @@ const commands = [];
 const commandDirs = [
   path.join(__dirname, 'commands/ping.js'),
   path.join(__dirname, 'commands/who.js'),
+  path.join(__dirname, 'commands/inventory.js'),
   path.join(__dirname, 'src/commands/game.js'),
   path.join(__dirname, 'src/commands/adventure.js')
 ];

--- a/discord-bot/tests/inventory.test.js
+++ b/discord-bot/tests/inventory.test.js
@@ -1,0 +1,43 @@
+const inventory = require('../commands/inventory');
+
+jest.mock('../src/utils/userService', () => ({
+  getUser: jest.fn()
+}));
+const userService = require('../src/utils/userService');
+
+describe('inventory command', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('public reply when user has a class', async () => {
+    userService.getUser.mockResolvedValue({ name: 'Tester', class: 'Warrior' });
+    const interaction = {
+      user: { id: '123', displayAvatarURL: jest.fn().mockReturnValue('https://example.com/avatar.png') },
+      reply: jest.fn().mockResolvedValue()
+    };
+    await inventory.execute(interaction);
+    expect(interaction.reply).toHaveBeenCalledWith(expect.objectContaining({ embeds: expect.any(Array) }));
+    expect(interaction.reply.mock.calls[0][0].ephemeral).toBeUndefined();
+  });
+
+  test('ephemeral reply when user lacks a class', async () => {
+    userService.getUser.mockResolvedValue({ name: 'Tester', class: null });
+    const interaction = {
+      user: { id: '123', displayAvatarURL: jest.fn().mockReturnValue('https://example.com/avatar.png') },
+      reply: jest.fn().mockResolvedValue()
+    };
+    await inventory.execute(interaction);
+    expect(interaction.reply).toHaveBeenCalledWith(expect.objectContaining({ ephemeral: true }));
+  });
+
+  test('ephemeral reply when user not found', async () => {
+    userService.getUser.mockResolvedValue(null);
+    const interaction = {
+      user: { id: '123', displayAvatarURL: jest.fn().mockReturnValue('https://example.com/avatar.png') },
+      reply: jest.fn().mockResolvedValue()
+    };
+    await inventory.execute(interaction);
+    expect(interaction.reply).toHaveBeenCalledWith(expect.objectContaining({ ephemeral: true }));
+  });
+});


### PR DESCRIPTION
## Summary
- create `/inventory` command returning a Player Inventory embed
- register command in deploy script
- add Jest tests for the new command

## Testing
- `npm test --silent --prefix discord-bot`

------
https://chatgpt.com/codex/tasks/task_e_685df2bcfffc8327a1442b7995a9b2e7