### PR TITLE
Fix heal over time behavior

### DIFF
--- a/backend/game/engine.js
+++ b/backend/game/engine.js
@@ -76,12 +76,12 @@ class GameEngine {
            }
        }
 
-       const healSelfMatch = ability.effect.match(/heal yourself for (\d+) HP/i);
+       const healSelfMatch = ability.effect.match(/heal yourself for (\d+) HP(?!\s*per turn)/i);
        if (healSelfMatch) {
            healingDone = parseInt(healSelfMatch[1], 10);
            healTarget = attacker;
        } else {
-           const generalHealMatch = ability.effect.match(/Heal .*? for (\d+) HP/i);
+           const generalHealMatch = ability.effect.match(/Heal .*? for (\d+) HP(?!\s*per turn)/i);
            if (generalHealMatch) {
                healingDone = parseInt(generalHealMatch[1], 10);
                healTarget = target;

--- a/backend/tests/statusEffects.test.js
+++ b/backend/tests/statusEffects.test.js
@@ -13,17 +13,18 @@ describe('Status effect processing', () => {
 
     engine.startRound();
     engine.processTurn(); // druid casts Regrowth
-    engine.processTurn(); // enemy
+    engine.processTurn(); // enemy attacks
 
     let caster = engine.combatants.find(c => c.id === druid.id);
     expect(caster.statusEffects.some(s => s.name === 'Regrowth')).toBe(true);
+    const enemyAtk = enemy.attack;
+    expect(caster.currentHp).toBe(druid.maxHp - 4 - enemyAtk);
 
     // next round - first tick
     engine.startRound();
     engine.processTurn(); // druid
     caster = engine.combatants.find(c => c.id === druid.id);
-    const enemyAtk = enemy.attack;
-    expect(caster.currentHp).toBe(druid.maxHp - 4 + 2 - enemyAtk + 2);
+    expect(caster.currentHp).toBe(druid.maxHp - 4 - enemyAtk + 2);
     expect(engine.battleLog.some(l => l.message.includes('healed for 2 by Regrowth'))).toBe(true);
   });
 


### PR DESCRIPTION
## Summary
- avoid generic heal regex grabbing HoT phrases
- ensure Regrowth applies HoT without instant heal
- update tests for Regrowth timing

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6861f38bf4008327bb3ef38334042693