### PR TITLE
Add equip alias for inventory set

### DIFF
--- a/discord-bot/commands/inventory.js
+++ b/discord-bot/commands/inventory.js
@@ -27,6 +27,19 @@ const data = new SlashCommandBuilder()
           .setRequired(true)
           .setAutocomplete(true)
       )
+  )
+  // temporary alias for backwards compatibility
+  .addSubcommand(sub =>
+    sub
+      .setName('equip')
+      .setDescription('Equip an ability card')
+      .addStringOption(opt =>
+        opt
+          .setName('ability')
+          .setDescription('Name of the ability to equip')
+          .setRequired(true)
+          .setAutocomplete(true)
+      )
   );
 
 async function execute(interaction) {
@@ -72,7 +85,7 @@ async function execute(interaction) {
     return;
   }
 
-  if (sub === 'set') {
+  if (sub === 'set' || sub === 'equip') {
     const abilityName = interaction.options.getString('ability');
     const ability = allPossibleAbilities.find(a => a.name.toLowerCase() === abilityName.toLowerCase());
     if (!ability) {


### PR DESCRIPTION
## Summary
- add `equip` alias subcommand in `/inventory`
- handle both `set` and `equip` during execution
- keep autocomplete suggestions for ability names

## Testing
- `npm install` within `discord-bot`
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_685ec84309ac8327a8edf2d3bb31c70f