### PR TITLE
Fix ability effects to heal and damage correctly

### DIFF
--- a/backend/tests/abilityEffect.test.js
+++ b/backend/tests/abilityEffect.test.js
@@ -1,0 +1,38 @@
+const GameEngine = require('../game/engine');
+const { createCombatant } = require('../game/utils');
+
+describe('Ability effect application', () => {
+  test('Divine Strike deals damage and heals the caster', () => {
+    const player = createCombatant({ hero_id: 1, ability_id: 3211 }, 'player', 0);
+    const enemy = createCombatant({ hero_id: 1 }, 'enemy', 0);
+    // weaken player to observe healing
+    player.currentHp = player.maxHp - 4;
+    // reduce enemy attack so player survives
+    enemy.attack = 1;
+
+    const engine = new GameEngine([player, enemy]);
+
+    // two rounds to build energy
+    engine.startRound();
+    engine.processTurn(); // player
+    engine.processTurn(); // enemy
+    engine.startRound();
+    engine.processTurn(); // player
+    engine.processTurn(); // enemy
+
+    // third round - ability should trigger
+    engine.startRound();
+    engine.processTurn(); // player uses Divine Strike
+
+    const p = engine.combatants.find(c => c.team === 'player');
+    const e = engine.combatants.find(c => c.team === 'enemy');
+
+    expect(p.currentHp).toBe(player.maxHp - 4 - 2 + 2); // took 2 damage then healed 2
+
+    const expectedEnemyHp = enemy.maxHp - player.attack * 2 - 2;
+    expect(e.currentHp).toBe(expectedEnemyHp);
+
+    // log should mention combined damage and healing
+    expect(engine.battleLog.some(l => l.includes('hits') && l.includes('and is healed for 2'))).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- implement ability effect parsing (damage + self-heal) in backend engine
- call new `applyAbilityEffect` when using an ability
- add regression test for Divine Strike effect

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685eee57596c832793e9c9d0ec6e9662