### PR TITLE
Enhance /who character sheet

### DIFF
--- a/discord-bot/README.md
+++ b/discord-bot/README.md
@@ -40,19 +40,22 @@ After confirmation the champion is saved to your roster and you can explore the 
 
 ## Using `/who`
 
-`/who` displays the champion bound to a Discord user. You must mention the target player:
+`/who` displays a short character sheet for the mentioned player. You must mention the target user:
 
 ```bash
 /who @SomePlayer
 ```
 
-The command replies with a styled embed showing the player's name and class. If the player has not started the game or has not chosen a class, the embed will display that message instead.
+The command responds with a styled embed showing the player's name, class, base HP and Attack, and the ability they currently have equipped. If the player has not started the game or has not chosen a class, the embed will indicate that instead.
 
 Example output:
 
 ```
-Player Details
+Character Sheet
 Player: SomePlayer - Bard
+HP: 16
+Attack: 2
+Equipped Ability: Power Strike
 ```
 
 ## Admin Tools

--- a/discord-bot/src/utils/abilityCardService.js
+++ b/discord-bot/src/utils/abilityCardService.js
@@ -18,6 +18,15 @@ async function getCards(userId) {
   return rows;
 }
 
+// Retrieve a single ability card by id
+async function getCard(cardId) {
+  const [rows] = await db.query(
+    'SELECT * FROM user_ability_cards WHERE id = ?',
+    [cardId]
+  );
+  return rows[0] || null;
+}
+
 // Mark a specific card as equipped and unequip others for the user
 async function setEquippedCard(userId, cardId) {
   await db.query('UPDATE users SET equipped_ability_id = ? WHERE id = ?', [cardId, userId]);
@@ -31,4 +40,4 @@ async function decrementCharge(cardId) {
   );
 }
 
-module.exports = { addCard, getCards, setEquippedCard, decrementCharge };
+module.exports = { addCard, getCards, getCard, setEquippedCard, decrementCharge };


### PR DESCRIPTION
## Summary
- expand ability card service with a `getCard` helper
- display character sheet stats and equipped ability in `/who`
- document enhanced `/who` command
- test `/who` command with equipped and unequipped states

## Testing
- `npm test` *(fails: `jest` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ed1278a7c83278c8ca104bd51ea89