### PR TITLE
Update inventory command

### DIFF
--- a/discord-bot/commands/inventory.js
+++ b/discord-bot/commands/inventory.js
@@ -1,6 +1,8 @@
 const { SlashCommandBuilder } = require('discord.js');
 const { simple } = require('../src/utils/embedBuilder');
 const userService = require('../src/utils/userService');
+const abilityCardService = require('../src/utils/abilityCardService');
+const { allPossibleAbilities } = require('../../backend/game/data');
 
 const data = new SlashCommandBuilder()
   .setName('inventory')
@@ -17,15 +19,25 @@ async function execute(interaction) {
     return;
   }
 
-  const inventory = await userService.getInventory(interaction.user.id);
-  const list = inventory.length
-    ? inventory.map(a => `${a.name} ${a.charges}/10`).join('\n')
+  const cards = await abilityCardService.getCards(user.id);
+  const list = cards.length
+    ? cards.map(c => {
+        const ability = allPossibleAbilities.find(a => a.id === c.ability_id);
+        const name = ability ? ability.name : `Ability ${c.ability_id}`;
+        return `${name} ${c.charges}/10`;
+      }).join('\n')
     : 'Your backpack is empty.';
+
+  const equippedCard = cards.find(c => c.id === user.equipped_ability_id);
+  const equippedName = equippedCard
+    ? (allPossibleAbilities.find(a => a.id === equippedCard.ability_id)?.name || `Ability ${equippedCard.ability_id}`)
+    : 'None';
 
   const embed = simple(
     'Player Inventory',
     [
       { name: 'Player', value: `${user.name} - ${user.class}` },
+      { name: 'Equipped', value: equippedName },
       { name: 'Backpack', value: list }
     ],
     interaction.user.displayAvatarURL()


### PR DESCRIPTION
## Summary
- fetch ability cards from `abilityCardService`
- list charges for each card
- show equipped ability in inventory
- update unit tests

## Testing
- `npm install --prefix discord-bot`
- `npm test --prefix discord-bot --silent`

------
https://chatgpt.com/codex/tasks/task_e_685eba7d485c8327911ec0be53307703