### PR TITLE
Filter inventory autocomplete by class archetype

### DIFF
--- a/discord-bot/commands/inventory.js
+++ b/discord-bot/commands/inventory.js
@@ -221,12 +221,11 @@ async function autocomplete(interaction) {
     return;
   }
   const cards = await abilityCardService.getCards(user.id);
-  const abilities = [...new Set(
-    cards.filter(c => c.charges > 0).map(c => c.ability_id)
-  )]
+  const abilityIds = [...new Set(cards.filter(c => c.charges > 0).map(c => c.ability_id))];
+  let abilities = abilityIds
     .map(id => allPossibleAbilities.find(a => a.id === id))
-    .filter(Boolean)
-    .filter(a => classAbilityMap[user.class] === a.class);
+    .filter(Boolean);
+  abilities = abilities.filter(a => classAbilityMap[user.class] === a.class);
   const filtered = abilities
     .filter(a => a.name.toLowerCase().includes(focused.toLowerCase()))
     .slice(0, 25)

--- a/discord-bot/tests/inventory.test.js
+++ b/discord-bot/tests/inventory.test.js
@@ -107,7 +107,8 @@ describe('inventory command', () => {
     abilityCardService.getCards.mockResolvedValue([
       { id: 1, ability_id: 3111, charges: 5 },
       { id: 2, ability_id: 3112, charges: 0 },
-      { id: 3, ability_id: 3121, charges: 3 }
+      { id: 3, ability_id: 3121, charges: 3 },
+      { id: 4, ability_id: 3211, charges: 2 }
     ]);
     const interaction = {
       user: { id: '123' },
@@ -119,6 +120,7 @@ describe('inventory command', () => {
     const names = options.map(o => o.name);
     expect(names).toContain('Power Strike');
     expect(names).toContain('Crippling Blow');
+    expect(names).not.toContain('Divine Strike');
   });
 
   test('handleEquipSelect equips card', async () => {


### PR DESCRIPTION
## Summary
- filter autocomplete suggestions using the class ability mapping
- test autocomplete only returns abilities usable by the player's class

## Testing
- `npm test` in `discord-bot`
- `npm test` in `backend`


------
https://chatgpt.com/codex/tasks/task_e_685ecf0672c88327a3075103274eb36e