### PR TITLE
Adjust loot drop logic

### DIFF
--- a/discord-bot/commands/tutorial.js
+++ b/discord-bot/commands/tutorial.js
@@ -80,8 +80,14 @@ async function execute(interaction) {
       }
     }
 
-    const commonAbilities = allPossibleAbilities.filter(a => a.rarity === 'Common');
-    const drop = commonAbilities[Math.floor(Math.random() * commonAbilities.length)];
+    const commonOffenseAbilities = allPossibleAbilities.filter(
+      a =>
+        a.rarity === 'Common' &&
+        a.category === 'Offense' &&
+        a.class === baseHero.class
+    );
+    const drop =
+      commonOffenseAbilities[Math.floor(Math.random() * commonOffenseAbilities.length)];
     await userService.addAbility(interaction.user.id, drop.id);
 
     const summaryEmbed = new EmbedBuilder()

--- a/discord-bot/src/commands/adventure.js
+++ b/discord-bot/src/commands/adventure.js
@@ -101,15 +101,19 @@ async function execute(interaction) {
   const enemyName = `a **Goblin ${goblinBase.name}**`;
 
   if (engine.winner === 'player') {
-    lootDrop =
-      goblinAbilityPool[Math.floor(Math.random() * goblinAbilityPool.length)];
     let dropText = 'who was slain.';
-    if (lootDrop) {
-      dropText = `who was slain and dropped **${lootDrop.name}**.`;
-      console.log(
-        `[ITEM LOOT] User: ${interaction.user.username} looted Ability: ${lootDrop.name} (ID: ${lootDrop.id})`
+    if (Math.random() < 0.5) {
+      const lootOptions = allPossibleAbilities.filter(
+        a => a.class === goblinBase.class && a.rarity === 'Common'
       );
-      await userService.addAbility(interaction.user.id, lootDrop.id);
+      lootDrop = lootOptions[Math.floor(Math.random() * lootOptions.length)];
+      if (lootDrop) {
+        dropText = `who was slain and dropped **${lootDrop.name}**.`;
+        console.log(
+          `[ITEM LOOT] User: ${interaction.user.username} looted Ability: ${lootDrop.name} (ID: ${lootDrop.id})`
+        );
+        await userService.addAbility(interaction.user.id, lootDrop.id);
+      }
     }
     narrativeDescription = `${adventurerName} adventured into the goblin caves and encountered ${enemyName}, ${dropText}`;
   } else {

--- a/discord-bot/tests/tutorial.test.js
+++ b/discord-bot/tests/tutorial.test.js
@@ -11,7 +11,10 @@ jest.mock('../../backend/game/engine');
 const userService = require('../src/utils/userService');
 const GameEngine = require('../../backend/game/engine');
 const utils = require('../../backend/game/utils');
-const { allPossibleAbilities } = require('../../backend/game/data');
+const {
+  allPossibleAbilities,
+  allPossibleHeroes
+} = require('../../backend/game/data');
 
 jest.spyOn(utils, 'createCombatant');
 
@@ -63,7 +66,13 @@ describe('tutorial command', () => {
     };
     jest.spyOn(Math, 'random').mockReturnValue(0);
     await tutorial.execute(interaction);
-    const abilityId = allPossibleAbilities.filter(a => a.rarity === 'Common')[0].id;
+    const abilityId = allPossibleAbilities.filter(
+      a =>
+        a.rarity === 'Common' &&
+        a.category === 'Offense' &&
+        a.class ===
+          (allPossibleHeroes.find(h => h.isBase) || allPossibleHeroes[0]).class
+    )[0].id;
     expect(userService.addAbility).toHaveBeenCalledWith('1', abilityId);
     jest.runAllTimers();
     await Promise.resolve();


### PR DESCRIPTION
## Summary
- adventure goblins now drop loot with a 50% chance
- tutorial goblin drops only offense common cards matching its archetype
- update tests to match new loot selection

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6862e55f01988327b131dd27da52dd89