### PR TITLE
Handle Discord DM failures

### DIFF
--- a/discord-bot/commands/admin.js
+++ b/discord-bot/commands/admin.js
@@ -70,6 +70,10 @@ async function execute(interaction) {
     await sendCardDM(target, ability);
   } catch (err) {
     console.error('Failed to DM ability card:', err);
+    await interaction.followUp({
+      content: "I couldn't DM the ability card. Please check the target's privacy settings.",
+      ephemeral: true
+    });
   }
 }
 

--- a/discord-bot/src/commands/adventure.js
+++ b/discord-bot/src/commands/adventure.js
@@ -250,6 +250,11 @@ async function execute(interaction) {
         await sendCardDM(interaction.user, lootDrop);
       } catch (err) {
         console.error('Failed to DM card drop:', err);
+        await interaction.followUp({
+          content:
+            "I couldn't DM you the item drop. Please check your privacy settings if you'd like to receive them in the future.",
+          ephemeral: true
+        });
       }
     } else {
       console.log(

--- a/discord-bot/src/commands/challenge.js
+++ b/discord-bot/src/commands/challenge.js
@@ -175,12 +175,15 @@ async function handleAccept(interaction) {
   const logBuffer = Buffer.from(finalLogString, 'utf-8');
   const attachment = { attachment: logBuffer, name: `battle-log-${id}.txt` };
 
+  let dmFailed = false;
+
   if (challenger.dm_battle_logs_enabled) {
     try {
       const challengerDiscordUser = await interaction.client.users.fetch(challenger.discord_id);
       await challengerDiscordUser.send({ files: [attachment] });
     } catch (e) {
       console.error(`Failed to DM log to challenger ${challenger.name}`);
+      dmFailed = true;
     }
   } else {
     console.log(
@@ -194,6 +197,7 @@ async function handleAccept(interaction) {
       await challengedDiscordUser.send({ files: [attachment] });
     } catch (e) {
       console.error(`Failed to DM log to challenged user ${challenged.name}`);
+      dmFailed = true;
     }
   } else {
     console.log(
@@ -211,6 +215,14 @@ async function handleAccept(interaction) {
     await channel.send(victoryMessage);
   } catch (e) {
     /* ignore */
+  }
+
+  if (dmFailed) {
+    await interaction.followUp({
+      content:
+        "I couldn't DM one or both players the battle log. Please check your privacy settings.",
+      ephemeral: true
+    });
   }
 
   await interaction.update({ content: 'Challenge accepted! Battle complete.', components: [] });

--- a/discord-bot/tests/admin.test.js
+++ b/discord-bot/tests/admin.test.js
@@ -19,7 +19,8 @@ function createInteraction(role = 'Game Master') {
       getUser: jest.fn().mockReturnValue({ id: '200', username: 'Target' }),
       getString: jest.fn()
     },
-    reply: jest.fn().mockResolvedValue()
+    reply: jest.fn().mockResolvedValue(),
+    followUp: jest.fn().mockResolvedValue()
   };
 }
 
@@ -71,6 +72,19 @@ describe('admin grant-ability command', () => {
       ephemeral: true,
       content: expect.stringContaining('successfully granted')
     }));
+  });
+
+  test('notifies when ability card DM fails', async () => {
+    const interaction = createInteraction();
+    interaction.options.getString.mockReturnValue('Power Strike');
+    userService.getUser.mockResolvedValue({ id: 1 });
+    userService.addAbility.mockResolvedValue(99);
+    sendCardDM.mockRejectedValue(new Error('fail'));
+    await admin.execute(interaction);
+    expect(sendCardDM).toHaveBeenCalled();
+    expect(interaction.followUp).toHaveBeenCalledWith(
+      expect.objectContaining({ ephemeral: true })
+    );
   });
 
   test('autocomplete suggests ability names', async () => {

--- a/discord-bot/tests/practice.test.js
+++ b/discord-bot/tests/practice.test.js
@@ -1,0 +1,47 @@
+const practice = require('../src/commands/practice');
+
+jest.mock('../src/utils/userService', () => ({
+  getUser: jest.fn(),
+  createUser: jest.fn()
+}));
+jest.mock('../src/utils/abilityCardService', () => ({
+  getCards: jest.fn()
+}));
+jest.mock('../../backend/game/engine');
+
+const userService = require('../src/utils/userService');
+const abilityCardService = require('../src/utils/abilityCardService');
+const GameEngine = require('../../backend/game/engine');
+const utils = require('../../backend/game/utils');
+
+jest.spyOn(utils, 'createCombatant');
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  GameEngine.mockImplementation(() => ({
+    runGameSteps: function* () {
+      yield { combatants: [], log: [{ round: 1, type: 'info', level: 'summary', message: 'log' }] };
+    },
+    runFullGame: jest.fn(),
+    winner: 'player',
+    finalPlayerState: {}
+  }));
+});
+
+test('follow up when battle log DM fails', async () => {
+  userService.getUser.mockResolvedValue({
+    id: 1,
+    class: 'Warrior',
+    equipped_ability_id: 50,
+    dm_battle_logs_enabled: true
+  });
+  abilityCardService.getCards.mockResolvedValue([{ id: 50, ability_id: 3111, charges: 5 }]);
+  const interaction = {
+    user: { id: '123', username: 'tester', send: jest.fn().mockRejectedValue(new Error('fail')) },
+    reply: jest.fn().mockResolvedValue(),
+    followUp: jest.fn().mockResolvedValue()
+  };
+  await practice.execute(interaction);
+  const ephemerals = interaction.followUp.mock.calls.filter(c => c[0].ephemeral);
+  expect(ephemerals.length).toBeGreaterThan(0);
+});


### PR DESCRIPTION
## Summary
- notify command users when DMs fail
- add regression tests for DM failure scenarios

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686308dc00248327a7aacb853e289281