### PR TITLE
Implement tutorial command

### DIFF
--- a/discord-bot/commands/tutorial.js
+++ b/discord-bot/commands/tutorial.js
@@ -1,0 +1,95 @@
+const { SlashCommandBuilder, EmbedBuilder } = require('discord.js');
+const userService = require('../src/utils/userService');
+const { buildBattleEmbed } = require('../src/utils/embedBuilder');
+const GameEngine = require('../../backend/game/engine');
+const { createCombatant } = require('../../backend/game/utils');
+const { allPossibleHeroes, allPossibleAbilities } = require('../../backend/game/data');
+
+function formatLog(entry) {
+  const prefix = `[R${entry.round}]`;
+  let text = entry.message;
+  if (entry.type === 'round') text = `**${text}**`;
+  else if (entry.type === 'victory' || entry.type === 'defeat') text = `🏆 **${text}** 🏆`;
+  else if (entry.type === 'ability-cast') text = `*${text}*`;
+  return `${prefix} ${text}`;
+}
+
+const data = new SlashCommandBuilder()
+  .setName('tutorial')
+  .setDescription('Start the guided tutorial');
+
+async function execute(interaction) {
+  let user = await userService.getUser(interaction.user.id);
+  if (!user) {
+    await userService.createUser(interaction.user.id, interaction.user.username);
+    user = await userService.getUser(interaction.user.id);
+  }
+
+  if (user.tutorial_completed) {
+    await interaction.reply({ content: 'You have already completed the tutorial.', ephemeral: true });
+    return;
+  }
+
+  const baseHero = allPossibleHeroes.find(h => h.isBase) || allPossibleHeroes[0];
+  const player = createCombatant({ hero_id: baseHero.id }, 'player', 0);
+
+  const goblin = {
+    id: 'enemy-0',
+    heroData: { name: 'Tutorial Goblin', hp: 10, attack: 1, speed: 1, defense: 0 },
+    weaponData: null,
+    armorData: null,
+    abilityData: null,
+    abilityCharges: 0,
+    deck: [],
+    team: 'enemy',
+    position: 0,
+    currentHp: 10,
+    maxHp: 10,
+    currentEnergy: 0,
+    statusEffects: [],
+    hp: 10,
+    attack: 1,
+    speed: 1,
+    defense: 0
+  };
+
+  await interaction.reply({ content: 'A Tutorial Goblin appears! Prepare for battle!' });
+
+  const engine = new GameEngine([player, goblin]);
+  const wait = ms => new Promise(r => setTimeout(r, ms));
+  let logText = '';
+  let battleMessage;
+  for (const step of engine.runGameSteps()) {
+    const lines = step.log.map(formatLog);
+    logText = [logText, ...lines].filter(Boolean).join('\n');
+    const embed = buildBattleEmbed(step.combatants, logText);
+    if (!battleMessage) {
+      battleMessage = await interaction.followUp({ embeds: [embed] });
+    } else {
+      await wait(1000);
+      await battleMessage.edit({ embeds: [embed] });
+    }
+  }
+
+  const commonAbilities = allPossibleAbilities.filter(a => a.rarity === 'Common');
+  const drop = commonAbilities[Math.floor(Math.random() * commonAbilities.length)];
+  await userService.addAbility(interaction.user.id, drop.id);
+
+  const summaryEmbed = new EmbedBuilder()
+    .setColor('#57F287')
+    .setDescription(`Victory! The Tutorial Goblin dropped **${drop.name}**.`);
+  await interaction.followUp({ embeds: [summaryEmbed] });
+
+  interaction.followUp("Congratulations on your victory! You've found your first Ability Card. Use the /inventory show command to see what's in your backpack.");
+
+  setTimeout(() => {
+    interaction.followUp(`Now, equip your new ability using the command: /inventory set ability:${drop.name}`);
+  }, 5000);
+
+  setTimeout(async () => {
+    await interaction.followUp('You can now use /adventure to battle monsters, /challenge @user to duel other players, and /who @user to inspect a character.');
+    await userService.markTutorialComplete(interaction.user.id);
+  }, 10000);
+}
+
+module.exports = { data, execute };

--- a/discord-bot/db-schema.sql
+++ b/discord-bot/db-schema.sql
@@ -5,7 +5,8 @@ CREATE TABLE IF NOT EXISTS users (
     id INT AUTO_INCREMENT PRIMARY KEY,
     discord_id VARCHAR(255) NOT NULL UNIQUE,
     name VARCHAR(255) NOT NULL UNIQUE COLLATE utf8mb4_unicode_ci,
-    class VARCHAR(50) DEFAULT NULL
+    class VARCHAR(50) DEFAULT NULL,
+    tutorial_completed TINYINT(1) DEFAULT 0
 );
 
 -- Ability cards owned by users
