### PR TITLE
Fix lazy-loaded status effects

### DIFF
--- a/backend/game/engine.js
+++ b/backend/game/engine.js
@@ -1,6 +1,7 @@
 // GameEngine handles simple auto-attack combat rounds
 
 const { allPossibleMinions } = require('./data');
+const { STATUS_EFFECTS } = require('./statusEffects');
 
 let abilityCardService;
 try {
@@ -45,7 +46,6 @@ class GameEngine {
    }
 
    applyCleanse(target) {
-       const { STATUS_EFFECTS } = require('./statusEffects');
        const effectsToRemove = target.statusEffects.filter(e => {
            const info = STATUS_EFFECTS[e.name];
            return info && info.type === 'debuff';


### PR DESCRIPTION
## Summary
- load statusEffects at module load instead of during cleanse

## Testing
- `npm test` in backend
- `npm test` in discord-bot

------
https://chatgpt.com/codex/tasks/task_e_686420a616008327a81f2e03e9edceaf