### PR TITLE
Fix ability usage and battle pacing

### DIFF
--- a/backend/game/engine.js
+++ b/backend/game/engine.js
@@ -167,6 +167,7 @@ class GameEngine {
                    ? attacker
                    : enemies[0];
 
+               let usedAbility = false;
                if (ability && attacker.abilityCharges > 0 && attacker.currentEnergy >= cost) {
                    this.applyAbilityEffect(attacker, abilityTarget, ability);
                    attacker.currentEnergy -= cost;
@@ -184,7 +185,10 @@ class GameEngine {
                            attacker.abilityData = null;
                        }
                    }
-               } else {
+                   usedAbility = true;
+               }
+
+               if (!usedAbility) {
                    this.applyDamage(attacker, enemies[0], attacker.attack);
                }
            }

--- a/backend/tests/energy.test.js
+++ b/backend/tests/energy.test.js
@@ -32,4 +32,31 @@ describe('Energy accumulation and ability usage', () => {
     expect(p.abilityCharges).toBe(9);
     expect(engine.battleLog.some(l => l.includes('uses Power Strike'))).toBe(true);
   });
+
+  test('enemy ability also triggers with sufficient energy', () => {
+    const player = createCombatant({ hero_id: 1 }, 'player', 0);
+    const enemy = createCombatant({ hero_id: 1, ability_id: 3111 }, 'enemy', 0);
+    enemy.speed = 10;
+
+    const engine = new GameEngine([player, enemy]);
+
+    // round 1
+    engine.startRound();
+    engine.processTurn(); // enemy
+    engine.processTurn(); // player
+
+    // round 2
+    engine.startRound();
+    engine.processTurn(); // enemy
+    engine.processTurn(); // player
+
+    // round 3 - enemy ability should fire
+    engine.startRound();
+    engine.processTurn(); // enemy uses ability
+
+    const e = engine.combatants.find(c => c.team === 'enemy');
+    expect(e.currentEnergy).toBe(1);
+    expect(e.abilityCharges).toBe(9);
+    expect(engine.battleLog.some(l => l.includes('uses Power Strike'))).toBe(true);
+  });
 });

--- a/discord-bot/src/commands/adventure.js
+++ b/discord-bot/src/commands/adventure.js
@@ -77,7 +77,7 @@ async function execute(interaction) {
     if (!battleMessage) {
       battleMessage = await interaction.followUp({ embeds: [embed] });
     } else {
-      await wait(1500);
+      await wait(750);
       await battleMessage.edit({ embeds: [embed] });
     }
   }


### PR DESCRIPTION
## Summary
- avoid double actions in `GameEngine` and apply same ability logic to every combatant
- speed up adventure battle updates to improve pacing
- test that enemy abilities fire as expected

## Testing
- `npm test --silent` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685f5f4887cc8327a9e073d389fd0ee3