### PR TITLE
Add PvP battles table schema

### DIFF
--- a/discord-bot/db-schema.sql
+++ b/discord-bot/db-schema.sql
@@ -53,3 +53,16 @@ CREATE TABLE IF NOT EXISTS user_inventory (
     PRIMARY KEY (user_id, item_id),
     FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
 );
+
+-- PvP battle challenges
+CREATE TABLE IF NOT EXISTS pvp_battles (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    challenger_id INT NOT NULL,
+    challenged_id INT NOT NULL,
+    status ENUM('pending','accepted','declined','expired') DEFAULT 'pending',
+    winner_id INT DEFAULT NULL,
+    battle_log TEXT,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    FOREIGN KEY (challenger_id) REFERENCES users(id) ON DELETE CASCADE,
+    FOREIGN KEY (challenged_id) REFERENCES users(id) ON DELETE CASCADE
+);


### PR DESCRIPTION
## Summary
- extend Discord bot SQL schema with `pvp_battles` table

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68628608b5d48327b40f1d078fd1002a