### PR TITLE
Use Discord mentions on leaderboard

### DIFF
--- a/discord-bot/commands/leaderboard.js
+++ b/discord-bot/commands/leaderboard.js
@@ -12,13 +12,13 @@ async function execute(interaction) {
   const topPve = allUsers
     .sort((a, b) => b.pve_ratio - a.pve_ratio)
     .slice(0, 3)
-    .map((u, i) => `${i + 1}. **${u.name}** (${u.pve_wins}-${u.pve_losses})`)
+    .map((u, i) => `${i + 1}. <@${u.discord_id}> (${u.pve_wins}-${u.pve_losses})`)
     .join('\n') || 'No PvE battles recorded yet.';
 
   const topPvp = allUsers
     .sort((a, b) => b.pvp_ratio - a.pvp_ratio)
     .slice(0, 3)
-    .map((u, i) => `${i + 1}. **${u.name}** (${u.pvp_wins}-${u.pvp_losses})`)
+    .map((u, i) => `${i + 1}. <@${u.discord_id}> (${u.pvp_wins}-${u.pvp_losses})`)
     .join('\n') || 'No PvP battles recorded yet.';
 
   const embed = simple('Leaderboards', [

--- a/discord-bot/src/utils/userService.js
+++ b/discord-bot/src/utils/userService.js
@@ -46,8 +46,9 @@ async function incrementPvpLoss(userId) {
 
 async function getLeaderboardData() {
   const [rows] = await db.query(`
-        SELECT 
+        SELECT
             name,
+            discord_id,
             pve_wins, pve_losses,
             pvp_wins, pvp_losses,
             CASE WHEN pve_losses = 0 THEN pve_wins + 99999 ELSE pve_wins / pve_losses END AS pve_ratio,

--- a/discord-bot/tests/leaderboard.test.js
+++ b/discord-bot/tests/leaderboard.test.js
@@ -7,9 +7,9 @@ const userService = require('../src/utils/userService');
 
 test('replies with leaderboard embed', async () => {
   userService.getLeaderboardData.mockResolvedValue([
-    { name: 'Alice', pve_wins: 5, pve_losses: 1, pvp_wins: 2, pvp_losses: 0, pve_ratio: 5/1, pvp_ratio: 2+99999 },
-    { name: 'Bob', pve_wins: 3, pve_losses: 0, pvp_wins: 1, pvp_losses: 1, pve_ratio: 3+99999, pvp_ratio: 1 },
-    { name: 'Cara', pve_wins: 1, pve_losses: 1, pvp_wins: 0, pvp_losses: 2, pve_ratio: 1, pvp_ratio: 0 }
+    { name: 'Alice', discord_id: '1', pve_wins: 5, pve_losses: 1, pvp_wins: 2, pvp_losses: 0, pve_ratio: 5/1, pvp_ratio: 2+99999 },
+    { name: 'Bob', discord_id: '2', pve_wins: 3, pve_losses: 0, pvp_wins: 1, pvp_losses: 1, pve_ratio: 3+99999, pvp_ratio: 1 },
+    { name: 'Cara', discord_id: '3', pve_wins: 1, pve_losses: 1, pvp_wins: 0, pvp_losses: 2, pve_ratio: 1, pvp_ratio: 0 }
   ]);
   const interaction = { reply: jest.fn().mockResolvedValue() };
   await leaderboard.execute(interaction);


### PR DESCRIPTION
## Summary
- include `discord_id` in leaderboard query
- show Discord mentions in leaderboard output so names stay updated
- adjust leaderboard tests for new field

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686319eb5618832798fa52887cba9726