### PR TITLE
Resolve ability name in /set command

### DIFF
--- a/discord-bot/commands/set.js
+++ b/discord-bot/commands/set.js
@@ -1,5 +1,7 @@
 const { SlashCommandBuilder } = require('discord.js');
 const userService = require('../src/utils/userService');
+const abilityCardService = require('../src/utils/abilityCardService');
+const { allPossibleAbilities } = require('../../backend/game/data');
 
 const data = new SlashCommandBuilder()
   .setName('set')
@@ -12,8 +14,30 @@ const data = new SlashCommandBuilder()
 
 async function execute(interaction) {
   const abilityName = interaction.options.getString('ability');
-  await userService.setActiveAbility(interaction.user.id, abilityName);
-  await interaction.reply({ content: `Equipped ${abilityName}.`, ephemeral: true });
+  const user = await userService.getUser(interaction.user.id);
+  if (!user) {
+    await interaction.reply({ content: 'User not found.', ephemeral: true });
+    return;
+  }
+
+  const ability = allPossibleAbilities.find(
+    a => a.name.toLowerCase() === abilityName.toLowerCase()
+  );
+  if (!ability) {
+    await interaction.reply({ content: 'Ability not found.', ephemeral: true });
+    return;
+  }
+
+  const cards = await abilityCardService.getCards(user.id);
+  const card = cards.find(c => c.ability_id === ability.id);
+
+  if (!card) {
+    await interaction.reply({ content: `You don't own any copies of ${ability.name}.`, ephemeral: true });
+    return;
+  }
+
+  await userService.setActiveAbility(interaction.user.id, card.id);
+  await interaction.reply({ content: `Equipped ${ability.name}.`, ephemeral: true });
 }
 
 module.exports = { data, execute };

--- a/discord-bot/tests/set.test.js
+++ b/discord-bot/tests/set.test.js
@@ -1,21 +1,29 @@
 const set = require('../commands/set');
 
 jest.mock('../src/utils/userService', () => ({
+  getUser: jest.fn(),
   setActiveAbility: jest.fn()
 }));
+jest.mock('../src/utils/abilityCardService', () => ({
+  getCards: jest.fn()
+}));
 const userService = require('../src/utils/userService');
+const abilityCardService = require('../src/utils/abilityCardService');
 
 describe('set command', () => {
   beforeEach(() => jest.clearAllMocks());
 
   test('calls userService to set ability', async () => {
+    userService.getUser.mockResolvedValue({ id: 1 });
+    abilityCardService.getCards.mockResolvedValue([{ id: 42, ability_id: 3113 }]);
     const interaction = {
       user: { id: '123' },
       options: { getString: jest.fn().mockReturnValue('Shield Bash') },
       reply: jest.fn().mockResolvedValue()
     };
     await set.execute(interaction);
-    expect(userService.setActiveAbility).toHaveBeenCalledWith('123', 'Shield Bash');
+    expect(abilityCardService.getCards).toHaveBeenCalledWith(1);
+    expect(userService.setActiveAbility).toHaveBeenCalledWith('123', 42);
     expect(interaction.reply).toHaveBeenCalledWith(expect.objectContaining({ ephemeral: true }));
   });
 });


### PR DESCRIPTION
## Summary
- update `/set` command logic to look up the card by ability name and equip by card id
- expand tests for updated logic

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_685ec2b1ec2083279433858557ba6178