### PR TITLE
Fix log order in adventure command

### DIFF
--- a/discord-bot/src/commands/adventure.js
+++ b/discord-bot/src/commands/adventure.js
@@ -55,7 +55,7 @@ async function execute(interaction) {
   let battleMessage;
   let logText = '';
   for (const step of engine.runGameSteps()) {
-    logText = [...step.log, logText].filter(Boolean).join('\n');
+    logText = [logText, ...step.log].filter(Boolean).join('\n');
     const embed = buildBattleEmbed(step.combatants, logText);
     if (!battleMessage) {
       battleMessage = await interaction.followUp({ embeds: [embed] });

--- a/discord-bot/tests/adventure.test.js
+++ b/discord-bot/tests/adventure.test.js
@@ -60,11 +60,17 @@ describe('adventure command', () => {
   });
 
   test('battle log is included in embed', async () => {
+    GameEngine.mockImplementationOnce(() => ({
+      runGameSteps: function* () {
+        yield { combatants: [], log: ['first', 'second'] };
+      },
+      winner: 'player'
+    }));
     userService.getUser.mockResolvedValue({ discord_id: '123', class: 'Barbarian' });
     const interaction = { user: { id: '123' }, reply: jest.fn().mockResolvedValue(), followUp: jest.fn().mockResolvedValue() };
     await adventure.execute(interaction);
     const description = interaction.followUp.mock.calls[0][0].embeds[0].data.description;
-    expect(description).toContain('log');
+    expect(description).toBe('first\nsecond');
   });
 
   test('drops correct ability based on goblin class', async () => {


### PR DESCRIPTION
## Summary
- show adventure combat logs in chronological order
- check new log order in adventure test

## Testing
- `npm test --silent` in `discord-bot`
- `npm test --silent` in `backend`

------
https://chatgpt.com/codex/tasks/task_e_685ee100532083278b5ed04146c8cf20