### PR TITLE
Implement enhanced logs and practice mode

### DIFF
--- a/auto-battler-react/src/components/BattleLog.jsx
+++ b/auto-battler-react/src/components/BattleLog.jsx
@@ -55,8 +55,13 @@ export default function BattleLog({ battleLog = [] }) {
   const handleFilter = (filter) => setActiveFilter(filter)
 
   const entries = battleLog.map(e => {
-    if (typeof e === 'string') return { message: e, type: guessType(e) }
+    if (typeof e === 'string') return { message: e, type: guessType(e), round: 0 }
     return e
+  })
+
+  const filtered = entries.filter(e => {
+    const category = getCategory(e.type || 'info')
+    return activeFilter === 'all' || category === activeFilter
   })
 
   const summary = entries.length ? entries[entries.length - 1].message : 'The battle is about to begin...'
@@ -77,19 +82,18 @@ export default function BattleLog({ battleLog = [] }) {
           ))}
         </div>
         <div id="log-entries-container">
-          {entries.slice().reverse().map((entry, idx) => {
+          {filtered.slice().reverse().map((entry, idx) => {
             const type = entry.type || 'info'
             const category = getCategory(type)
             const iconClass = getIconClass(type)
-            const hidden = activeFilter !== 'all' && category !== activeFilter
             return (
               <div
                 key={idx}
-                className={`log-entry ${type} ${hidden ? 'hidden-by-filter' : ''}`}
+                className={`log-entry ${type}`}
                 data-category={category}
               >
                 <i className={`log-entry-icon fas ${iconClass}`}></i>
-                {entry.message}
+                {[`[R${entry.round ?? 0}]`, entry.message].join(' ')}
               </div>
             )
           })}

--- a/backend/tests/abilityEffect.test.js
+++ b/backend/tests/abilityEffect.test.js
@@ -33,9 +33,9 @@ describe('Ability effect application', () => {
     expect(e.currentHp).toBe(expectedEnemyHp);
 
     // log should show ability usage and a separate line with the effects
-    const useLine = engine.battleLog.find(l => l.includes('uses Divine Strike'));
+    const useLine = engine.battleLog.find(l => l.message.includes('uses Divine Strike'));
     expect(useLine).toBeTruthy();
-    const actionLines = engine.battleLog.filter(l => l.includes('hits') && l.includes('heals'));
+    const actionLines = engine.battleLog.filter(l => l.message.includes('hits') && l.message.includes('heals'));
     expect(actionLines).toHaveLength(1);
   });
 });

--- a/backend/tests/abilityPattern.test.js
+++ b/backend/tests/abilityPattern.test.js
@@ -15,7 +15,7 @@ describe('Additional ability effect patterns', () => {
 
     const updated = engine.combatants.find(c => c.id === target.id);
     expect(updated.currentHp).toBe(updated.maxHp);
-    expect(engine.battleLog.some(l => l.includes('heals') && l.includes('5'))).toBe(true);
+    expect(engine.battleLog.some(l => l.message.includes('heals') && l.message.includes('5'))).toBe(true);
   });
 
   test('area damage hits all enemies', () => {
@@ -31,6 +31,6 @@ describe('Additional ability effect patterns', () => {
     const e2 = engine.combatants.find(c => c.id === enemy2.id);
     expect(e1.currentHp).toBe(enemy1.maxHp - 3);
     expect(e2.currentHp).toBe(enemy2.maxHp - 3);
-    expect(engine.battleLog.some(l => l.includes('all enemies') && l.includes('3'))).toBe(true);
+    expect(engine.battleLog.some(l => l.message.includes('all enemies') && l.message.includes('3'))).toBe(true);
   });
 });

--- a/backend/tests/energy.test.js
+++ b/backend/tests/energy.test.js
@@ -30,7 +30,7 @@ describe('Energy accumulation and ability usage', () => {
     p = engine.combatants.find(c => c.team === 'player');
     expect(p.currentEnergy).toBe(1);
     expect(p.abilityCharges).toBe(9);
-    expect(engine.battleLog.some(l => l.includes('uses Power Strike'))).toBe(true);
+    expect(engine.battleLog.some(l => l.message.includes('uses Power Strike'))).toBe(true);
   });
 
   test('enemy ability also triggers with sufficient energy', () => {
@@ -57,6 +57,6 @@ describe('Energy accumulation and ability usage', () => {
     const e = engine.combatants.find(c => c.team === 'enemy');
     expect(e.currentEnergy).toBe(1);
     expect(e.abilityCharges).toBe(9);
-    expect(engine.battleLog.some(l => l.includes('uses Power Strike'))).toBe(true);
+    expect(engine.battleLog.some(l => l.message.includes('uses Power Strike'))).toBe(true);
   });
 });

--- a/backend/tests/friendlyTargeting.test.js
+++ b/backend/tests/friendlyTargeting.test.js
@@ -13,8 +13,8 @@ describe('Friendly ability targeting', () => {
     engine.processTurn();
     const updated = engine.combatants.find(c => c.id === cleric.id);
     expect(updated.currentHp).toBe(updated.maxHp);
-    expect(engine.battleLog.some(l => l.includes('uses Divine Light'))).toBe(true);
-    expect(engine.battleLog.some(l => l.includes('heals'))).toBe(true);
+    expect(engine.battleLog.some(l => l.message.includes('uses Divine Light'))).toBe(true);
+    expect(engine.battleLog.some(l => l.message.includes('heals'))).toBe(true);
   });
 
   test('Regrowth heals the caster', () => {
@@ -28,8 +28,8 @@ describe('Friendly ability targeting', () => {
     engine.processTurn();
     const updated = engine.combatants.find(c => c.id === druid.id);
     expect(updated.currentHp).toBe(updated.maxHp);
-    expect(engine.battleLog.some(l => l.includes('uses Regrowth'))).toBe(true);
-    expect(engine.battleLog.some(l => l.includes('heals'))).toBe(true);
+    expect(engine.battleLog.some(l => l.message.includes('uses Regrowth'))).toBe(true);
+    expect(engine.battleLog.some(l => l.message.includes('heals'))).toBe(true);
   });
 
   test('lack of energy causes cleric to attack the enemy', () => {

--- a/backend/tests/stepGenerator.test.js
+++ b/backend/tests/stepGenerator.test.js
@@ -8,8 +8,8 @@ describe('runGameSteps generator', () => {
     const engine = new GameEngine([player, enemy]);
     const steps = Array.from(engine.runGameSteps());
     expect(steps.length).toBeGreaterThan(1);
-    expect(steps[0].log[0]).toContain('Battle Starting');
+    expect(steps[0].log[0].message).toContain('Battle Starting');
     const last = steps[steps.length - 1];
-    expect(last.log.join('\n')).toContain('Battle Finished');
+    expect(last.log.map(l => l.message).join('\n')).toContain('Battle Finished');
   });
 });

--- a/discord-bot/deploy-commands.js
+++ b/discord-bot/deploy-commands.js
@@ -10,7 +10,8 @@ const commandDirs = [
   path.join(__dirname, 'commands/inventory.js'),
   path.join(__dirname, 'commands/set.js'),
   path.join(__dirname, 'src/commands/game.js'),
-  path.join(__dirname, 'src/commands/adventure.js')
+  path.join(__dirname, 'src/commands/adventure.js'),
+  path.join(__dirname, 'src/commands/practice.js')
 ];
 
 console.log('Registering slash commands:', commandDirs.map(f => path.basename(f)).join(', '));

--- a/discord-bot/src/commands/practice.js
+++ b/discord-bot/src/commands/practice.js
@@ -1,7 +1,7 @@
 const { SlashCommandBuilder, EmbedBuilder } = require('discord.js');
 const userService = require('../utils/userService');
 const abilityCardService = require('../utils/abilityCardService');
-const { sendCardDM, buildBattleEmbed } = require('../utils/embedBuilder');
+const { buildBattleEmbed } = require('../utils/embedBuilder');
 
 const MAX_LOG_LINES = 20;
 const GameEngine = require('../../../backend/game/engine');
@@ -9,6 +9,10 @@ const { createCombatant } = require('../../../backend/game/utils');
 const { allPossibleHeroes, allPossibleAbilities } = require('../../../backend/game/data');
 const classes = require('../data/classes');
 const classAbilityMap = require('../data/classAbilityMap');
+
+const data = new SlashCommandBuilder()
+  .setName('practice')
+  .setDescription('Test your skills against a goblin with no risk.');
 
 function formatLog(entry) {
   const prefix = `[R${entry.round}]`;
@@ -19,15 +23,11 @@ function formatLog(entry) {
   return `${prefix} ${text}`;
 }
 
-const data = new SlashCommandBuilder()
-  .setName('adventure')
-  .setDescription('Enter the goblin cave for a practice battle');
-
 async function execute(interaction) {
   const user = await userService.getUser(interaction.user.id);
 
   if (!user || !user.class) {
-    await interaction.reply({ content: 'You must select a class before you can go on an adventure! Use the /game command to get started.', ephemeral: true });
+    await interaction.reply({ content: 'You must select a class before you can practice! Use the /game command to get started.', ephemeral: true });
     return;
   }
 
@@ -64,25 +64,23 @@ async function execute(interaction) {
   const goblin = createCombatant({ hero_id: goblinBase.id, deck: goblinAbilities }, 'enemy', 0);
   if (equippedCard && player.abilityData) {
     player.abilityData = { ...player.abilityData, cardId: equippedCard.id, charges: equippedCard.charges };
+    player.abilityData.isPractice = true;
     player.abilityCharges = equippedCard.charges;
   }
+  if (player.abilityData) player.abilityData.isPractice = true;
   goblin.heroData = { ...goblin.heroData, name: `Goblin ${goblinClass}` };
 
-  console.log(`[BATTLE START] Player ${user.class} vs Goblin ${goblinClass}`);
-
-  await interaction.reply({ content: `${interaction.user.username} delves into the goblin cave and encounters a ferocious Goblin ${goblinClass}! The battle begins!` });
+  await interaction.reply({ content: `${interaction.user.username} begins a practice battle against a Goblin ${goblinClass}!` });
 
   const engine = new GameEngine([player, goblin]);
   const wait = ms => new Promise(r => setTimeout(r, ms));
   let battleMessage;
   let logText = '';
   for (const step of engine.runGameSteps()) {
-    const formatted = step.log.map(formatLog);
-    logText = [logText, ...formatted].filter(Boolean).join('\n');
-    const lines = logText.split('\n');
-    if (lines.length > MAX_LOG_LINES) {
-      logText = lines.slice(-MAX_LOG_LINES).join('\n');
-    }
+    const lines = step.log.map(formatLog);
+    logText = [logText, ...lines].filter(Boolean).join('\n');
+    const parts = logText.split('\n');
+    if (parts.length > MAX_LOG_LINES) logText = parts.slice(-MAX_LOG_LINES).join('\n');
     const embed = buildBattleEmbed(step.combatants, logText);
     if (!battleMessage) {
       battleMessage = await interaction.followUp({ embeds: [embed] });
@@ -92,46 +90,11 @@ async function execute(interaction) {
     }
   }
 
-  console.log(
-    `[BATTLE END] User: ${interaction.user.username} | Result: ${
-      engine.winner === 'player' ? 'Victory' : 'Defeat'
-    }`
-  );
-
-  let narrativeDescription = '';
-  let lootDrop = null;
-  const adventurerName = `**${interaction.user.username}**`;
-  const enemyName = `a **Goblin ${goblinClass}**`;
-
-  if (engine.winner === 'player') {
-    lootDrop =
-      goblinAbilityPool[Math.floor(Math.random() * goblinAbilityPool.length)];
-    let dropText = 'who was slain.';
-    if (lootDrop) {
-      dropText = `who was slain and dropped **${lootDrop.name}**.`;
-      console.log(
-        `[ITEM LOOT] User: ${interaction.user.username} looted Ability: ${lootDrop.name} (ID: ${lootDrop.id})`
-      );
-      await userService.addAbility(interaction.user.id, lootDrop.id);
-    }
-    narrativeDescription = `${adventurerName} adventured into the goblin caves and encountered ${enemyName}, ${dropText}`;
-  } else {
-    narrativeDescription = `${adventurerName} adventured into the goblin caves and encountered ${enemyName} who defeated them.`;
-  }
-
   const summaryEmbed = new EmbedBuilder()
     .setColor(engine.winner === 'player' ? '#57F287' : '#ED4245')
-    .setDescription(narrativeDescription);
+    .setDescription('Practice Complete');
 
   await interaction.followUp({ embeds: [summaryEmbed] });
-
-  if (lootDrop) {
-    try {
-      await sendCardDM(interaction.user, lootDrop);
-    } catch (err) {
-      console.error('Failed to DM card drop:', err);
-    }
-  }
 }
 
 module.exports = { data, execute };

--- a/discord-bot/tests/adventure.test.js
+++ b/discord-bot/tests/adventure.test.js
@@ -25,7 +25,7 @@ describe('adventure command', () => {
     createCombatantSpy = utils.createCombatant;
     GameEngine.mockImplementation(() => ({
       runGameSteps: function* () {
-        yield { combatants: [], log: ['log'] };
+        yield { combatants: [], log: [{ round: 1, type: 'info', message: 'log' }] };
       },
       runFullGame: jest.fn(),
       winner: 'player'
@@ -93,7 +93,10 @@ describe('adventure command', () => {
   test('battle log is included in embed', async () => {
     GameEngine.mockImplementationOnce(() => ({
       runGameSteps: function* () {
-        yield { combatants: [], log: ['first', 'second'] };
+        yield { combatants: [], log: [
+          { round: 1, type: 'info', message: 'first' },
+          { round: 1, type: 'info', message: 'second' }
+        ] };
       },
       runFullGame: jest.fn(),
       winner: 'player'
@@ -104,7 +107,8 @@ describe('adventure command', () => {
     await adventure.execute(interaction);
     expect(abilityCardService.getCards).toHaveBeenCalledWith('123');
     const description = interaction.followUp.mock.calls[0][0].embeds[0].data.description;
-    expect(description).toBe('first\nsecond');
+    expect(description.includes('first')).toBe(true);
+    expect(description.includes('second')).toBe(true);
   });
 
   test('drops correct ability based on goblin class', async () => {
@@ -124,7 +128,7 @@ describe('adventure command', () => {
   });
 
   test('battle log is truncated to last 20 lines', async () => {
-    const logs = Array.from({ length: 30 }, (_, i) => String(i + 1));
+    const logs = Array.from({ length: 30 }, (_, i) => ({ round: 1, type: 'info', message: String(i + 1) }));
     GameEngine.mockImplementationOnce(() => ({
       runGameSteps: function* () {
         yield { combatants: [], log: logs };
@@ -140,7 +144,7 @@ describe('adventure command', () => {
     const description = interaction.followUp.mock.calls[0][0].embeds[0].data.description;
     const lines = description.split('\n');
     expect(lines.length).toBe(20);
-    expect(lines[0]).toBe('11');
-    expect(lines[19]).toBe('30');
+    expect(lines[0].includes('11')).toBe(true);
+    expect(lines[19].includes('30')).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary
- add structured log entries with round metadata
- filter and prefix battle log entries in the React UI
- style log messages in Discord embeds
- introduce `/practice` command for risk‑free battles
- update tests for new logging format

## Testing
- `npm test` within `backend`
- `npm run lint` within `auto-battler-react`
- `npm test` within `discord-bot`

------
https://chatgpt.com/codex/tasks/task_e_68616dd6c2188327a2f1ce38aeeaa52c