### PR TITLE
Implement defense stat and confusion miss logic

### DIFF
--- a/backend/game/utils.js
+++ b/backend/game/utils.js
@@ -38,7 +38,7 @@ function createCombatant(playerData, team, position) {
         hp: hero.hp,
         attack: hero.attack + (weapon ? weapon.statBonuses.ATK || 0 : 0),
         speed: hero.speed,
-        defense: hero.defense || 0
+        defense: (hero.defense || 0) + (armor ? armor.statBonuses.Block || 0 : 0)
     };
 
     return {

--- a/backend/tests/statusEffects.test.js
+++ b/backend/tests/statusEffects.test.js
@@ -65,7 +65,7 @@ describe('Status effect processing', () => {
     engine.processTurn();
     const updatedP = engine.combatants.find(c => c.id === p.id);
     expect(updatedP.currentHp).toBe(before);
-    expect(engine.battleLog.some(l => l.message.includes('misses the turn'))).toBe(true);
+    expect(engine.battleLog.some(l => l.message.includes('attack misses'))).toBe(true);
 
     engine.applyAbilityEffect(p, e, ability);
     expect(e.statusEffects.some(s => s.name === 'Confuse')).toBe(true);


### PR DESCRIPTION
## Summary
- factor armor block into combatant defense
- allow abilities to apply Defense Down status
- reduce damage by defense, accounting for Defense Down
- chance for confused units to miss attacks instead of losing the turn
- adjust tests for new confusion messaging

## Testing
- `npm test --silent --prefix backend`

------
https://chatgpt.com/codex/tasks/task_e_6862d6dd57508327a189beffc9bcafc2