### PR TITLE
Add ability card selling

### DIFF
--- a/discord-bot/src/utils/auctionHouseService.js
+++ b/discord-bot/src/utils/auctionHouseService.js
@@ -1,0 +1,11 @@
+const db = require('../../util/database');
+
+async function createListing(userId, cardId, price) {
+  const [result] = await db.query(
+    'INSERT INTO market_listings (seller_id, card_id, price) VALUES (?, ?, ?)',
+    [userId, cardId, price]
+  );
+  return result.insertId;
+}
+
+module.exports = { createListing };


### PR DESCRIPTION
## Summary
- add AuctionHouse service with createListing
- extend inventory command to show Sell Cards button and handlers
- open modal to choose price and create listing
- test card selling flows

## Testing
- `npm test` in `discord-bot`
- `npm test` in `backend`

------
https://chatgpt.com/codex/tasks/task_e_686319ccc50c832790f6bdea843af029