### PR TITLE
Add ability equip subcommand to inventory

### DIFF
--- a/discord-bot/commands/inventory.js
+++ b/discord-bot/commands/inventory.js
@@ -1,10 +1,25 @@
-const { SlashCommandBuilder } = require('discord.js');
+const { SlashCommandBuilder, ActionRowBuilder, StringSelectMenuBuilder } = require('discord.js');
 const { simple } = require('../src/utils/embedBuilder');
 const userService = require('../src/utils/userService');
+const abilityCardService = require('../src/utils/abilityCardService');
 
 const data = new SlashCommandBuilder()
   .setName('inventory')
-  .setDescription("Display your current status and backpack");
+  .setDescription('Manage your inventory')
+  .addSubcommand(sub =>
+    sub
+      .setName('view')
+      .setDescription('Display your current status and backpack'))
+  .addSubcommand(sub =>
+    sub
+      .setName('equip')
+      .setDescription('Equip an ability card')
+      .addIntegerOption(opt =>
+        opt
+          .setName('ability')
+          .setDescription('Ability id to equip')
+          .setRequired(true)
+      ));
 
 async function execute(interaction) {
   const user = await userService.getUser(interaction.user.id);
@@ -17,16 +32,46 @@ async function execute(interaction) {
     return;
   }
 
-  const embed = simple(
-    'Player Inventory',
-    [
-      { name: 'Player', value: `${user.name} - ${user.class}` },
-      { name: 'Backpack', value: 'Your backpack is empty.' }
-    ],
-    interaction.user.displayAvatarURL()
-  );
+  const sub = interaction.options.getSubcommand();
 
-  await interaction.reply({ embeds: [embed] });
+  if (sub === 'view') {
+    const embed = simple(
+      'Player Inventory',
+      [
+        { name: 'Player', value: `${user.name} - ${user.class}` },
+        { name: 'Backpack', value: 'Your backpack is empty.' }
+      ],
+      interaction.user.displayAvatarURL()
+    );
+
+    await interaction.reply({ embeds: [embed] });
+  } else if (sub === 'equip') {
+    const abilityId = interaction.options.getInteger('ability');
+    const cards = await abilityCardService.getCardsByAbility(interaction.user.id, abilityId);
+
+    if (!cards.length) {
+      await interaction.reply({ content: 'You do not own any copies of that ability.', ephemeral: true });
+      return;
+    }
+
+    const menu = new StringSelectMenuBuilder()
+      .setCustomId(`equip-ability:${abilityId}`)
+      .setPlaceholder('Select a card');
+
+    cards.forEach(card => {
+      menu.addOptions({ label: `${card.name} ${card.charges}/10`, value: String(card.id) });
+    });
+
+    const row = new ActionRowBuilder().addComponents(menu);
+
+    await interaction.reply({ content: 'Choose a card to equip:', components: [row], ephemeral: true });
+  }
 }
 
-module.exports = { data, execute };
+async function handleEquipSelect(interaction) {
+  const cardId = interaction.values[0];
+  await abilityCardService.setEquippedCard(interaction.user.id, cardId);
+  await interaction.update({ content: 'Equipped new ability card.', components: [] });
+}
+
+module.exports = { data, execute, handleEquipSelect };

--- a/discord-bot/index.js
+++ b/discord-bot/index.js
@@ -7,6 +7,7 @@ const client = new Client({ intents: [GatewayIntentBits.Guilds] });
 client.commands = new Collection();
 
 const gameHandlers = require('./src/commands/game');
+const inventoryHandlers = require('./commands/inventory');
 
 const commandDirs = [
   path.join(__dirname, 'commands'),
@@ -47,6 +48,8 @@ client.on(Events.InteractionCreate, async interaction => {
   } else if (interaction.isStringSelectMenu()) {
     if (interaction.customId === 'class-select') {
       await gameHandlers.handleClassSelect(interaction);
+    } else if (interaction.customId.startsWith('equip-ability')) {
+      await inventoryHandlers.handleEquipSelect(interaction);
     }
   } else if (interaction.isButton()) {
     if (interaction.customId.startsWith('class-confirm') || interaction.customId === 'class-choose-again') {

--- a/discord-bot/src/utils/abilityCardService.js
+++ b/discord-bot/src/utils/abilityCardService.js
@@ -1,0 +1,25 @@
+const db = require('../../util/database');
+
+async function getCardsByAbility(discordId, abilityId) {
+  const [rows] = await db.query(
+    `SELECT ac.id, ac.ability_id, ac.charges, a.name
+     FROM ability_cards ac
+     JOIN users u ON ac.user_id = u.id
+     JOIN abilities a ON ac.ability_id = a.id
+     WHERE u.discord_id = ? AND ac.ability_id = ?`,
+    [discordId, abilityId]
+  );
+  return rows;
+}
+
+async function setEquippedCard(discordId, cardId) {
+  await db.query(
+    `UPDATE user_champions uc
+     JOIN users u ON uc.user_id = u.id
+     SET uc.equipped_ability_id = ?
+     WHERE u.discord_id = ?`,
+    [cardId, discordId]
+  );
+}
+
+module.exports = { getCardsByAbility, setEquippedCard };

--- a/discord-bot/tests/inventory.test.js
+++ b/discord-bot/tests/inventory.test.js
@@ -14,6 +14,7 @@ describe('inventory command', () => {
     userService.getUser.mockResolvedValue({ name: 'Tester', class: 'Warrior' });
     const interaction = {
       user: { id: '123', displayAvatarURL: jest.fn().mockReturnValue('https://example.com/avatar.png') },
+      options: { getSubcommand: jest.fn().mockReturnValue('view') },
       reply: jest.fn().mockResolvedValue()
     };
     await inventory.execute(interaction);
@@ -25,6 +26,7 @@ describe('inventory command', () => {
     userService.getUser.mockResolvedValue({ name: 'Tester', class: null });
     const interaction = {
       user: { id: '123', displayAvatarURL: jest.fn().mockReturnValue('https://example.com/avatar.png') },
+      options: { getSubcommand: jest.fn().mockReturnValue('view') },
       reply: jest.fn().mockResolvedValue()
     };
     await inventory.execute(interaction);
@@ -35,6 +37,7 @@ describe('inventory command', () => {
     userService.getUser.mockResolvedValue(null);
     const interaction = {
       user: { id: '123', displayAvatarURL: jest.fn().mockReturnValue('https://example.com/avatar.png') },
+      options: { getSubcommand: jest.fn().mockReturnValue('view') },
       reply: jest.fn().mockResolvedValue()
     };
     await inventory.execute(interaction);


### PR DESCRIPTION
## Summary
- add new abilityCardService util
- extend `/inventory` slash command with `view` and `equip` subcommands
- allow selecting an ability card copy to equip via dropdown
- update index interaction handler
- adjust tests for new `view` subcommand

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685eb13f21448327becafd81dbfd89a0