### PR TITLE
Add gold rewards on adventure victories

### DIFF
--- a/discord-bot/src/commands/adventure.js
+++ b/discord-bot/src/commands/adventure.js
@@ -111,8 +111,11 @@ async function execute(interaction) {
     }`
   );
 
+  let goldEarned = 0;
   if (engine.winner === 'player') {
     await userService.incrementPveWin(user.id);
+    goldEarned = Math.floor(Math.random() * 3);
+    await userService.addGold(interaction.user.id, goldEarned);
   } else {
     await userService.incrementPveLoss(user.id);
   }
@@ -123,14 +126,14 @@ async function execute(interaction) {
   const enemyName = `a **Goblin ${goblinBase.name}**`;
 
   if (engine.winner === 'player') {
-    let dropText = 'who was slain.';
+    let dropText = `who was slain and dropped ${goldEarned} gold.`;
     if (Math.random() < 0.5) {
       const lootOptions = allPossibleAbilities.filter(
         a => a.class === goblinBase.class && a.rarity === 'Common'
       );
       lootDrop = lootOptions[Math.floor(Math.random() * lootOptions.length)];
       if (lootDrop) {
-        dropText = `who was slain and dropped **${lootDrop.name}**.`;
+        dropText = `who was slain and dropped **${lootDrop.name}** and ${goldEarned} gold.`;
         console.log(
           `[ITEM LOOT] User: ${interaction.user.username} looted Ability: ${lootDrop.name} (ID: ${lootDrop.id})`
         );

--- a/discord-bot/src/utils/userService.js
+++ b/discord-bot/src/utils/userService.js
@@ -28,6 +28,16 @@ async function addAbility(discordId, abilityId) {
   return abilityCards.addCard(user.id, abilityId);
 }
 
+async function addGold(discordId, amount) {
+  const user = await getUser(discordId);
+  if (!user) return null;
+  await db.query(
+    'UPDATE users SET gold = IFNULL(gold, 0) + ? WHERE id = ?',
+    [amount, user.id]
+  );
+  return { discordId, amount };
+}
+
 async function incrementPveWin(userId) {
   await db.query('UPDATE users SET pve_wins = pve_wins + 1 WHERE id = ?', [userId]);
 }
@@ -107,5 +117,6 @@ module.exports = {
   incrementPveLoss,
   incrementPvpWin,
   incrementPvpLoss,
-  getLeaderboardData
+  getLeaderboardData,
+  addGold
 };

--- a/discord-bot/tests/adventure.test.js
+++ b/discord-bot/tests/adventure.test.js
@@ -5,7 +5,8 @@ jest.mock('../src/utils/userService', () => ({
   setActiveAbility: jest.fn(),
   setDmPreference: jest.fn(),
   incrementPveWin: jest.fn(),
-  incrementPveLoss: jest.fn()
+  incrementPveLoss: jest.fn(),
+  addGold: jest.fn()
 }));
 jest.mock('../src/utils/abilityCardService', () => ({
   getCards: jest.fn()
@@ -55,6 +56,7 @@ describe('adventure command', () => {
     };
     await adventure.execute(interaction);
     expect(userService.createUser).toHaveBeenCalledWith('123', 'tester');
+    expect(userService.addGold).toHaveBeenCalledWith('123', expect.any(Number));
     expect(interaction.reply).toHaveBeenCalledWith(
       expect.objectContaining({ content: expect.stringContaining('Goblin') })
     );
@@ -74,6 +76,7 @@ describe('adventure command', () => {
       'player',
       0
     );
+    expect(userService.addGold).toHaveBeenCalledWith('123', expect.any(Number));
     expect(interaction.reply).toHaveBeenCalledWith(expect.objectContaining({ content: expect.stringContaining('Goblin') }));
     expect(interaction.followUp).toHaveBeenCalledWith(expect.objectContaining({ embeds: expect.any(Array) }));
   });
@@ -100,6 +103,7 @@ describe('adventure command', () => {
       a => a.class === baseHeroes[0].class && a.rarity === 'Common'
     ).id;
     expect(userService.addAbility).toHaveBeenCalledWith('123', expectedId);
+    expect(userService.addGold).toHaveBeenCalledWith('123', expect.any(Number));
     Math.random.mockRestore();
     expect(interaction.followUp).toHaveBeenCalledWith(
       expect.objectContaining({ embeds: expect.any(Array) })
@@ -119,6 +123,7 @@ describe('adventure command', () => {
     await adventure.execute(interaction);
     expect(abilityCardService.getCards).toHaveBeenCalledWith(1);
     expect(userService.addAbility).not.toHaveBeenCalled();
+    expect(userService.addGold).not.toHaveBeenCalled();
     const calls = interaction.followUp.mock.calls.filter(c => c[0].ephemeral);
     expect(calls.length).toBe(0);
   });
@@ -140,6 +145,7 @@ describe('adventure command', () => {
     const interaction = { user: { id: '123', username: 'tester' }, reply: jest.fn().mockResolvedValue(), followUp: jest.fn().mockResolvedValue() };
     await adventure.execute(interaction);
     expect(abilityCardService.getCards).toHaveBeenCalledWith(1);
+    expect(userService.addGold).toHaveBeenCalledWith('123', expect.any(Number));
     const description = interaction.followUp.mock.calls[0][0].embeds[0].data.description;
     expect(description.includes('first')).toBe(true);
     expect(description.includes('second')).toBe(true);
@@ -158,6 +164,7 @@ describe('adventure command', () => {
       a => a.class === baseHeroes[index].class && a.rarity === 'Common'
     ).id;
     expect(userService.addAbility).toHaveBeenCalledWith('123', expectedDrop);
+    expect(userService.addGold).toHaveBeenCalledWith('123', expect.any(Number));
     Math.random.mockRestore();
   });
 
@@ -176,6 +183,7 @@ describe('adventure command', () => {
     const interaction = { user: { id: '123', username: 'tester' }, reply: jest.fn().mockResolvedValue(), followUp: jest.fn().mockResolvedValue() };
     await adventure.execute(interaction);
     expect(abilityCardService.getCards).toHaveBeenCalledWith(1);
+    expect(userService.addGold).toHaveBeenCalledWith('123', expect.any(Number));
     const description = interaction.followUp.mock.calls[0][0].embeds[0].data.description;
     const lines = description.split('\n');
     expect(lines.length).toBe(20);
@@ -194,6 +202,7 @@ describe('adventure command', () => {
     abilityCardService.getCards.mockResolvedValue([{ id: 50, ability_id: 3111, charges: 5 }]);
     const interaction = { user: { id: '123', username: 'tester' }, reply: jest.fn().mockResolvedValue(), followUp: jest.fn().mockResolvedValue() };
     await adventure.execute(interaction);
+    expect(userService.addGold).toHaveBeenCalledWith('123', expect.any(Number));
     expect(userService.setActiveAbility).toHaveBeenCalledWith('123', 99);
   });
 
@@ -224,6 +233,7 @@ describe('adventure command', () => {
       followUp: jest.fn().mockResolvedValue()
     };
     await adventure.execute(interaction);
+    expect(userService.addGold).toHaveBeenCalledWith('123', expect.any(Number));
     expect(interaction.user.send).not.toHaveBeenCalled();
   });
 
@@ -255,6 +265,7 @@ describe('adventure command', () => {
       followUp: jest.fn().mockResolvedValue()
     };
     await adventure.execute(interaction);
+    expect(userService.addGold).toHaveBeenCalledWith('123', expect.any(Number));
     expect(embedBuilder.sendCardDM).not.toHaveBeenCalled();
     Math.random.mockRestore();
   });
@@ -275,6 +286,7 @@ describe('adventure command', () => {
       followUp: jest.fn().mockResolvedValue()
     };
     await adventure.execute(interaction);
+    expect(userService.addGold).toHaveBeenCalledWith('123', expect.any(Number));
     const ephemerals = interaction.followUp.mock.calls.filter(c => c[0].ephemeral);
     expect(ephemerals.length).toBeGreaterThan(0);
   });
@@ -297,6 +309,7 @@ describe('adventure command', () => {
       followUp: jest.fn().mockResolvedValue()
     };
     await adventure.execute(interaction);
+    expect(userService.addGold).toHaveBeenCalledWith('123', expect.any(Number));
     const ephemerals = interaction.followUp.mock.calls.filter(c => c[0].ephemeral);
     expect(ephemerals.length).toBeGreaterThan(0);
     Math.random.mockRestore();


### PR DESCRIPTION
## Summary
- grant players a random gold reward when winning `/adventure`
- persist gold via `userService.addGold`
- show gold earned in the adventure summary
- update adventure tests for new gold logic

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686319cb54248327a44450ae37c757ca