### PR TITLE
Add energy rounds and ability charge handling

### DIFF
--- a/backend/tests/energy.test.js
+++ b/backend/tests/energy.test.js
@@ -9,7 +9,7 @@ describe('Energy and charge system', () => {
     player.abilityCharges = 1;
 
     const engine = new GameEngine([player, enemy]);
-    engine.turnQueue = engine.computeTurnQueue();
+    engine.startRound();
     engine.processTurn();
     const combatant = engine.combatants.find(c => c.team === 'player');
 
@@ -28,7 +28,7 @@ describe('Energy and charge system', () => {
     player.abilityCharges = 1;
 
     const engine = new GameEngine([player, enemy]);
-    engine.turnQueue = engine.computeTurnQueue();
+    engine.startRound();
     engine.processTurn();
     const combatant = engine.combatants.find(c => c.team === 'player');
 


### PR DESCRIPTION
## Summary
- track and increase energy at the start of each round
- prefer ability attacks when energy and charges allow
- call `abilityCardService.decrementCharge` on ability use and auto-equip the next copy
- update energy tests to use `startRound`

## Testing
- `npm test --prefix backend` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685eb971583483279f947add46cb16e5