### PR TITLE
Fix crash on empty battle logs

### DIFF
--- a/discord-bot/src/utils/embedBuilder.js
+++ b/discord-bot/src/utils/embedBuilder.js
@@ -64,7 +64,7 @@ function buildBattleEmbed(combatants, logText) {
     .setTitle('Battle')
     .setTimestamp()
     .setFooter({ text: 'Auto\u2011Battler Bot' })
-    .setDescription(logText)
+    .setDescription(logText || 'The battle is about to begin...')
     .addFields({ name: 'HP', value: hpLines });
   return embed;
 }

--- a/discord-bot/tests/adventure.test.js
+++ b/discord-bot/tests/adventure.test.js
@@ -104,8 +104,8 @@ describe('adventure command', () => {
     GameEngine.mockImplementationOnce(() => ({
       runGameSteps: function* () {
         yield { combatants: [], log: [
-          { round: 1, type: 'info', message: 'first' },
-          { round: 1, type: 'info', message: 'second' }
+          { round: 1, type: 'info', level: 'summary', message: 'first' },
+          { round: 1, type: 'info', level: 'summary', message: 'second' }
         ] };
       },
       runFullGame: jest.fn(),
@@ -138,7 +138,7 @@ describe('adventure command', () => {
   });
 
   test('battle log is truncated to last 20 lines', async () => {
-    const logs = Array.from({ length: 30 }, (_, i) => ({ round: 1, type: 'info', message: String(i + 1) }));
+    const logs = Array.from({ length: 30 }, (_, i) => ({ round: 1, type: 'info', level: 'summary', message: String(i + 1) }));
     GameEngine.mockImplementationOnce(() => ({
       runGameSteps: function* () {
         yield { combatants: [], log: logs };


### PR DESCRIPTION
## Summary
- default embed description if log text is empty
- update adventure tests for summary log format

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6862f0c1f828832791f84efb461b543a