### PR TITLE
Add admin autocomplete test

### DIFF
--- a/discord-bot/tests/admin.test.js
+++ b/discord-bot/tests/admin.test.js
@@ -82,4 +82,14 @@ describe('admin grant-ability command', () => {
     const options = interaction.respond.mock.calls[0][0];
     expect(options.some(o => o.name === 'Power Strike')).toBe(true);
   });
+
+  test('autocomplete does not suggest nonexistent abilities', async () => {
+    const interaction = {
+      options: { getFocused: jest.fn().mockReturnValue('Nonexistent') },
+      respond: jest.fn().mockResolvedValue()
+    };
+    await admin.autocomplete(interaction);
+    const options = interaction.respond.mock.calls[0][0];
+    expect(options).toHaveLength(0);
+  });
 });


### PR DESCRIPTION
## Summary
- verify `admin.autocomplete` only suggests valid ability names
- ensure abilities not in the canonical list never appear in suggestions

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685ed4975064832788932b5506b55349