### PR TITLE
Make /who and /inventory show ephemeral

### DIFF
--- a/discord-bot/commands/inventory.js
+++ b/discord-bot/commands/inventory.js
@@ -83,7 +83,7 @@ async function execute(interaction) {
       interaction.user.displayAvatarURL()
     );
 
-    await interaction.reply({ embeds: [embed] });
+    await interaction.reply({ embeds: [embed], ephemeral: true });
     return;
   }
 

--- a/discord-bot/commands/who.js
+++ b/discord-bot/commands/who.js
@@ -62,7 +62,7 @@ async function execute(interaction) {
     ],
     mentionedUser.displayAvatarURL()
   );
-  await interaction.reply({ embeds: [embed] });
+  await interaction.reply({ embeds: [embed], ephemeral: true });
 }
 
 module.exports = { data, execute };

--- a/discord-bot/tests/inventory.test.js
+++ b/discord-bot/tests/inventory.test.js
@@ -28,7 +28,7 @@ describe('inventory command', () => {
     };
     await inventory.execute(interaction);
     expect(interaction.reply).toHaveBeenCalledWith(expect.objectContaining({ embeds: expect.any(Array) }));
-    expect(interaction.reply.mock.calls[0][0].ephemeral).toBeUndefined();
+    expect(interaction.reply.mock.calls[0][0].ephemeral).toBe(true);
     const fields = interaction.reply.mock.calls[0][0].embeds[0].data.fields;
     expect(fields[0].value).toContain('Stalwart Defender (Common)');
     expect(fields[1].value).toContain('Power Strike');

--- a/discord-bot/tests/who.test.js
+++ b/discord-bot/tests/who.test.js
@@ -33,7 +33,7 @@ describe('who command', () => {
     expect(fields[0].value).toBe('Tester');
     expect(fields[1].value).toBe('Stalwart Defender (Common)');
     expect(fields[4].value).toContain('Power Strike');
-    expect(interaction.reply.mock.calls[0][0].ephemeral).toBeUndefined();
+    expect(interaction.reply.mock.calls[0][0].ephemeral).toBe(true);
   });
 
   test('public reply when user lacks a class', async () => {
@@ -44,7 +44,7 @@ describe('who command', () => {
     };
     await who.execute(interaction);
     expect(interaction.reply).toHaveBeenCalledWith(expect.objectContaining({ embeds: expect.any(Array) }));
-    expect(interaction.reply.mock.calls[0][0].ephemeral).toBeUndefined();
+    expect(interaction.reply.mock.calls[0][0].ephemeral).toBe(true);
   });
 
   test('shows None when no ability equipped', async () => {


### PR DESCRIPTION
## Summary
- hide the reply for `/inventory show` behind ephemeral response
- also hide the `/who` reply
- adjust unit tests for new ephemeral behavior

## Testing
- `npm test` within discord-bot
- `npm test` within backend

------
https://chatgpt.com/codex/tasks/task_e_6862da8e97808327858afe1c9e6750d6