### PR TITLE
Display ability cards in inventory

### DIFF
--- a/discord-bot/commands/inventory.js
+++ b/discord-bot/commands/inventory.js
@@ -1,6 +1,7 @@
 const { SlashCommandBuilder } = require('discord.js');
 const { simple } = require('../src/utils/embedBuilder');
 const userService = require('../src/utils/userService');
+const abilityCardService = require('../src/utils/abilityCardService');
 
 const data = new SlashCommandBuilder()
   .setName('inventory')
@@ -17,14 +18,20 @@ async function execute(interaction) {
     return;
   }
 
-  const embed = simple(
-    'Player Inventory',
-    [
-      { name: 'Player', value: `${user.name} - ${user.class}` },
-      { name: 'Backpack', value: 'Your backpack is empty.' }
-    ],
-    interaction.user.displayAvatarURL()
-  );
+  const cards = await abilityCardService.getAbilityCards(interaction.user.id);
+  const equipped = await abilityCardService.getEquippedAbility(interaction.user.id);
+
+  const backpackValue = cards.length
+    ? cards.map(c => `${c.name} ${c.charges}/10`).join('\n')
+    : 'Your backpack is empty.';
+
+  const fields = [
+    { name: 'Player', value: `${user.name} - ${user.class}` },
+    { name: 'Equipped Ability', value: equipped ? `${equipped.name} ${equipped.charges}/10` : 'None' },
+    { name: 'Backpack', value: backpackValue }
+  ];
+
+  const embed = simple('Player Inventory', fields, interaction.user.displayAvatarURL());
 
   await interaction.reply({ embeds: [embed] });
 }

--- a/discord-bot/src/utils/abilityCardService.js
+++ b/discord-bot/src/utils/abilityCardService.js
@@ -1,0 +1,16 @@
+const cardsByUser = new Map();
+
+async function getAbilityCards(discordId) {
+  return cardsByUser.get(discordId) || [];
+}
+
+async function getEquippedAbility(discordId) {
+  const cards = await getAbilityCards(discordId);
+  return cards.find(c => c.equipped) || null;
+}
+
+function __setCards(discordId, cards) {
+  cardsByUser.set(discordId, cards);
+}
+
+module.exports = { getAbilityCards, getEquippedAbility, __setCards };

--- a/discord-bot/tests/inventory.test.js
+++ b/discord-bot/tests/inventory.test.js
@@ -5,6 +5,12 @@ jest.mock('../src/utils/userService', () => ({
 }));
 const userService = require('../src/utils/userService');
 
+jest.mock('../src/utils/abilityCardService', () => ({
+  getAbilityCards: jest.fn(),
+  getEquippedAbility: jest.fn()
+}));
+const abilityCardService = require('../src/utils/abilityCardService');
+
 describe('inventory command', () => {
   beforeEach(() => {
     jest.clearAllMocks();
@@ -12,6 +18,8 @@ describe('inventory command', () => {
 
   test('public reply when user has a class', async () => {
     userService.getUser.mockResolvedValue({ name: 'Tester', class: 'Warrior' });
+    abilityCardService.getAbilityCards.mockResolvedValue([{ name: 'Shield Bash', charges: 5 }]);
+    abilityCardService.getEquippedAbility.mockResolvedValue({ name: 'Shield Bash', charges: 5, equipped: true });
     const interaction = {
       user: { id: '123', displayAvatarURL: jest.fn().mockReturnValue('https://example.com/avatar.png') },
       reply: jest.fn().mockResolvedValue()
@@ -19,6 +27,8 @@ describe('inventory command', () => {
     await inventory.execute(interaction);
     expect(interaction.reply).toHaveBeenCalledWith(expect.objectContaining({ embeds: expect.any(Array) }));
     expect(interaction.reply.mock.calls[0][0].ephemeral).toBeUndefined();
+    expect(abilityCardService.getAbilityCards).toHaveBeenCalledWith('123');
+    expect(abilityCardService.getEquippedAbility).toHaveBeenCalledWith('123');
   });
 
   test('ephemeral reply when user lacks a class', async () => {
@@ -29,6 +39,8 @@ describe('inventory command', () => {
     };
     await inventory.execute(interaction);
     expect(interaction.reply).toHaveBeenCalledWith(expect.objectContaining({ ephemeral: true }));
+    expect(abilityCardService.getAbilityCards).not.toHaveBeenCalled();
+    expect(abilityCardService.getEquippedAbility).not.toHaveBeenCalled();
   });
 
   test('ephemeral reply when user not found', async () => {
@@ -39,5 +51,7 @@ describe('inventory command', () => {
     };
     await inventory.execute(interaction);
     expect(interaction.reply).toHaveBeenCalledWith(expect.objectContaining({ ephemeral: true }));
+    expect(abilityCardService.getAbilityCards).not.toHaveBeenCalled();
+    expect(abilityCardService.getEquippedAbility).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary
- list ability cards with charges in `/inventory`
- show the currently equipped ability
- add a simple in-memory `abilityCardService`
- extend inventory tests to mock ability cards

## Testing
- `npm install`
- `npx jest --runInBand`

------
https://chatgpt.com/codex/tasks/task_e_685eb13dd6b883279cf8d0fe86cca718