### PR TITLE
Update docs for ability charge and inventory

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,3 +66,7 @@ node index.js
 
 When configured correctly the bot logs a `Database connection successful` message on start.
 
+### Inventory Commands & Charge System
+
+The bot includes a simple `/inventory` command for viewing your backpack. Once the ability card system is implemented it will also support `/inventory set` to choose which ability card is active.  The design for this charge-based system is documented in [docs/ability_card_charge_gdd.md](docs/ability_card_charge_gdd.md).
+

--- a/docs/ability_card_charge_gdd.md
+++ b/docs/ability_card_charge_gdd.md
@@ -3,6 +3,8 @@
 ## 1. Concept Overview
 This system replaces temporary drafted abilities with persistent Ability Cards that drop from monsters. Cards are stored in the player's inventory and must be equipped to use in combat. Each card carries a limited number of charges, adding resource management to battles.
 
+*Implementation note:* as of the current prototype the Discord bot exposes only a basic `/inventory` command. The charge logic described below is not yet coded. The planned `/inventory set` command will allow selecting which card is active once the inventory system is fully implemented.
+
 ## 2. Core Mechanics
 ### 2.1 Acquiring Ability Cards
 - **Loot Drops:** Monsters have a chance to drop an Ability Card matching their class.
@@ -17,7 +19,7 @@ This system replaces temporary drafted abilities with persistent Ability Cards t
   - `Power Strike 0/10`
 
 ### 2.3 Equipping and Using Abilities
-- **Setting an Ability:** Players select one card from their inventory to become their active ability. Only one ability can be set at a time.
+- **Setting an Ability:** Players select one card from their inventory to become their active ability. Only one ability can be set at a time. The planned `/inventory set <card name>` command in the Discord bot will handle this once implemented.
 - **Combat Usage:**
   - Heroes gain 1 energy per round.
   - When enough energy is available, the equipped ability is used automatically.


### PR DESCRIPTION
## Summary
- clarify that the ability charge system is not yet implemented
- note upcoming `/inventory set` command
- document charge system usage in README

## Testing
- `npm test` in `backend` *(fails: jest not found)*
- `npm test` in `discord-bot` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685eb14543908327bf7c33f35263ae63