### PR TITLE
Improve battle round updates

### DIFF
--- a/backend/game/engine.js
+++ b/backend/game/engine.js
@@ -58,9 +58,9 @@ class GameEngine {
        target.currentHp = Math.max(0, target.currentHp - effective);
        if (log) {
            if (attacker === target) {
-               this.log({ type: 'damage', message: `${target.heroData.name} takes ${effective} damage.` });
+               this.log({ type: 'damage', message: `${target.heroData.name} takes ${effective} damage.` }, 'summary');
            } else {
-               this.log({ type: 'damage', message: `${attacker.heroData.name} hits ${target.heroData.name} for ${effective} damage.` });
+               this.log({ type: 'damage', message: `${attacker.heroData.name} hits ${target.heroData.name} for ${effective} damage.` }, 'summary');
            }
            if (target.currentHp <= 0) {
                this.log({ type: 'status', message: `💀 ${target.heroData.name} has been defeated.` }, 'summary');


### PR DESCRIPTION
## Summary
- log auto-attacks in summary for concise battle log
- update adventure loop to edit battle embed once per round

## Testing
- `npm install --prefix discord-bot`
- `npm test --prefix discord-bot`

------
https://chatgpt.com/codex/tasks/task_e_6862f52d5fa483279b6ce45a8edcfe82