### PR TITLE
Implement basic auction house system

### DIFF
--- a/discord-bot/commands/auctionhouse.js
+++ b/discord-bot/commands/auctionhouse.js
@@ -1,0 +1,22 @@
+const { SlashCommandBuilder, ActionRowBuilder, ButtonBuilder, ButtonStyle } = require('discord.js');
+
+const data = new SlashCommandBuilder()
+  .setName('auctionhouse')
+  .setDescription('Open the auction house');
+
+async function execute(interaction) {
+  const row = new ActionRowBuilder().addComponents(
+    new ButtonBuilder()
+      .setCustomId('auction-buy')
+      .setLabel('Buy')
+      .setStyle(ButtonStyle.Primary),
+    new ButtonBuilder()
+      .setCustomId('auction-sell')
+      .setLabel('Sell')
+      .setStyle(ButtonStyle.Success)
+  );
+
+  await interaction.reply({ content: 'Welcome to the Auction House!', components: [row], ephemeral: true });
+}
+
+module.exports = { data, execute };

--- a/discord-bot/deploy-commands.js
+++ b/discord-bot/deploy-commands.js
@@ -11,6 +11,7 @@ const commandDirs = [
   path.join(__dirname, 'commands/settings.js'),
   path.join(__dirname, 'commands/tutorial.js'),
   path.join(__dirname, 'commands/leaderboard.js'),
+  path.join(__dirname, 'commands/auctionhouse.js'),
   path.join(__dirname, 'src/commands/adventure.js'),
   path.join(__dirname, 'src/commands/challenge.js'),
   path.join(__dirname, 'src/commands/practice.js')

--- a/discord-bot/src/utils/auctionHouseService.js
+++ b/discord-bot/src/utils/auctionHouseService.js
@@ -1,0 +1,27 @@
+const db = require('../../util/database');
+
+async function createListing(sellerId, itemId, quantity, price) {
+  const [result] = await db.query(
+    'INSERT INTO market_listings (seller_id, item_id, quantity, price) VALUES (?, ?, ?, ?)',
+    [sellerId, itemId, quantity, price]
+  );
+  return result.insertId;
+}
+
+async function getCheapestListings(itemId, limit = 5) {
+  const [rows] = await db.query(
+    'SELECT * FROM market_listings WHERE item_id = ? AND buyer_id IS NULL ORDER BY price ASC LIMIT ?',
+    [itemId, limit]
+  );
+  return rows;
+}
+
+async function purchaseListing(listingId, buyerId) {
+  const [result] = await db.query(
+    'UPDATE market_listings SET buyer_id = ?, purchased_at = NOW() WHERE id = ? AND buyer_id IS NULL',
+    [buyerId, listingId]
+  );
+  return result.affectedRows > 0;
+}
+
+module.exports = { createListing, getCheapestListings, purchaseListing };

--- a/discord-bot/tests/auctionHouseService.test.js
+++ b/discord-bot/tests/auctionHouseService.test.js
@@ -1,0 +1,39 @@
+const service = require('../src/utils/auctionHouseService');
+
+jest.mock('../util/database', () => ({
+  query: jest.fn()
+}));
+const db = require('../util/database');
+
+describe('auctionHouseService', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('createListing inserts listing', async () => {
+    db.query.mockResolvedValueOnce([{ insertId: 10 }]);
+    await service.createListing(1, 2, 3, 100);
+    expect(db.query).toHaveBeenCalledWith(
+      'INSERT INTO market_listings (seller_id, item_id, quantity, price) VALUES (?, ?, ?, ?)',
+      [1, 2, 3, 100]
+    );
+  });
+
+  test('getCheapestListings selects cheapest', async () => {
+    db.query.mockResolvedValueOnce([[]]);
+    await service.getCheapestListings(2, 5);
+    expect(db.query).toHaveBeenCalledWith(
+      'SELECT * FROM market_listings WHERE item_id = ? AND buyer_id IS NULL ORDER BY price ASC LIMIT ?',
+      [2, 5]
+    );
+  });
+
+  test('purchaseListing updates record', async () => {
+    db.query.mockResolvedValueOnce([{ affectedRows: 1 }]);
+    await service.purchaseListing(7, 4);
+    expect(db.query).toHaveBeenCalledWith(
+      'UPDATE market_listings SET buyer_id = ?, purchased_at = NOW() WHERE id = ? AND buyer_id IS NULL',
+      [4, 7]
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- add `/auctionhouse` command with Buy and Sell buttons
- implement `auctionHouseService` for creating, fetching and buying listings
- register the new slash command
- test auction house service logic

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686319cbc8508327a52178474cf44c67