### PR TITLE
Add autocomplete 'set' subcommand

### DIFF
--- a/discord-bot/commands/inventory.js
+++ b/discord-bot/commands/inventory.js
@@ -18,13 +18,14 @@ const data = new SlashCommandBuilder()
   )
   .addSubcommand(sub =>
     sub
-      .setName('equip')
+      .setName('set')
       .setDescription('Equip an ability card')
       .addStringOption(opt =>
         opt
           .setName('ability')
           .setDescription('Name of the ability to equip')
           .setRequired(true)
+          .setAutocomplete(true)
       )
   );
 
@@ -71,7 +72,7 @@ async function execute(interaction) {
     return;
   }
 
-  if (sub === 'equip') {
+  if (sub === 'set') {
     const abilityName = interaction.options.getString('ability');
     const ability = allPossibleAbilities.find(a => a.name.toLowerCase() === abilityName.toLowerCase());
     if (!ability) {
@@ -79,9 +80,17 @@ async function execute(interaction) {
       return;
     }
 
-    const cards = (await abilityCardService.getCards(user.id)).filter(c => c.ability_id === ability.id);
+    const cards = (await abilityCardService.getCards(user.id)).filter(
+      c => c.ability_id === ability.id && c.charges > 0
+    );
     if (!cards.length) {
-      await interaction.reply({ content: `You don't own any copies of ${ability.name}.`, ephemeral: true });
+      await interaction.reply({ content: `You don't own any charged copies of ${ability.name}.`, ephemeral: true });
+      return;
+    }
+
+    if (cards.length === 1) {
+      await abilityCardService.setEquippedCard(user.id, cards[0].id);
+      await interaction.reply({ content: `Equipped ${ability.name}.`, ephemeral: true });
       return;
     }
 
@@ -90,7 +99,7 @@ async function execute(interaction) {
       .setPlaceholder('Select a card')
       .addOptions(
         cards.map(card => ({
-          label: `${ability.name} ${card.charges}/10`,
+          label: `${ability.name} (${card.charges}/10)`,
           value: String(card.id)
         }))
       );
@@ -175,10 +184,31 @@ async function handleEquipSelect(interaction) {
   await interaction.update({ content: `Equipped ${abilityName}.`, components: [], embeds: [], ephemeral: true });
 }
 
+async function autocomplete(interaction) {
+  const user = await userService.getUser(interaction.user.id);
+  if (!user) {
+    await interaction.respond([]);
+    return;
+  }
+
+  const cards = (await abilityCardService.getCards(user.id)).filter(c => c.charges > 0);
+  const uniqueIds = [...new Set(cards.map(c => c.ability_id))];
+  const abilities = uniqueIds
+    .map(id => allPossibleAbilities.find(a => a.id === id))
+    .filter(Boolean);
+  const focused = interaction.options.getFocused().toLowerCase();
+  const choices = abilities
+    .filter(a => a.name.toLowerCase().includes(focused))
+    .slice(0, 25)
+    .map(a => ({ name: a.name, value: a.name }));
+  await interaction.respond(choices);
+}
+
 module.exports = {
   data,
   execute,
   handleEquipSelect,
   handleSetAbilityButton,
-  handleAbilitySelect
+  handleAbilitySelect,
+  autocomplete
 };

--- a/discord-bot/index.js
+++ b/discord-bot/index.js
@@ -30,7 +30,16 @@ client.once(Events.ClientReady, () => {
 });
 
 client.on(Events.InteractionCreate, async interaction => {
-  if (interaction.isChatInputCommand()) {
+  if (interaction.isAutocomplete()) {
+    const command = client.commands.get(interaction.commandName);
+    if (command && command.autocomplete) {
+      try {
+        await command.autocomplete(interaction);
+      } catch (error) {
+        console.error(`Error in autocomplete for ${interaction.commandName}`, error);
+      }
+    }
+  } else if (interaction.isChatInputCommand()) {
     const command = client.commands.get(interaction.commandName);
     if (!command) return;
 

--- a/discord-bot/tests/inventory.test.js
+++ b/discord-bot/tests/inventory.test.js
@@ -68,7 +68,7 @@ describe('inventory command', () => {
     expect(interaction.reply.mock.calls[0][0].embeds[0].data.fields[2].value).toContain('Power Strike');
   });
 
-  test('equip subcommand shows dropdown', async () => {
+  test('set subcommand shows dropdown', async () => {
     userService.getUser.mockResolvedValue({ id: 1, name: 'Tester', class: 'Warrior', equipped_ability_id: null });
     abilityCardService.getCards.mockResolvedValue([
       { id: 1, ability_id: 3111, charges: 5 },
@@ -77,13 +77,29 @@ describe('inventory command', () => {
     const interaction = {
       user: { id: '123' },
       options: {
-        getSubcommand: jest.fn().mockReturnValue('equip'),
+        getSubcommand: jest.fn().mockReturnValue('set'),
         getString: jest.fn().mockReturnValue('Power Strike')
       },
       reply: jest.fn().mockResolvedValue()
     };
     await inventory.execute(interaction);
     expect(interaction.reply).toHaveBeenCalledWith(expect.objectContaining({ components: expect.any(Array) }));
+  });
+
+  test('set subcommand equips when single copy', async () => {
+    userService.getUser.mockResolvedValue({ id: 1, name: 'Tester', class: 'Warrior', equipped_ability_id: null });
+    abilityCardService.getCards.mockResolvedValue([{ id: 5, ability_id: 3111, charges: 5 }]);
+    const interaction = {
+      user: { id: '123' },
+      options: {
+        getSubcommand: jest.fn().mockReturnValue('set'),
+        getString: jest.fn().mockReturnValue('Power Strike')
+      },
+      reply: jest.fn().mockResolvedValue()
+    };
+    await inventory.execute(interaction);
+    expect(abilityCardService.setEquippedCard).toHaveBeenCalledWith(1, 5);
+    expect(interaction.reply).toHaveBeenCalledWith(expect.objectContaining({ content: expect.stringContaining('Equipped Power Strike') }));
   });
 
   test('handleEquipSelect equips card', async () => {
@@ -131,5 +147,22 @@ describe('inventory command', () => {
     await inventory.handleAbilitySelect(interaction);
     expect(abilityCardService.setEquippedCard).toHaveBeenCalledWith(1, 10);
     expect(interaction.update).toHaveBeenCalled();
+  });
+
+  test('autocomplete suggests charged abilities', async () => {
+    userService.getUser.mockResolvedValue({ id: 1, name: 'Tester' });
+    abilityCardService.getCards.mockResolvedValue([
+      { id: 1, ability_id: 3111, charges: 5 },
+      { id: 2, ability_id: 3112, charges: 0 }
+    ]);
+    const interaction = {
+      user: { id: '123' },
+      options: { getFocused: jest.fn().mockReturnValue('pow') },
+      respond: jest.fn().mockResolvedValue()
+    };
+    await inventory.autocomplete(interaction);
+    expect(interaction.respond).toHaveBeenCalledWith(
+      expect.arrayContaining([{ name: 'Power Strike', value: 'Power Strike' }])
+    );
   });
 });


### PR DESCRIPTION
## Summary
- add new `set` subcommand inside inventory command
- autocomplete ability names based on user's charged cards
- reuse dropdown equip logic and route autocomplete interactions
- update tests for new subcommand and autocomplete

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_685ec6d25b9c8327b9ff32a46e0cf626