### PR TITLE
Implement ability card drops

### DIFF
--- a/discord-bot/src/utils/abilityCardService.js
+++ b/discord-bot/src/utils/abilityCardService.js
@@ -3,7 +3,7 @@ const db = require('../../util/database');
 // Add a new ability card to the user's inventory with default charges
 async function addCard(userId, abilityId) {
   const [result] = await db.query(
-    'INSERT INTO ability_cards (user_id, ability_id, charges) VALUES (?, ?, 10)',
+    'INSERT INTO user_ability_cards (user_id, ability_id, charges) VALUES (?, ?, 10)',
     [userId, abilityId]
   );
   return result.insertId;
@@ -12,7 +12,7 @@ async function addCard(userId, abilityId) {
 // Retrieve all ability cards owned by a user
 async function getCards(userId) {
   const [rows] = await db.query(
-    'SELECT * FROM ability_cards WHERE user_id = ? ORDER BY id',
+    'SELECT * FROM user_ability_cards WHERE user_id = ? ORDER BY id',
     [userId]
   );
   return rows;
@@ -20,14 +20,13 @@ async function getCards(userId) {
 
 // Mark a specific card as equipped and unequip others for the user
 async function setEquippedCard(userId, cardId) {
-  await db.query('UPDATE ability_cards SET equipped = 0 WHERE user_id = ?', [userId]);
-  await db.query('UPDATE ability_cards SET equipped = 1 WHERE id = ? AND user_id = ?', [cardId, userId]);
+  await db.query('UPDATE users SET equipped_ability_id = ? WHERE id = ?', [cardId, userId]);
 }
 
 // Reduce the charge count of a card by one, clamping at zero
 async function decrementCharge(cardId) {
   await db.query(
-    'UPDATE ability_cards SET charges = GREATEST(charges - 1, 0) WHERE id = ?',
+    'UPDATE user_ability_cards SET charges = GREATEST(charges - 1, 0) WHERE id = ?',
     [cardId]
   );
 }


### PR DESCRIPTION
## Summary
- update ability card service to use the `user_ability_cards` table
- extend user service with DB-backed inventory helpers
- DM players a card image after a successful adventure

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685eb790c4648327939d58ba985fb346