### PR TITLE
Add Defense stat and update damage mechanics

### DIFF
--- a/backend/game/data.js
+++ b/backend/game/data.js
@@ -144,6 +144,16 @@ const allPossibleHeroes = [
     { type: 'hero', id: 9001, name: 'Goblin', class: 'Goblin', rarity: 'Common', hp: 10, attack: 1, speed: 4, isMonster: true, abilities: [] },
 ];
 
+// Assign base defense values. Most heroes have 0 defense by default, while
+// tank-like classes start with a bit more.
+const classDefense = {
+    'Stalwart Defender': 2,
+    'Holy Warrior': 2,
+};
+allPossibleHeroes.forEach(h => {
+    h.defense = classDefense[h.class] ?? 0;
+});
+
 const allPossibleMinions = {
     SKELETON: {
         id: 'MINION_SKELETON',

--- a/backend/game/utils.js
+++ b/backend/game/utils.js
@@ -37,7 +37,8 @@ function createCombatant(playerData, team, position) {
     const finalStats = {
         hp: hero.hp,
         attack: hero.attack + (weapon ? weapon.statBonuses.ATK || 0 : 0),
-        speed: hero.speed
+        speed: hero.speed,
+        defense: hero.defense || 0
     };
 
     return {

--- a/backend/tests/abilityEffect.test.js
+++ b/backend/tests/abilityEffect.test.js
@@ -29,7 +29,7 @@ describe('Ability effect application', () => {
 
     expect(p.currentHp).toBe(player.maxHp - 4 - 2 + 2); // took 2 damage then healed 2
 
-    const expectedEnemyHp = enemy.maxHp - player.attack * 3 - 2;
+    const expectedEnemyHp = enemy.maxHp - 4; // 3 reduced auto-attacks plus mitigated ability damage
     expect(e.currentHp).toBe(expectedEnemyHp);
 
     // log should show ability usage and a separate line with the effects

--- a/backend/tests/autoAttack.test.js
+++ b/backend/tests/autoAttack.test.js
@@ -13,4 +13,16 @@ describe('Auto attack combat', () => {
     const target = engine.combatants.find(c => c.id === defender.id);
     expect(target.currentHp).toBe(defender.maxHp - attacker.attack);
   });
+
+  test('defense reduces incoming damage', () => {
+    const attacker = createCombatant({ hero_id: 2 }, 'player', 0); // attack 2
+    const defender = createCombatant({ hero_id: 1 }, 'enemy', 0); // defense 2
+
+    const engine = new GameEngine([attacker, defender]);
+    engine.turnQueue = engine.computeTurnQueue();
+    engine.processTurn();
+
+    const target = engine.combatants.find(c => c.id === defender.id);
+    expect(target.currentHp).toBe(defender.maxHp - 1);
+  });
 });

--- a/backend/tests/friendlyTargeting.test.js
+++ b/backend/tests/friendlyTargeting.test.js
@@ -51,7 +51,7 @@ describe('Friendly ability targeting', () => {
     engine.processTurn();
     const updatedPlayer = engine.combatants.find(c => c.id === player.id);
     const updatedCleric = engine.combatants.find(c => c.id === cleric.id);
-    expect(updatedPlayer.currentHp).toBe(player.maxHp - cleric.attack);
+    expect(updatedPlayer.currentHp).toBe(player.maxHp - 1);
     expect(updatedCleric.currentHp).toBe(cleric.maxHp);
   });
 });


### PR DESCRIPTION
## Summary
- add defense field to all heroes and give tanks higher base defense
- include defense in combatant creation stats
- account for defense in GameEngine.damage calculations
- log poison damage after mitigation
- update tests and add defense check

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6862c8fb2b548327ac41e3effb73c6f3