### PR TITLE
Filter inventory autocomplete by class

### DIFF
--- a/discord-bot/commands/inventory.js
+++ b/discord-bot/commands/inventory.js
@@ -7,6 +7,7 @@ const { simple } = require('../src/utils/embedBuilder');
 const userService = require('../src/utils/userService');
 const abilityCardService = require('../src/utils/abilityCardService');
 const { allPossibleAbilities } = require('../../backend/game/data');
+const classAbilityMap = require('../src/data/classAbilityMap');
 
 const data = new SlashCommandBuilder()
   .setName('inventory')
@@ -205,11 +206,13 @@ async function autocomplete(interaction) {
     return;
   }
   const cards = await abilityCardService.getCards(user.id);
+  const abilityClass = classAbilityMap[user.class] || user.class;
   const abilities = [...new Set(
     cards.filter(c => c.charges > 0).map(c => c.ability_id)
   )]
     .map(id => allPossibleAbilities.find(a => a.id === id))
-    .filter(Boolean);
+    .filter(Boolean)
+    .filter(a => !abilityClass || a.class === abilityClass);
   const filtered = abilities
     .filter(a => a.name.toLowerCase().includes(focused.toLowerCase()))
     .slice(0, 25)

--- a/discord-bot/src/commands/adventure.js
+++ b/discord-bot/src/commands/adventure.js
@@ -5,20 +5,7 @@ const GameEngine = require('../../../backend/game/engine');
 const { createCombatant } = require('../../../backend/game/utils');
 const { allPossibleHeroes, allPossibleAbilities } = require('../../../backend/game/data');
 const classes = require('../data/classes');
-
-const classAbilityMap = {
-  Warrior: 'Stalwart Defender',
-  Bard: 'Inspiring Artist',
-  Barbarian: 'Raging Fighter',
-  Cleric: 'Divine Healer',
-  Druid: 'Nature Shaper',
-  Enchanter: 'Mystic Deceiver',
-  Paladin: 'Holy Warrior',
-  Rogue: 'Shadow Striker',
-  Ranger: 'Wilderness Expert',
-  Sorcerer: 'Raw Power Mage',
-  Wizard: 'Arcane Savant'
-};
+const classAbilityMap = require('../data/classAbilityMap');
 
 const data = new SlashCommandBuilder()
   .setName('adventure')

--- a/discord-bot/src/data/classAbilityMap.js
+++ b/discord-bot/src/data/classAbilityMap.js
@@ -1,0 +1,13 @@
+module.exports = {
+  Warrior: 'Stalwart Defender',
+  Bard: 'Inspiring Artist',
+  Barbarian: 'Raging Fighter',
+  Cleric: 'Divine Healer',
+  Druid: 'Nature Shaper',
+  Enchanter: 'Mystic Deceiver',
+  Paladin: 'Holy Warrior',
+  Rogue: 'Shadow Striker',
+  Ranger: 'Wilderness Expert',
+  Sorcerer: 'Raw Power Mage',
+  Wizard: 'Arcane Savant'
+};

--- a/discord-bot/tests/inventory.test.js
+++ b/discord-bot/tests/inventory.test.js
@@ -103,11 +103,12 @@ describe('inventory command', () => {
   });
 
   test('autocomplete suggests charged abilities', async () => {
-    userService.getUser.mockResolvedValue({ id: 1 });
+    userService.getUser.mockResolvedValue({ id: 1, class: 'Warrior' });
     abilityCardService.getCards.mockResolvedValue([
       { id: 1, ability_id: 3111, charges: 5 },
       { id: 2, ability_id: 3112, charges: 0 },
-      { id: 3, ability_id: 3121, charges: 3 }
+      { id: 3, ability_id: 3121, charges: 3 },
+      { id: 4, ability_id: 3411, charges: 5 }
     ]);
     const interaction = {
       user: { id: '123' },
@@ -119,6 +120,7 @@ describe('inventory command', () => {
     const names = options.map(o => o.name);
     expect(names).toContain('Power Strike');
     expect(names).toContain('Crippling Blow');
+    expect(names).not.toContain('Chaos Bolt');
   });
 
   test('handleEquipSelect equips card', async () => {


### PR DESCRIPTION
## Summary
- centralize class-to-archetype mapping
- use mapping in adventure and inventory commands
- filter autocomplete results by the user's class
- adjust inventory autocomplete test to ensure filtering

## Testing
- `npm install`
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_685ecc552b3483278efc78d06a26e426