### PR TITLE
Add settings command and tests

### DIFF
--- a/discord-bot/commands/settings.js
+++ b/discord-bot/commands/settings.js
@@ -1,0 +1,50 @@
+const { SlashCommandBuilder } = require('discord.js');
+const userService = require('../src/utils/userService');
+
+const data = new SlashCommandBuilder()
+  .setName('settings')
+  .setDescription('Configure your bot settings')
+  .addSubcommand(sub =>
+    sub
+      .setName('battle_logs')
+      .setDescription('Toggle receiving battle log DMs')
+      .addBooleanOption(opt =>
+        opt
+          .setName('enabled')
+          .setDescription('Enable battle log DMs')
+          .setRequired(true)
+      )
+  )
+  .addSubcommand(sub =>
+    sub
+      .setName('item_drops')
+      .setDescription('Toggle receiving item drop DMs')
+      .addBooleanOption(opt =>
+        opt
+          .setName('enabled')
+          .setDescription('Enable item drop DMs')
+          .setRequired(true)
+      )
+  );
+
+async function execute(interaction) {
+  const sub = interaction.options.getSubcommand();
+  const enabled = interaction.options.getBoolean('enabled');
+  const update = {};
+  if (sub === 'battle_logs') {
+    update.battle_logs = enabled;
+  } else {
+    update.item_drops = enabled;
+  }
+  await userService.updateSettings(interaction.user.id, update);
+  if (enabled && sub === 'battle_logs' && typeof interaction.user.send === 'function') {
+    try {
+      await interaction.user.send('Battle logs enabled.');
+    } catch (err) {
+      /* ignore DM errors */
+    }
+  }
+  await interaction.reply({ content: 'Settings updated.', ephemeral: true });
+}
+
+module.exports = { data, execute };

