### PR TITLE
Implement XP leveling for adventure wins

### DIFF
--- a/discord-bot/src/commands/adventure.js
+++ b/discord-bot/src/commands/adventure.js
@@ -128,9 +128,15 @@ async function execute(interaction) {
     narrativeDescription = `${adventurerName} was victorious and found **${goldDropped} gold**!`;
 
     if (Math.random() < 0.5) {
-      const lootOptions = allPossibleAbilities.filter(
-        a => a.class === goblinBase.class && a.rarity === 'Common'
+      let lootOptions = allPossibleAbilities.filter(
+        a => a.class === goblinBase.class
       );
+
+      const level = user.level ?? 1;
+      if (level >= 1 && level <= 4) {
+        lootOptions = lootOptions.filter(a => a.rarity === 'Common');
+      }
+
       lootDrop = lootOptions[Math.floor(Math.random() * lootOptions.length)];
       if (lootDrop) {
         narrativeDescription += ` They also found **${lootDrop.name}**.`;
@@ -139,6 +145,13 @@ async function execute(interaction) {
         );
         await userService.addAbility(interaction.user.id, lootDrop.id);
       }
+    }
+
+    const xpResult = await userService.addXp(user.id, 10);
+    if (xpResult.leveledUp) {
+      await interaction.followUp({
+        content: `🎉 **Congratulations, ${interaction.user.username}! You have reached Level ${xpResult.newLevel}!** 🎉`
+      });
     }
   } else {
     narrativeDescription = `${adventurerName} adventured into the goblin caves and encountered ${enemyName} who defeated them.`;

--- a/discord-bot/tests/adventure.test.js
+++ b/discord-bot/tests/adventure.test.js
@@ -5,6 +5,7 @@ jest.mock('../src/utils/userService', () => ({
   setActiveAbility: jest.fn(),
   setDmPreference: jest.fn(),
   addGold: jest.fn(),
+  addXp: jest.fn().mockResolvedValue({ leveledUp: false, newLevel: 1 }),
   incrementPveWin: jest.fn(),
   incrementPveLoss: jest.fn()
 }));

--- a/discord-bot/tests/userService.test.js
+++ b/discord-bot/tests/userService.test.js
@@ -24,3 +24,38 @@ describe('userService.addGold', () => {
     expect(db.query).not.toHaveBeenCalled();
   });
 });
+
+describe('userService.addXp', () => {
+  beforeEach(() => {
+    db.query.mockClear();
+  });
+
+  test('updates xp when below threshold', async () => {
+    db.query
+      .mockResolvedValueOnce([[{ id: 1, level: 1, xp: 0 }]])
+      .mockResolvedValueOnce();
+
+    const result = await userService.addXp(1, 10);
+    expect(db.query).toHaveBeenNthCalledWith(1, 'SELECT id, level, xp FROM users WHERE id = ?', [1]);
+    expect(db.query).toHaveBeenNthCalledWith(2, 'UPDATE users SET xp = ? WHERE id = ?', [10, 1]);
+    expect(result).toEqual({ leveledUp: false, newLevel: 1 });
+  });
+
+  test('levels up when threshold reached', async () => {
+    db.query
+      .mockResolvedValueOnce([[{ id: 1, level: 1, xp: 4995 }]])
+      .mockResolvedValueOnce();
+
+    const result = await userService.addXp(1, 10);
+    expect(db.query).toHaveBeenNthCalledWith(2, 'UPDATE users SET level = ?, xp = ? WHERE id = ?', [2, 5005, 1]);
+    expect(result).toEqual({ leveledUp: true, newLevel: 2 });
+  });
+
+  test('no xp when at level cap', async () => {
+    db.query.mockResolvedValueOnce([[{ id: 1, level: 4, xp: 22500 }]]);
+
+    const result = await userService.addXp(1, 10);
+    expect(db.query).toHaveBeenCalledTimes(1);
+    expect(result).toEqual({ leveledUp: false, newLevel: 4 });
+  });
+});


### PR DESCRIPTION
## Summary
- add XP thresholds and `addXp` function in `userService`
- gate loot by player level and grant XP in `/adventure`
- mock new function in tests and cover `addXp`

## Testing
- `npm install --prefix discord-bot`
- `npm test --prefix discord-bot`

------
https://chatgpt.com/codex/tasks/task_e_68635f8430a48327b3bf2ce629701f62