### PR TITLE
Integrate equipped ability card in adventure battles

### DIFF
--- a/discord-bot/src/commands/adventure.js
+++ b/discord-bot/src/commands/adventure.js
@@ -1,5 +1,6 @@
 const { SlashCommandBuilder } = require('discord.js');
 const userService = require('../utils/userService');
+const abilityCardService = require('../utils/abilityCardService');
 const { sendCardDM, buildCardEmbed, buildBattleEmbed, simple } = require('../utils/embedBuilder');
 
 const MAX_LOG_LINES = 20;
@@ -38,16 +39,23 @@ async function execute(interaction) {
     return;
   }
 
-  const playerAbilities = allPossibleAbilities
-    .filter(a => a.class === (classAbilityMap[user.class] || user.class) && a.rarity === 'Common')
-    .map(a => a.id);
+  const cards = await abilityCardService.getCards(user.id);
+  const equippedCard = cards.find(c => c.id === user.equipped_ability_id);
+  const playerAbilityId = equippedCard ? equippedCard.ability_id : undefined;
+  const playerAbilities = cards
+    .filter(c => c.id !== user.equipped_ability_id)
+    .map(c => c.ability_id);
 
   const goblinAbilityPool = allPossibleAbilities
     .filter(a => a.class === (classAbilityMap[goblinClass] || goblinClass) && a.rarity === 'Common');
   const goblinAbilities = goblinAbilityPool.map(a => a.id);
 
-  const player = createCombatant({ hero_id: playerHero.id, deck: playerAbilities }, 'player', 0);
+  const player = createCombatant({ hero_id: playerHero.id, ability_id: playerAbilityId, deck: playerAbilities }, 'player', 0);
   const goblin = createCombatant({ hero_id: goblinBase.id, deck: goblinAbilities }, 'enemy', 0);
+  if (equippedCard && player.abilityData) {
+    player.abilityData = { ...player.abilityData, cardId: equippedCard.id, charges: equippedCard.charges };
+    player.abilityCharges = equippedCard.charges;
+  }
   goblin.heroData = { ...goblin.heroData, name: `Goblin ${goblinClass}` };
 
   console.log(`[BATTLE START] Player ${user.class} vs Goblin ${goblinClass}`);


### PR DESCRIPTION
## Summary
- fetch player ability cards in `/adventure`
- apply equipped card ability and deck to combatant
- attach ability card metadata to the combatant for charge tracking
- mock ability card retrieval in `adventure` tests and verify equipped ability usage

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_685eea112ff083278eb5a19d7f09f9e0