### PR TITLE
Add DM preference checks

### DIFF
--- a/discord-bot/src/commands/adventure.js
+++ b/discord-bot/src/commands/adventure.js
@@ -220,29 +220,41 @@ async function execute(interaction) {
 
   const logBuffer = Buffer.from(finalLogString, 'utf-8');
 
-  try {
-    if (typeof interaction.user.send === 'function') {
-      await interaction.user.send({
-        content: 'Here is the full transcript of your last battle:',
-        files: [{ attachment: logBuffer, name: `battle-log-${Date.now()}.txt` }]
+  if (user.dm_battle_logs_enabled) {
+    try {
+      if (typeof interaction.user.send === 'function') {
+        await interaction.user.send({
+          content: 'Here is the full transcript of your last battle:',
+          files: [{ attachment: logBuffer, name: `battle-log-${Date.now()}.txt` }]
+        });
+      } else {
+        throw new Error('DM function unavailable');
+      }
+    } catch (error) {
+      console.error(`Could not send battle log DM to ${interaction.user.tag}.`, error);
+      await interaction.followUp({
+        content:
+          "I couldn't DM you the full battle log. Please check your privacy settings if you'd like to receive them in the future.",
+        ephemeral: true
       });
-    } else {
-      throw new Error('DM function unavailable');
     }
-  } catch (error) {
-    console.error(`Could not send battle log DM to ${interaction.user.tag}.`, error);
-    await interaction.followUp({
-      content:
-        "I couldn't DM you the full battle log. Please check your privacy settings if you'd like to receive them in the future.",
-      ephemeral: true
-    });
+  } else {
+    console.log(
+      `[DM DISABLED] Skipping battle log DM for ${interaction.user.username} (dm_battle_logs_enabled = false)`
+    );
   }
 
   if (lootDrop) {
-    try {
-      await sendCardDM(interaction.user, lootDrop);
-    } catch (err) {
-      console.error('Failed to DM card drop:', err);
+    if (user.dm_item_drops_enabled) {
+      try {
+        await sendCardDM(interaction.user, lootDrop);
+      } catch (err) {
+        console.error('Failed to DM card drop:', err);
+      }
+    } else {
+      console.log(
+        `[DM DISABLED] Skipping loot DM for ${interaction.user.username} (dm_item_drops_enabled = false)`
+      );
     }
   }
 }

--- a/discord-bot/src/commands/practice.js
+++ b/discord-bot/src/commands/practice.js
@@ -168,22 +168,28 @@ async function execute(interaction) {
 
   const logBuffer = Buffer.from(finalLogString, 'utf-8');
 
-  try {
-    if (typeof interaction.user.send === 'function') {
-      await interaction.user.send({
-        content: 'Here is the full transcript of your last battle:',
-        files: [{ attachment: logBuffer, name: `battle-log-${Date.now()}.txt` }]
+  if (user.dm_battle_logs_enabled) {
+    try {
+      if (typeof interaction.user.send === 'function') {
+        await interaction.user.send({
+          content: 'Here is the full transcript of your last battle:',
+          files: [{ attachment: logBuffer, name: `battle-log-${Date.now()}.txt` }]
+        });
+      } else {
+        throw new Error('DM function unavailable');
+      }
+    } catch (error) {
+      console.error(`Could not send battle log DM to ${interaction.user.tag}.`, error);
+      await interaction.followUp({
+        content:
+          "I couldn't DM you the full battle log. Please check your privacy settings if you'd like to receive them in the future.",
+        ephemeral: true
       });
-    } else {
-      throw new Error('DM function unavailable');
     }
-  } catch (error) {
-    console.error(`Could not send battle log DM to ${interaction.user.tag}.`, error);
-    await interaction.followUp({
-      content:
-        "I couldn't DM you the full battle log. Please check your privacy settings if you'd like to receive them in the future.",
-      ephemeral: true
-    });
+  } else {
+    console.log(
+      `[DM DISABLED] Skipping battle log DM for ${interaction.user.username} (dm_battle_logs_enabled = false)`
+    );
   }
 }
 

--- a/discord-bot/tests/adventure.test.js
+++ b/discord-bot/tests/adventure.test.js
@@ -111,7 +111,7 @@ describe('adventure command', () => {
     expect(abilityCardService.getCards).toHaveBeenCalledWith(1);
     expect(userService.addAbility).not.toHaveBeenCalled();
     const calls = interaction.followUp.mock.calls.filter(c => c[0].ephemeral);
-    expect(calls.length).toBe(1);
+    expect(calls.length).toBe(0);
   });
 
   test('battle log is included in embed', async () => {


### PR DESCRIPTION
## Summary
- retrieve user via `userService.getUser`
- respect `dm_battle_logs_enabled` when sending logs
- respect `dm_item_drops_enabled` for loot messages
- update tests for new behaviour

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686302b567c883279a0e045babc76e68