### PR TITLE
Check battle pending before expiring challenges

### DIFF
--- a/discord-bot/src/commands/challenge.js
+++ b/discord-bot/src/commands/challenge.js
@@ -205,9 +205,16 @@ async function handleDecline(interaction) {
 }
 
 async function expireChallenge(id, challenger, client) {
-  await db.query('UPDATE pvp_battles SET status = ? WHERE id = ?', ['expired', id]);
   const [rows] = await db.query('SELECT * FROM pvp_battles WHERE id = ?', [id]);
   const battle = rows[0];
+
+  if (!battle || battle.status !== 'pending') {
+    console.log(`[CHALLENGE] Challenge ${id} is not pending; skipping expiration.`);
+    return;
+  }
+
+  await db.query('UPDATE pvp_battles SET status = ? WHERE id = ?', ['expired', id]);
+
   try {
     const channel = await client.channels.fetch(battle.channel_id);
     const msg = await channel.messages.fetch(battle.message_id);


### PR DESCRIPTION
## Summary
- verify a challenge is still pending before expiring
- ensure expireChallenge early exits when status isn't pending
- update challenge tests for new expire logic

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6862b4484de08327bf30ff3a9a021ebd