### PR TITLE
Clarify battle log orientation

### DIFF
--- a/discord-bot/README.md
+++ b/discord-bot/README.md
@@ -62,8 +62,9 @@ Equipped Ability: Power Strike
 
 `/adventure` sends your hero into a practice fight against a random goblin. The
 command posts an embed that updates every couple seconds to show remaining HP
-for all combatants and the latest log entries at the top. When the fight ends a
-final embed announces **Victory** or **Defeat** and any loot is granted.
+for all combatants. The battle log grows from top to bottom, with new entries
+appended to the bottom of the list. When the fight ends a final embed announces
+**Victory** or **Defeat** and any loot is granted.
 
 ## Admin Tools
 

--- a/docs/gdd.md
+++ b/docs/gdd.md
@@ -444,6 +444,7 @@ For detailed information on Deck Size Progression, Card Power Curves, and Loot D
 - The scene is split into two sides: Player team on the left, Enemy team on the right.
 - Heroes on each side are arranged in a vertical column (top and bottom positions).
 - A Battle Log is displayed at the bottom of the screen to show turn-by-turn actions.
+  The log grows from top to bottom with new entries appended to the end.
 - A "Speed Control" button is present at the top-center of the screen.
 - In the Discord bot version the battle log is streamed live by editing a single message every few seconds.
 


### PR DESCRIPTION
## Summary
- update `/adventure` docs about log order
- clarify log order in gdd

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685ee1015ecc8327be7046798e237c20