### PR TITLE
Add ability selection handler

### DIFF
--- a/discord-bot/index.js
+++ b/discord-bot/index.js
@@ -48,11 +48,15 @@ client.on(Events.InteractionCreate, async interaction => {
   } else if (interaction.isStringSelectMenu()) {
     if (interaction.customId === 'class-select') {
       await gameHandlers.handleClassSelect(interaction);
+    } else if (interaction.customId === 'ability-select') {
+      await inventoryHandlers.handleAbilitySelect(interaction);
     } else if (interaction.customId === 'equip-card') {
       await inventoryHandlers.handleEquipSelect(interaction);
     }
   } else if (interaction.isButton()) {
-    if (interaction.customId.startsWith('class-confirm') || interaction.customId === 'class-choose-again') {
+    if (interaction.customId === 'set-ability') {
+      await inventoryHandlers.handleSetAbilityButton(interaction);
+    } else if (interaction.customId.startsWith('class-confirm') || interaction.customId === 'class-choose-again') {
       await gameHandlers.handleClassButton(interaction);
     }
   }

--- a/discord-bot/tests/inventory.test.js
+++ b/discord-bot/tests/inventory.test.js
@@ -98,4 +98,38 @@ describe('inventory command', () => {
     expect(abilityCardService.setEquippedCard).toHaveBeenCalledWith(1, 99);
     expect(interaction.update).toHaveBeenCalled();
   });
+
+  test('handleSetAbilityButton shows ability dropdown', async () => {
+    userService.getUser.mockResolvedValue({ id: 1, name: 'Tester' });
+    abilityCardService.getCards.mockResolvedValue([
+      { id: 1, ability_id: 3111, charges: 5 },
+      { id: 2, ability_id: 3111, charges: 0 },
+      { id: 3, ability_id: 3121, charges: 2 }
+    ]);
+    const interaction = { user: { id: '123' }, reply: jest.fn().mockResolvedValue() };
+    await inventory.handleSetAbilityButton(interaction);
+    expect(interaction.reply).toHaveBeenCalledWith(expect.objectContaining({ components: expect.any(Array) }));
+    const options = interaction.reply.mock.calls[0][0].components[0].components[0].toJSON().options;
+    expect(options).toHaveLength(2);
+  });
+
+  test('handleAbilitySelect shows card dropdown when multiple copies', async () => {
+    userService.getUser.mockResolvedValue({ id: 1, name: 'Tester' });
+    abilityCardService.getCards.mockResolvedValue([
+      { id: 10, ability_id: 3111, charges: 5 },
+      { id: 11, ability_id: 3111, charges: 4 }
+    ]);
+    const interaction = { user: { id: '123' }, values: ['3111'], update: jest.fn().mockResolvedValue() };
+    await inventory.handleAbilitySelect(interaction);
+    expect(interaction.update).toHaveBeenCalledWith(expect.objectContaining({ components: expect.any(Array) }));
+  });
+
+  test('handleAbilitySelect equips when single copy', async () => {
+    userService.getUser.mockResolvedValue({ id: 1, name: 'Tester' });
+    abilityCardService.getCards.mockResolvedValue([{ id: 10, ability_id: 3111, charges: 5 }]);
+    const interaction = { user: { id: '123' }, values: ['3111'], update: jest.fn().mockResolvedValue() };
+    await inventory.handleAbilitySelect(interaction);
+    expect(abilityCardService.setEquippedCard).toHaveBeenCalledWith(1, 10);
+    expect(interaction.update).toHaveBeenCalled();
+  });
 });


### PR DESCRIPTION
## Summary
- enable ability selection via `set-ability` button
- add dropdown flow to pick abilities and cards
- wire up handlers in main bot entry
- test new inventory handlers

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_685ec2b2cd3c8327b8a1b20cd6d73b2d