### PR TITLE
Add public PvP challenge announcements

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -16,7 +16,7 @@ DB_PASSWORD=password
 DB_DATABASE=auto_battler
 
 # Channel used for announcements
-ANNOUNCEMENT_CHANNEL_ID=YOUR_CHANNEL_ID
+ANNOUNCEMENT_CHANNEL_ID=1389239394812170410
 
 # Port for the Express backend (optional)
 PORT=3000

--- a/.env.example
+++ b/.env.example
@@ -16,7 +16,7 @@ DB_PASSWORD=password
 DB_DATABASE=auto_battler
 
 # Channel used for announcements
-ANNOUNCEMENT_CHANNEL_ID=1389239394812170410
+PVP_CHANNEL_ID=1389239394812170410
 
 # Port for the Express backend (optional)
 PORT=3000

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Copy the `.env.example` file in the repository root to `.env` and populate the f
 - `DISCORD_TOKEN` – your bot token.
 - `APP_ID` and `GUILD_ID` – used when deploying slash commands.
 - `DB_HOST`, `DB_USER`, `DB_PASSWORD`, `DB_DATABASE` – credentials for the MySQL database. `DB_HOST` must be the remote host address provided by GoDaddy.
-- `ANNOUNCEMENT_CHANNEL_ID` – Discord channel ID used for market notifications.
+- `PVP_CHANNEL_ID` – Discord channel ID used for challenge announcements.
 
 Install the dependencies and start the bot:
 

