### PR TITLE
Fix friendly ability fallback attack targeting

### DIFF
--- a/backend/game/engine.js
+++ b/backend/game/engine.js
@@ -162,12 +162,13 @@ class GameEngine {
            if (enemies.length > 0) {
                const ability = attacker.abilityData;
                const cost = ability ? ability.energyCost || 1 : 1;
-               let target = enemies[0];
-               if (ability && ability.targetType === 'friendly') {
-                   target = attacker;
-               }
+
+               const abilityTarget = ability && ability.targetType === 'friendly'
+                   ? attacker
+                   : enemies[0];
+
                if (ability && attacker.abilityCharges > 0 && attacker.currentEnergy >= cost) {
-                   this.applyAbilityEffect(attacker, target, ability);
+                   this.applyAbilityEffect(attacker, abilityTarget, ability);
                    attacker.currentEnergy -= cost;
                    attacker.abilityCharges -= 1;
                    if (ability.cardId) {
@@ -184,7 +185,7 @@ class GameEngine {
                        }
                    }
                } else {
-                   this.applyDamage(attacker, target, attacker.attack);
+                   this.applyDamage(attacker, enemies[0], attacker.attack);
                }
            }
        }

--- a/backend/tests/friendlyTargeting.test.js
+++ b/backend/tests/friendlyTargeting.test.js
@@ -29,4 +29,18 @@ describe('Friendly ability targeting', () => {
     expect(updated.currentHp).toBe(updated.maxHp);
     expect(engine.battleLog.some(l => l.includes('Regrowth') && l.includes('healed'))).toBe(true);
   });
+
+  test('lack of energy causes cleric to attack the enemy', () => {
+    const cleric = createCombatant({ hero_id: 4, ability_id: 3511 }, 'enemy', 0);
+    const player = createCombatant({ hero_id: 1 }, 'player', 0);
+    cleric.currentEnergy = 0; // not enough for Divine Light
+    cleric.speed = 10;
+    const engine = new GameEngine([cleric, player]);
+    engine.startRound();
+    engine.processTurn();
+    const updatedPlayer = engine.combatants.find(c => c.id === player.id);
+    const updatedCleric = engine.combatants.find(c => c.id === cleric.id);
+    expect(updatedPlayer.currentHp).toBe(player.maxHp - cleric.attack);
+    expect(updatedCleric.currentHp).toBe(cleric.maxHp);
+  });
 });


### PR DESCRIPTION
## Summary
- ensure attacks fall back to enemy targets if a friendly ability can't be used
- test cleric lacking energy attacks the player

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_685f3e152a64832785025a07b31fae42