### PR TITLE
Update docs for auto-battler-react path

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,34 +1,27 @@
 # Auto Battler Prototypes
 
-This repository contains a series of HTML and JavaScript prototypes for a card based auto‑battler.  The main implementation lives in the `hero-game` folder, while the root directory holds several earlier proof‑of‑concept files.
+This repository contains a series of HTML and JavaScript prototypes for a card based auto‑battler.  The most complete browser implementation now lives in the `auto-battler-react/` folder, while the root directory holds several earlier proof‑of‑concept files.
 
-For details on the current prototype and its user interface, see [hero-game/README.md](hero-game/README.md).
+For details on the current prototype and its user interface, see [auto-battler-react/README.md](auto-battler-react/README.md).
 
 ## Repository Layout
 
-- `hero-game/` – Modern prototype with modular JavaScript, scenes and battle logic.
-- `index.html`, `poc.html`, `poc2`, `poc3.html` – Stand‑alone prototypes kept for reference.
+- `auto-battler-react/` – React-based prototype with modular scenes and battle logic.
+- `index.html`, `poc2` – Stand‑alone HTML prototypes kept for reference.
 - `docs/` – Game design documents and technical notes.
 - `backend/` – Basic Express server used for local development.
 
 ## Running the Game
 
-The `hero-game` prototype uses ES module imports and must be served from a local web server.  Any simple static server will work.  From the repository root run:
+The React prototype is built with Vite. From the repository root run:
 
 ```bash
-# Using Python
-python3 -m http.server 8000
+cd auto-battler-react
+npm install
+npm run dev
 ```
 
-Then open `http://localhost:8000/hero-game/` in your browser.
-
-If you prefer Node.js you can run:
-
-```bash
-npx http-server -p 8000
-```
-
-Any other static file server will work as long as it serves the repository root.
+This starts the Vite development server (usually on `http://localhost:5173`).
 
 ## Running the Backend
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -2,7 +2,7 @@
 
 This directory contains design documents and technical references for the auto‑battler prototypes.  New contributors should begin with `technical_overview.md` for a code walkthrough and `event_schema.md` for the battle event format.
 
-For instructions on running the playable demo see [../hero-game/README.md](../hero-game/README.md).  The general repository layout is described in [../README.md](../README.md).
+For instructions on running the playable demo see [../auto-battler-react/README.md](../auto-battler-react/README.md).  The general repository layout is described in [../README.md](../README.md).
 
 ## Files
 

--- a/docs/event_schema.md
+++ b/docs/event_schema.md
@@ -109,5 +109,5 @@ Emitted once when a battle begins.
 Other events currently produced by the simulator include `TURN_SKIPPED`, `TURN_PASSED`, `ENERGY_GAIN`, `TURN_ACTION`, `ACTION_FAILED` and `EFFECT_APPLYING`. These share the same envelope structure and follow a similar pattern with `turn`, `actor`/`caster` and relevant fields.
 
 ## Entity Formats
-`GameEntity` and `Card` entries appear as plain JSON objects containing identifiers, names, stats and any active effects.  The current JavaScript implementation defines these structures in `hero-game/js/data.js` and related modules.
+`GameEntity` and `Card` entries appear as plain JSON objects containing identifiers, names, stats and any active effects.  The current JavaScript implementation defines these structures in `auto-battler-react/src/data/data.js` and related modules.
 

--- a/docs/poc2_html_GDD.md
+++ b/docs/poc2_html_GDD.md
@@ -81,8 +81,8 @@
 
 ## 8. Connections to Other Projects
 
-*   **Evolution of Drafting:** This PoC represents an earlier, simpler version of the multi-stage drafting (hero, then ability, then weapon, then armor) found in `hero-game/`.
-*   **Card Visuals:** The compact card style with circular art is distinct from the rectangular art in `poc.html` and `hero-game/`, showing exploration of different visual approaches.
+*   **Evolution of Drafting:** This PoC represents an earlier, simpler version of the multi-stage drafting (hero, then ability, then weapon, then armor) found in the `auto-battler-react/` prototype.
+*   **Card Visuals:** The compact card style with circular art is distinct from the rectangular art in `poc.html` and `auto-battler-react/`, showing exploration of different visual approaches.
 *   The "Ultra Rare" rarity likely maps to "Epic" in the more developed projects.
 
 ## 9. Future Ideas / Potential Improvements (If this PoC were to be expanded)

