### PR TITLE
Personalized names in battle logs

### DIFF
--- a/backend/game/engine.js
+++ b/backend/game/engine.js
@@ -53,7 +53,7 @@ class GameEngine {
                const info = STATUS_EFFECTS[e.name];
                return !info || info.type !== 'debuff';
            });
-           this.log({ type: 'status', message: `${target.heroData.name}'s negative effects were cleansed.` }, 'summary');
+           this.log({ type: 'status', message: `${target.name}'s negative effects were cleansed.` }, 'summary');
        }
    }
 
@@ -75,12 +75,12 @@ class GameEngine {
        target.currentHp = Math.max(0, target.currentHp - effective);
        if (log) {
            if (attacker === target) {
-               this.log({ type: 'damage', message: `${target.heroData.name} takes ${effective} damage.` }, 'summary');
+               this.log({ type: 'damage', message: `${target.name} takes ${effective} damage.` }, 'summary');
            } else {
-               this.log({ type: 'damage', message: `${attacker.heroData.name} hits ${target.heroData.name} for ${effective} damage.` }, 'summary');
+               this.log({ type: 'damage', message: `${attacker.name} hits ${target.name} for ${effective} damage.` }, 'summary');
            }
            if (target.currentHp <= 0) {
-               this.log({ type: 'status', message: `💀 ${target.heroData.name} has been defeated.` }, 'summary');
+               this.log({ type: 'status', message: `💀 ${target.name} has been defeated.` }, 'summary');
            }
        }
        return effective;
@@ -132,7 +132,7 @@ class GameEngine {
            const healing = parseInt(hotMatch[1], 10);
            const turns = parseInt(hotMatch[2], 10);
            target.statusEffects.push({ name: 'Regrowth', healing, turnsRemaining: turns, sourceAbility: ability.name });
-           this.log({ type: 'status', message: `↳ ${target.heroData.name} is blessed with Regrowth.` });
+           this.log({ type: 'status', message: `↳ ${target.name} is blessed with Regrowth.` });
        }
 
        const poisonMatchDetailed = ability.effect.match(/apply Poison \((\d+) dmg\/turn for (\d+) turns\)/i);
@@ -141,26 +141,26 @@ class GameEngine {
            const damage = poisonMatchDetailed ? parseInt(poisonMatchDetailed[1], 10) : 1;
            const turns = poisonMatchDetailed ? parseInt(poisonMatchDetailed[2], 10) : parseInt(poisonMatchSimple[1], 10);
            target.statusEffects.push({ name: 'Poison', damage, turnsRemaining: turns, sourceAbility: ability.name });
-           this.log({ type: 'status', message: `↳ ${target.heroData.name} is poisoned.` });
+           this.log({ type: 'status', message: `↳ ${target.name} is poisoned.` });
        }
 
        if (/confuse/i.test(ability.effect)) {
            target.statusEffects.push({ name: 'Confuse', turnsRemaining: 1, sourceAbility: ability.name });
-           this.log({ type: 'status', message: `↳ ${target.heroData.name} is confused.` });
+           this.log({ type: 'status', message: `↳ ${target.name} is confused.` });
        }
 
        if (/Armor Break/i.test(ability.effect)) {
            const match = ability.effect.match(/(\d+) turns?/i);
            const turns = match ? parseInt(match[1], 10) : 2;
            target.statusEffects.push({ name: 'Armor Break', bonusDamage: 1, turnsRemaining: turns, sourceAbility: ability.name });
-           this.log({ type: 'status', message: `↳ ${target.heroData.name} suffers Armor Break.` });
+           this.log({ type: 'status', message: `↳ ${target.name} suffers Armor Break.` });
        }
 
        if (/Defense Down/i.test(ability.effect)) {
            const match = ability.effect.match(/Defense Down for (\d+) turns?/i);
            const turns = match ? parseInt(match[1], 10) : 2;
            target.statusEffects.push({ name: 'Defense Down', turnsRemaining: turns, sourceAbility: ability.name });
-           this.log({ type: 'status', message: `↳ ${target.heroData.name} suffers Defense Down.` });
+           this.log({ type: 'status', message: `↳ ${target.name} suffers Defense Down.` });
        }
 
        if (ability.summons) {
@@ -171,6 +171,7 @@ class GameEngine {
                if (minionData) {
                    const newMinion = {
                        id: `${attacker.team}-minion-${Date.now()}-${Math.random()}`,
+                       name: minionData.name,
                        heroData: { ...minionData },
                        team: attacker.team,
                        position: this.combatants.filter(c => c.team === attacker.team).length,
@@ -183,7 +184,7 @@ class GameEngine {
                        statusEffects: [],
                    };
                    this.combatants.push(newMinion);
-                   this.log({ type: 'info', message: `${attacker.heroData.name} summons a ${minionData.name}!` }, 'summary');
+                   this.log({ type: 'info', message: `${attacker.name} summons a ${minionData.name}!` }, 'summary');
                }
            }
            this.turnQueue = this.computeTurnQueue();
@@ -194,13 +195,13 @@ class GameEngine {
        }
 
        if (ability.effect.includes('extra action') && !this.extraActionTaken[attacker.id]) {
-           this.log({ type: 'info', message: `${attacker.heroData.name} gains an extra action!` }, 'summary');
+           this.log({ type: 'info', message: `${attacker.name} gains an extra action!` }, 'summary');
            this.extraActionTaken[attacker.id] = true;
            this.turnQueue.unshift(attacker);
        }
 
        // first log line - announce ability usage
-       this.log({ type: 'ability-cast', message: `${attacker.heroData.name} uses ${ability.name}!` }, 'summary');
+       this.log({ type: 'ability-cast', message: `${attacker.name} uses ${ability.name}!` }, 'summary');
 
        // build description of the ability effects
        let descParts = [];
@@ -208,14 +209,14 @@ class GameEngine {
            if (multiTarget) {
                descParts.push(`hits all enemies for ${damageDealt} damage`);
            } else {
-               descParts.push(`hits ${target.heroData.name} for ${damageDealt} damage`);
+               descParts.push(`hits ${target.name} for ${damageDealt} damage`);
            }
        }
        if (healingDone > 0) {
            if (healTarget === attacker) {
                descParts.push(`heals for ${healingDone} HP`);
            } else if (healTarget) {
-               descParts.push(`heals ${healTarget.heroData.name} for ${healingDone} HP`);
+               descParts.push(`heals ${healTarget.name} for ${healingDone} HP`);
            }
        }
 
@@ -238,16 +239,16 @@ class GameEngine {
            descParts.push(remaining);
        }
 
-       const effectLine = `${attacker.heroData.name} ${descParts.join(' and ')}.`;
+       const effectLine = `${attacker.name} ${descParts.join(' and ')}.`;
        this.log({ type: 'ability-result', message: effectLine });
 
        if (multiTarget && damageDealt > 0) {
            const enemies = this.combatants.filter(c => c.team !== attacker.team && c.currentHp <= 0);
            for (const enemy of enemies) {
-               this.log({ type: 'status', message: `💀 ${enemy.heroData.name} has been defeated.` }, 'summary');
+               this.log({ type: 'status', message: `💀 ${enemy.name} has been defeated.` }, 'summary');
            }
        } else if (damageDealt > 0 && target.currentHp <= 0) {
-           this.log({ type: 'status', message: `💀 ${target.heroData.name} has been defeated.` }, 'summary');
+           this.log({ type: 'status', message: `💀 ${target.name} has been defeated.` }, 'summary');
        }
    }
 
@@ -263,23 +264,23 @@ class GameEngine {
         for (const effect of [...combatant.statusEffects]) {
             if (effect.name === 'Regrowth') {
                 this.applyHeal(combatant, effect.healing);
-                this.log({ type: 'status', message: `💚 ${combatant.heroData.name} is healed for ${effect.healing} by Regrowth.` });
+                this.log({ type: 'status', message: `💚 ${combatant.name} is healed for ${effect.healing} by Regrowth.` });
             } else if (effect.name === 'Poison') {
                 const dealt = this.applyDamage(combatant, combatant, effect.damage, { log: false });
-                this.log({ type: 'status', message: `☣️ ${combatant.heroData.name} takes ${dealt} poison damage.` });
+                this.log({ type: 'status', message: `☣️ ${combatant.name} takes ${dealt} poison damage.` });
             }
 
             if (effect.name !== 'Confuse') {
                 effect.turnsRemaining -= 1;
                 if (effect.turnsRemaining <= 0) {
                     combatant.statusEffects = combatant.statusEffects.filter(e => e !== effect);
-                    this.log({ type: 'status', message: `${effect.name} on ${combatant.heroData.name} has worn off.` });
+                    this.log({ type: 'status', message: `${effect.name} on ${combatant.name} has worn off.` });
                 }
             }
         }
 
        if (combatant.statusEffects.some(s => s.name === 'Stun')) {
-           this.log({ type: 'status', message: `${combatant.heroData.name} is stunned and misses the turn.` });
+           this.log({ type: 'status', message: `${combatant.name} is stunned and misses the turn.` });
            skip = true;
        }
        return skip;
@@ -306,7 +307,7 @@ class GameEngine {
             return;
        }
 
-       this.log({ type: 'turn', message: `> Turn: ${attacker.heroData.name} (${attacker.currentHp}/${attacker.maxHp} HP)` });
+       this.log({ type: 'turn', message: `> Turn: ${attacker.name} (${attacker.currentHp}/${attacker.maxHp} HP)` });
 
        const wasSkipped = this.processStatuses(attacker);
        if (this.checkVictory()) return;
@@ -321,19 +322,19 @@ class GameEngine {
                const cost = ability ? ability.energyCost || 1 : 0;
 
                if (ability) {
-                   console.log(`${attacker.heroData.name} is checking if they can use ${ability.name}.`);
+                   console.log(`${attacker.name} is checking if they can use ${ability.name}.`);
                }
 
                if (confused) {
                    if (Math.random() < 0.5) {
-                       this.log({ type: 'status', message: `${attacker.heroData.name}'s attack misses ${targetEnemy.heroData.name}!` });
+                       this.log({ type: 'status', message: `${attacker.name}'s attack misses ${targetEnemy.name}!` });
                        attacker.statusEffects = attacker.statusEffects.filter(e => e !== confused);
-                       this.log({ type: 'status', message: `Confuse on ${attacker.heroData.name} has worn off.` });
+                       this.log({ type: 'status', message: `Confuse on ${attacker.name} has worn off.` });
                        attacker.currentEnergy = (attacker.currentEnergy || 0) + 1;
                        return;
                    } else {
                        attacker.statusEffects = attacker.statusEffects.filter(e => e !== confused);
-                       this.log({ type: 'status', message: `Confuse on ${attacker.heroData.name} has worn off.` });
+                       this.log({ type: 'status', message: `Confuse on ${attacker.name} has worn off.` });
                    }
                }
 
@@ -348,7 +349,7 @@ class GameEngine {
                    : remainingEnemies[0];
 
                if (ability && attacker.abilityCharges > 0 && attacker.currentEnergy >= cost && abilityTarget) {
-                   console.log(`${attacker.heroData.name} spends ${cost} energy to use ${ability.name}.`);
+                   console.log(`${attacker.name} spends ${cost} energy to use ${ability.name}.`);
                    this.applyAbilityEffect(attacker, abilityTarget, ability);
                    attacker.currentEnergy -= cost;
                    attacker.abilityCharges -= 1;
@@ -366,7 +367,7 @@ class GameEngine {
                        }
                    }
                } else if (ability) {
-                   console.log(`${attacker.heroData.name} has ${attacker.currentEnergy} energy and requires ${cost}. Unable to use ${ability.name}.`);
+                   console.log(`${attacker.name} has ${attacker.currentEnergy} energy and requires ${cost}. Unable to use ${ability.name}.`);
                }
            }
        }

--- a/backend/game/utils.js
+++ b/backend/game/utils.js
@@ -43,6 +43,7 @@ function createCombatant(playerData, team, position) {
 
     return {
         id: `${team}-hero-${position}`,
+        name: playerData.name || hero.name,
         heroData: hero,
         weaponData: weapon,
         armorData: armor,

--- a/discord-bot/src/commands/adventure.js
+++ b/discord-bot/src/commands/adventure.js
@@ -66,12 +66,14 @@ async function execute(interaction) {
   const player = createCombatant({
     hero_id: playerHero.id,
     ability_card: equippedCard,
-    deck: deck
+    deck: deck,
+    name: interaction.user.username
   }, 'player', 0);
 
   const goblin = createCombatant({ hero_id: goblinBase.id, deck: goblinAbilities }, 'enemy', 0);
 
   goblin.heroData = { ...goblin.heroData, name: `Goblin ${goblinBase.name}` };
+  goblin.name = goblin.heroData.name;
 
   console.log(`[BATTLE START] Player ${playerClass} vs Goblin ${goblinBase.name}`);
 

--- a/discord-bot/src/commands/challenge.js
+++ b/discord-bot/src/commands/challenge.js
@@ -137,8 +137,8 @@ async function handleAccept(interaction) {
   const chalHero = allPossibleHeroes.find(h => h.class === chalClass && h.isBase);
   const oppHero = allPossibleHeroes.find(h => h.class === oppClass && h.isBase);
 
-  const player1 = createCombatant({ hero_id: chalHero.id, ability_card: chalEquipped, deck: chalDeck }, 'player', 0);
-  const player2 = createCombatant({ hero_id: oppHero.id, ability_card: challengedEquipped, deck: challengedDeck }, 'enemy', 0);
+  const player1 = createCombatant({ hero_id: chalHero.id, ability_card: chalEquipped, deck: chalDeck, name: challenger.name }, 'player', 0);
+  const player2 = createCombatant({ hero_id: oppHero.id, ability_card: challengedEquipped, deck: challengedDeck, name: challenged.name }, 'enemy', 0);
 
   if (player1.abilityData) player1.abilityData.isPractice = true;
   if (player2.abilityData) player2.abilityData.isPractice = true;

--- a/discord-bot/src/commands/practice.js
+++ b/discord-bot/src/commands/practice.js
@@ -66,12 +66,14 @@ async function execute(interaction) {
   const player = createCombatant({
     hero_id: playerHero.id,
     ability_card: equippedCard,
-    deck: deck
+    deck: deck,
+    name: interaction.user.username
   }, 'player', 0);
   const goblin = createCombatant({ hero_id: goblinBase.id, deck: goblinAbilities }, 'enemy', 0);
 
   if (player.abilityData) player.abilityData.isPractice = true;
   goblin.heroData = { ...goblin.heroData, name: `Goblin ${goblinBase.name}` };
+  goblin.name = goblin.heroData.name;
 
   await interaction.reply({ content: `${interaction.user.username} begins a practice battle against a Goblin ${goblinBase.name}!` });
 

--- a/discord-bot/src/utils/embedBuilder.js
+++ b/discord-bot/src/utils/embedBuilder.js
@@ -57,7 +57,7 @@ function buildCardEmbed(card) {
  */
 function buildBattleEmbed(combatants, logText) {
   const hpLines = combatants
-    .map(c => `${c.heroData.name}: ${c.currentHp}/${c.maxHp} HP`)
+    .map(c => `${c.name}: ${c.currentHp}/${c.maxHp} HP`)
     .join('\n');
   const embed = new EmbedBuilder()
     .setColor('#29b6f6')

--- a/discord-bot/tests/adventure.test.js
+++ b/discord-bot/tests/adventure.test.js
@@ -55,11 +55,11 @@ describe('adventure command', () => {
       { id: 50, ability_id: 3111, charges: 5 },
       { id: 51, ability_id: 3112, charges: 5 }
     ]);
-    const interaction = { user: { id: '123' }, reply: jest.fn().mockResolvedValue(), followUp: jest.fn().mockResolvedValue() };
+    const interaction = { user: { id: '123', username: 'tester' }, reply: jest.fn().mockResolvedValue(), followUp: jest.fn().mockResolvedValue() };
     await adventure.execute(interaction);
     expect(abilityCardService.getCards).toHaveBeenCalledWith(1);
     expect(createCombatantSpy).toHaveBeenCalledWith(
-      expect.objectContaining({ ability_card: { id: 50, ability_id: 3111, charges: 5 } }),
+      expect.objectContaining({ ability_card: { id: 50, ability_id: 3111, charges: 5 }, name: 'tester' }),
       'player',
       0
     );
@@ -70,7 +70,7 @@ describe('adventure command', () => {
   test('ability drop message sent', async () => {
     userService.getUser.mockResolvedValue({ id: 1, discord_id: '123', class: 'Warrior', equipped_ability_id: 50 });
     abilityCardService.getCards.mockResolvedValue([{ id: 50, ability_id: 3111, charges: 5 }]);
-    const interaction = { user: { id: '123' }, reply: jest.fn().mockResolvedValue(), followUp: jest.fn().mockResolvedValue() };
+    const interaction = { user: { id: '123', username: 'tester' }, reply: jest.fn().mockResolvedValue(), followUp: jest.fn().mockResolvedValue() };
     jest.spyOn(Math, 'random').mockReturnValue(0);
     await adventure.execute(interaction);
     expect(abilityCardService.getCards).toHaveBeenCalledWith(1);
@@ -92,7 +92,7 @@ describe('adventure command', () => {
     }));
     userService.getUser.mockResolvedValue({ id: 1, discord_id: '123', class: 'Warrior', equipped_ability_id: 50 });
     abilityCardService.getCards.mockResolvedValue([{ id: 50, ability_id: 3111, charges: 5 }]);
-    const interaction = { user: { id: '123' }, reply: jest.fn().mockResolvedValue(), followUp: jest.fn().mockResolvedValue() };
+    const interaction = { user: { id: '123', username: 'tester' }, reply: jest.fn().mockResolvedValue(), followUp: jest.fn().mockResolvedValue() };
     await adventure.execute(interaction);
     expect(abilityCardService.getCards).toHaveBeenCalledWith(1);
     expect(userService.addAbility).not.toHaveBeenCalled();
@@ -113,7 +113,7 @@ describe('adventure command', () => {
     }));
     userService.getUser.mockResolvedValue({ id: 1, discord_id: '123', class: 'Barbarian', equipped_ability_id: 50 });
     abilityCardService.getCards.mockResolvedValue([{ id: 50, ability_id: 3111, charges: 5 }]);
-    const interaction = { user: { id: '123' }, reply: jest.fn().mockResolvedValue(), followUp: jest.fn().mockResolvedValue() };
+    const interaction = { user: { id: '123', username: 'tester' }, reply: jest.fn().mockResolvedValue(), followUp: jest.fn().mockResolvedValue() };
     await adventure.execute(interaction);
     expect(abilityCardService.getCards).toHaveBeenCalledWith(1);
     const description = interaction.followUp.mock.calls[0][0].embeds[0].data.description;
@@ -127,7 +127,7 @@ describe('adventure command', () => {
     jest.spyOn(Math, 'random').mockReturnValue(index / baseHeroes.length + 0.0001);
     userService.getUser.mockResolvedValue({ id: 1, discord_id: '123', class: 'Warrior', equipped_ability_id: 50 });
     abilityCardService.getCards.mockResolvedValue([{ id: 50, ability_id: 3111, charges: 5 }]);
-    const interaction = { user: { id: '123', send: jest.fn().mockResolvedValue() }, reply: jest.fn().mockResolvedValue(), followUp: jest.fn().mockResolvedValue() };
+    const interaction = { user: { id: '123', username: 'tester', send: jest.fn().mockResolvedValue() }, reply: jest.fn().mockResolvedValue(), followUp: jest.fn().mockResolvedValue() };
     await adventure.execute(interaction);
     expect(abilityCardService.getCards).toHaveBeenCalledWith(1);
     const expectedDrop = allPossibleAbilities.find(
@@ -148,7 +148,7 @@ describe('adventure command', () => {
     }));
     userService.getUser.mockResolvedValue({ id: 1, discord_id: '123', class: 'Barbarian', equipped_ability_id: 50 });
     abilityCardService.getCards.mockResolvedValue([{ id: 50, ability_id: 3111, charges: 5 }]);
-    const interaction = { user: { id: '123' }, reply: jest.fn().mockResolvedValue(), followUp: jest.fn().mockResolvedValue() };
+    const interaction = { user: { id: '123', username: 'tester' }, reply: jest.fn().mockResolvedValue(), followUp: jest.fn().mockResolvedValue() };
     await adventure.execute(interaction);
     expect(abilityCardService.getCards).toHaveBeenCalledWith(1);
     const description = interaction.followUp.mock.calls[0][0].embeds[0].data.description;


### PR DESCRIPTION
## Summary
- show player's Discord username in logs by storing name in combatant objects
- pass usernames from commands to the game engine
- update engine and embed builder to reference `combatant.name`
- adjust tests for new parameter

## Testing
- `npm test --prefix backend`
- `npm test --prefix discord-bot`


------
https://chatgpt.com/codex/tasks/task_e_6862f91845b4832785498ee490cec387