### PR TITLE
Improve ability card drops with detailed embeds

### DIFF
--- a/discord-bot/src/commands/adventure.js
+++ b/discord-bot/src/commands/adventure.js
@@ -1,6 +1,6 @@
 const { SlashCommandBuilder } = require('discord.js');
 const userService = require('../utils/userService');
-const { sendCardDM } = require('../utils/embedBuilder');
+const { sendCardDM, buildCardEmbed } = require('../utils/embedBuilder');
 const GameEngine = require('../../../backend/game/engine');
 const { createCombatant } = require('../../../backend/game/utils');
 const { allPossibleHeroes, allPossibleAbilities } = require('../../../backend/game/data');
@@ -84,10 +84,10 @@ async function execute(interaction) {
         await sendCardDM(interaction.user, drop);
       } catch (err) {
         console.error('Failed to DM card drop:', err);
-        await interaction.followUp({ content: `You found ${drop.name}!`, ephemeral: true });
+        await interaction.followUp({ embeds: [buildCardEmbed(drop)], ephemeral: true });
       }
     } else {
-      await interaction.followUp({ content: `You found ${drop.name}!`, ephemeral: true });
+      await interaction.followUp({ embeds: [buildCardEmbed(drop)], ephemeral: true });
     }
   }
 }

--- a/discord-bot/src/utils/embedBuilder.js
+++ b/discord-bot/src/utils/embedBuilder.js
@@ -25,6 +25,28 @@ function simple(title, fields = [], thumbnailUrl) {
   return embed;
 }
 
+/**
+ * Build an embed describing an ability card.
+ *
+ * @param {object} card
+ * @returns {EmbedBuilder}
+ */
+function buildCardEmbed(card) {
+  const embed = new EmbedBuilder()
+    .setColor('#29b6f6')
+    .setTimestamp()
+    .setFooter({ text: 'Auto\u2011Battler Bot' })
+    .addFields(
+      { name: 'Name', value: card.name, inline: true },
+      { name: 'Class', value: card.class, inline: true },
+      { name: 'Rarity', value: card.rarity, inline: true },
+      { name: 'Charges', value: '10/10', inline: true },
+      { name: 'Description', value: card.effect }
+    );
+
+  return embed;
+}
+
 
 /**
  * DM a player when they obtain a new ability card.
@@ -33,18 +55,8 @@ function simple(title, fields = [], thumbnailUrl) {
  * @param {object} card
  */
 async function sendCardDM(user, card) {
-  const embed = new EmbedBuilder()
-    .setColor('#29b6f6')
-    .setTitle('✨ You found a new ability card! ✨')
-    .addFields(
-      { name: 'Name', value: card.name, inline: true },
-      { name: 'Rarity', value: card.rarity, inline: true },
-      { name: 'Charges', value: '10/10', inline: true }
-    )
-    .setTimestamp()
-    .setFooter({ text: 'Auto‑Battler Bot' });
-
+  const embed = buildCardEmbed(card).setTitle('✨ You found a new ability card! ✨');
   await user.send({ embeds: [embed] });
 }
 
-module.exports = { simple, sendCardDM };
+module.exports = { simple, sendCardDM, buildCardEmbed };

--- a/discord-bot/tests/adventure.test.js
+++ b/discord-bot/tests/adventure.test.js
@@ -31,7 +31,7 @@ describe('adventure command', () => {
     const interaction = { user: { id: '123' }, reply: jest.fn().mockResolvedValue(), followUp: jest.fn().mockResolvedValue() };
     await adventure.execute(interaction);
     expect(userService.addAbility).toHaveBeenCalled();
-    expect(interaction.followUp).toHaveBeenCalledWith(expect.objectContaining({ content: expect.stringContaining('You found'), ephemeral: true }));
+    expect(interaction.followUp).toHaveBeenCalledWith(expect.objectContaining({ embeds: expect.any(Array), ephemeral: true }));
   });
 
   test('battle log reflects class base stats', async () => {


### PR DESCRIPTION
## Summary
- create `buildCardEmbed` helper for ability card info
- refactor `sendCardDM` to use new embed builder
- show embed as fallback drop message in `/adventure`
- update tests for new embed usage

## Testing
- `npm test` in `discord-bot`
- `npm test` in `backend`


------
https://chatgpt.com/codex/tasks/task_e_685ec38a8e688327b8d65ec4d6d06e11