--- a/docs/poc_html_GDD.md
+++ b/docs/poc_html_GDD.md
@@ -61,7 +61,7 @@
 *   **Tailwind CSS for Rapid UI Prototyping:** Demonstrates the utility of a utility-first CSS framework for quickly building UI mockups.
 
 ## 8. Connections to Other Projects
-*   **Visual Basis:** Provides a potential visual direction for the cards used in `hero-game/`, `auto-battler-react/`, and the `discord-bot/` (especially for `cardRenderer.js`).
+*   **Visual Basis:** Provides a potential visual direction for the cards used in the `auto-battler-react/` client and the `discord-bot/` (especially for `cardRenderer.js`).
 *   **Data Structure Ideas:** The hardcoded data (hero stats, abilities) reflects the kind of information that is structured in `data.js` files in other projects.
 *   The "Ultra Rare" rarity used here likely corresponds to the "Epic" rarity defined in the main game data.
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,5 +1,5 @@
-# Project Roadmap: Hero-Game Discord Bot
-To evolve the hero-game into a feature-rich Discord bot experience by implementing the following 10 key features.
+# Project Roadmap: Auto Battler Discord Bot
+To evolve the project into a feature-rich Discord bot experience by implementing the following 10 key features.
 
 ## Core Gameplay Mechanics
 1.  **Character Creation and Customization:** Allow users to create unique heroes with customizable stats, abilities, and appearances.
@@ -51,7 +51,7 @@ The core combat is already implemented but can be expanded for a Discord environ
 
 ### Detailed Combat Logs
 **Implementation Plan:**
--   **Existing Feature:** Note that `BattleScene.js` in the hero-game and the `GameEngine` in the backend already produce detailed battle logs.
+    -   **Existing Feature:** Note that `BattleScene.jsx` in `auto-battler-react/src/scenes` and the `GameEngine` in the backend already produce detailed battle logs.
 -   **Discord Display:** The task is to format this log output within a Discord embed, potentially using pagination for long fights. Reference the simple embed builder in `discord-bot/src/utils/embedBuilder.js`.
 
 ## 3. In-Game Economy and Currency

--- a/docs/technical_overview.md
+++ b/docs/technical_overview.md
@@ -1,36 +1,35 @@
 # Technical Overview
 
-This document explains the structure of the playable prototype located in `hero-game/` and how the pieces fit together. It is intended for developers who want to extend the prototype or integrate AI generated features.
+This document explains the structure of the playable prototype located in `auto-battler-react/` and how the pieces fit together. It is intended for developers who want to extend the prototype or integrate AI generated features.
 
 Additional design documents are listed in [README.md](README.md).
 
 ## Folder Layout
 
 ```
-hero-game/
-├── index.html       # Entry point for the browser game
-├── style.css        # Basic styling
-└── js/
-    ├── main.js      # Game bootstrap and scene management
-    ├── data.js      # Static card and hero data, including `allPossibleMinions`
-    ├── background-animation.js
-    ├── utils.js
-    ├── scenes/      # Individual scenes (pack, draft, battle, recap)
-    ├── systems/     # Game systems such as EffectProcessor
-    └── ui/          # UI helpers like CardRenderer
+auto-battler-react/
+├── index.html            # HTML entry point loaded by Vite
+├── src/
+│   ├── main.jsx          # Application bootstrap
+│   ├── data/             # Static card and hero data
+│   ├── scenes/           # Individual scenes (pack, draft, battle, recap)
+│   ├── components/       # Shared React components
+│   └── store.js          # Zustand store and helpers
+└── public/
+    └── vite.svg          # Example static asset
 ```
 
 ## Running Locally
 
-From the repository root start any static server, e.g.:
+From the repository root run the React development server:
 
 ```bash
-python3 -m http.server 8000
+cd ../auto-battler-react
+npm install
+npm run dev
 ```
 
-Then open `http://localhost:8000/hero-game/` in your browser. Additional options are described in [../README.md](../README.md).
-
-If you prefer Node.js you can run `npx http-server -p 8000` instead of the Python command above.
+This will launch Vite on `http://localhost:5173` by default. Additional options are described in [../README.md](../README.md).
 
 ### Client Logic
 


### PR DESCRIPTION
## Summary
- point README to the React prototype
- adjust docs for the current folder structure
- remove old hero-game paths

## Testing
- `npm run lint` in `auto-battler-react`
- `npm test` in `backend`
- `npm test` in `discord-bot`


------
https://chatgpt.com/codex/tasks/task_e_685edbb47c4883278b939ec57eb3b381