--- a/discord-bot/db-schema.sql
+++ b/discord-bot/db-schema.sql
@@ -60,6 +60,8 @@ CREATE TABLE IF NOT EXISTS pvp_battles (
     challenger_id INT NOT NULL,
     challenged_id INT NOT NULL,
     status ENUM('pending','accepted','declined','expired') DEFAULT 'pending',
+    message_id VARCHAR(255) DEFAULT NULL,
+    channel_id VARCHAR(255) DEFAULT NULL,
     winner_id INT DEFAULT NULL,
     battle_log TEXT,
     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,

--- a/discord-bot/src/commands/challenge.js
+++ b/discord-bot/src/commands/challenge.js
@@ -37,7 +37,7 @@ async function execute(interaction) {
   );
   const challengeId = result.insertId;
 
-  const announcementChannel = await interaction.client.channels.fetch(process.env.ANNOUNCEMENT_CHANNEL_ID);
+  const announcementChannel = await interaction.client.channels.fetch(process.env.PVP_CHANNEL_ID);
   const publicMessage = await announcementChannel.send({
     content: `${interaction.user.username} has challenged ${target.username}!`
   });

--- a/discord-bot/src/commands/challenge.js
+++ b/discord-bot/src/commands/challenge.js
@@ -37,6 +37,13 @@ async function execute(interaction) {
   );
   const challengeId = result.insertId;
 
+  const announcementChannel = await interaction.client.channels.fetch(process.env.ANNOUNCEMENT_CHANNEL_ID);
+  const publicMessage = await announcementChannel.send({
+    content: `${interaction.user.username} has challenged ${target.username}!`
+  });
+
+  await db.query('UPDATE pvp_battles SET message_id = ?, channel_id = ? WHERE id = ?', [publicMessage.id, announcementChannel.id, challengeId]);
+
   const row = new ActionRowBuilder().addComponents(
     new ButtonBuilder()
       .setCustomId(`challenge-accept:${challengeId}`)
@@ -52,7 +59,7 @@ async function execute(interaction) {
   await interaction.reply({ content: `Challenge sent to ${target.username}.`, ephemeral: true });
 
   // automatically expire the challenge after 5 minutes
-  setTimeout(() => expireChallenge(challengeId, interaction.user), 5 * 60 * 1000);
+  setTimeout(() => expireChallenge(challengeId, interaction.user, interaction.client), 5 * 60 * 1000);
 }
 
 async function handleAccept(interaction) {
@@ -63,12 +70,27 @@ async function handleAccept(interaction) {
   if (!battle || battle.status !== 'pending' || Date.now() - new Date(battle.created_at).getTime() > 5 * 60 * 1000) {
     if (battle && battle.status === 'pending') {
       await db.query('UPDATE pvp_battles SET status = ? WHERE id = ?', ['expired', id]);
+      try {
+        const channel = await interaction.client.channels.fetch(battle.channel_id);
+        const msg = await channel.messages.fetch(battle.message_id);
+        await msg.edit({ content: 'Challenge Expired.' });
+      } catch (e) {
+        /* ignore */
+      }
     }
     await interaction.update({ content: 'This challenge has expired.', components: [] });
     return;
   }
 
   await db.query('UPDATE pvp_battles SET status = ? WHERE id = ?', ['accepted', id]);
+
+  try {
+    const channel = await interaction.client.channels.fetch(battle.channel_id);
+    const msg = await channel.messages.fetch(battle.message_id);
+    await msg.edit({ content: `${interaction.user.username} has accepted the challenge!` });
+  } catch (e) {
+    /* ignore */
+  }
 
   const [challengerRows] = await db.query('SELECT * FROM users WHERE id = ?', [battle.challenger_id]);
   const [targetRows] = await db.query('SELECT * FROM users WHERE id = ?', [battle.challenged_id]);
@@ -134,6 +156,15 @@ async function handleAccept(interaction) {
     /* ignore */
   }
 
+  try {
+    const channel = await interaction.client.channels.fetch(battle.channel_id);
+    await channel.send({
+      content: `⚔️ Victory! ${engine.winner === 'player' ? challenger.name : opponent.name} has defeated ${engine.winner === 'player' ? opponent.name : challenger.name} in a duel!`
+    });
+  } catch (e) {
+    /* ignore */
+  }
+
   await interaction.update({ content: 'Challenge accepted! Battle complete.', components: [] });
 }
 
@@ -141,11 +172,31 @@ async function handleDecline(interaction) {
   const [, idStr] = interaction.customId.split(':');
   const id = Number(idStr);
   await db.query('UPDATE pvp_battles SET status = ? WHERE id = ?', ['declined', id]);
+
+  const [rows] = await db.query('SELECT * FROM pvp_battles WHERE id = ?', [id]);
+  const battle = rows[0];
+  try {
+    const channel = await interaction.client.channels.fetch(battle.channel_id);
+    const msg = await channel.messages.fetch(battle.message_id);
+    await msg.edit({ content: 'Challenge Declined.' });
+  } catch (e) {
+    /* ignore */
+  }
+
   await interaction.update({ content: 'Challenge declined.', components: [] });
 }
 
-async function expireChallenge(id, challenger) {
+async function expireChallenge(id, challenger, client) {
   await db.query('UPDATE pvp_battles SET status = ? WHERE id = ?', ['expired', id]);
+  const [rows] = await db.query('SELECT * FROM pvp_battles WHERE id = ?', [id]);
+  const battle = rows[0];
+  try {
+    const channel = await client.channels.fetch(battle.channel_id);
+    const msg = await channel.messages.fetch(battle.message_id);
+    await msg.edit({ content: 'Challenge Expired.' });
+  } catch (e) {
+    /* ignore */
+  }
   try {
     await challenger.send(`Your challenge #${id} has expired.`);
   } catch (e) {

--- a/discord-bot/tests/challenge.test.js
+++ b/discord-bot/tests/challenge.test.js
@@ -19,7 +19,7 @@ beforeEach(() => {
     battleLog: [],
     winner: 'player'
   }));
-  process.env.ANNOUNCEMENT_CHANNEL_ID = '100';
+  process.env.PVP_CHANNEL_ID = '100';
   jest.useFakeTimers();
 });
 


### PR DESCRIPTION
## Summary
- store announcement message details in DB
- update public message when a challenge is accepted, declined or expired
- post victory notice publicly when duel ends
- expose announcement channel ID in `.env.example`
- adjust tests for new flow

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686294ca930883279a257c080d1a2986