### PR TITLE
Add basic test for auction house command

### DIFF
--- a/discord-bot/tests/auctionHouseHandlers.test.js
+++ b/discord-bot/tests/auctionHouseHandlers.test.js
@@ -1,0 +1,13 @@
+const auctionHouse = require('../commands/auctionhouse');
+
+test('command posts welcome message with buy/sell buttons', async () => {
+  const interaction = { reply: jest.fn().mockResolvedValue() };
+  await auctionHouse.execute(interaction);
+  expect(interaction.reply).toHaveBeenCalledWith(
+    expect.objectContaining({
+      content: expect.stringContaining('Welcome'),
+      components: expect.any(Array),
+      ephemeral: true
+    })
+  );
+});


### PR DESCRIPTION
## Summary
- add auctionHouseHandlers.test.js verifying ephemeral reply for /auctionhouse command

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_686345560b70832797e3bd9f6beae22d