### PR TITLE
Fix adventure test mocking order

### DIFF
--- a/discord-bot/tests/adventure.test.js
+++ b/discord-bot/tests/adventure.test.js
@@ -1,12 +1,12 @@
-const adventure = require('../src/commands/adventure');
-const classes = require('../src/data/classes');
-const goblinLootMap = require('../src/data/goblinLootMap');
-
 jest.mock('../src/utils/userService', () => ({
   getUser: jest.fn(),
   addAbility: jest.fn()
 }));
 jest.mock('../../backend/game/engine');
+
+const adventure = require('../src/commands/adventure');
+const classes = require('../src/data/classes');
+const goblinLootMap = require('../src/data/goblinLootMap');
 const userService = require('../src/utils/userService');
 const GameEngine = require('../../backend/game/engine');
 


### PR DESCRIPTION
## Summary
- fix order of mocks in `adventure.test.js`
- ensure ability drop tests spy on mocked `addAbility`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685edbb539c88327a4663ef52ba0df11