### PR TITLE
Pruned ability list and fixed loot map

### DIFF
--- a/discord-bot/src/data/goblinLootMap.js
+++ b/discord-bot/src/data/goblinLootMap.js
@@ -1,12 +1,12 @@
 module.exports = {
   Warrior: 3111,
-  Bard: 3711,
-  Barbarian: 3311,
+  Bard: 3712,
+  Barbarian: 3312,
   Cleric: 3511,
-  Druid: 3611,
-  Enchanter: 4001,
+  Druid: 3612,
+  Enchanter: 4004,
   Paladin: 3211,
-  Rogue: 4101,
+  Rogue: 4104,
   Ranger: 3811,
   Sorcerer: 3411,
   Wizard: 4201

--- a/discord-bot/tests/inventory.test.js
+++ b/discord-bot/tests/inventory.test.js
@@ -146,7 +146,8 @@ describe('inventory command', () => {
     await inventory.handleSetAbilityButton(interaction);
     expect(interaction.reply).toHaveBeenCalledWith(expect.objectContaining({ components: expect.any(Array) }));
     const options = interaction.reply.mock.calls[0][0].components[0].components[0].toJSON().options;
-    expect(options).toHaveLength(2);
+    // Only one unique ability should be presented
+    expect(options).toHaveLength(1);
   });
 
   test('handleAbilitySelect shows card dropdown when multiple copies', async () => {

--- a/docs/gdd.md
+++ b/docs/gdd.md
@@ -20,8 +20,13 @@
 - **Hero Chassis:** Classes determine innate keywords, card slots, and an unchangeable AI Persona that guides combat behavior.
 - **Progression System:** Player Level increases automatically each turn, unlocking higher Tier cards in the draft packs.
 
-## 3. Game Components
+-## 3. Game Components
 - **Ability Cards:** Unique to each class, used for attacks, defense, and special effects.
+  *Prototype note:* the codebase currently implements only a small set of eleven
+  ability cards: Power Strike (3111), Raging Strike (3312), Divine Strike (3211),
+  Divine Light (3511), Regrowth (3612), Illusionary Strike (4004), Dissonant
+  Chord (3712), Precision Shot (3811), Chaos Bolt (3411), Backstab (4104) and
+  Fireball (4201).
 - **Item Cards:** Grant temporary buffs, healing, or special actions.
 - **Monster Cards:** AI-controlled enemies with varying difficulty levels and attack patterns. Monsters can also be played by players and can take multiple team slots.
 - **Player Board:** Tracks health, mana, and other status effects.


### PR DESCRIPTION
## Summary
- document the trimmed ability list in the GDD
- align goblin ability drops with the remaining ability ids
- update inventory dropdown test for deduped abilities

## Testing
- `npm test --silent` in `backend`
- `npm test --silent` in `discord-bot`

------
https://chatgpt.com/codex/tasks/task_e_685ed92556108327a9e11fd91d334456