### PR TITLE
Implement narrative battle recap

### DIFF
--- a/discord-bot/tests/adventure.test.js
+++ b/discord-bot/tests/adventure.test.js
@@ -69,7 +69,9 @@ describe('adventure command', () => {
     ).id;
     expect(userService.addAbility).toHaveBeenCalledWith('123', expectedId);
     Math.random.mockRestore();
-    expect(interaction.followUp).toHaveBeenCalledWith(expect.objectContaining({ embeds: expect.any(Array), ephemeral: true }));
+    expect(interaction.followUp).toHaveBeenCalledWith(
+      expect.objectContaining({ embeds: expect.any(Array) })
+    );
   });
 
   test('no ability drop when defeated', async () => {


### PR DESCRIPTION
## Summary
- improve `/adventure` command summary to use a narrative recap
- adjust unit tests to match new embed behavior

## Testing
- `npm test` in `backend`
- `npm test` in `discord-bot`

------
https://chatgpt.com/codex/tasks/task_e_685f03a2ff208327867a237c3327b21e