### PR TITLE
Add settings command for DM preferences

### DIFF
--- a/discord-bot/commands/settings.js
+++ b/discord-bot/commands/settings.js
@@ -1,0 +1,42 @@
+const { SlashCommandBuilder } = require('discord.js');
+const userService = require('../src/utils/userService');
+
+const data = new SlashCommandBuilder()
+  .setName('settings')
+  .setDescription('Manage DM notification settings')
+  .addSubcommand(sub =>
+    sub
+      .setName('battle_logs')
+      .setDescription('Toggle battle log DMs')
+      .addBooleanOption(opt =>
+        opt
+          .setName('enabled')
+          .setDescription('Enable battle log DMs')
+          .setRequired(true)
+      )
+  )
+  .addSubcommand(sub =>
+    sub
+      .setName('item_drops')
+      .setDescription('Toggle item drop DMs')
+      .addBooleanOption(opt =>
+        opt
+          .setName('enabled')
+          .setDescription('Enable item drop DMs')
+          .setRequired(true)
+      )
+  );
+
+async function execute(interaction) {
+  const sub = interaction.options.getSubcommand();
+  const enabled = interaction.options.getBoolean('enabled');
+  const column =
+    sub === 'battle_logs'
+      ? 'dm_battle_logs_enabled'
+      : 'dm_item_drops_enabled';
+  await userService.setDmPreference(interaction.user.id, column, enabled);
+  const msg = `${enabled ? 'Enabled' : 'Disabled'} DMs for ${sub.replace('_', ' ')}`;
+  await interaction.reply({ content: msg, ephemeral: true });
+}
+
+module.exports = { data, execute };

--- a/discord-bot/deploy-commands.js
+++ b/discord-bot/deploy-commands.js
@@ -9,6 +9,7 @@ const commandDirs = [
   path.join(__dirname, 'commands/admin.js'),
   path.join(__dirname, 'commands/inventory.js'),
   path.join(__dirname, 'commands/set.js'),
+  path.join(__dirname, 'commands/settings.js'),
   path.join(__dirname, 'commands/tutorial.js'),
   path.join(__dirname, 'src/commands/adventure.js'),
   path.join(__dirname, 'src/commands/challenge.js'),

--- a/discord-bot/tests/settings.test.js
+++ b/discord-bot/tests/settings.test.js
@@ -1,0 +1,36 @@
+const settings = require('../commands/settings');
+
+jest.mock('../src/utils/userService', () => ({
+  setDmPreference: jest.fn()
+}));
+
+const userService = require('../src/utils/userService');
+
+function createInteraction(sub, enabled) {
+  return {
+    user: { id: '123' },
+    options: {
+      getSubcommand: jest.fn().mockReturnValue(sub),
+      getBoolean: jest.fn().mockReturnValue(enabled)
+    },
+    reply: jest.fn().mockResolvedValue()
+  };
+}
+
+describe('settings command', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  test('updates battle log preference', async () => {
+    const interaction = createInteraction('battle_logs', true);
+    await settings.execute(interaction);
+    expect(userService.setDmPreference).toHaveBeenCalledWith('123', 'dm_battle_logs_enabled', true);
+    expect(interaction.reply).toHaveBeenCalledWith(expect.objectContaining({ ephemeral: true }));
+  });
+
+  test('updates item drop preference', async () => {
+    const interaction = createInteraction('item_drops', false);
+    await settings.execute(interaction);
+    expect(userService.setDmPreference).toHaveBeenCalledWith('123', 'dm_item_drops_enabled', false);
+    expect(interaction.reply).toHaveBeenCalledWith(expect.objectContaining({ ephemeral: true }));
+  });
+});


### PR DESCRIPTION
## Summary
- add `settings` slash command with subcommands to configure DM notifications
- register new command in deploy script
- test that proper user service calls are made

## Testing
- `npm test --silent` *(fails: missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_686302b1f2808327ac76b8388a718e18