### PR TITLE
Add gold rewards and auction house utilities

### DIFF
--- a/discord-bot/commands/auctionhouse.js
+++ b/discord-bot/commands/auctionhouse.js
@@ -2,19 +2,13 @@ const { SlashCommandBuilder, ActionRowBuilder, ButtonBuilder, ButtonStyle } = re
 
 const data = new SlashCommandBuilder()
   .setName('auctionhouse')
-  .setDescription('Open the auction house');
+  .setDescription('Buy and sell ability cards.');
 
 async function execute(interaction) {
-  const row = new ActionRowBuilder().addComponents(
-    new ButtonBuilder()
-      .setCustomId('auction-buy')
-      .setLabel('Buy')
-      .setStyle(ButtonStyle.Primary),
-    new ButtonBuilder()
-      .setCustomId('auction-sell')
-      .setLabel('Sell')
-      .setStyle(ButtonStyle.Success)
-  );
+    const row = new ActionRowBuilder().addComponents(
+        new ButtonBuilder().setCustomId('ah-buy-start').setLabel('Buy Cards').setStyle(ButtonStyle.Success),
+        new ButtonBuilder().setCustomId('ah-sell-start').setLabel('Sell Cards').setStyle(ButtonStyle.Primary)
+    );
 
   await interaction.reply({ content: 'Welcome to the Auction House!', components: [row], ephemeral: true });
 }

