### PR TITLE
Use config utility for Discord bot env vars

### DIFF
--- a/discord-bot/README.md
+++ b/discord-bot/README.md
@@ -10,6 +10,9 @@ This folder contains the Node.js bot that powers the game's Discord integration.
    - `DB_HOST`, `DB_USER`, `DB_PASSWORD`, `DB_DATABASE` – location and credentials for the database.
    - `APP_ID` and `GUILD_ID` are needed when running `deploy-commands.js`.
 
+The bot reads these variables using `util/config.js`. Import this module wherever
+configuration values are needed instead of referencing `process.env` directly.
+
 ## Running the Bot
 
 ```bash

--- a/discord-bot/deploy-commands.js
+++ b/discord-bot/deploy-commands.js
@@ -1,6 +1,6 @@
 const { REST, Routes } = require('discord.js');
 const path = require('node:path');
-require('dotenv').config();
+const config = require('./util/config');
 
 const commands = [];
 const commandDirs = [
@@ -24,14 +24,14 @@ for (const filePath of commandDirs) {
   commands.push(command.data.toJSON());
 }
 
-const rest = new REST({ version: '10' }).setToken(process.env.DISCORD_TOKEN);
+const rest = new REST({ version: '10' }).setToken(config.DISCORD_TOKEN);
 
 (async () => {
   try {
     console.log(`Started refreshing ${commands.length} application (/) commands.`);
 
     const data = await rest.put(
-      Routes.applicationGuildCommands(process.env.APP_ID, process.env.GUILD_ID),
+      Routes.applicationGuildCommands(config.APP_ID, config.GUILD_ID),
       { body: commands }
     );
 

--- a/discord-bot/index.js
+++ b/discord-bot/index.js
@@ -1,7 +1,7 @@
 const { Client, Collection, GatewayIntentBits, Events } = require('discord.js');
 const fs = require('node:fs');
 const path = require('node:path');
-require('dotenv').config();
+const config = require('./util/config');
 
 const client = new Client({ intents: [GatewayIntentBits.Guilds] });
 client.commands = new Collection();
@@ -93,4 +93,4 @@ client.on(Events.InteractionCreate, async interaction => {
   }
 });
 
-client.login(process.env.DISCORD_TOKEN);
+client.login(config.DISCORD_TOKEN);

--- a/discord-bot/src/commands/challenge.js
+++ b/discord-bot/src/commands/challenge.js
@@ -2,6 +2,7 @@ const { SlashCommandBuilder, ActionRowBuilder, ButtonBuilder, ButtonStyle } = re
 const userService = require('../utils/userService');
 const abilityCardService = require('../utils/abilityCardService');
 const db = require('../../util/database');
+const config = require('../../util/config');
 const { allPossibleHeroes } = require('../../../backend/game/data');
 const { createCombatant } = require('../../../backend/game/utils');
 const GameEngine = require('../../../backend/game/engine');
@@ -12,7 +13,7 @@ const data = new SlashCommandBuilder()
   .addUserOption(opt => opt.setName('target').setDescription('User to challenge').setRequired(true));
 
 async function execute(interaction) {
-  if (!process.env.PVP_CHANNEL_ID) {
+  if (!config.PVP_CHANNEL_ID) {
     console.error('PVP_CHANNEL_ID is not set in the .env file.');
     return interaction.reply({
       content: 'Error: The challenge channel is not configured. Please contact an admin.',
@@ -45,7 +46,7 @@ async function execute(interaction) {
   );
   const challengeId = result.insertId;
 
-  const announcementChannel = await interaction.client.channels.fetch(process.env.PVP_CHANNEL_ID);
+  const announcementChannel = await interaction.client.channels.fetch(config.PVP_CHANNEL_ID);
   const publicMessage = await announcementChannel.send({
     content: `${interaction.user.username} has challenged ${target.username}!`
   });

--- a/discord-bot/util/config.js
+++ b/discord-bot/util/config.js
@@ -1,0 +1,13 @@
+const dotenv = require('dotenv');
+dotenv.config();
+
+module.exports = {
+  get DISCORD_TOKEN() { return process.env.DISCORD_TOKEN; },
+  get DB_HOST() { return process.env.DB_HOST; },
+  get DB_USER() { return process.env.DB_USER; },
+  get DB_PASSWORD() { return process.env.DB_PASSWORD; },
+  get DB_DATABASE() { return process.env.DB_DATABASE; },
+  get APP_ID() { return process.env.APP_ID; },
+  get GUILD_ID() { return process.env.GUILD_ID; },
+  get PVP_CHANNEL_ID() { return process.env.PVP_CHANNEL_ID; }
+};

--- a/discord-bot/util/database.js
+++ b/discord-bot/util/database.js
@@ -1,11 +1,11 @@
 const mysql = require('mysql2');
-require('dotenv').config();
+const config = require('./config');
 
 const pool = mysql.createPool({
-  host: process.env.DB_HOST,
-  user: process.env.DB_USER,
-  password: process.env.DB_PASSWORD,
-  database: process.env.DB_DATABASE,
+  host: config.DB_HOST,
+  user: config.DB_USER,
+  password: config.DB_PASSWORD,
+  database: config.DB_DATABASE,
   waitForConnections: true,
   connectionLimit: 10,
   queueLimit: 0


### PR DESCRIPTION
## Summary
- centralize env access in `util/config.js`
- swap direct `process.env` uses for config imports
- document configuration module in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686308d2d00483278f0dcaf43973473a