### PR TITLE
Refactor combat turn for auto-attack and ability

### DIFF
--- a/backend/game/engine.js
+++ b/backend/game/engine.js
@@ -187,12 +187,17 @@ class GameEngine {
                const ability = attacker.abilityData;
                const cost = ability ? ability.energyCost || 1 : 1;
 
+               // Always perform the auto-attack first
+               this.applyDamage(attacker, enemies[0], attacker.attack);
+               if (this.checkVictory()) return;
+
+               // Re-evaluate potential targets in case the first enemy was defeated
+               const remainingEnemies = this.combatants.filter(c => c.team !== attacker.team && c.currentHp > 0);
                const abilityTarget = ability && ability.targetType === 'friendly'
                    ? attacker
-                   : enemies[0];
+                   : remainingEnemies[0];
 
-               let usedAbility = false;
-               if (ability && attacker.abilityCharges > 0 && attacker.currentEnergy >= cost) {
+               if (ability && attacker.abilityCharges > 0 && attacker.currentEnergy >= cost && abilityTarget) {
                    this.applyAbilityEffect(attacker, abilityTarget, ability);
                    attacker.currentEnergy -= cost;
                    attacker.abilityCharges -= 1;
@@ -209,11 +214,6 @@ class GameEngine {
                            attacker.abilityData = null;
                        }
                    }
-                   usedAbility = true;
-               }
-
-               if (!usedAbility) {
-                   this.applyDamage(attacker, enemies[0], attacker.attack);
                }
            }
        }

--- a/backend/tests/abilityEffect.test.js
+++ b/backend/tests/abilityEffect.test.js
@@ -29,7 +29,7 @@ describe('Ability effect application', () => {
 
     expect(p.currentHp).toBe(player.maxHp - 4 - 2 + 2); // took 2 damage then healed 2
 
-    const expectedEnemyHp = enemy.maxHp - player.attack * 2 - 2;
+    const expectedEnemyHp = enemy.maxHp - player.attack * 3 - 2;
     expect(e.currentHp).toBe(expectedEnemyHp);
 
     // log should show ability usage and a separate line with the effects


### PR DESCRIPTION
## Summary
- refactor combat turn so units always auto-attack before optional ability
- adjust expected damage in ability effect test

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6861d2d5e648832793981111805d19fa