### PR TITLE
Remove runFullGame call from adventure.js

### DIFF
--- a/discord-bot/src/commands/adventure.js
+++ b/discord-bot/src/commands/adventure.js
@@ -83,7 +83,6 @@ async function execute(interaction) {
 
   const outcome = engine.winner === 'player' ? 'Victory!' : 'Defeat!';
   await interaction.followUp({ embeds: [simple(outcome)] });
-  engine.runFullGame();
   console.log(`[BATTLE END] ${engine.winner}`);
 
   if (engine.winner === 'player') {


### PR DESCRIPTION
## Summary
- avoid calling `runFullGame` after running step generator

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685efd9b159c83279be3c2db26680edf