@@ -21,6 +22,9 @@ CREATE TABLE IF NOT EXISTS user_ability_cards (
 ALTER TABLE users
     ADD COLUMN equipped_ability_id INT DEFAULT NULL,
     ADD FOREIGN KEY (equipped_ability_id) REFERENCES user_ability_cards(id);
+
+ALTER TABLE users
+    ADD COLUMN tutorial_completed TINYINT(1) DEFAULT 0;
 
 -- Champions owned by users
 CREATE TABLE IF NOT EXISTS user_champions (

--- a/discord-bot/deploy-commands.js
+++ b/discord-bot/deploy-commands.js
@@ -9,6 +9,7 @@ const commandDirs = [
   path.join(__dirname, 'commands/admin.js'),
   path.join(__dirname, 'commands/inventory.js'),
   path.join(__dirname, 'commands/set.js'),
+  path.join(__dirname, 'commands/tutorial.js'),
   path.join(__dirname, 'src/commands/adventure.js'),
   path.join(__dirname, 'src/commands/challenge.js'),
   path.join(__dirname, 'src/commands/practice.js')

--- a/discord-bot/src/utils/userService.js
+++ b/discord-bot/src/utils/userService.js
@@ -51,6 +51,10 @@ async function setActiveAbility(discordId, cardId) {
   return { discordId, cardId };
 }
 
+async function markTutorialComplete(discordId) {
+  await db.query('UPDATE users SET tutorial_completed = 1 WHERE discord_id = ?', [discordId]);
+}
+
 module.exports = {
   getUser,
   createUser,
@@ -58,5 +62,6 @@ module.exports = {
   setUserClass,
   addAbility,
   getInventory,
-  setActiveAbility
+  setActiveAbility,
+  markTutorialComplete
 };

--- a/discord-bot/tests/tutorial.test.js
+++ b/discord-bot/tests/tutorial.test.js
@@ -1,0 +1,62 @@
+const tutorial = require('../commands/tutorial');
+
+jest.mock('../src/utils/userService', () => ({
+  getUser: jest.fn(),
+  createUser: jest.fn(),
+  addAbility: jest.fn(),
+  markTutorialComplete: jest.fn()
+}));
+jest.mock('../../backend/game/engine');
+
+const userService = require('../src/utils/userService');
+const GameEngine = require('../../backend/game/engine');
+const utils = require('../../backend/game/utils');
+const { allPossibleAbilities } = require('../../backend/game/data');
+
+jest.spyOn(utils, 'createCombatant');
+
+describe('tutorial command', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+    jest.clearAllMocks();
+    GameEngine.mockImplementation(() => ({
+      runGameSteps: function* () {
+        yield { combatants: [], log: [{ round: 1, type: 'info', message: 'log' }] };
+      },
+      runFullGame: jest.fn(),
+      winner: 'player'
+    }));
+  });
+
+  afterEach(() => {
+    jest.runOnlyPendingTimers();
+    jest.useRealTimers();
+  });
+
+  test('creates a user when none exists', async () => {
+    userService.getUser.mockResolvedValueOnce(null).mockResolvedValueOnce({ id: 1 });
+    const interaction = { user: { id: '1', username: 'Tester' }, reply: jest.fn().mockResolvedValue(), followUp: jest.fn().mockResolvedValue() };
+    await tutorial.execute(interaction);
+    expect(userService.createUser).toHaveBeenCalledWith('1', 'Tester');
+  });
+
+  test('replies when already completed', async () => {
+    userService.getUser.mockResolvedValue({ id: 1, tutorial_completed: 1 });
+    const interaction = { user: { id: '1' }, reply: jest.fn().mockResolvedValue() };
+    await tutorial.execute(interaction);
+    expect(interaction.reply).toHaveBeenCalledWith(expect.objectContaining({ ephemeral: true }));
+  });
+
+  test('grants a common ability and marks completion', async () => {
+    userService.getUser.mockResolvedValue({ id: 1, tutorial_completed: 0 });
+    const interaction = { user: { id: '1', username: 'Tester' }, reply: jest.fn().mockResolvedValue(), followUp: jest.fn().mockResolvedValue() };
+    jest.spyOn(Math, 'random').mockReturnValue(0);
+    await tutorial.execute(interaction);
+    const abilityId = allPossibleAbilities.filter(a => a.rarity === 'Common')[0].id;
+    expect(userService.addAbility).toHaveBeenCalledWith('1', abilityId);
+    jest.runAllTimers();
+    await Promise.resolve();
+    expect(userService.markTutorialComplete).toHaveBeenCalledWith('1');
+    Math.random.mockRestore();
+  });
+});


### PR DESCRIPTION
## Summary
- add a `/tutorial` command that runs an introductory battle
- track tutorial completion in the database and user service
- register the command
- provide Jest tests for tutorial flow

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6862d6a92a48832782707a8734bf5a7c