--- a/discord-bot/src/commands/adventure.js
+++ b/discord-bot/src/commands/adventure.js
@@ -123,21 +123,23 @@ async function execute(interaction) {
   const enemyName = `a **Goblin ${goblinBase.name}**`;
 
   if (engine.winner === 'player') {
-    let dropText = 'who was slain.';
+    const goldDropped = Math.floor(Math.random() * 3);
+    await userService.addGold(user.id, goldDropped);
+    narrativeDescription = `${adventurerName} was victorious and found **${goldDropped} gold**!`;
+
     if (Math.random() < 0.5) {
       const lootOptions = allPossibleAbilities.filter(
         a => a.class === goblinBase.class && a.rarity === 'Common'
       );
       lootDrop = lootOptions[Math.floor(Math.random() * lootOptions.length)];
       if (lootDrop) {
-        dropText = `who was slain and dropped **${lootDrop.name}**.`;
+        narrativeDescription += ` They also found **${lootDrop.name}**.`;
         console.log(
           `[ITEM LOOT] User: ${interaction.user.username} looted Ability: ${lootDrop.name} (ID: ${lootDrop.id})`
         );
         await userService.addAbility(interaction.user.id, lootDrop.id);
       }
     }
-    narrativeDescription = `${adventurerName} adventured into the goblin caves and encountered ${enemyName}, ${dropText}`;
   } else {
     narrativeDescription = `${adventurerName} adventured into the goblin caves and encountered ${enemyName} who defeated them.`;
   }

--- a/discord-bot/src/utils/auctionHouseService.js
+++ b/discord-bot/src/utils/auctionHouseService.js
@@ -1,27 +1,59 @@
 const db = require('../../util/database');
 
-async function createListing(sellerId, itemId, quantity, price) {
-  const [result] = await db.query(
-    'INSERT INTO market_listings (seller_id, item_id, quantity, price) VALUES (?, ?, ?, ?)',
-    [sellerId, itemId, quantity, price]
-  );
-  return result.insertId;
+async function createListing(sellerId, card, price) {
+  const connection = await db.getConnection();
+  try {
+    await connection.beginTransaction();
+    await connection.query('DELETE FROM user_ability_cards WHERE id = ?', [card.id]);
+    await connection.query(
+      'INSERT INTO auction_house_listings (seller_id, ability_id, charges, price) VALUES (?, ?, ?, ?)',
+      [sellerId, card.ability_id, card.charges, price]
+    );
+    await connection.commit();
+  } catch (error) {
+    await connection.rollback();
+    throw error;
+  } finally {
+    connection.release();
+  }
 }
 
-async function getCheapestListings(itemId, limit = 5) {
-  const [rows] = await db.query(
-    'SELECT * FROM market_listings WHERE item_id = ? AND buyer_id IS NULL ORDER BY price ASC LIMIT ?',
-    [itemId, limit]
-  );
+async function getCheapestListings() {
+  const [rows] = await db.query(`
+        SELECT t1.* FROM auction_house_listings t1
+        INNER JOIN (
+            SELECT ability_id, MIN(price) as min_price
+            FROM auction_house_listings
+            GROUP BY ability_id
+        ) t2 ON t1.ability_id = t2.ability_id AND t1.price = t2.min_price
+    `);
   return rows;
 }
 
-async function purchaseListing(listingId, buyerId) {
-  const [result] = await db.query(
-    'UPDATE market_listings SET buyer_id = ?, purchased_at = NOW() WHERE id = ? AND buyer_id IS NULL',
-    [buyerId, listingId]
-  );
-  return result.affectedRows > 0;
+async function purchaseListing(buyerId, listingId) {
+  const connection = await db.getConnection();
+  try {
+    await connection.beginTransaction();
+    const [listingRows] = await connection.query('SELECT * FROM auction_house_listings WHERE id = ? FOR UPDATE', [listingId]);
+    if (listingRows.length === 0) throw new Error('This item has already been sold.');
+    const listing = listingRows[0];
+
+    const [buyerRows] = await connection.query('SELECT gold FROM users WHERE id = ?', [buyerId]);
+    if (buyerRows[0].gold < listing.price) throw new Error("You don't have enough gold.");
+
+    await connection.query('UPDATE users SET gold = gold - ? WHERE id = ?', [listing.price, buyerId]);
+    await connection.query('UPDATE users SET gold = gold + ? WHERE id = ?', [listing.price, listing.seller_id]);
+    await connection.query('INSERT INTO user_ability_cards (user_id, ability_id, charges) VALUES (?, ?, ?)', [buyerId, listing.ability_id, listing.charges]);
+    await connection.query('DELETE FROM auction_house_listings WHERE id = ?', [listingId]);
+
+    await connection.commit();
+    return listing;
+  } catch (error) {
+    await connection.rollback();
+    throw error;
+  } finally {
+    connection.release();
+  }
 }
 
 module.exports = { createListing, getCheapestListings, purchaseListing };

--- a/discord-bot/src/utils/userService.js
+++ b/discord-bot/src/utils/userService.js
@@ -46,6 +46,7 @@ async function incrementPvpLoss(userId) {
 
 // Add gold to the user by incrementing the gold column
 async function addGold(userId, amount) {
+  if (amount === 0) return;
   await db.query('UPDATE users SET gold = gold + ? WHERE id = ?', [amount, userId]);
 }
 

--- a/discord-bot/tests/adventure.test.js
+++ b/discord-bot/tests/adventure.test.js
@@ -4,6 +4,7 @@ jest.mock('../src/utils/userService', () => ({
   createUser: jest.fn(),
   setActiveAbility: jest.fn(),
   setDmPreference: jest.fn(),
+  addGold: jest.fn(),
   incrementPveWin: jest.fn(),
   incrementPveLoss: jest.fn()
 }));

--- a/discord-bot/tests/auctionHouseService.test.js
+++ b/discord-bot/tests/auctionHouseService.test.js
@@ -1,7 +1,8 @@
 const service = require('../src/utils/auctionHouseService');
 
 jest.mock('../util/database', () => ({
-  query: jest.fn()
+  query: jest.fn(),
+  getConnection: jest.fn()
 }));
 const db = require('../util/database');
 
@@ -10,30 +11,53 @@ describe('auctionHouseService', () => {
     jest.clearAllMocks();
   });
 
-  test('createListing inserts listing', async () => {
-    db.query.mockResolvedValueOnce([{ insertId: 10 }]);
-    await service.createListing(1, 2, 3, 100);
-    expect(db.query).toHaveBeenCalledWith(
-      'INSERT INTO market_listings (seller_id, item_id, quantity, price) VALUES (?, ?, ?, ?)',
-      [1, 2, 3, 100]
+  test('createListing removes card and creates listing inside transaction', async () => {
+    const connection = {
+      beginTransaction: jest.fn(),
+      query: jest.fn(),
+      commit: jest.fn(),
+      rollback: jest.fn(),
+      release: jest.fn()
+    };
+    db.getConnection.mockResolvedValue(connection);
+
+    await service.createListing(1, { id: 5, ability_id: 2, charges: 7 }, 100);
+
+    expect(connection.beginTransaction).toHaveBeenCalled();
+    expect(connection.query).toHaveBeenNthCalledWith(1, 'DELETE FROM user_ability_cards WHERE id = ?', [5]);
+    expect(connection.query).toHaveBeenNthCalledWith(
+      2,
+      'INSERT INTO auction_house_listings (seller_id, ability_id, charges, price) VALUES (?, ?, ?, ?)',
+      [1, 2, 7, 100]
     );
+    expect(connection.commit).toHaveBeenCalled();
+    expect(connection.release).toHaveBeenCalled();
   });
 
-  test('getCheapestListings selects cheapest', async () => {
+  test('getCheapestListings selects grouped cheapest', async () => {
     db.query.mockResolvedValueOnce([[]]);
-    await service.getCheapestListings(2, 5);
-    expect(db.query).toHaveBeenCalledWith(
-      'SELECT * FROM market_listings WHERE item_id = ? AND buyer_id IS NULL ORDER BY price ASC LIMIT ?',
-      [2, 5]
-    );
+    await service.getCheapestListings();
+    expect(db.query).toHaveBeenCalledWith(expect.stringContaining('auction_house_listings'));
   });
 
-  test('purchaseListing updates record', async () => {
-    db.query.mockResolvedValueOnce([{ affectedRows: 1 }]);
-    await service.purchaseListing(7, 4);
-    expect(db.query).toHaveBeenCalledWith(
-      'UPDATE market_listings SET buyer_id = ?, purchased_at = NOW() WHERE id = ? AND buyer_id IS NULL',
-      [4, 7]
-    );
+  test('purchaseListing transfers gold and card', async () => {
+    const connection = {
+      beginTransaction: jest.fn(),
+      query: jest.fn()
+        .mockResolvedValueOnce([[{ id: 9, seller_id: 2, ability_id: 3, charges: 5, price: 20 }]])
+        .mockResolvedValueOnce([[{ gold: 50 }]])
+        .mockResolvedValue({}),
+      commit: jest.fn(),
+      rollback: jest.fn(),
+      release: jest.fn()
+    };
+    db.getConnection.mockResolvedValue(connection);
+
+    await service.purchaseListing(1, 9);
+
+    expect(connection.beginTransaction).toHaveBeenCalled();
+    expect(connection.query).toHaveBeenNthCalledWith(1, 'SELECT * FROM auction_house_listings WHERE id = ? FOR UPDATE', [9]);
+    expect(connection.commit).toHaveBeenCalled();
+    expect(connection.release).toHaveBeenCalled();
   });
 });

--- a/discord-bot/tests/userService.test.js
+++ b/discord-bot/tests/userService.test.js
@@ -18,4 +18,9 @@ describe('userService.addGold', () => {
       [10, 5]
     );
   });
+
+  test('no query when amount is zero', async () => {
+    await userService.addGold(5, 0);
+    expect(db.query).not.toHaveBeenCalled();
+  });
 });


### PR DESCRIPTION
## Summary
- award 0-2 gold for winning an adventure
- expose `addGold` with a no-op for zero values
- update `/auctionhouse` command button labels
- implement transactional auction house service
- expand related Jest tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68631cd4752c8327aee4f9ff072fd910