### PR TITLE
Add inventory management buttons

### DIFF
--- a/discord-bot/index.js
+++ b/discord-bot/index.js
@@ -66,9 +66,15 @@ client.on(Events.InteractionCreate, async interaction => {
       await inventoryHandlers.handleAbilitySelect(interaction);
     } else if (interaction.customId === 'equip-card') {
       await inventoryHandlers.handleEquipSelect(interaction);
+    } else if (interaction.customId === 'merge-ability-select') {
+      await inventoryHandlers.handleMergeSelect(interaction);
     }
   } else if (interaction.isButton()) {
-    if (interaction.customId === 'set-ability') {
+    if (interaction.customId === 'inventory-equip-start') {
+      await inventoryHandlers.handleEquipButton(interaction);
+    } else if (interaction.customId === 'inventory-merge-start') {
+      await inventoryHandlers.handleMergeButton(interaction);
+    } else if (interaction.customId === 'set-ability') {
       await inventoryHandlers.handleSetAbilityButton(interaction);
     } else if (interaction.customId.startsWith('challenge-accept:')) {
       await challengeHandlers.handleAccept(interaction);


### PR DESCRIPTION
## Summary
- add "Merge Duplicates" and "Equip Ability" buttons to `/inventory show`
- route new button and dropdown interactions
- implement handlers for merging and equipping via buttons
- remove legacy merge subcommand

## Testing
- `npm test` in `discord-bot`
- `npm test` in `backend`


------
https://chatgpt.com/codex/tasks/task_e_6862ff18e7608327b1c92062471b73ca