### PR TITLE
Update who embed to show archetype

### DIFF
--- a/discord-bot/commands/who.js
+++ b/discord-bot/commands/who.js
@@ -29,14 +29,6 @@ async function execute(interaction) {
     return;
   }
 
-  if (!user.class) {
-    const embed = simple('Player Details', [{
-      name: 'Player',
-      value: `${user.name} has not yet chosen a class.`
-    }], mentionedUser.displayAvatarURL());
-    await interaction.reply({ embeds: [embed] });
-    return;
-  }
 
   const baseHero = allPossibleHeroes.find(
     h => (h.class === user.class || h.name === user.class) && h.isBase
@@ -45,18 +37,25 @@ async function execute(interaction) {
   const atk = baseHero ? baseHero.attack : '??';
 
   let abilityName = 'None';
+  let archetype = 'None';
   if (user.equipped_ability_id) {
     const card = await abilityCardService.getCard(user.equipped_ability_id);
     if (card) {
       const ability = allPossibleAbilities.find(a => a.id === card.ability_id);
-      abilityName = ability ? ability.name : `Ability ${card.ability_id}`;
+      if (ability) {
+        abilityName = ability.name;
+        archetype = `${ability.class} (${ability.rarity})`;
+      } else {
+        abilityName = `Ability ${card.ability_id}`;
+      }
     }
   }
 
   const embed = simple(
     'Character Sheet',
     [
-      { name: 'Player', value: `${user.name} - ${user.class}` },
+      { name: 'Player', value: `${user.name}` },
+      { name: 'Archetype', value: archetype },
       { name: 'HP', value: String(hp), inline: true },
       { name: 'Attack', value: String(atk), inline: true },
       { name: 'Equipped Ability', value: abilityName }

--- a/discord-bot/tests/who.test.js
+++ b/discord-bot/tests/who.test.js
@@ -30,8 +30,9 @@ describe('who command', () => {
     await who.execute(interaction);
     expect(interaction.reply).toHaveBeenCalledWith(expect.objectContaining({ embeds: expect.any(Array) }));
     const fields = interaction.reply.mock.calls[0][0].embeds[0].data.fields;
-    expect(fields[0].value).toContain('Tester - Warrior');
-    expect(fields[3].value).toContain('Power Strike');
+    expect(fields[0].value).toBe('Tester');
+    expect(fields[1].value).toBe('Stalwart Defender (Common)');
+    expect(fields[4].value).toContain('Power Strike');
     expect(interaction.reply.mock.calls[0][0].ephemeral).toBeUndefined();
   });
 
@@ -60,7 +61,8 @@ describe('who command', () => {
     };
     await who.execute(interaction);
     const fields = interaction.reply.mock.calls[0][0].embeds[0].data.fields;
-    expect(fields[3].value).toBe('None');
+    expect(fields[1].value).toBe('None');
+    expect(fields[4].value).toBe('None');
   });
 
   test('ephemeral reply on lookup failure', async () => {


### PR DESCRIPTION
## Summary
- show archetype using equipped ability class + rarity
- display player name only
- adjust tests for new output

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6862b785950c8327b341183017436f40