### PR TITLE
Fix ability data flow and logging

### DIFF
--- a/discord-bot/src/commands/adventure.js
+++ b/discord-bot/src/commands/adventure.js
@@ -47,12 +47,9 @@ async function execute(interaction) {
     return;
   }
 
-  const cards = await abilityCardService.getCards(interaction.user.id);
+  const cards = await abilityCardService.getCards(user.id);
   const equippedCard = cards.find(c => c.id === user.equipped_ability_id);
-  const playerAbilityId = equippedCard ? equippedCard.ability_id : undefined;
-  const playerAbilities = cards
-    .filter(c => c.id !== user.equipped_ability_id)
-    .map(c => c.ability_id);
+  const deck = cards.filter(c => c.id !== user.equipped_ability_id);
 
   const goblinAbilityPool = allPossibleAbilities
     .filter(
@@ -60,12 +57,14 @@ async function execute(interaction) {
     );
   const goblinAbilities = goblinAbilityPool.map(a => a.id);
 
-  const player = createCombatant({ hero_id: playerHero.id, ability_id: playerAbilityId, deck: playerAbilities }, 'player', 0);
+  const player = createCombatant({
+    hero_id: playerHero.id,
+    ability_card: equippedCard,
+    deck: deck
+  }, 'player', 0);
+
   const goblin = createCombatant({ hero_id: goblinBase.id, deck: goblinAbilities }, 'enemy', 0);
-  if (equippedCard && player.abilityData) {
-    player.abilityData = { ...player.abilityData, cardId: equippedCard.id, charges: equippedCard.charges };
-    player.abilityCharges = equippedCard.charges;
-  }
+
   goblin.heroData = { ...goblin.heroData, name: `Goblin ${goblinClass}` };
 
   console.log(`[BATTLE START] Player ${user.class} vs Goblin ${goblinClass}`);

--- a/discord-bot/src/commands/practice.js
+++ b/discord-bot/src/commands/practice.js
@@ -47,12 +47,9 @@ async function execute(interaction) {
     return;
   }
 
-  const cards = await abilityCardService.getCards(interaction.user.id);
+  const cards = await abilityCardService.getCards(user.id);
   const equippedCard = cards.find(c => c.id === user.equipped_ability_id);
-  const playerAbilityId = equippedCard ? equippedCard.ability_id : undefined;
-  const playerAbilities = cards
-    .filter(c => c.id !== user.equipped_ability_id)
-    .map(c => c.ability_id);
+  const deck = cards.filter(c => c.id !== user.equipped_ability_id);
 
   const goblinAbilityPool = allPossibleAbilities
     .filter(
@@ -60,13 +57,13 @@ async function execute(interaction) {
     );
   const goblinAbilities = goblinAbilityPool.map(a => a.id);
 
-  const player = createCombatant({ hero_id: playerHero.id, ability_id: playerAbilityId, deck: playerAbilities }, 'player', 0);
+  const player = createCombatant({
+    hero_id: playerHero.id,
+    ability_card: equippedCard,
+    deck: deck
+  }, 'player', 0);
   const goblin = createCombatant({ hero_id: goblinBase.id, deck: goblinAbilities }, 'enemy', 0);
-  if (equippedCard && player.abilityData) {
-    player.abilityData = { ...player.abilityData, cardId: equippedCard.id, charges: equippedCard.charges };
-    player.abilityData.isPractice = true;
-    player.abilityCharges = equippedCard.charges;
-  }
+
   if (player.abilityData) player.abilityData.isPractice = true;
   goblin.heroData = { ...goblin.heroData, name: `Goblin ${goblinClass}` };
 

--- a/discord-bot/tests/adventure.test.js
+++ b/discord-bot/tests/adventure.test.js
@@ -47,9 +47,9 @@ describe('adventure command', () => {
     ]);
     const interaction = { user: { id: '123' }, reply: jest.fn().mockResolvedValue(), followUp: jest.fn().mockResolvedValue() };
     await adventure.execute(interaction);
-    expect(abilityCardService.getCards).toHaveBeenCalledWith('123');
+    expect(abilityCardService.getCards).toHaveBeenCalledWith(1);
     expect(createCombatantSpy).toHaveBeenCalledWith(
-      expect.objectContaining({ ability_id: 3111 }),
+      expect.objectContaining({ ability_card: { id: 50, ability_id: 3111, charges: 5 } }),
       'player',
       0
     );
@@ -63,7 +63,7 @@ describe('adventure command', () => {
     const interaction = { user: { id: '123' }, reply: jest.fn().mockResolvedValue(), followUp: jest.fn().mockResolvedValue() };
     jest.spyOn(Math, 'random').mockReturnValue(0);
     await adventure.execute(interaction);
-    expect(abilityCardService.getCards).toHaveBeenCalledWith('123');
+    expect(abilityCardService.getCards).toHaveBeenCalledWith(1);
     const expectedId = allPossibleAbilities.find(
       a => a.class === classAbilityMap.Warrior && a.rarity === 'Common'
     ).id;
@@ -84,7 +84,7 @@ describe('adventure command', () => {
     abilityCardService.getCards.mockResolvedValue([{ id: 50, ability_id: 3111, charges: 5 }]);
     const interaction = { user: { id: '123' }, reply: jest.fn().mockResolvedValue(), followUp: jest.fn().mockResolvedValue() };
     await adventure.execute(interaction);
-    expect(abilityCardService.getCards).toHaveBeenCalledWith('123');
+    expect(abilityCardService.getCards).toHaveBeenCalledWith(1);
     expect(userService.addAbility).not.toHaveBeenCalled();
     const calls = interaction.followUp.mock.calls.filter(c => c[0].ephemeral);
     expect(calls.length).toBe(1);
@@ -105,7 +105,7 @@ describe('adventure command', () => {
     abilityCardService.getCards.mockResolvedValue([{ id: 50, ability_id: 3111, charges: 5 }]);
     const interaction = { user: { id: '123' }, reply: jest.fn().mockResolvedValue(), followUp: jest.fn().mockResolvedValue() };
     await adventure.execute(interaction);
-    expect(abilityCardService.getCards).toHaveBeenCalledWith('123');
+    expect(abilityCardService.getCards).toHaveBeenCalledWith(1);
     const description = interaction.followUp.mock.calls[0][0].embeds[0].data.description;
     expect(description.includes('first')).toBe(true);
     expect(description.includes('second')).toBe(true);
@@ -119,7 +119,7 @@ describe('adventure command', () => {
     abilityCardService.getCards.mockResolvedValue([{ id: 50, ability_id: 3111, charges: 5 }]);
     const interaction = { user: { id: '123', send: jest.fn().mockResolvedValue() }, reply: jest.fn().mockResolvedValue(), followUp: jest.fn().mockResolvedValue() };
     await adventure.execute(interaction);
-    expect(abilityCardService.getCards).toHaveBeenCalledWith('123');
+    expect(abilityCardService.getCards).toHaveBeenCalledWith(1);
     const expectedDrop = allPossibleAbilities.find(
       a => a.class === classAbilityMap[targetClass] && a.rarity === 'Common'
     ).id;
@@ -140,7 +140,7 @@ describe('adventure command', () => {
     abilityCardService.getCards.mockResolvedValue([{ id: 50, ability_id: 3111, charges: 5 }]);
     const interaction = { user: { id: '123' }, reply: jest.fn().mockResolvedValue(), followUp: jest.fn().mockResolvedValue() };
     await adventure.execute(interaction);
-    expect(abilityCardService.getCards).toHaveBeenCalledWith('123');
+    expect(abilityCardService.getCards).toHaveBeenCalledWith(1);
     const description = interaction.followUp.mock.calls[0][0].embeds[0].data.description;
     const lines = description.split('\n');
     expect(lines.length).toBe(20);


### PR DESCRIPTION
## Summary
- pass DB user id when fetching ability cards
- pass equipped card object to `createCombatant`
- adjust practice command similarly
- update adventure tests for new arguments

## Testing
- `npm test` in `discord-bot`
- `npm test` in `backend`


------
https://chatgpt.com/codex/tasks/task_e_6862076b27408327a444f8ac38e17bd3