### PR TITLE
Add user ability card table and migration notes

### DIFF
--- a/discord-bot/README.md
+++ b/discord-bot/README.md
@@ -54,3 +54,15 @@ Example output:
 Player Details
 Player: SomePlayer - Bard
 ```
+
+## Database Migration
+
+The updated schema introduces a `user_ability_cards` table and a new
+`equipped_ability_id` column on `users`.
+
+1. Run the statements in `db-schema.sql` against your MySQL database.
+2. For existing installs, create a `user_ability_cards` row for each
+   player's current ability and update `users.equipped_ability_id` to
+   point to that card.
+
+New deployments only need to execute the schema file.

--- a/discord-bot/db-schema.sql
+++ b/discord-bot/db-schema.sql
@@ -8,6 +8,20 @@ CREATE TABLE IF NOT EXISTS users (
     class VARCHAR(50) DEFAULT NULL
 );
 
+-- Ability cards owned by users
+CREATE TABLE IF NOT EXISTS user_ability_cards (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    user_id INT NOT NULL,
+    ability_id INT NOT NULL,
+    charges INT DEFAULT 10,
+    FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
+);
+
+-- Equipped ability reference
+ALTER TABLE users
+    ADD COLUMN equipped_ability_id INT DEFAULT NULL,
+    ADD FOREIGN KEY (equipped_ability_id) REFERENCES user_ability_cards(id);
+
 -- Champions owned by users
 CREATE TABLE IF NOT EXISTS user_champions (
     id INT AUTO_INCREMENT PRIMARY KEY,


### PR DESCRIPTION
## Summary
- create `user_ability_cards` table and link `users.equipped_ability_id`
- document how to run the migration in Discord bot README

## Testing
- `npm install` (to install test deps)
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685eb13b7d748327ae8a0966bdf472af