### PR TITLE
Add PvP challenge command

### DIFF
--- a/discord-bot/commands/challenge.js
+++ b/discord-bot/commands/challenge.js
@@ -1,0 +1,113 @@
+const { SlashCommandBuilder, ActionRowBuilder, ButtonBuilder, ButtonStyle } = require('discord.js');
+const db = require('../util/database');
+const userService = require('../src/utils/userService');
+const { simple } = require('../src/utils/embedBuilder');
+
+const timeouts = new Map();
+const challenges = new Map();
+
+const data = new SlashCommandBuilder()
+  .setName('challenge')
+  .setDescription('Challenge another player to a duel')
+  .addUserOption(opt =>
+    opt
+      .setName('opponent')
+      .setDescription('Player to challenge')
+      .setRequired(true)
+  );
+
+async function execute(interaction) {
+  const opponent = interaction.options.getUser('opponent');
+  const challenger = interaction.user;
+
+  if (opponent.bot || opponent.id === challenger.id) {
+    await interaction.reply({ content: 'Invalid opponent.', ephemeral: true });
+    return;
+  }
+
+  const challengerData = await userService.getUser(challenger.id);
+  const opponentData = await userService.getUser(opponent.id);
+
+  if (!challengerData || !challengerData.class || !opponentData || !opponentData.class) {
+    await interaction.reply({ content: 'Both players must choose a class first.', ephemeral: true });
+    return;
+  }
+
+  const [result] = await db.query(
+    'INSERT INTO pvp_battles (challenger_id, challenged_id, status) VALUES (?, ?, ?)',
+    [challengerData.id, opponentData.id, 'pending']
+  );
+  const battleId = result.insertId;
+
+  challenges.set(battleId, { challenger, opponent });
+
+  const row = new ActionRowBuilder().addComponents(
+    new ButtonBuilder().setCustomId(`challenge-accept:${battleId}`).setLabel('Accept').setStyle(ButtonStyle.Success),
+    new ButtonBuilder().setCustomId(`challenge-decline:${battleId}`).setLabel('Decline').setStyle(ButtonStyle.Danger)
+  );
+
+  const embed = simple('You have been challenged!', [
+    { name: 'Challenger', value: challenger.username }
+  ], challenger.displayAvatarURL());
+
+  try {
+    await opponent.send({ embeds: [embed], components: [row] });
+  } catch (err) {
+    console.error('Failed to DM opponent:', err);
+  }
+
+  await interaction.reply({ content: `Challenge sent to ${opponent.username}.`, ephemeral: true });
+
+  const timeout = setTimeout(async () => {
+    timeouts.delete(battleId);
+    challenges.delete(battleId);
+    await db.query('UPDATE pvp_battles SET status = ? WHERE id = ?', ['expired', battleId]);
+    try {
+      await challenger.send(`Your challenge to ${opponent.username} has expired.`);
+    } catch (err) {
+      console.error('Failed to DM challenger:', err);
+    }
+  }, 5 * 60 * 1000);
+
+  timeouts.set(battleId, timeout);
+}
+
+async function handleChallengeAccept(interaction) {
+  const id = parseInt(interaction.customId.split(':')[1], 10);
+  const info = challenges.get(id);
+  if (!info) {
+    await interaction.update({ content: 'This challenge is no longer active.', components: [] });
+    return;
+  }
+  clearTimeout(timeouts.get(id));
+  timeouts.delete(id);
+  challenges.delete(id);
+  await db.query('UPDATE pvp_battles SET status = ? WHERE id = ?', ['accepted', id]);
+  await interaction.update({ content: 'Challenge accepted!', components: [] });
+  try {
+    await info.challenger.send(`${info.opponent.username} accepted your challenge!`);
+  } catch (err) {
+    console.error('Failed to DM challenger:', err);
+  }
+}
+
+async function handleChallengeDecline(interaction) {
+  const id = parseInt(interaction.customId.split(':')[1], 10);
+  const info = challenges.get(id);
+  if (!info) {
+    await interaction.update({ content: 'This challenge is no longer active.', components: [] });
+    return;
+  }
+  clearTimeout(timeouts.get(id));
+  timeouts.delete(id);
+  challenges.delete(id);
+  await db.query('UPDATE pvp_battles SET status = ? WHERE id = ?', ['declined', id]);
+  await interaction.update({ content: 'Challenge declined.', components: [] });
+  try {
+    await info.challenger.send(`${info.opponent.username} declined your challenge.`);
+  } catch (err) {
+    console.error('Failed to DM challenger:', err);
+  }
+}
+
+module.exports = { data, execute, handleChallengeAccept, handleChallengeDecline };

