### PR TITLE
Add confuse and defense down parsing

### DIFF
--- a/backend/game/engine.js
+++ b/backend/game/engine.js
@@ -116,6 +116,21 @@ class GameEngine {
            this.log({ type: 'status', message: `↳ ${target.heroData.name} is poisoned.` });
        }
 
+       // Confuse / Defense Down debuffs
+       const confuseMatch = ability.effect.match(/confuse the target/i) || ability.effect.match(/apply Confuse(?:[^\d]*(\d+))?\s*turns?/i);
+       if (confuseMatch) {
+           const turns = confuseMatch[1] ? parseInt(confuseMatch[1], 10) : 1;
+           target.statusEffects.push({ name: 'Confuse', turnsRemaining: turns, sourceAbility: ability.name });
+           this.log({ type: 'status', message: `↳ ${target.heroData.name} is confused.` });
+       }
+
+       const defDownMatch = ability.effect.match(/apply Defense Down for (\d+) turns?/i);
+       if (defDownMatch) {
+           const turns = parseInt(defDownMatch[1], 10);
+           target.statusEffects.push({ name: 'Defense Down', turnsRemaining: turns, sourceAbility: ability.name });
+           this.log({ type: 'status', message: `↳ ${target.heroData.name} suffers Defense Down.` });
+       }
+
        // first log line - announce ability usage
        this.log({ type: 'ability-cast', message: `${attacker.heroData.name} uses ${ability.name}!` });
 

--- a/backend/tests/abilityPattern.test.js
+++ b/backend/tests/abilityPattern.test.js
@@ -33,4 +33,34 @@ describe('Additional ability effect patterns', () => {
     expect(e2.currentHp).toBe(enemy2.maxHp - 3);
     expect(engine.battleLog.some(l => l.message.includes('all enemies') && l.message.includes('3'))).toBe(true);
   });
+
+  test('confuse text applies status effect', () => {
+    const caster = createCombatant({ hero_id: 6 }, 'player', 0);
+    const target = createCombatant({ hero_id: 1 }, 'enemy', 0);
+    const engine = new GameEngine([caster, target]);
+    const ability = { name: 'Illusionary Strike', effect: 'Deal 1 damage and confuse the target.' };
+
+    engine.applyAbilityEffect(caster, target, ability);
+
+    const updated = engine.combatants.find(c => c.id === target.id);
+    const confuse = updated.statusEffects.find(s => s.name === 'Confuse');
+    expect(confuse).toBeTruthy();
+    expect(confuse.turnsRemaining).toBe(1);
+    expect(engine.battleLog.some(l => l.message.includes('confused'))).toBe(true);
+  });
+
+  test('defense down pattern applies status with turns', () => {
+    const caster = createCombatant({ hero_id: 1 }, 'player', 0);
+    const target = createCombatant({ hero_id: 1 }, 'enemy', 0);
+    const engine = new GameEngine([caster, target]);
+    const ability = { name: 'Armor Crack', effect: 'Apply Defense Down for 2 turns.' };
+
+    engine.applyAbilityEffect(caster, target, ability);
+
+    const updated = engine.combatants.find(c => c.id === target.id);
+    const dd = updated.statusEffects.find(s => s.name === 'Defense Down');
+    expect(dd).toBeTruthy();
+    expect(dd.turnsRemaining).toBe(2);
+    expect(engine.battleLog.some(l => l.message.includes('Defense Down'))).toBe(true);
+  });
 });


### PR DESCRIPTION
## Summary
- detect confuse and defense down phrases in ability text
- apply Confuse and Defense Down status effects
- log debuff status messages
- test new effect parsing

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6862d0e99848832786f3e4fb76e2fc01