### PR TITLE
Implement ability energy and charge logic

### DIFF
--- a/backend/game/abilityCardService.js
+++ b/backend/game/abilityCardService.js
@@ -1,0 +1,48 @@
+class AbilityCardService {
+  constructor() {
+    this.inventories = new Map();
+  }
+
+  /**
+   * Assign an inventory of ability cards to a combatant.
+   * Each card is an object: { id, abilityId, abilityData, charges }
+   */
+  setInventory(combatantId, cards) {
+    this.inventories.set(combatantId, cards);
+  }
+
+  /**
+   * Consume one charge from the combatant's equipped card.
+   * If the equipped card has no charges, attempt to swap in another copy with
+   * remaining charges. Returns true if a charge was consumed and the ability
+   * should fire, otherwise false.
+   */
+  useCharge(combatant) {
+    const inv = this.inventories.get(combatant.id);
+    if (!inv || !combatant.equippedCardId) return false;
+
+    let card = inv.find(c => c.id === combatant.equippedCardId);
+    if (!card) return false;
+
+    if (card.charges <= 0) {
+      const replacement = inv.find(c => c.abilityId === card.abilityId && c.charges > 0);
+      if (!replacement) return false;
+      combatant.equippedCardId = replacement.id;
+      card = replacement;
+    }
+
+    if (card.charges <= 0) return false;
+    card.charges -= 1;
+
+    if (card.charges <= 0) {
+      const replacement = inv.find(c => c.abilityId === card.abilityId && c.charges > 0);
+      if (replacement) {
+        combatant.equippedCardId = replacement.id;
+      }
+    }
+
+    return true;
+  }
+}
+
+module.exports = new AbilityCardService();

--- a/backend/game/utils.js
+++ b/backend/game/utils.js
@@ -7,6 +7,12 @@ function createCombatant(playerData, team, position) {
     const armor = allPossibleArmors.find(a => a.id === playerData.armor_id);
     const ability = allPossibleAbilities.find(a => a.id === playerData.ability_id);
     const deckAbilities = (playerData.deck || []).map(id => allPossibleAbilities.find(a => a.id === id));
+    const abilityCards = (playerData.ability_cards || []).map(card => ({
+        id: card.id,
+        abilityId: card.abilityId,
+        abilityData: allPossibleAbilities.find(a => a.id === card.abilityId),
+        charges: card.charges
+    }));
 
     if (!hero) return null;
 
@@ -24,6 +30,7 @@ function createCombatant(playerData, team, position) {
         armorData: armor,
         abilityData: ability,
         deck: deckAbilities,
+        abilityCards: abilityCards,
         team: team,
         position: position,
         currentHp: finalStats.hp,

--- a/backend/tests/autoAttack.test.js
+++ b/backend/tests/autoAttack.test.js
@@ -1,7 +1,12 @@
 const GameEngine = require('../game/engine');
 const { createCombatant } = require('../game/utils');
+const abilityCardService = require('../game/abilityCardService');
+const { allPossibleAbilities } = require('../game/data');
 
 describe('Auto attack combat', () => {
+  afterEach(() => {
+    abilityCardService.inventories = new Map();
+  });
   test('attacker deals damage equal to its attack stat', () => {
     const attacker = createCombatant({ hero_id: 1, weapon_id: null, armor_id: null }, 'player', 0);
     const defender = createCombatant({ hero_id: 2001, weapon_id: null, armor_id: null }, 'enemy', 0);
@@ -12,5 +17,62 @@ describe('Auto attack combat', () => {
 
     const target = engine.combatants.find(c => c.id === defender.id);
     expect(target.currentHp).toBe(defender.maxHp - attacker.attack);
+  });
+
+  test('ability energy and charge usage', () => {
+    const ability = allPossibleAbilities.find(a => a.name === 'Power Strike');
+    const attacker = createCombatant({
+      hero_id: 1,
+      weapon_id: null,
+      armor_id: null,
+      ability_id: ability.id,
+      ability_cards: [
+        { id: 'c1', abilityId: ability.id, charges: 1 },
+        { id: 'c2', abilityId: ability.id, charges: 1 }
+      ]
+    }, 'player', 0);
+    const defender = createCombatant({ hero_id: 2001, weapon_id: null, armor_id: null }, 'enemy', 0);
+
+    abilityCardService.setInventory(attacker.id, attacker.abilityCards);
+    attacker.equippedCardId = attacker.abilityCards[0].id;
+
+    const engine = new GameEngine([attacker, defender]);
+
+    const takeTurn = () => {
+      engine.turnQueue = engine.computeTurnQueue();
+      engine.processTurn();
+    };
+
+    // Turn 1: basic attack, gain energy
+    takeTurn();
+    let stateDef = engine.combatants.find(c => c.id === defender.id);
+    expect(stateDef.currentHp).toBe(defender.maxHp - attacker.attack);
+    expect(engine.combatants.find(c => c.id === attacker.id).currentEnergy).toBe(1);
+
+    // Turn 2: uses first card
+    takeTurn();
+    stateDef = engine.combatants.find(c => c.id === defender.id);
+    let stateAtt = engine.combatants.find(c => c.id === attacker.id);
+    expect(stateDef.currentHp).toBe(defender.maxHp - attacker.attack - 2);
+    expect(attacker.abilityCards[0].charges).toBe(0);
+    stateAtt = engine.combatants.find(c => c.id === attacker.id);
+    expect(stateAtt.equippedCardId).toBe(attacker.abilityCards[1].id);
+    expect(stateAtt.currentEnergy).toBe(1);
+
+    // Turn 3: uses second card
+    takeTurn();
+    stateDef = engine.combatants.find(c => c.id === defender.id);
+    stateAtt = engine.combatants.find(c => c.id === attacker.id);
+    expect(stateDef.currentHp).toBe(defender.maxHp - attacker.attack - 2 - 2);
+    expect(attacker.abilityCards[1].charges).toBe(0);
+    stateAtt = engine.combatants.find(c => c.id === attacker.id);
+    expect(stateAtt.currentEnergy).toBe(1);
+
+    // Turn 4: no charges remain, basic attack
+    takeTurn();
+    stateDef = engine.combatants.find(c => c.id === defender.id);
+    stateAtt = engine.combatants.find(c => c.id === attacker.id);
+    expect(stateDef.currentHp).toBe(defender.maxHp - attacker.attack - 2 - 2 - attacker.attack);
+    expect(stateAtt.currentEnergy).toBe(2);
   });
 });


### PR DESCRIPTION
## Summary
- add `abilityCardService` for tracking charges and swapping depleted cards
- extend `createCombatant` to include ability card inventories
- expand `GameEngine` to handle energy, ability usage and charge management
- test ability energy flow and auto swap logic

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685eb13c8780832782154641958592d4