### PR TITLE
Implement auction house purchasing

### DIFF
--- a/discord-bot/commands/auction.js
+++ b/discord-bot/commands/auction.js
@@ -1,0 +1,78 @@
+const {
+  SlashCommandBuilder,
+  ActionRowBuilder,
+  ButtonBuilder,
+  ButtonStyle,
+  EmbedBuilder
+} = require('discord.js');
+const auctionHouseService = require('../src/utils/auctionHouseService');
+const { allPossibleAbilities } = require('../../backend/game/data');
+
+const data = new SlashCommandBuilder()
+  .setName('auction')
+  .setDescription('Browse the auction house');
+
+async function execute(interaction) {
+  const row = new ActionRowBuilder().addComponents(
+    new ButtonBuilder()
+      .setCustomId('auction-buy')
+      .setLabel('Browse Listings')
+      .setStyle(ButtonStyle.Primary)
+  );
+  await interaction.reply({ content: 'Welcome to the Auction House!', components: [row], ephemeral: true });
+}
+
+async function handleBuyButton(interaction) {
+  const listings = await auctionHouseService.getCheapestListings();
+  if (!listings.length) {
+    await interaction.update({ content: 'No listings found.', components: [], embeds: [], ephemeral: true });
+    return;
+  }
+
+  const embed = new EmbedBuilder()
+    .setColor('#29b6f6')
+    .setTitle('Cheapest Listings');
+
+  const row = new ActionRowBuilder();
+
+  listings.forEach(listing => {
+    const ability = allPossibleAbilities.find(a => a.id === listing.card_id);
+    const name = ability ? ability.name : `Card ${listing.card_id}`;
+    embed.addFields({ name, value: `${listing.price} gold - Seller: ${listing.seller_name}` });
+    row.addComponents(
+      new ButtonBuilder()
+        .setCustomId(`ah-buy-listing:${listing.id}`)
+        .setLabel(`Buy ${name}`)
+        .setStyle(ButtonStyle.Success)
+    );
+  });
+
+  await interaction.update({ content: 'Select a listing to purchase:', embeds: [embed], components: [row], ephemeral: true });
+}
+
+async function handleBuyListing(interaction) {
+  const [, idStr] = interaction.customId.split(':');
+  const listingId = Number(idStr);
+  try {
+    const { buyer, seller, listing } = await auctionHouseService.purchaseListing(listingId, interaction.user.id);
+    const ability = allPossibleAbilities.find(a => a.id === listing.card_id);
+    const name = ability ? ability.name : `Card ${listing.card_id}`;
+    await interaction.update({
+      content: `You bought **${name}** for ${listing.price} gold from ${seller.name}.`,
+      components: [],
+      embeds: [],
+      ephemeral: true
+    });
+
+    try {
+      const sellerUser = await interaction.client.users.fetch(seller.discord_id);
+      await sellerUser.send(`${buyer.name} bought your ${name} for ${listing.price} gold.`);
+    } catch (e) {
+      /* ignore DM failures */
+    }
+  } catch (err) {
+    await interaction.update({ content: err.message, components: [], embeds: [], ephemeral: true });
+  }
+}
+
+module.exports = { data, execute, handleBuyButton, handleBuyListing };

--- a/discord-bot/index.js
+++ b/discord-bot/index.js
@@ -8,6 +8,7 @@ client.commands = new Collection();
 
 const inventoryHandlers = require('./commands/inventory');
 const challengeHandlers = require('./src/commands/challenge');
