### PR TITLE
Implement live battle log for Discord adventure

### DIFF
--- a/backend/game/engine.js
+++ b/backend/game/engine.js
@@ -118,15 +118,37 @@ class GameEngine {
    }
 
 
-   runFullGame() {
+
+   *runGameSteps() {
        this.log('⚔️ --- Battle Starting --- ⚔️');
+       let lastIndex = 0;
+       yield { combatants: this.combatants.map(c => ({ ...c })), log: this.battleLog.slice(lastIndex) };
+       lastIndex = this.battleLog.length;
+
        while (!this.isBattleOver) {
            this.startRound();
-           while(this.turnQueue.length > 0 && !this.isBattleOver){
+           if (this.battleLog.length > lastIndex) {
+               yield { combatants: this.combatants.map(c => ({ ...c })), log: this.battleLog.slice(lastIndex) };
+               lastIndex = this.battleLog.length;
+           }
+           while (this.turnQueue.length > 0 && !this.isBattleOver) {
                this.processTurn();
+               if (this.battleLog.length > lastIndex) {
+                   yield { combatants: this.combatants.map(c => ({ ...c })), log: this.battleLog.slice(lastIndex) };
+                   lastIndex = this.battleLog.length;
+               }
            }
        }
        this.log(`\n🏆 --- Battle Finished! --- 🏆`);
+       if (this.battleLog.length > lastIndex) {
+           yield { combatants: this.combatants.map(c => ({ ...c })), log: this.battleLog.slice(lastIndex) };
+       }
+   }
+
+   runFullGame() {
+       for (const _ of this.runGameSteps()) {
+           // exhaust generator to completion
+       }
        return this.battleLog;
    }
 }

--- a/backend/tests/stepGenerator.test.js
+++ b/backend/tests/stepGenerator.test.js
@@ -1,0 +1,15 @@
+const GameEngine = require('../game/engine');
+const { createCombatant } = require('../game/utils');
+
+describe('runGameSteps generator', () => {
+  test('yields battle steps sequentially', () => {
+    const player = createCombatant({ hero_id: 1 }, 'player', 0);
+    const enemy = createCombatant({ hero_id: 2001 }, 'enemy', 0);
+    const engine = new GameEngine([player, enemy]);
+    const steps = Array.from(engine.runGameSteps());
+    expect(steps.length).toBeGreaterThan(1);
+    expect(steps[0].log[0]).toContain('Battle Starting');
+    const last = steps[steps.length - 1];
+    expect(last.log.join('\n')).toContain('Battle Finished');
+  });
+});

--- a/discord-bot/README.md
+++ b/discord-bot/README.md
@@ -58,6 +58,13 @@ Attack: 2
 Equipped Ability: Power Strike
 ```
 
+## Using `/adventure`
+
+`/adventure` sends your hero into a practice fight against a random goblin. The
+command posts an embed that updates every couple seconds to show remaining HP
+for all combatants and the latest log entries at the top. When the fight ends a
+final embed announces **Victory** or **Defeat** and any loot is granted.
+
 ## Admin Tools
 
 `/admin grant-ability` lets users with the **Game Master** role grant an ability card to any player. The command requires two options:

--- a/discord-bot/src/utils/embedBuilder.js
+++ b/discord-bot/src/utils/embedBuilder.js
@@ -47,6 +47,28 @@ function buildCardEmbed(card) {
   return embed;
 }
 
+/**
+ * Build an embed showing current combatant HP and log lines.
+ * New log entries should appear at the top of the description.
+ *
+ * @param {object[]} combatants
+ * @param {string} logText
+ * @returns {EmbedBuilder}
+ */
+function buildBattleEmbed(combatants, logText) {
+  const hpLines = combatants
+    .map(c => `${c.heroData.name}: ${c.currentHp}/${c.maxHp} HP`)
+    .join('\n');
+  const embed = new EmbedBuilder()
+    .setColor('#29b6f6')
+    .setTitle('Battle')
+    .setTimestamp()
+    .setFooter({ text: 'Auto\u2011Battler Bot' })
+    .setDescription(logText)
+    .addFields({ name: 'HP', value: hpLines });
+  return embed;
+}
+
 
 /**
  * DM a player when they obtain a new ability card.
@@ -59,4 +81,4 @@ async function sendCardDM(user, card) {
   await user.send({ embeds: [embed] });
 }
 
-module.exports = { simple, sendCardDM, buildCardEmbed };
+module.exports = { simple, sendCardDM, buildCardEmbed, buildBattleEmbed };

--- a/discord-bot/tests/adventure.test.js
+++ b/discord-bot/tests/adventure.test.js
@@ -14,7 +14,9 @@ describe('adventure command', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     GameEngine.mockImplementation(() => ({
-      runFullGame: jest.fn(() => ['log']),
+      runGameSteps: function* () {
+        yield { combatants: [], log: ['log'] };
+      },
       winner: 'player'
     }));
   });
@@ -46,7 +48,7 @@ describe('adventure command', () => {
 
   test('no ability drop when defeated', async () => {
     GameEngine.mockImplementationOnce(() => ({
-      runFullGame: jest.fn(() => ['log']),
+      runGameSteps: function* () { yield { combatants: [], log: ['log'] }; },
       winner: 'enemy'
     }));
     userService.getUser.mockResolvedValue({ discord_id: '123', class: 'Warrior' });

--- a/docs/gdd.md
+++ b/docs/gdd.md
@@ -445,6 +445,7 @@ For detailed information on Deck Size Progression, Card Power Curves, and Loot D
 - Heroes on each side are arranged in a vertical column (top and bottom positions).
 - A Battle Log is displayed at the bottom of the screen to show turn-by-turn actions.
 - A "Speed Control" button is present at the top-center of the screen.
+- In the Discord bot version the battle log is streamed live by editing a single message every few seconds.
 
 ### Team Generation
 - The Player's team consists of the 2 heroes and 2 weapons they drafted.


### PR DESCRIPTION
## Summary
- expose `runGameSteps` generator in game engine
- stream battle updates in `/adventure` command
- show combatant HP and latest log lines using `buildBattleEmbed`
- document adventure battle log in README and GDD
- add tests for the generator

## Testing
- `npm test` in `backend`
- `npm test` in `discord-bot`

------
https://chatgpt.com/codex/tasks/task_e_685edbb3baac83279928397af544dd12