### PR TITLE
Update base stats for classes

### DIFF
--- a/backend/game/data.js
+++ b/backend/game/data.js
@@ -2,17 +2,17 @@
 // In a real application, this would likely be fetched from a server API.
 
 const allPossibleHeroes = [
-    { type: 'hero', id: 1, name: 'Warrior', class: 'Warrior', rarity: 'Common', hp: 18, attack: 3, speed: 3, abilities: [], isBase: true },
-    { type: 'hero', id: 2, name: 'Bard', class: 'Bard', rarity: 'Common', hp: 14, attack: 3, speed: 5, abilities: [], isBase: true },
-    { type: 'hero', id: 3, name: 'Barbarian', class: 'Barbarian', rarity: 'Common', hp: 20, attack: 3, speed: 3, abilities: [], isBase: true },
-    { type: 'hero', id: 4, name: 'Cleric', class: 'Cleric', rarity: 'Common', hp: 16, attack: 3, speed: 4, abilities: [], isBase: true },
-    { type: 'hero', id: 5, name: 'Druid', class: 'Druid', rarity: 'Common', hp: 15, attack: 3, speed: 4, abilities: [], isBase: true },
-    { type: 'hero', id: 6, name: 'Enchanter', class: 'Enchanter', rarity: 'Common', hp: 14, attack: 3, speed: 4, abilities: [], isBase: true },
-    { type: 'hero', id: 7, name: 'Paladin', class: 'Paladin', rarity: 'Common', hp: 18, attack: 3, speed: 3, abilities: [], isBase: true },
-    { type: 'hero', id: 8, name: 'Rogue', class: 'Rogue', rarity: 'Common', hp: 13, attack: 3, speed: 6, abilities: [], isBase: true },
-    { type: 'hero', id: 9, name: 'Ranger', class: 'Ranger', rarity: 'Common', hp: 14, attack: 3, speed: 5, abilities: [], isBase: true },
-    { type: 'hero', id: 10, name: 'Sorcerer', class: 'Sorcerer', rarity: 'Common', hp: 13, attack: 3, speed: 4, abilities: [], isBase: true },
-    { type: 'hero', id: 11, name: 'Wizard', class: 'Wizard', rarity: 'Common', hp: 13, attack: 3, speed: 4, abilities: [], isBase: true },
+    { type: 'hero', id: 1, name: 'Warrior', class: 'Warrior', rarity: 'Common', hp: 22, attack: 3, speed: 3, abilities: [], isBase: true },
+    { type: 'hero', id: 2, name: 'Bard', class: 'Bard', rarity: 'Common', hp: 16, attack: 2, speed: 5, abilities: [], isBase: true },
+    { type: 'hero', id: 3, name: 'Barbarian', class: 'Barbarian', rarity: 'Common', hp: 20, attack: 4, speed: 3, abilities: [], isBase: true },
+    { type: 'hero', id: 4, name: 'Cleric', class: 'Cleric', rarity: 'Common', hp: 18, attack: 2, speed: 4, abilities: [], isBase: true },
+    { type: 'hero', id: 5, name: 'Druid', class: 'Druid', rarity: 'Common', hp: 17, attack: 3, speed: 4, abilities: [], isBase: true },
+    { type: 'hero', id: 6, name: 'Enchanter', class: 'Enchanter', rarity: 'Common', hp: 15, attack: 2, speed: 4, abilities: [], isBase: true },
+    { type: 'hero', id: 7, name: 'Paladin', class: 'Paladin', rarity: 'Common', hp: 20, attack: 3, speed: 3, abilities: [], isBase: true },
+    { type: 'hero', id: 8, name: 'Rogue', class: 'Rogue', rarity: 'Common', hp: 14, attack: 5, speed: 6, abilities: [], isBase: true },
+    { type: 'hero', id: 9, name: 'Ranger', class: 'Ranger', rarity: 'Common', hp: 15, attack: 4, speed: 5, abilities: [], isBase: true },
+    { type: 'hero', id: 10, name: 'Sorcerer', class: 'Sorcerer', rarity: 'Common', hp: 14, attack: 4, speed: 4, abilities: [], isBase: true },
+    { type: 'hero', id: 11, name: 'Wizard', class: 'Wizard', rarity: 'Common', hp: 14, attack: 4, speed: 4, abilities: [], isBase: true },
     // 1. Stalwart Defender
     { type: 'hero', id: 101, name: 'Recruit', class: 'Stalwart Defender', rarity: 'Common', art: '../img/recruit_card.png', imageUrl: 'https://placehold.co/300x400/1e293b/ffffff?text=Recruit', hp: 22, attack: 4, speed: 5, abilities: [] },
     { type: 'hero', id: 102, name: 'Soldier', class: 'Stalwart Defender', rarity: 'Uncommon', art: '../img/soldier_card.png', imageUrl: 'https://placehold.co/300x400/1e293b/ffffff?text=Soldier', hp: 30, attack: 6, speed: 5, abilities: [] },

--- a/discord-bot/tests/adventure.test.js
+++ b/discord-bot/tests/adventure.test.js
@@ -33,4 +33,15 @@ describe('adventure command', () => {
     expect(userService.addAbility).toHaveBeenCalled();
     expect(interaction.followUp).toHaveBeenCalledWith(expect.objectContaining({ content: expect.stringContaining('You found'), ephemeral: true }));
   });
+
+  test('battle log reflects class base stats', async () => {
+    userService.getUser.mockResolvedValue({ discord_id: '123', class: 'Barbarian' });
+    jest.spyOn(Math, 'random').mockReturnValue(0.2);
+    const interaction = { user: { id: '123' }, reply: jest.fn().mockResolvedValue(), followUp: jest.fn().mockResolvedValue() };
+    await adventure.execute(interaction);
+    const description = interaction.followUp.mock.calls[0][0].embeds[0].data.description;
+    expect(description).toContain('(20/20 HP)');
+    expect(description).toMatch(/for 4 damage/);
+    Math.random.mockRestore();
+  });
 });


### PR DESCRIPTION
## Summary
- set unique HP/ATK on the 11 basic hero classes
- ensure `/adventure` logs show correct stats

## Testing
- `npm test` in `backend`
- `npm test` in `discord-bot`


------
https://chatgpt.com/codex/tasks/task_e_685ebfa69ee08327bd5a65320ea10370