### PR TITLE
Refactor ability effect logging

### DIFF
--- a/backend/game/engine.js
+++ b/backend/game/engine.js
@@ -46,7 +46,6 @@ class GameEngine {
    }
 
    applyAbilityEffect(attacker, target, ability) {
-       this.log(`${attacker.heroData.name} uses ${ability.name}!`);
 
        let damageDealt = 0;
        let healingDone = 0;
@@ -63,13 +62,15 @@ class GameEngine {
            this.applyHeal(attacker, healingDone);
        }
 
-       let logParts = [];
-       if (damageDealt > 0) logParts.push(`${attacker.heroData.name} hits ${target.heroData.name} for ${damageDealt} damage`);
-       if (healingDone > 0) logParts.push(`and is healed for ${healingDone} hit points.`);
-
-       if (logParts.length > 0) {
-           this.log(logParts.join(' '));
+       let message = `${attacker.heroData.name} uses ${ability.name}`;
+       if (damageDealt > 0) {
+           message += `, hits ${target.heroData.name} for ${damageDealt} damage`;
        }
+       if (healingDone > 0) {
+           const healPart = `and is healed for ${healingDone} hit points`;
+           message += damageDealt > 0 ? ` ${healPart}` : `, ${healPart}`;
+       }
+       this.log(message + '.');
 
        if (target.currentHp <= 0) {
            this.log(`💀 ${target.heroData.name} has been defeated.`);

--- a/backend/tests/abilityEffect.test.js
+++ b/backend/tests/abilityEffect.test.js
@@ -32,7 +32,10 @@ describe('Ability effect application', () => {
     const expectedEnemyHp = enemy.maxHp - player.attack * 2 - 2;
     expect(e.currentHp).toBe(expectedEnemyHp);
 
-    // log should mention combined damage and healing
-    expect(engine.battleLog.some(l => l.includes('hits') && l.includes('and is healed for 2'))).toBe(true);
+    // single log line should describe both damage and healing
+    const lines = engine.battleLog.filter(l => l.includes('uses Divine Strike'));
+    expect(lines.length).toBe(1);
+    expect(lines[0]).toContain('hits');
+    expect(lines[0]).toContain('and is healed for 2');
   });
 });


### PR DESCRIPTION
## Summary
- log ability usage and effects in a single message
- update ability effect test to expect combined log entry

## Testing
- `npm --prefix backend test`

------
https://chatgpt.com/codex/tasks/task_e_685ef36a813c8327ae92e6dc9e0538a5