### PR TITLE
Add ability card charges

### DIFF
--- a/backend/game/utils.js
+++ b/backend/game/utils.js
@@ -5,10 +5,16 @@ function createCombatant(playerData, team, position) {
     const hero = allPossibleHeroes.find(h => h.id === playerData.hero_id);
     const weapon = allPossibleWeapons.find(w => w.id === playerData.weapon_id);
     const armor = allPossibleArmors.find(a => a.id === playerData.armor_id);
-    const ability = allPossibleAbilities.find(a => a.id === playerData.ability_id);
-    const deckAbilities = (playerData.deck || []).map(id => {
-        const a = allPossibleAbilities.find(ab => ab.id === id);
-        return a ? { ...a, charges: 10 } : null;
+    const abilityId = playerData.ability_id || (playerData.ability_card && playerData.ability_card.ability_id);
+    const ability = allPossibleAbilities.find(a => a.id === abilityId);
+    const deckAbilities = (playerData.deck || []).map(entry => {
+        if (typeof entry === 'object') {
+            const a = allPossibleAbilities.find(ab => ab.id === entry.ability_id);
+            return a ? { ...a, cardId: entry.id, charges: entry.charges ?? 10 } : null;
+        } else {
+            const a = allPossibleAbilities.find(ab => ab.id === entry);
+            return a ? { ...a, charges: 10 } : null;
+        }
     }).filter(Boolean);
 
     if (!hero) return null;
@@ -25,8 +31,12 @@ function createCombatant(playerData, team, position) {
         heroData: hero,
         weaponData: weapon,
         armorData: armor,
-        abilityData: ability || deckAbilities[0] || null,
-        abilityCharges: ability ? 10 : (deckAbilities[0] ? deckAbilities[0].charges : 0),
+        abilityData: ability
+            ? (playerData.ability_card ? { ...ability, cardId: playerData.ability_card.id } : ability)
+            : deckAbilities[0] || null,
+        abilityCharges: ability
+            ? (playerData.ability_card ? playerData.ability_card.charges : 10)
+            : (deckAbilities[0] ? deckAbilities[0].charges : 0),
         deck: ability ? deckAbilities : deckAbilities.slice(1),
         team: team,
         position: position,

--- a/backend/tests/abilityCard.test.js
+++ b/backend/tests/abilityCard.test.js
@@ -1,0 +1,33 @@
+jest.mock('../../discord-bot/src/utils/abilityCardService', () => ({
+  decrementCharge: jest.fn()
+}));
+const abilityCardService = require('../../discord-bot/src/utils/abilityCardService');
+const GameEngine = require('../game/engine');
+const { createCombatant } = require('../game/utils');
+
+describe('Ability card charges', () => {
+  beforeEach(() => {
+    abilityCardService.decrementCharge.mockClear();
+  });
+
+  test('decrementCharge is called when ability card is used', () => {
+    const card = { id: 99, ability_id: 3111, charges: 2 };
+    const player = createCombatant({ hero_id: 1, ability_id: 3111, ability_card: card }, 'player', 0);
+    const enemy = createCombatant({ hero_id: 2001 }, 'enemy', 0);
+    const engine = new GameEngine([player, enemy]);
+
+    // Build energy and use ability
+    engine.startRound();
+    engine.processTurn(); // player
+    engine.processTurn(); // enemy
+    engine.startRound();
+    engine.processTurn(); // player
+    engine.processTurn(); // enemy
+    engine.startRound();
+    engine.processTurn(); // player uses ability
+
+    expect(abilityCardService.decrementCharge).toHaveBeenCalledWith(card.id);
+    const updated = engine.combatants.find(c => c.team === 'player');
+    expect(updated.abilityCharges).toBe(card.charges - 1);
+  });
+});


### PR DESCRIPTION
## Summary
- support ability cards in `createCombatant`
- include cardId/charges when building ability decks
- add tests for ability card charge decrement

## Testing
- `npm --prefix backend test`

------
https://chatgpt.com/codex/tasks/task_e_685ee10a33b883279e64f30fb9756b37