### PR TITLE
Implement cached game data loading

### DIFF
--- a/discord-bot/commands/admin.js
+++ b/discord-bot/commands/admin.js
@@ -1,7 +1,7 @@
 const { SlashCommandBuilder } = require('discord.js');
 const userService = require('../src/utils/userService');
 const { sendCardDM } = require('../src/utils/embedBuilder');
-const { allPossibleAbilities } = require('../../backend/game/data');
+const gameData = require('../util/gameData');
 
 const data = new SlashCommandBuilder()
   .setName('admin')
@@ -26,6 +26,7 @@ const data = new SlashCommandBuilder()
   );
 
 async function execute(interaction) {
+  const allPossibleAbilities = Array.from(gameData.gameData.abilities.values());
   if (!interaction.member?.roles?.cache?.some(r => r.name === 'Game Master')) {
     await interaction.reply({
       content: 'You do not have the necessary permissions to use this command.',
@@ -78,6 +79,7 @@ async function execute(interaction) {
 }
 
 async function autocomplete(interaction) {
+  const allPossibleAbilities = Array.from(gameData.gameData.abilities.values());
   const focused = interaction.options.getFocused();
   const filtered = allPossibleAbilities
     .filter(a => a.name.toLowerCase().includes(focused.toLowerCase()))

--- a/discord-bot/commands/inventory.js
+++ b/discord-bot/commands/inventory.js
@@ -8,7 +8,11 @@ const {
 const { simple } = require('../src/utils/embedBuilder');
 const userService = require('../src/utils/userService');
 const abilityCardService = require('../src/utils/abilityCardService');
-const { allPossibleAbilities } = require('../../backend/game/data');
+const gameData = require('../util/gameData');
+
+function getAllAbilities() {
+  return Array.from(gameData.gameData.abilities.values());
+}
 
 const data = new SlashCommandBuilder()
   .setName('inventory')
@@ -45,6 +49,7 @@ const data = new SlashCommandBuilder()
   );
 
 async function execute(interaction) {
+  const allPossibleAbilities = getAllAbilities();
   const sub = interaction.options.getSubcommand(false) || 'show';
   let user = await userService.getUser(interaction.user.id);
   if (!user) {
@@ -159,6 +164,7 @@ async function execute(interaction) {
 }
 
 async function handleSetAbilityButton(interaction) {
+  const allPossibleAbilities = getAllAbilities();
   const user = await userService.getUser(interaction.user.id);
   if (!user) {
     await interaction.reply({ content: 'User not found.', ephemeral: true });
@@ -187,6 +193,7 @@ async function handleSetAbilityButton(interaction) {
 }
 
 async function handleAbilitySelect(interaction) {
+  const allPossibleAbilities = getAllAbilities();
   const abilityId = parseInt(interaction.values[0], 10);
   const user = await userService.getUser(interaction.user.id);
   if (!user) {
@@ -224,6 +231,7 @@ async function handleAbilitySelect(interaction) {
 }
 
 async function handleEquipSelect(interaction) {
+  const allPossibleAbilities = getAllAbilities();
   const cardId = parseInt(interaction.values[0], 10);
   const user = await userService.getUser(interaction.user.id);
   if (!user) {
@@ -251,6 +259,7 @@ async function handleEquipButton(interaction) {
 }
 
 async function handleMergeButton(interaction) {
+  const allPossibleAbilities = getAllAbilities();
   const user = await userService.getUser(interaction.user.id);
   const cards = await abilityCardService.getCards(user.id);
 
@@ -283,6 +292,7 @@ async function handleMergeButton(interaction) {
 }
 
 async function handleMergeSelect(interaction) {
+  const allPossibleAbilities = getAllAbilities();
   const abilityId = parseInt(interaction.values[0], 10);
   const user = await userService.getUser(interaction.user.id);
   const allCards = await abilityCardService.getCards(user.id);
@@ -309,6 +319,7 @@ async function handleMergeSelect(interaction) {
 }
 
 async function autocomplete(interaction) {
+  const allPossibleAbilities = getAllAbilities();
   const sub = interaction.options.getSubcommand();
   const focused = interaction.options.getFocused();
   const user = await userService.getUser(interaction.user.id);

--- a/discord-bot/commands/tutorial.js
+++ b/discord-bot/commands/tutorial.js
@@ -3,7 +3,8 @@ const userService = require('../src/utils/userService');
 const { buildBattleEmbed } = require('../src/utils/embedBuilder');
 const GameEngine = require('../../backend/game/engine');
 const { createCombatant } = require('../../backend/game/utils');
-const { allPossibleHeroes, allPossibleAbilities } = require('../../backend/game/data');
+const gameData = require('../util/gameData');
+
 
 function formatLog(entry) {
   const prefix = `[R${entry.round}]`;
@@ -19,6 +20,8 @@ const data = new SlashCommandBuilder()
   .setDescription('Start the guided tutorial');
 
 async function execute(interaction) {
+  const allPossibleHeroes = gameData.getHeroes();
+  const allPossibleAbilities = Array.from(gameData.gameData.abilities.values());
   let user = await userService.getUser(interaction.user.id);
   if (!user) {
     await userService.createUser(interaction.user.id, interaction.user.username);

--- a/discord-bot/commands/who.js
+++ b/discord-bot/commands/who.js
@@ -2,10 +2,8 @@ const { SlashCommandBuilder } = require('discord.js');
 const { simple } = require('../src/utils/embedBuilder');
 const userService = require('../src/utils/userService');
 const abilityCardService = require('../src/utils/abilityCardService');
-const {
-  allPossibleHeroes,
-  allPossibleAbilities
-} = require('../../backend/game/data');
+const gameData = require('../util/gameData');
+
 
 const data = new SlashCommandBuilder()
   .setName('who')
@@ -17,6 +15,8 @@ const data = new SlashCommandBuilder()
   );
 
 async function execute(interaction) {
+  const allPossibleHeroes = gameData.getHeroes();
+  const allPossibleAbilities = Array.from(gameData.gameData.abilities.values());
   const mentionedUser = interaction.options.getUser('user');
   const user = await userService.getUser(mentionedUser.id);
 

--- a/discord-bot/index.js
+++ b/discord-bot/index.js
@@ -2,6 +2,7 @@ const { Client, Collection, GatewayIntentBits, Events } = require('discord.js');
 const fs = require('node:fs');
 const path = require('node:path');
 const config = require('./util/config');
+const gameData = require('./util/gameData');
 
 const client = new Client({ intents: [GatewayIntentBits.Guilds] });
 client.commands = new Collection();
@@ -26,8 +27,9 @@ for (const dir of commandDirs) {
   }
 }
 
-client.once(Events.ClientReady, () => {
+client.once(Events.ClientReady, async () => {
   console.log(`✅ Logged in as ${client.user.tag}!`);
+  await gameData.loadAllData();
 });
 
 client.on(Events.InteractionCreate, async interaction => {

--- a/discord-bot/src/commands/adventure.js
+++ b/discord-bot/src/commands/adventure.js
@@ -12,7 +12,7 @@ const { runBattleLoop, sendBattleLogDM, formatLog } = require('../utils/battleRu
 
 const GameEngine = require('../../../backend/game/engine');
 const { createCombatant } = require('../../../backend/game/utils');
-const { allPossibleHeroes, allPossibleAbilities } = require('../../../backend/game/data');
+const gameData = require('../../util/gameData');
 const classAbilityMap = require('../data/classAbilityMap');
 
 function respond(interaction, options) {
@@ -27,6 +27,8 @@ const data = new SlashCommandBuilder()
   .setDescription('Enter the goblin cave for a practice battle');
 
 async function execute(interaction) {
+  const allPossibleHeroes = gameData.getHeroes();
+  const allPossibleAbilities = Array.from(gameData.gameData.abilities.values());
   let user = await userService.getUser(interaction.user.id);
   if (!user) {
     await userService.createUser(interaction.user.id, interaction.user.username);

--- a/discord-bot/src/commands/challenge.js
+++ b/discord-bot/src/commands/challenge.js
@@ -3,7 +3,7 @@ const userService = require('../utils/userService');
 const abilityCardService = require('../utils/abilityCardService');
 const db = require('../../util/database');
 const config = require('../../util/config');
-const { allPossibleHeroes } = require('../../../backend/game/data');
+const gameData = require('../../util/gameData');
 const { createCombatant } = require('../../../backend/game/utils');
 const GameEngine = require('../../../backend/game/engine');
 
@@ -13,6 +13,7 @@ const data = new SlashCommandBuilder()
   .addUserOption(opt => opt.setName('target').setDescription('User to challenge').setRequired(true));
 
 async function execute(interaction) {
+  const allPossibleHeroes = gameData.getHeroes();
   if (!config.PVP_CHANNEL_ID) {
     console.error('PVP_CHANNEL_ID is not set in the .env file.');
     return interaction.reply({

--- a/discord-bot/src/commands/practice.js
+++ b/discord-bot/src/commands/practice.js
@@ -11,7 +11,7 @@ const { runBattleLoop, sendBattleLogDM, formatLog } = require('../utils/battleRu
 
 const GameEngine = require('../../../backend/game/engine');
 const { createCombatant } = require('../../../backend/game/utils');
-const { allPossibleHeroes, allPossibleAbilities } = require('../../../backend/game/data');
+const gameData = require('../../util/gameData');
 const classAbilityMap = require('../data/classAbilityMap');
 
 function respond(interaction, options) {
@@ -26,6 +26,8 @@ const data = new SlashCommandBuilder()
   .setDescription('Test your skills against a goblin with no risk.');
 
 async function execute(interaction) {
+  const allPossibleHeroes = gameData.getHeroes();
+  const allPossibleAbilities = Array.from(gameData.gameData.abilities.values());
   let user = await userService.getUser(interaction.user.id);
   if (!user) {
     await userService.createUser(interaction.user.id, interaction.user.username);

--- a/discord-bot/src/utils/auctionHouseHandlers.js
+++ b/discord-bot/src/utils/auctionHouseHandlers.js
@@ -8,10 +8,14 @@ const {
 const userService = require('./userService');
 const abilityCardService = require('./abilityCardService');
 const auctionService = require('./auctionHouseService');
-const { allPossibleAbilities } = require('../../../backend/game/data');
+const gameData = require('../../util/gameData');
+
+function getAllAbilities() {
+  return Array.from(gameData.gameData.abilities.values());
+}
 
 function abilityName(id) {
-  const ability = allPossibleAbilities.find(a => a.id === id);
+  const ability = getAllAbilities().find(a => a.id === id);
   return ability ? ability.name : `Ability ${id}`;
 }
 

--- a/discord-bot/src/utils/userService.js
+++ b/discord-bot/src/utils/userService.js
@@ -1,6 +1,10 @@
 const db = require('../../util/database');
 const abilityCards = require('./abilityCardService');
-const { allPossibleAbilities } = require('../../../backend/game/data');
+const gameData = require('../../util/gameData');
+
+function getAllAbilities() {
+  return Array.from(gameData.gameData.abilities.values());
+}
 
 // XP required to reach each level
 const XP_THRESHOLDS = {
@@ -101,7 +105,7 @@ async function getInventory(discordId) {
   if (!user) return [];
   const cards = await abilityCards.getCards(user.id);
   return cards.map(card => {
-    const ability = allPossibleAbilities.find(a => a.id === card.ability_id);
+    const ability = getAllAbilities().find(a => a.id === card.ability_id);
     return {
       name: ability ? ability.name : `Ability ${card.ability_id}`,
       charges: card.charges,

--- a/discord-bot/tests/admin.test.js
+++ b/discord-bot/tests/admin.test.js
@@ -10,6 +10,8 @@ jest.mock('../src/utils/embedBuilder', () => ({
 
 const userService = require('../src/utils/userService');
 const { sendCardDM } = require('../src/utils/embedBuilder');
+const gameData = require('../util/gameData');
+const { allPossibleAbilities } = require('../../backend/game/data');
 
 function createInteraction(role = 'Game Master') {
   return {
@@ -27,6 +29,7 @@ function createInteraction(role = 'Game Master') {
 describe('admin grant-ability command', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    gameData.gameData.abilities = new Map(allPossibleAbilities.map(a => [a.id, a]));
   });
 
   test('requires Game Master role', async () => {

--- a/discord-bot/tests/adventure.test.js
+++ b/discord-bot/tests/adventure.test.js
@@ -23,6 +23,7 @@ jest.spyOn(utils, 'createCombatant');
 const adventure = require('../src/commands/adventure');
 const { allPossibleAbilities, allPossibleHeroes } = require('../../backend/game/data');
 const baseHeroes = allPossibleHeroes.filter(h => h.isBase);
+const gameData = require('../util/gameData');
 const userService = require('../src/utils/userService');
 const abilityCardService = require('../src/utils/abilityCardService');
 const embedBuilder = require('../src/utils/embedBuilder');
@@ -33,6 +34,8 @@ describe('adventure command', () => {
   let createCombatantSpy;
   beforeEach(() => {
     jest.clearAllMocks();
+    gameData.gameData.heroes = new Map(allPossibleHeroes.map(h => [h.id, h]));
+    gameData.gameData.abilities = new Map(allPossibleAbilities.map(a => [a.id, a]));
     abilityCardService.getCards.mockResolvedValue([]);
     createCombatantSpy = utils.createCombatant;
     GameEngine.mockImplementation(() => ({

--- a/discord-bot/tests/challenge.test.js
+++ b/discord-bot/tests/challenge.test.js
@@ -13,9 +13,12 @@ jest.mock('../../backend/game/engine');
 const userService = require('../src/utils/userService');
 const db = require('../util/database');
 const GameEngine = require('../../backend/game/engine');
+const gameData = require('../util/gameData');
+const { allPossibleHeroes } = require('../../backend/game/data');
 
 beforeEach(() => {
   jest.clearAllMocks();
+  gameData.gameData.heroes = new Map(allPossibleHeroes.map(h => [h.id, h]));
   GameEngine.mockImplementation(() => ({
     runFullGame: jest.fn(),
     battleLog: [],

--- a/discord-bot/tests/inventory.test.js
+++ b/discord-bot/tests/inventory.test.js
@@ -10,10 +10,13 @@ jest.mock('../src/utils/abilityCardService', () => ({
 }));
 const userService = require('../src/utils/userService');
 const abilityCardService = require('../src/utils/abilityCardService');
+const gameData = require('../util/gameData');
+const { allPossibleAbilities } = require('../../backend/game/data');
 
 describe('inventory command', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    gameData.gameData.abilities = new Map(allPossibleAbilities.map(a => [a.id, a]));
   });
 
   test('public reply when user has a class', async () => {

--- a/discord-bot/tests/practice.test.js
+++ b/discord-bot/tests/practice.test.js
@@ -13,11 +13,15 @@ const userService = require('../src/utils/userService');
 const abilityCardService = require('../src/utils/abilityCardService');
 const GameEngine = require('../../backend/game/engine');
 const utils = require('../../backend/game/utils');
+const gameData = require('../util/gameData');
+const { allPossibleHeroes, allPossibleAbilities } = require('../../backend/game/data');
 
 jest.spyOn(utils, 'createCombatant');
 
 beforeEach(() => {
   jest.clearAllMocks();
+  gameData.gameData.heroes = new Map(allPossibleHeroes.map(h => [h.id, h]));
+  gameData.gameData.abilities = new Map(allPossibleAbilities.map(a => [a.id, a]));
   GameEngine.mockImplementation(() => ({
     runGameSteps: function* () {
       yield { combatants: [], log: [{ round: 1, type: 'info', level: 'summary', message: 'log' }] };

--- a/discord-bot/tests/tutorial.test.js
+++ b/discord-bot/tests/tutorial.test.js
@@ -15,6 +15,7 @@ const {
   allPossibleAbilities,
   allPossibleHeroes
 } = require('../../backend/game/data');
+const gameData = require('../util/gameData');
 
 jest.spyOn(utils, 'createCombatant');
 
@@ -22,6 +23,8 @@ describe('tutorial command', () => {
   beforeEach(() => {
     jest.useFakeTimers();
     jest.clearAllMocks();
+    gameData.gameData.heroes = new Map(allPossibleHeroes.map(h => [h.id, h]));
+    gameData.gameData.abilities = new Map(allPossibleAbilities.map(a => [a.id, a]));
     GameEngine.mockImplementation(() => ({
       runGameSteps: function* () {
         yield { combatants: [], log: [{ round: 1, type: 'info', message: 'log' }] };

--- a/discord-bot/tests/who.test.js
+++ b/discord-bot/tests/who.test.js
@@ -8,10 +8,14 @@ jest.mock('../src/utils/abilityCardService', () => ({
 }));
 const userService = require('../src/utils/userService');
 const abilityCardService = require('../src/utils/abilityCardService');
+const gameData = require('../util/gameData');
+const { allPossibleAbilities, allPossibleHeroes } = require('../../backend/game/data');
 
 describe('who command', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    gameData.gameData.heroes = new Map(allPossibleHeroes.map(h => [h.id, h]));
+    gameData.gameData.abilities = new Map(allPossibleAbilities.map(a => [a.id, a]));
   });
 
   test('public reply when user has a class', async () => {


### PR DESCRIPTION
## Summary
- load game data once at startup
- use `gameData` helper in all Discord commands
- populate the cache in tests

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6863f64ac08483279732b9fee10cce81