### PR TITLE
Summarize ability effects in single log entry

### DIFF
--- a/backend/game/engine.js
+++ b/backend/game/engine.js
@@ -46,7 +46,6 @@ class GameEngine {
    }
 
    applyAbilityEffect(attacker, target, ability) {
-       this.log(`${attacker.heroData.name} uses ${ability.name}!`);
 
        let damageDealt = 0;
        let healingDone = 0;
@@ -86,25 +85,25 @@ class GameEngine {
            this.applyHeal(healTarget, healingDone);
        }
 
-       let logParts = [];
+       let log = `${attacker.heroData.name} uses ${ability.name}`;
        if (damageDealt > 0) {
            if (multiTarget) {
-               logParts.push(`${attacker.heroData.name} hits all enemies for ${damageDealt} damage`);
+               log += ` and hits all enemies for ${damageDealt} damage`;
            } else {
-               logParts.push(`${attacker.heroData.name} hits ${target.heroData.name} for ${damageDealt} damage`);
+               log += ` and hits ${target.heroData.name} for ${damageDealt} damage`;
            }
        }
        if (healingDone > 0) {
            if (healTarget === attacker) {
-               logParts.push(`and is healed for ${healingDone} hit points.`);
+               log += ` and is healed for ${healingDone} hit points.`;
            } else if (healTarget) {
-               logParts.push(`and heals ${healTarget.heroData.name} for ${healingDone} hit points.`);
+               log += ` and heals ${healTarget.heroData.name} for ${healingDone} hit points.`;
            }
+       } else {
+           log += '.';
        }
 
-       if (logParts.length > 0) {
-           this.log(logParts.join(' '));
-       }
+       this.log(log);
 
        if (multiTarget && damageDealt > 0) {
            const enemies = this.combatants.filter(c => c.team !== attacker.team && c.currentHp <= 0);

--- a/backend/tests/abilityEffect.test.js
+++ b/backend/tests/abilityEffect.test.js
@@ -32,7 +32,8 @@ describe('Ability effect application', () => {
     const expectedEnemyHp = enemy.maxHp - player.attack * 2 - 2;
     expect(e.currentHp).toBe(expectedEnemyHp);
 
-    // log should mention combined damage and healing
-    expect(engine.battleLog.some(l => l.includes('hits') && l.includes('and is healed for 2'))).toBe(true);
+    // there should be exactly one log entry describing both damage and healing
+    const actionLines = engine.battleLog.filter(l => l.includes('hits') && l.includes('healed'));
+    expect(actionLines).toHaveLength(1);
   });
 });


### PR DESCRIPTION
## Summary
- combine ability use and effect logs in `applyAbilityEffect`
- update ability effect test to expect a single log line

## Testing
- `npm test --prefix backend`

------
https://chatgpt.com/codex/tasks/task_e_685ef7e634d08327b423b6a556c5f08a