--- a/discord-bot/src/commands/adventure.js
+++ b/discord-bot/src/commands/adventure.js
@@ -220,25 +220,27 @@ async function execute(interaction) {
 
   const logBuffer = Buffer.from(finalLogString, 'utf-8');
 
-  try {
-    if (typeof interaction.user.send === 'function') {
-      await interaction.user.send({
-        content: 'Here is the full transcript of your last battle:',
-        files: [{ attachment: logBuffer, name: `battle-log-${Date.now()}.txt` }]
+  if (user.battle_logs !== false) {
+    try {
+      if (typeof interaction.user.send === 'function') {
+        await interaction.user.send({
+          content: 'Here is the full transcript of your last battle:',
+          files: [{ attachment: logBuffer, name: `battle-log-${Date.now()}.txt` }]
+        });
+      } else {
+        throw new Error('DM function unavailable');
+      }
+    } catch (error) {
+      console.error(`Could not send battle log DM to ${interaction.user.tag}.`, error);
+      await interaction.followUp({
+        content:
+          "I couldn't DM you the full battle log. Please check your privacy settings if you'd like to receive them in the future.",
+        ephemeral: true
       });
-    } else {
-      throw new Error('DM function unavailable');
     }
-  } catch (error) {
-    console.error(`Could not send battle log DM to ${interaction.user.tag}.`, error);
-    await interaction.followUp({
-      content:
-        "I couldn't DM you the full battle log. Please check your privacy settings if you'd like to receive them in the future.",
-      ephemeral: true
-    });
   }
 
-  if (lootDrop) {
+  if (lootDrop && user.item_drops !== false) {
     try {
       await sendCardDM(interaction.user, lootDrop);
     } catch (err) {

--- a/discord-bot/src/utils/userService.js
+++ b/discord-bot/src/utils/userService.js
@@ -55,6 +55,14 @@ async function markTutorialComplete(discordId) {
   await db.query('UPDATE users SET tutorial_completed = 1 WHERE discord_id = ?', [discordId]);
 }
 
+async function updateSettings(discordId, settings) {
+  const columns = Object.keys(settings)
+    .map(key => `${key} = ?`)
+    .join(', ');
+  const values = Object.values(settings);
+  await db.query(`UPDATE users SET ${columns} WHERE discord_id = ?`, [...values, discordId]);
+}
+
 module.exports = {
   getUser,
   createUser,
@@ -63,5 +71,6 @@ module.exports = {
   addAbility,
   getInventory,
   setActiveAbility,
-  markTutorialComplete
+  markTutorialComplete,
+  updateSettings
 };

--- a/discord-bot/tests/settings.test.js
+++ b/discord-bot/tests/settings.test.js
@@ -1,0 +1,91 @@
+const settings = require('../commands/settings');
+
+jest.mock('../src/utils/userService', () => ({
+  getUser: jest.fn(),
+  updateSettings: jest.fn(),
+  addAbility: jest.fn(),
+  createUser: jest.fn(),
+  setActiveAbility: jest.fn()
+}));
+jest.mock('../src/utils/embedBuilder', () => ({
+  sendCardDM: jest.fn(),
+  buildBattleEmbed: jest.fn(() => ({}))
+}));
+const userService = require('../src/utils/userService');
+const { sendCardDM } = require('../src/utils/embedBuilder');
+const adventure = require('../src/commands/adventure');
+const abilityCardService = require('../src/utils/abilityCardService');
+jest.mock('../src/utils/abilityCardService', () => ({
+  getCards: jest.fn(),
+  addCard: jest.fn()
+}));
+const GameEngine = require('../../backend/game/engine');
+jest.mock('../../backend/game/engine');
+const utils = require('../../backend/game/utils');
+
+jest.spyOn(utils, 'createCombatant');
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  GameEngine.mockImplementation(() => ({
+    runGameSteps: function* () {
+      yield { combatants: [], log: [] };
+    },
+    runFullGame: jest.fn(),
+    winner: 'player',
+    finalPlayerState: {}
+  }));
+});
+
+test('battle_logs disabled updates DB and no DM is sent', async () => {
+  userService.getUser.mockResolvedValue({ id: 1 });
+  const interaction = {
+    user: { id: '1', send: jest.fn() },
+    options: {
+      getSubcommand: jest.fn().mockReturnValue('battle_logs'),
+      getBoolean: jest.fn().mockReturnValue(false)
+    },
+    reply: jest.fn().mockResolvedValue()
+  };
+  await settings.execute(interaction);
+  expect(userService.updateSettings).toHaveBeenCalledWith('1', {
+    battle_logs: false
+  });
+  expect(interaction.user.send).not.toHaveBeenCalled();
+});
+
+test('item_drops disabled prevents sendCardDM', async () => {
+  // first disable item drops
+  userService.getUser.mockResolvedValue({ id: 1 });
+  const settingsInteraction = {
+    user: { id: '1' },
+    options: {
+      getSubcommand: jest.fn().mockReturnValue('item_drops'),
+      getBoolean: jest.fn().mockReturnValue(false)
+    },
+    reply: jest.fn().mockResolvedValue()
+  };
+  await settings.execute(settingsInteraction);
+  expect(userService.updateSettings).toHaveBeenCalledWith('1', {
+    item_drops: false
+  });
+
+  // run an adventure with item drops disabled
+  userService.getUser.mockResolvedValue({
+    id: 1,
+    discord_id: '1',
+    class: 'Warrior',
+    equipped_ability_id: 50,
+    item_drops: false
+  });
+  abilityCardService.getCards.mockResolvedValue([{ id: 50, ability_id: 3111, charges: 5 }]);
+  jest.spyOn(Math, 'random').mockReturnValue(0);
+  const advInteraction = {
+    user: { id: '1', username: 'tester', send: jest.fn() },
+    reply: jest.fn().mockResolvedValue(),
+    followUp: jest.fn().mockResolvedValue()
+  };
+  await adventure.execute(advInteraction);
+  expect(sendCardDM).not.toHaveBeenCalled();
+  Math.random.mockRestore();
+});


### PR DESCRIPTION
## Summary
- add `/settings` command with `battle_logs` and `item_drops`
- allow adventure to respect user settings for DMs
- expose `updateSettings` from `userService`
- test disabling battle log and item drop DMs

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686302b8d8dc8327a5fcbf74a168e4ec