### PR TITLE
Add challenge command stubs and tests

### DIFF
--- a/discord-bot/src/commands/challenge.js
+++ b/discord-bot/src/commands/challenge.js
@@ -1,0 +1,65 @@
+const { SlashCommandBuilder, ActionRowBuilder, ButtonBuilder, ButtonStyle } = require('discord.js');
+const userService = require('../utils/userService');
+const db = require('../../util/database');
+
+const data = new SlashCommandBuilder()
+  .setName('challenge')
+  .setDescription('Challenge another player to a duel.')
+  .addUserOption(opt => opt.setName('target').setDescription('User to challenge').setRequired(true));
+
+async function execute(interaction) {
+  const target = interaction.options.getUser('target');
+  if (target.id === interaction.user.id) {
+    await interaction.reply({ content: 'You cannot challenge yourself.', ephemeral: true });
+    return;
+  }
+  if (target.bot) {
+    await interaction.reply({ content: 'You cannot challenge bots.', ephemeral: true });
+    return;
+  }
+  const targetUser = await userService.getUser(target.id);
+  if (!targetUser) {
+    await interaction.reply({ content: 'That player has not started playing yet.', ephemeral: true });
+    return;
+  }
+  const [result] = await db.query(
+    'INSERT INTO challenges (challenger_id, target_id, status) VALUES (?, ?, ?)',
+    [interaction.user.id, target.id, 'pending']
+  );
+  const challengeId = result.insertId;
+
+  const row = new ActionRowBuilder().addComponents(
+    new ButtonBuilder()
+      .setCustomId(`challenge-accept:${challengeId}`)
+      .setLabel('Accept')
+      .setStyle(ButtonStyle.Success),
+    new ButtonBuilder()
+      .setCustomId(`challenge-decline:${challengeId}`)
+      .setLabel('Decline')
+      .setStyle(ButtonStyle.Danger)
+  );
+
+  await target.send({ content: `${interaction.user.username} has challenged you!`, components: [row] });
+  await interaction.reply({ content: `Challenge sent to ${target.username}.`, ephemeral: true });
+}
+
+async function handleAccept(interaction) {
+  const [, idStr] = interaction.customId.split(':');
+  const id = Number(idStr);
+  await db.query('UPDATE challenges SET status = ? WHERE id = ?', ['accepted', id]);
+  await interaction.update({ content: 'Challenge accepted!', components: [] });
+}
+
+async function handleDecline(interaction) {
+  const [, idStr] = interaction.customId.split(':');
+  const id = Number(idStr);
+  await db.query('UPDATE challenges SET status = ? WHERE id = ?', ['declined', id]);
+  await interaction.update({ content: 'Challenge declined.', components: [] });
+}
+
+async function expireChallenge(id, challenger) {
+  await db.query('UPDATE challenges SET status = ? WHERE id = ?', ['expired', id]);
+  await challenger.send(`Your challenge #${id} has expired.`);
+}
+
+module.exports = { data, execute, handleAccept, handleDecline, expireChallenge };

--- a/discord-bot/tests/challenge.test.js
+++ b/discord-bot/tests/challenge.test.js
@@ -1,0 +1,84 @@
+const challenge = require('../src/commands/challenge');
+
+jest.mock('../src/utils/userService', () => ({
+  getUser: jest.fn()
+}));
+jest.mock('../util/database', () => ({
+  query: jest.fn()
+}));
+jest.mock('../../backend/game/engine');
+
+const userService = require('../src/utils/userService');
+const db = require('../util/database');
+const GameEngine = require('../../backend/game/engine');
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+test('cannot challenge yourself', async () => {
+  const user = { id: '1', username: 'Self', bot: false };
+  const interaction = {
+    user,
+    options: { getUser: jest.fn().mockReturnValue(user) },
+    reply: jest.fn().mockResolvedValue()
+  };
+  await challenge.execute(interaction);
+  expect(interaction.reply).toHaveBeenCalledWith(expect.objectContaining({ ephemeral: true }));
+});
+
+test('cannot challenge bots', async () => {
+  const interaction = {
+    user: { id: '1', username: 'Tester' },
+    options: { getUser: jest.fn().mockReturnValue({ id: '2', bot: true }) },
+    reply: jest.fn().mockResolvedValue()
+  };
+  await challenge.execute(interaction);
+  expect(interaction.reply).toHaveBeenCalledWith(expect.objectContaining({ ephemeral: true }));
+});
+
+test('cannot challenge unregistered users', async () => {
+  const target = { id: '2', bot: false };
+  userService.getUser.mockResolvedValueOnce(null);
+  const interaction = {
+    user: { id: '1', username: 'Tester' },
+    options: { getUser: jest.fn().mockReturnValue(target) },
+    reply: jest.fn().mockResolvedValue()
+  };
+  await challenge.execute(interaction);
+  expect(userService.getUser).toHaveBeenCalledWith('2');
+  expect(interaction.reply).toHaveBeenCalledWith(expect.objectContaining({ ephemeral: true }));
+});
+
+test('sends challenge DM with buttons and handles accept/decline', async () => {
+  const target = { id: '2', username: 'Target', bot: false, send: jest.fn().mockResolvedValue() };
+  userService.getUser.mockResolvedValue({ id: 2 });
+  db.query.mockResolvedValueOnce([{ insertId: 5 }]);
+  const interaction = {
+    user: { id: '1', username: 'Challenger' },
+    options: { getUser: jest.fn().mockReturnValue(target) },
+    reply: jest.fn().mockResolvedValue()
+  };
+  await challenge.execute(interaction);
+  expect(target.send).toHaveBeenCalled();
+  const components = target.send.mock.calls[0][0].components;
+  expect(components[0].components[0].data.label).toBe('Accept');
+  expect(components[0].components[1].data.label).toBe('Decline');
+
+  const acceptInteraction = { customId: 'challenge-accept:5', update: jest.fn().mockResolvedValue() };
+  await challenge.handleAccept(acceptInteraction);
+  expect(db.query).toHaveBeenLastCalledWith('UPDATE challenges SET status = ? WHERE id = ?', ['accepted', 5]);
+  expect(acceptInteraction.update).toHaveBeenCalled();
+
+  const declineInteraction = { customId: 'challenge-decline:5', update: jest.fn().mockResolvedValue() };
+  await challenge.handleDecline(declineInteraction);
+  expect(db.query).toHaveBeenLastCalledWith('UPDATE challenges SET status = ? WHERE id = ?', ['declined', 5]);
+  expect(declineInteraction.update).toHaveBeenCalled();
+});
+
+test('expired challenges notify challenger', async () => {
+  const challenger = { send: jest.fn().mockResolvedValue() };
+  await challenge.expireChallenge(7, challenger);
+  expect(db.query).toHaveBeenCalledWith('UPDATE challenges SET status = ? WHERE id = ?', ['expired', 7]);
+  expect(challenger.send).toHaveBeenCalled();
+});


### PR DESCRIPTION
## Summary
- add challenge command stub implementation
- create comprehensive tests for challenge interactions

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6862860ce60c8327b5df80864ee70fb0