### PR TITLE
Add autocomplete equip subcommand

### DIFF
--- a/discord-bot/index.js
+++ b/discord-bot/index.js
@@ -45,6 +45,15 @@ client.on(Events.InteractionCreate, async interaction => {
         await interaction.reply(replyOptions);
       }
     }
+  } else if (interaction.isAutocomplete()) {
+    const command = client.commands.get(interaction.commandName);
+    if (command && command.autocomplete) {
+      try {
+        await command.autocomplete(interaction);
+      } catch (error) {
+        console.error(`Error handling autocomplete for ${interaction.commandName}`, error);
+      }
+    }
   } else if (interaction.isStringSelectMenu()) {
     if (interaction.customId === 'class-select') {
       await gameHandlers.handleClassSelect(interaction);


### PR DESCRIPTION
## Summary
- rename inventory `equip` to `set`
- autocomplete ability names from charged cards
- show dropdown only when multiple copies exist
- handle autocomplete interactions in the bot
- update inventory tests for new behavior

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_685ec2b438e0832780dd8d6855b3d74c