### PR TITLE
Implement leaderboard tracking

### DIFF
--- a/discord-bot/commands/leaderboard.js
+++ b/discord-bot/commands/leaderboard.js
@@ -1,0 +1,32 @@
+const { SlashCommandBuilder } = require('discord.js');
+const { simple } = require('../src/utils/embedBuilder');
+const userService = require('../src/utils/userService');
+
+const data = new SlashCommandBuilder()
+  .setName('leaderboard')
+  .setDescription('Displays the top players.');
+
+async function execute(interaction) {
+  const allUsers = await userService.getLeaderboardData();
+
+  const topPve = allUsers
+    .sort((a, b) => b.pve_ratio - a.pve_ratio)
+    .slice(0, 3)
+    .map((u, i) => `${i + 1}. **${u.name}** (${u.pve_wins}-${u.pve_losses})`)
+    .join('\n') || 'No PvE battles recorded yet.';
+
+  const topPvp = allUsers
+    .sort((a, b) => b.pvp_ratio - a.pvp_ratio)
+    .slice(0, 3)
+    .map((u, i) => `${i + 1}. **${u.name}** (${u.pvp_wins}-${u.pvp_losses})`)
+    .join('\n') || 'No PvP battles recorded yet.';
+
+  const embed = simple('Leaderboards', [
+    { name: 'Top 3 PvE Adventurers', value: topPve },
+    { name: 'Top 3 PvP Duelists', value: topPvp }
+  ]);
+
+  await interaction.reply({ embeds: [embed] });
+}
+
+module.exports = { data, execute };

