### PR TITLE
Ability card cleanup and merge

### DIFF
--- a/backend/game/engine.js
+++ b/backend/game/engine.js
@@ -4,7 +4,7 @@ let abilityCardService;
 try {
     abilityCardService = require('../../discord-bot/src/utils/abilityCardService');
 } catch (e) {
-    abilityCardService = { decrementCharge: () => {} };
+    abilityCardService = { decrementCharge: () => {}, deleteCard: () => {} };
 }
 
 class GameEngine {
@@ -355,6 +355,10 @@ class GameEngine {
                    attacker.abilityCharges -= 1;
                    if (ability.cardId && !ability.isPractice) {
                        try { abilityCardService.decrementCharge(ability.cardId); } catch(e) { /* ignore */ }
+                   }
+                   if (attacker.abilityCharges <= 0 && ability.cardId && !ability.isPractice) {
+                       this.log({ type: 'info', message: `${attacker.name}'s ${ability.name} card has run out of charges and crumbled to dust.` });
+                       try { abilityCardService.deleteCard(ability.cardId); } catch(e) { /* ignore in engine */ }
                    }
                    if (attacker.abilityCharges <= 0) {
                        const idx = attacker.deck.findIndex(a => a.charges > 0);

--- a/discord-bot/src/utils/abilityCardService.js
+++ b/discord-bot/src/utils/abilityCardService.js
@@ -1,10 +1,10 @@
 const db = require('../../util/database');
 
-// Add a new ability card to the user's inventory with default charges
-async function addCard(userId, abilityId) {
+// Add a new ability card to the user's inventory with configurable charges
+async function addCard(userId, abilityId, charges = 10) {
   const [result] = await db.query(
-    'INSERT INTO user_ability_cards (user_id, ability_id, charges) VALUES (?, ?, 10)',
-    [userId, abilityId]
+    'INSERT INTO user_ability_cards (user_id, ability_id, charges) VALUES (?, ?, ?)',
+    [userId, abilityId, charges]
   );
   return result.insertId;
 }
@@ -48,4 +48,16 @@ async function decrementCharge(cardId) {
   );
 }
 
-module.exports = { addCard, getCards, getCard, setEquippedCard, decrementCharge };
+// Delete a single ability card by id
+async function deleteCard(cardId) {
+  await db.query('DELETE FROM user_ability_cards WHERE id = ?', [cardId]);
+}
+
+// Delete multiple cards using an array of ids
+async function deleteCards(cardIds) {
+  if (!cardIds.length) return;
+  const placeholders = cardIds.map(() => '?').join(',');
+  await db.query(`DELETE FROM user_ability_cards WHERE id IN (${placeholders})`, cardIds);
+}
+
+module.exports = { addCard, getCards, getCard, setEquippedCard, decrementCharge, deleteCard, deleteCards };

--- a/discord-bot/tests/inventory.test.js
+++ b/discord-bot/tests/inventory.test.js
@@ -123,7 +123,10 @@ describe('inventory command', () => {
     ]);
     const interaction = {
       user: { id: '123' },
-      options: { getFocused: jest.fn().mockReturnValue('') },
+      options: {
+        getFocused: jest.fn().mockReturnValue(''),
+        getSubcommand: jest.fn().mockReturnValue('set')
+      },
       respond: jest.fn().mockResolvedValue()
     };
     await inventory.autocomplete(interaction);


### PR DESCRIPTION
## Summary
- remove depleted ability cards during battle
- allow custom charge counts when adding cards
- add `/inventory merge` to combine duplicate cards
- support autocompleting merge-able abilities
- adjust inventory tests for new autocomplete parameter

## Testing
- `npm test` in `backend`
- `npm test` in `discord-bot`


------
https://chatgpt.com/codex/tasks/task_e_6862fc91a9988327af33b6973904279c