### PR TITLE
Implement summoning, extra action and cleanse

### DIFF
--- a/backend/game/statusEffects.js
+++ b/backend/game/statusEffects.js
@@ -1,0 +1,13 @@
+const STATUS_EFFECTS = {
+  Stun: { name: 'Stun', icon: '⭐', type: 'debuff' },
+  Poison: { name: 'Poison', icon: '☣️', type: 'debuff' },
+  Confuse: { name: 'Confuse', icon: '❓', type: 'debuff' },
+  'Defense Down': { name: 'Defense Down', icon: '🛡️', type: 'debuff' },
+  'Armor Break': { name: 'Armor Break', icon: '🛡️', type: 'debuff' },
+  'Attack Up': { name: 'Attack Up', icon: '⬆️', type: 'buff' },
+  Fortify: { name: 'Fortify', icon: '🛡️', type: 'buff' },
+  Regrowth: { name: 'Regrowth', icon: '💚', type: 'buff' },
+  Slow: { name: 'Slow', icon: '🐢', type: 'debuff' }
+};
+
+module.exports = { STATUS_EFFECTS };


### PR DESCRIPTION
## Summary
- add new `statusEffects` catalog with buff/debuff info
- track extra actions on `GameEngine`
- enable summoning of minions and extra action triggers
- implement `applyCleanse` and hook up cleanse ability logic

## Testing
- `npm test --prefix backend`

------
https://chatgpt.com/codex/tasks/task_e_6862f719eee883279ef3ecee5de5c68c