+const auctionHandlers = require('./commands/auction');
 
 const commandDirs = [
   path.join(__dirname, 'commands'),
@@ -80,6 +81,10 @@ client.on(Events.InteractionCreate, async interaction => {
       await challengeHandlers.handleAccept(interaction);
     } else if (interaction.customId.startsWith('challenge-decline:')) {
       await challengeHandlers.handleDecline(interaction);
+    } else if (interaction.customId === 'auction-buy') {
+      await auctionHandlers.handleBuyButton(interaction);
+    } else if (interaction.customId.startsWith('ah-buy-listing:')) {
+      await auctionHandlers.handleBuyListing(interaction);
     } else if (interaction.customId.startsWith('open-inventory:')) {
       const inventoryCommand = client.commands.get('inventory');
       interaction.options = { getSubcommand: () => 'show' };

--- a/discord-bot/src/utils/auctionHouseService.js
+++ b/discord-bot/src/utils/auctionHouseService.js
@@ -1,0 +1,40 @@
+const db = require('../../util/database');
+
+async function getCheapestListings(limit = 5) {
+  const [rows] = await db.query(
+    `SELECT ml.id, ml.card_id, ml.price, u.name AS seller_name, u.discord_id AS seller_discord_id
+     FROM market_listings ml
+     JOIN users u ON ml.seller_id = u.id
+     WHERE ml.sold = 0
+     ORDER BY ml.price ASC
+     LIMIT ?`,
+    [limit]
+  );
+  return rows;
+}
+
+async function purchaseListing(listingId, buyerDiscordId) {
+  const [listRows] = await db.query('SELECT * FROM market_listings WHERE id = ?', [listingId]);
+  const listing = listRows[0];
+  if (!listing || listing.sold) {
+    throw new Error('Listing already sold');
+  }
+  const [buyerRows] = await db.query('SELECT * FROM users WHERE discord_id = ?', [buyerDiscordId]);
+  const buyer = buyerRows[0];
+  if (!buyer) throw new Error('Buyer not found');
+  if (buyer.gold < listing.price) {
+    throw new Error('Insufficient funds');
+  }
+  const [sellerRows] = await db.query('SELECT * FROM users WHERE id = ?', [listing.seller_id]);
+  const seller = sellerRows[0];
+  if (!seller) throw new Error('Seller not found');
+
+  await db.query('UPDATE users SET gold = gold - ? WHERE id = ?', [listing.price, buyer.id]);
+  await db.query('UPDATE users SET gold = gold + ? WHERE id = ?', [listing.price, seller.id]);
+  await db.query('UPDATE user_ability_cards SET user_id = ? WHERE id = ?', [buyer.id, listing.card_id]);
+  await db.query('UPDATE market_listings SET sold = 1, buyer_id = ? WHERE id = ?', [buyer.id, listingId]);
+
+  return { buyer, seller, listing };
+}
+
+module.exports = { getCheapestListings, purchaseListing };

--- a/discord-bot/tests/auctionHouse.test.js
+++ b/discord-bot/tests/auctionHouse.test.js
@@ -1,0 +1,69 @@
+const auction = require('../commands/auction');
+
+jest.mock('../src/utils/auctionHouseService', () => ({
+  getCheapestListings: jest.fn(),
+  purchaseListing: jest.fn()
+}));
+const auctionHouseService = require('../src/utils/auctionHouseService');
+
+describe('auction house', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  test('handleBuyButton shows cheapest listings', async () => {
+    auctionHouseService.getCheapestListings.mockResolvedValue([
+      { id: 1, card_id: 3111, price: 100, seller_name: 'Alice' }
+    ]);
+    const interaction = { update: jest.fn().mockResolvedValue() };
+    await auction.handleBuyButton(interaction);
+    expect(auctionHouseService.getCheapestListings).toHaveBeenCalled();
+    expect(interaction.update).toHaveBeenCalledWith(
+      expect.objectContaining({ embeds: expect.any(Array), components: expect.any(Array) })
+    );
+    const button = interaction.update.mock.calls[0][0].components[0].components[0];
+    expect(button.data.custom_id).toBe('ah-buy-listing:1');
+  });
+
+  test('handleBuyListing successful purchase', async () => {
+    auctionHouseService.purchaseListing.mockResolvedValue({
+      buyer: { name: 'Buyer', discord_id: '1' },
+      seller: { name: 'Seller', discord_id: '2' },
+      listing: { card_id: 3111, price: 50 }
+    });
+    const sellerSend = jest.fn().mockResolvedValue();
+    const interaction = {
+      customId: 'ah-buy-listing:1',
+      user: { id: '1' },
+      client: { users: { fetch: jest.fn().mockResolvedValue({ send: sellerSend }) } },
+      update: jest.fn().mockResolvedValue()
+    };
+    await auction.handleBuyListing(interaction);
+    expect(auctionHouseService.purchaseListing).toHaveBeenCalledWith(1, '1');
+    expect(interaction.client.users.fetch).toHaveBeenCalledWith('2');
+    expect(sellerSend).toHaveBeenCalled();
+    expect(interaction.update).toHaveBeenCalledWith(expect.objectContaining({ content: expect.stringContaining('You bought') }));
+  });
+
+  test('handleBuyListing insufficient funds', async () => {
+    auctionHouseService.purchaseListing.mockRejectedValue(new Error('Insufficient funds'));
+    const interaction = {
+      customId: 'ah-buy-listing:2',
+      user: { id: '1' },
+      client: { users: { fetch: jest.fn() } },
+      update: jest.fn().mockResolvedValue()
+    };
+    await auction.handleBuyListing(interaction);
+    expect(interaction.update).toHaveBeenCalledWith(expect.objectContaining({ content: 'Insufficient funds' }));
+  });
+
+  test('handleBuyListing already sold', async () => {
+    auctionHouseService.purchaseListing.mockRejectedValue(new Error('Listing already sold'));
+    const interaction = {
+      customId: 'ah-buy-listing:3',
+      user: { id: '1' },
+      client: { users: { fetch: jest.fn() } },
+      update: jest.fn().mockResolvedValue()
+    };
+    await auction.handleBuyListing(interaction);
+    expect(interaction.update).toHaveBeenCalledWith(expect.objectContaining({ content: 'Listing already sold' }));
+  });
+});


### PR DESCRIPTION
## Summary
- implement DB helpers for auction house listings and purchases
- add new `/auction` command and buy button handlers
- wire handlers in bot main index
- test auction house flow

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686319cdbb348327b6f406c0c8ad6359