--- a/discord-bot/db-schema.sql
+++ b/discord-bot/db-schema.sql
@@ -6,6 +6,10 @@ CREATE TABLE IF NOT EXISTS users (
     discord_id VARCHAR(255) NOT NULL UNIQUE,
     name VARCHAR(255) NOT NULL UNIQUE COLLATE utf8mb4_unicode_ci,
     class VARCHAR(50) DEFAULT NULL,
+    pve_wins INT DEFAULT 0,
+    pve_losses INT DEFAULT 0,
+    pvp_wins INT DEFAULT 0,
+    pvp_losses INT DEFAULT 0,
     tutorial_completed TINYINT(1) DEFAULT 0,
     dm_battle_logs_enabled TINYINT(1) DEFAULT 1,
     dm_item_drops_enabled TINYINT(1) DEFAULT 1

--- a/discord-bot/deploy-commands.js
+++ b/discord-bot/deploy-commands.js
@@ -10,6 +10,7 @@ const commandDirs = [
   path.join(__dirname, 'commands/inventory.js'),
   path.join(__dirname, 'commands/settings.js'),
   path.join(__dirname, 'commands/tutorial.js'),
+  path.join(__dirname, 'commands/leaderboard.js'),
   path.join(__dirname, 'src/commands/adventure.js'),
   path.join(__dirname, 'src/commands/challenge.js'),
   path.join(__dirname, 'src/commands/practice.js')

--- a/discord-bot/src/commands/adventure.js
+++ b/discord-bot/src/commands/adventure.js
@@ -111,6 +111,12 @@ async function execute(interaction) {
     }`
   );
 
+  if (engine.winner === 'player') {
+    await userService.incrementPveWin(user.id);
+  } else {
+    await userService.incrementPveLoss(user.id);
+  }
+
   let narrativeDescription = '';
   let lootDrop = null;
   const adventurerName = `**${interaction.user.username}**`;

--- a/discord-bot/src/commands/challenge.js
+++ b/discord-bot/src/commands/challenge.js
@@ -208,6 +208,10 @@ async function handleAccept(interaction) {
 
   const winnerUser = engine.winner === 'player' ? challenger : challenged;
   const loserUser = engine.winner === 'player' ? challenged : challenger;
+
+  await userService.incrementPvpWin(winnerUser.id);
+  await userService.incrementPvpLoss(loserUser.id);
+
   const victoryMessage =
     `⚔️ **Victory!** <@${winnerUser.discord_id}> has defeated <@${loserUser.discord_id}> in a duel!`;
 

--- a/discord-bot/src/utils/userService.js
+++ b/discord-bot/src/utils/userService.js
@@ -28,6 +28,35 @@ async function addAbility(discordId, abilityId) {
   return abilityCards.addCard(user.id, abilityId);
 }
 
+async function incrementPveWin(userId) {
+  await db.query('UPDATE users SET pve_wins = pve_wins + 1 WHERE id = ?', [userId]);
+}
+
+async function incrementPveLoss(userId) {
+  await db.query('UPDATE users SET pve_losses = pve_losses + 1 WHERE id = ?', [userId]);
+}
+
+async function incrementPvpWin(userId) {
+  await db.query('UPDATE users SET pvp_wins = pvp_wins + 1 WHERE id = ?', [userId]);
+}
+
+async function incrementPvpLoss(userId) {
+  await db.query('UPDATE users SET pvp_losses = pvp_losses + 1 WHERE id = ?', [userId]);
+}
+
+async function getLeaderboardData() {
+  const [rows] = await db.query(`
+        SELECT 
+            name,
+            pve_wins, pve_losses,
+            pvp_wins, pvp_losses,
+            CASE WHEN pve_losses = 0 THEN pve_wins + 99999 ELSE pve_wins / pve_losses END AS pve_ratio,
+            CASE WHEN pvp_losses = 0 THEN pvp_wins + 99999 ELSE pvp_wins / pvp_losses END AS pvp_ratio
+        FROM users
+    `);
+  return rows;
+}
+
 // Retrieve the user's ability card inventory with names
 async function getInventory(discordId) {
   const user = await getUser(discordId);
@@ -73,5 +102,10 @@ module.exports = {
   getInventory,
   setActiveAbility,
   markTutorialComplete,
-  setDmPreference
+  setDmPreference,
+  incrementPveWin,
+  incrementPveLoss,
+  incrementPvpWin,
+  incrementPvpLoss,
+  getLeaderboardData
 };

--- a/discord-bot/tests/adventure.test.js
+++ b/discord-bot/tests/adventure.test.js
@@ -3,7 +3,9 @@ jest.mock('../src/utils/userService', () => ({
   addAbility: jest.fn(),
   createUser: jest.fn(),
   setActiveAbility: jest.fn(),
-  setDmPreference: jest.fn()
+  setDmPreference: jest.fn(),
+  incrementPveWin: jest.fn(),
+  incrementPveLoss: jest.fn()
 }));
 jest.mock('../src/utils/abilityCardService', () => ({
   getCards: jest.fn()

--- a/discord-bot/tests/challenge.test.js
+++ b/discord-bot/tests/challenge.test.js
@@ -1,7 +1,9 @@
 const challenge = require('../src/commands/challenge');
 
 jest.mock('../src/utils/userService', () => ({
-  getUser: jest.fn()
+  getUser: jest.fn(),
+  incrementPvpWin: jest.fn(),
+  incrementPvpLoss: jest.fn()
 }));
 jest.mock('../util/database', () => ({
   query: jest.fn()

--- a/discord-bot/tests/leaderboard.test.js
+++ b/discord-bot/tests/leaderboard.test.js
@@ -1,0 +1,18 @@
+const leaderboard = require('../commands/leaderboard');
+
+jest.mock('../src/utils/userService', () => ({
+  getLeaderboardData: jest.fn()
+}));
+const userService = require('../src/utils/userService');
+
+test('replies with leaderboard embed', async () => {
+  userService.getLeaderboardData.mockResolvedValue([
+    { name: 'Alice', pve_wins: 5, pve_losses: 1, pvp_wins: 2, pvp_losses: 0, pve_ratio: 5/1, pvp_ratio: 2+99999 },
+    { name: 'Bob', pve_wins: 3, pve_losses: 0, pvp_wins: 1, pvp_losses: 1, pve_ratio: 3+99999, pvp_ratio: 1 },
+    { name: 'Cara', pve_wins: 1, pve_losses: 1, pvp_wins: 0, pvp_losses: 2, pve_ratio: 1, pvp_ratio: 0 }
+  ]);
+  const interaction = { reply: jest.fn().mockResolvedValue() };
+  await leaderboard.execute(interaction);
+  expect(userService.getLeaderboardData).toHaveBeenCalled();
+  expect(interaction.reply).toHaveBeenCalledWith(expect.objectContaining({ embeds: expect.any(Array) }));
+});


### PR DESCRIPTION
## Summary
- track PvE/PvP wins and losses in the database
- expose helpers in `userService` for incrementing stats and fetching leaderboard data
- update adventure and challenge commands to update win/loss records
- add new `/leaderboard` slash command
- register leaderboard command for deployment
- adjust tests for new service functions and add tests for leaderboard

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686312d779a08327b7ac588b38fc2671