--- a/discord-bot/index.js
+++ b/discord-bot/index.js
@@ -8,6 +8,7 @@ client.commands = new Collection();
 
 const gameHandlers = require('./src/commands/game');
 const inventoryHandlers = require('./commands/inventory');
+const challengeHandlers = require('./commands/challenge');
 
 const commandDirs = [
   path.join(__dirname, 'commands'),
@@ -67,6 +68,10 @@ client.on(Events.InteractionCreate, async interaction => {
       await inventoryHandlers.handleSetAbilityButton(interaction);
     } else if (interaction.customId.startsWith('class-confirm') || interaction.customId === 'class-choose-again') {
       await gameHandlers.handleClassButton(interaction);
+    } else if (interaction.customId.startsWith('challenge-accept')) {
+      await challengeHandlers.handleChallengeAccept(interaction);
+    } else if (interaction.customId.startsWith('challenge-decline')) {
+      await challengeHandlers.handleChallengeDecline(interaction);
     }
   }
 });

--- a/discord-bot/tests/challenge.test.js
+++ b/discord-bot/tests/challenge.test.js
@@ -1,0 +1,57 @@
+const challenge = require('../commands/challenge');
+
+jest.mock('../util/database', () => ({
+  query: jest.fn().mockResolvedValue([{ insertId: 42 }])
+}));
+jest.mock('../src/utils/userService', () => ({
+  getUser: jest.fn()
+}));
+jest.mock('../src/utils/embedBuilder', () => ({
+  simple: jest.fn().mockReturnValue({})
+}));
+
+const db = require('../util/database');
+const userService = require('../src/utils/userService');
+const { simple } = require('../src/utils/embedBuilder');
+
+describe('challenge command', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('rejects self challenge', async () => {
+    const interaction = {
+      user: { id: '1' },
+      options: { getUser: jest.fn().mockReturnValue({ id: '1', bot: false }) },
+      reply: jest.fn().mockResolvedValue()
+    };
+    await challenge.execute(interaction);
+    expect(interaction.reply).toHaveBeenCalledWith(expect.objectContaining({ ephemeral: true }));
+  });
+
+  test('creates pending battle and sends DM', async () => {
+    userService.getUser
+      .mockResolvedValueOnce({ id: 10, class: 'Warrior' })
+      .mockResolvedValueOnce({ id: 20, class: 'Mage' });
+    const opponent = {
+      id: '2',
+      bot: false,
+      username: 'Opp',
+      send: jest.fn().mockResolvedValue(),
+      displayAvatarURL: jest.fn()
+    };
+    const interaction = {
+      user: { id: '1', username: 'Chal', displayAvatarURL: jest.fn() },
+      options: { getUser: jest.fn().mockReturnValue(opponent) },
+      reply: jest.fn().mockResolvedValue()
+    };
+    await challenge.execute(interaction);
+    expect(db.query).toHaveBeenCalledWith(
+      'INSERT INTO pvp_battles (challenger_id, challenged_id, status) VALUES (?, ?, ?)',
+      [10, 20, 'pending']
+    );
+    expect(opponent.send).toHaveBeenCalled();
+    expect(interaction.reply).toHaveBeenCalledWith(expect.objectContaining({ ephemeral: true }));
+    expect(simple).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- implement new `/challenge` command with accept/decline buttons
- wire button handlers into the bot
- test challenge creation and validation

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6862860b307483279241cc3d6a6ff885