### PR TITLE
Clarify unique ability dropdown in inventory tests

### DIFF
--- a/discord-bot/tests/inventory.test.js
+++ b/discord-bot/tests/inventory.test.js
@@ -145,9 +145,14 @@ describe('inventory command', () => {
     const interaction = { user: { id: '123' }, reply: jest.fn().mockResolvedValue() };
     await inventory.handleSetAbilityButton(interaction);
     expect(interaction.reply).toHaveBeenCalledWith(expect.objectContaining({ components: expect.any(Array) }));
-    const options = interaction.reply.mock.calls[0][0].components[0].components[0].toJSON().options;
-    // Only one unique ability should be presented
+    const options =
+      interaction.reply.mock.calls[0][0].components[0].components[0].toJSON().
+        options;
+    // The dropdown lists each ability only once regardless of duplicate cards
     expect(options).toHaveLength(1);
+    expect(options[0]).toEqual(
+      expect.objectContaining({ label: 'Power Strike', value: '3111' })
+    );
   });
 
   test('handleAbilitySelect shows card dropdown when multiple copies', async () => {


### PR DESCRIPTION
## Summary
- refine `handleSetAbilityButton` unit test to assert the dropdown only lists one option and includes the expected label/value

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_685edbb5dd948327b92641bbf71abfa6