### PR TITLE
Add admin ability grant command

### DIFF
--- a/discord-bot/README.md
+++ b/discord-bot/README.md
@@ -55,6 +55,16 @@ Player Details
 Player: SomePlayer - Bard
 ```
 
+## Admin Tools
+
+`/admin grant-ability` lets users with the **Game Master** role grant an ability card to any player. The command requires two options:
+
+```bash
+/admin grant-ability user:@SomePlayer ability:"Power Strike"
+```
+
+The Game Master receives an ephemeral confirmation message while the target player is sent a DM with the standard ability card embed.
+
 ## Database Migration
 
 The updated schema introduces a `user_ability_cards` table and a new

--- a/discord-bot/commands/admin.js
+++ b/discord-bot/commands/admin.js
@@ -1,0 +1,85 @@
+const { SlashCommandBuilder } = require('discord.js');
+const userService = require('../src/utils/userService');
+const { sendCardDM } = require('../src/utils/embedBuilder');
+const { allPossibleAbilities } = require('../../backend/game/data');
+
+const data = new SlashCommandBuilder()
+  .setName('admin')
+  .setDescription('Administrative commands')
+  .addSubcommand(sub =>
+    sub
+      .setName('grant-ability')
+      .setDescription('Grant an ability card to a player')
+      .addUserOption(opt =>
+        opt
+          .setName('user')
+          .setDescription('Recipient of the ability card')
+          .setRequired(true)
+      )
+      .addStringOption(opt =>
+        opt
+          .setName('ability')
+          .setDescription('Name of the ability to grant')
+          .setRequired(true)
+          .setAutocomplete(true)
+      )
+  );
+
+async function execute(interaction) {
+  if (!interaction.member?.roles?.cache?.some(r => r.name === 'Game Master')) {
+    await interaction.reply({
+      content: 'You do not have the necessary permissions to use this command.',
+      ephemeral: true
+    });
+    return;
+  }
+
+  const sub = interaction.options.getSubcommand();
+  if (sub !== 'grant-ability') return;
+
+  const target = interaction.options.getUser('user');
+  const abilityName = interaction.options.getString('ability');
+  const ability = allPossibleAbilities.find(
+    a => a.name.toLowerCase() === abilityName.toLowerCase()
+  );
+  if (!ability) {
+    await interaction.reply({
+      content: `Error: Could not find an ability named ${abilityName}.`,
+      ephemeral: true
+    });
+    return;
+  }
+
+  const user = await userService.getUser(target.id);
+  if (!user) {
+    await interaction.reply({
+      content: 'Error: This user has not started playing yet and cannot be granted an ability.',
+      ephemeral: true
+    });
+    return;
+  }
+
+  await userService.addAbility(target.id, ability.id);
+
+  await interaction.reply({
+    content: `You have successfully granted ${ability.name} to ${target.username}.`,
+    ephemeral: true
+  });
+
+  try {
+    await sendCardDM(target, ability);
+  } catch (err) {
+    console.error('Failed to DM ability card:', err);
+  }
+}
+
+async function autocomplete(interaction) {
+  const focused = interaction.options.getFocused();
+  const filtered = allPossibleAbilities
+    .filter(a => a.name.toLowerCase().includes(focused.toLowerCase()))
+    .slice(0, 25)
+    .map(a => ({ name: a.name, value: a.name }));
+  await interaction.respond(filtered);
+}
+
+module.exports = { data, execute, autocomplete };

--- a/discord-bot/deploy-commands.js
+++ b/discord-bot/deploy-commands.js
@@ -6,6 +6,7 @@ const commands = [];
 const commandDirs = [
   path.join(__dirname, 'commands/ping.js'),
   path.join(__dirname, 'commands/who.js'),
+  path.join(__dirname, 'commands/admin.js'),
   path.join(__dirname, 'commands/inventory.js'),
   path.join(__dirname, 'commands/set.js'),
   path.join(__dirname, 'src/commands/game.js'),

--- a/discord-bot/tests/admin.test.js
+++ b/discord-bot/tests/admin.test.js
@@ -1,0 +1,85 @@
+const admin = require('../commands/admin');
+
+jest.mock('../src/utils/userService', () => ({
+  getUser: jest.fn(),
+  addAbility: jest.fn()
+}));
+jest.mock('../src/utils/embedBuilder', () => ({
+  sendCardDM: jest.fn()
+}));
+
+const userService = require('../src/utils/userService');
+const { sendCardDM } = require('../src/utils/embedBuilder');
+
+function createInteraction(role = 'Game Master') {
+  return {
+    member: { roles: { cache: { some: jest.fn(fn => fn({ name: role })) } } },
+    options: {
+      getSubcommand: jest.fn().mockReturnValue('grant-ability'),
+      getUser: jest.fn().mockReturnValue({ id: '200', username: 'Target' }),
+      getString: jest.fn()
+    },
+    reply: jest.fn().mockResolvedValue()
+  };
+}
+
+describe('admin grant-ability command', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('requires Game Master role', async () => {
+    const interaction = createInteraction('Player');
+    interaction.options.getString.mockReturnValue('Power Strike');
+    await admin.execute(interaction);
+    expect(interaction.reply).toHaveBeenCalledWith(expect.objectContaining({
+      ephemeral: true,
+      content: expect.stringContaining('necessary permissions')
+    }));
+  });
+
+  test('errors when ability not found', async () => {
+    const interaction = createInteraction();
+    interaction.options.getString.mockReturnValue('Nonexistent');
+    await admin.execute(interaction);
+    expect(interaction.reply).toHaveBeenCalledWith(expect.objectContaining({
+      ephemeral: true,
+      content: expect.stringContaining('Could not find an ability')
+    }));
+  });
+
+  test('errors when user not found', async () => {
+    const interaction = createInteraction();
+    interaction.options.getString.mockReturnValue('Power Strike');
+    userService.getUser.mockResolvedValue(null);
+    await admin.execute(interaction);
+    expect(interaction.reply).toHaveBeenCalledWith(expect.objectContaining({
+      ephemeral: true,
+      content: expect.stringContaining('has not started playing yet')
+    }));
+  });
+
+  test('grants ability and sends DM', async () => {
+    const interaction = createInteraction();
+    interaction.options.getString.mockReturnValue('Power Strike');
+    userService.getUser.mockResolvedValue({ id: 1 });
+    userService.addAbility.mockResolvedValue(99);
+    await admin.execute(interaction);
+    expect(userService.addAbility).toHaveBeenCalled();
+    expect(sendCardDM).toHaveBeenCalled();
+    expect(interaction.reply).toHaveBeenCalledWith(expect.objectContaining({
+      ephemeral: true,
+      content: expect.stringContaining('successfully granted')
+    }));
+  });
+
+  test('autocomplete suggests ability names', async () => {
+    const interaction = {
+      options: { getFocused: jest.fn().mockReturnValue('Power') },
+      respond: jest.fn().mockResolvedValue()
+    };
+    await admin.autocomplete(interaction);
+    const options = interaction.respond.mock.calls[0][0];
+    expect(options.some(o => o.name === 'Power Strike')).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- add `/admin grant-ability` slash command
- load the command in deploy script
- document admin command usage
- test permission checks and basic behavior

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685ecb741a04832787fecb2fd08a59ac