### PR TITLE
Fix equip check

### DIFF
--- a/discord-bot/src/utils/abilityCardService.js
+++ b/discord-bot/src/utils/abilityCardService.js
@@ -29,7 +29,15 @@ async function getCard(cardId) {
 
 // Mark a specific card as equipped and unequip others for the user
 async function setEquippedCard(userId, cardId) {
-  await db.query('UPDATE users SET equipped_ability_id = ? WHERE id = ?', [cardId, userId]);
+  await db.query(
+    `UPDATE users
+     SET equipped_ability_id = ?
+     WHERE id = ? AND EXISTS (
+       SELECT 1 FROM user_ability_cards
+       WHERE id = ? AND user_id = ?
+     )`,
+    [cardId, userId, cardId, userId]
+  );
 }
 
 // Reduce the charge count of a card by one, clamping at zero

--- a/discord-bot/tests/abilityCardService.test.js
+++ b/discord-bot/tests/abilityCardService.test.js
@@ -1,0 +1,25 @@
+const abilityCardService = require('../src/utils/abilityCardService');
+
+jest.mock('../util/database', () => ({
+  query: jest.fn().mockResolvedValue([])
+}));
+const db = require('../util/database');
+
+describe('abilityCardService.setEquippedCard', () => {
+  beforeEach(() => {
+    db.query.mockClear();
+  });
+
+  test('updates equipped card only if card belongs to user', async () => {
+    await abilityCardService.setEquippedCard(5, 10);
+    expect(db.query).toHaveBeenCalledWith(
+      `UPDATE users
+     SET equipped_ability_id = ?
+     WHERE id = ? AND EXISTS (
+       SELECT 1 FROM user_ability_cards
+       WHERE id = ? AND user_id = ?
+     )`,
+      [10, 5, 10, 5]
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- ensure `setEquippedCard` checks card ownership
- test SQL used in `setEquippedCard`

## Testing
- `npm test` in `discord-bot`
- `npm test` in `backend`

------
https://chatgpt.com/codex/tasks/task_e_685eee5d93b08327a70284f4ebe1d3dc