### PR TITLE
Switch tutorial to ephemeral replies

### DIFF
--- a/discord-bot/commands/tutorial.js
+++ b/discord-bot/commands/tutorial.js
@@ -30,7 +30,10 @@ async function execute(interaction) {
     return;
   }
 
-  await interaction.reply({ content: "I've started your tutorial in your DMs!", ephemeral: true });
+  await interaction.reply({
+    content: 'A Tutorial Goblin appears! Prepare for battle!',
+    ephemeral: true
+  });
 
   try {
     const baseHero = allPossibleHeroes.find(h => h.isBase) || allPossibleHeroes[0];
@@ -56,7 +59,7 @@ async function execute(interaction) {
       defense: 0
     };
 
-    await interaction.user.send('A Tutorial Goblin appears! Prepare for battle!');
+
 
     const engine = new GameEngine([player, goblin]);
     const wait = ms => new Promise(r => setTimeout(r, ms));
@@ -67,7 +70,10 @@ async function execute(interaction) {
       logText = [logText, ...lines].filter(Boolean).join('\n');
       const embed = buildBattleEmbed(step.combatants, logText);
       if (!battleMessage) {
-        battleMessage = await interaction.user.send({ embeds: [embed] });
+        battleMessage = await interaction.followUp({
+          embeds: [embed],
+          ephemeral: true
+        });
       } else {
         await wait(1000);
         await battleMessage.edit({ embeds: [embed] });
@@ -81,7 +87,7 @@ async function execute(interaction) {
     const summaryEmbed = new EmbedBuilder()
       .setColor('#57F287')
       .setDescription(`Victory! The Tutorial Goblin dropped **${drop.name}**.`);
-    await interaction.user.send({ embeds: [summaryEmbed] });
+    await interaction.followUp({ embeds: [summaryEmbed], ephemeral: true });
 
     interaction.followUp({
       content:
@@ -105,9 +111,9 @@ async function execute(interaction) {
       await userService.markTutorialComplete(interaction.user.id);
     }, 10000);
   } catch (error) {
-    console.error(`Failed to send tutorial DM to ${interaction.user.tag}.`, error);
+    console.error(`Tutorial failed for ${interaction.user.tag}.`, error);
     await interaction.followUp({
-      content: "I couldn't send you a DM. Please check your Server Privacy Settings.",
+      content: 'An error occurred while running the tutorial. Please try again later.',
       ephemeral: true
     });
   }

--- a/discord-bot/tests/tutorial.test.js
+++ b/discord-bot/tests/tutorial.test.js
@@ -36,7 +36,7 @@ describe('tutorial command', () => {
   test('creates a user when none exists', async () => {
     userService.getUser.mockResolvedValueOnce(null).mockResolvedValueOnce({ id: 1 });
     const interaction = {
-      user: { id: '1', username: 'Tester', send: jest.fn().mockResolvedValue() },
+      user: { id: '1', username: 'Tester' },
       reply: jest.fn().mockResolvedValue(),
       followUp: jest.fn().mockResolvedValue()
     };
@@ -47,7 +47,7 @@ describe('tutorial command', () => {
   test('replies when already completed', async () => {
     userService.getUser.mockResolvedValue({ id: 1, tutorial_completed: 1 });
     const interaction = {
-      user: { id: '1', send: jest.fn().mockResolvedValue() },
+      user: { id: '1' },
       reply: jest.fn().mockResolvedValue()
     };
     await tutorial.execute(interaction);
@@ -57,7 +57,7 @@ describe('tutorial command', () => {
   test('grants a common ability and marks completion', async () => {
     userService.getUser.mockResolvedValue({ id: 1, tutorial_completed: 0 });
     const interaction = {
-      user: { id: '1', username: 'Tester', send: jest.fn().mockResolvedValue() },
+      user: { id: '1', username: 'Tester' },
       reply: jest.fn().mockResolvedValue(),
       followUp: jest.fn().mockResolvedValue()
     };
@@ -68,6 +68,8 @@ describe('tutorial command', () => {
     jest.runAllTimers();
     await Promise.resolve();
     expect(userService.markTutorialComplete).toHaveBeenCalledWith('1');
+    const ephemeralCalls = interaction.followUp.mock.calls.filter(c => c[0].ephemeral);
+    expect(ephemeralCalls.length).toBeGreaterThan(0);
     Math.random.mockRestore();
   });
 });


### PR DESCRIPTION
## Summary
- keep tutorial messages in-channel using ephemeral replies instead of DMs
- adapt tutorial tests for new behaviour

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6862e05a05448327ab6dd8c9e7a90197