### PR TITLE
Add DM preference update util

### DIFF
--- a/discord-bot/src/utils/userService.js
+++ b/discord-bot/src/utils/userService.js
@@ -55,6 +55,15 @@ async function markTutorialComplete(discordId) {
   await db.query('UPDATE users SET tutorial_completed = 1 WHERE discord_id = ?', [discordId]);
 }
 
+async function setDmPreference(discordId, preferenceKey, isEnabled) {
+  const allowed = ['dm_battle_logs_enabled', 'dm_item_drops_enabled'];
+  if (!allowed.includes(preferenceKey)) {
+    throw new Error('Invalid preference key');
+  }
+  const value = isEnabled ? 1 : 0;
+  await db.query(`UPDATE users SET ${preferenceKey} = ? WHERE discord_id = ?`, [value, discordId]);
+}
+
 module.exports = {
   getUser,
   createUser,
@@ -63,5 +72,6 @@ module.exports = {
   addAbility,
   getInventory,
   setActiveAbility,
-  markTutorialComplete
+  markTutorialComplete,
+  setDmPreference
 };


### PR DESCRIPTION
## Summary
- implement `setDmPreference` in user service
- export new helper

## Testing
- `npm test` in `discord-bot`
- `npm test` in `backend`

------
https://chatgpt.com/codex/tasks/task_e_686302b3d4ec8327832e1cbab00b89f1