### PR TITLE
Integrate weapons into inventory

### DIFF
--- a/discord-bot/index.js
+++ b/discord-bot/index.js
@@ -8,6 +8,7 @@ const client = new Client({ intents: [GatewayIntentBits.Guilds] });
 client.commands = new Collection();
 
 const inventoryHandlers = require('./commands/inventory');
+const invViewHandlers = require('./src/utils/inventoryHandlers');
 const challengeHandlers = require('./src/commands/challenge');
 const auctionHandlers = require('./src/utils/auctionHouseHandlers');
 
@@ -69,6 +70,8 @@ client.on(Events.InteractionCreate, async interaction => {
       await inventoryHandlers.handleAbilitySelect(interaction);
     } else if (interaction.customId === 'equip-card') {
       await inventoryHandlers.handleEquipSelect(interaction);
+    } else if (interaction.customId === 'weapon-select') {
+      await inventoryHandlers.handleWeaponSelect(interaction);
     } else if (interaction.customId === 'merge-ability-select') {
       await inventoryHandlers.handleMergeSelect(interaction);
     } else if (interaction.customId === 'ah-sell-select') {
@@ -83,6 +86,12 @@ client.on(Events.InteractionCreate, async interaction => {
       await inventoryHandlers.handleMergeButton(interaction);
     } else if (interaction.customId === 'set-ability') {
       await inventoryHandlers.handleSetAbilityButton(interaction);
+    } else if (interaction.customId === 'set-weapon') {
+      await inventoryHandlers.handleSetWeaponButton(interaction);
+    } else if (interaction.customId === 'inv-view-abilities') {
+      await invViewHandlers.showAbilities(interaction);
+    } else if (interaction.customId === 'inv-view-weapons') {
+      await invViewHandlers.showWeapons(interaction);
     } else if (interaction.customId.startsWith('challenge-accept:')) {
       await challengeHandlers.handleAccept(interaction);
     } else if (interaction.customId.startsWith('challenge-decline:')) {

--- a/discord-bot/src/utils/inventoryHandlers.js
+++ b/discord-bot/src/utils/inventoryHandlers.js
@@ -1,0 +1,76 @@
+const { simple } = require('./embedBuilder');
+const userService = require('./userService');
+const abilityCardService = require('./abilityCardService');
+const weaponService = require('./weaponService');
+const gameData = require('../../util/gameData');
+
+function getAllAbilities() {
+  return Array.from(gameData.gameData.abilities.values());
+}
+
+function getAllWeapons() {
+  return Array.from(gameData.gameData.weapons.values());
+}
+
+function buildBaseEmbed(user, equippedAbility, equippedWeapon, backpack) {
+  return simple('Player Inventory', [
+    { name: 'Archetype', value: equippedAbility ? `${equippedAbility.class} (${equippedAbility.rarity})` : 'No Archetype Selected' },
+    { name: 'Equipped Ability', value: equippedAbility ? equippedAbility.name : 'None', inline: true },
+    { name: 'Equipped Weapon', value: equippedWeapon ? equippedWeapon.name : 'None', inline: true },
+    { name: 'Backpack', value: backpack }
+  ]);
+}
+
+async function showAbilities(interaction) {
+  const user = await userService.getUser(interaction.user.id);
+  if (!user) {
+    await interaction.update({ content: 'User not found.', components: [], ephemeral: true });
+    return;
+  }
+  const abilities = getAllAbilities();
+  const weapons = getAllWeapons();
+  const cards = await abilityCardService.getCards(user.id);
+  const weaponRows = await weaponService.getWeapons(user.id);
+  const equippedCard = cards.find(c => c.id === user.equipped_ability_id);
+  const equippedAbility = equippedCard ? abilities.find(a => a.id === equippedCard.ability_id) : null;
+  let equippedWeapon = null;
+  if (user.equipped_weapon_id) {
+    const wRow = await weaponService.getWeapon(user.equipped_weapon_id);
+    if (wRow) equippedWeapon = weapons.find(w => w.id === wRow.weapon_id);
+  }
+  const list = cards.length ? cards.map(c => {
+    const ab = abilities.find(a => a.id === c.ability_id);
+    return `${ab ? ab.name : 'Ability'} ${c.charges}/10`;
+  }).join('\n') : 'Your backpack is empty.';
+
+  const embed = buildBaseEmbed(user, equippedAbility, equippedWeapon, list);
+  await interaction.update({ embeds: [embed], components: interaction.message.components, ephemeral: true });
+}
+
+async function showWeapons(interaction) {
+  const user = await userService.getUser(interaction.user.id);
+  if (!user) {
+    await interaction.update({ content: 'User not found.', components: [], ephemeral: true });
+    return;
+  }
+  const abilities = getAllAbilities();
+  const weapons = getAllWeapons();
+  const cards = await abilityCardService.getCards(user.id);
+  const weaponRows = await weaponService.getWeapons(user.id);
+  const equippedCard = cards.find(c => c.id === user.equipped_ability_id);
+  const equippedAbility = equippedCard ? abilities.find(a => a.id === equippedCard.ability_id) : null;
+  let equippedWeapon = null;
+  if (user.equipped_weapon_id) {
+    const wRow = await weaponService.getWeapon(user.equipped_weapon_id);
+    if (wRow) equippedWeapon = weapons.find(w => w.id === wRow.weapon_id);
+  }
+  const list = weaponRows.length ? weaponRows.map(w => {
+    const base = weapons.find(a => a.id === w.weapon_id);
+    return base ? base.name : `Weapon ${w.weapon_id}`;
+  }).join('\n') : 'Your backpack is empty.';
+
+  const embed = buildBaseEmbed(user, equippedAbility, equippedWeapon, list);
+  await interaction.update({ embeds: [embed], components: interaction.message.components, ephemeral: true });
+}
+
+module.exports = { showAbilities, showWeapons };

--- a/discord-bot/src/utils/weaponService.js
+++ b/discord-bot/src/utils/weaponService.js
@@ -1,0 +1,37 @@
+const db = require('../../util/database');
+
+// Add a new weapon to a user's inventory
+async function addWeapon(userId, weaponId) {
+    const [result] = await db.query(
+        'INSERT INTO user_weapons (user_id, weapon_id) VALUES (?, ?)',
+        [userId, weaponId]
+    );
+    return result.insertId;
+}
+
+// Get all weapons owned by a user
+async function getWeapons(userId) {
+    const [rows] = await db.query('SELECT * FROM user_weapons WHERE user_id = ?', [userId]);
+    return rows;
+}
+
+// Get a single weapon instance by its unique ID
+async function getWeapon(weaponInstanceId) {
+    const [rows] = await db.query('SELECT * FROM user_weapons WHERE id = ?', [weaponInstanceId]);
+    return rows[0] || null;
+}
+
+// Mark a specific weapon as equipped if it belongs to the user
+async function setEquippedWeapon(userId, weaponInstanceId) {
+    await db.query(
+        `UPDATE users
+         SET equipped_weapon_id = ?
+         WHERE id = ? AND EXISTS (
+           SELECT 1 FROM user_weapons
+           WHERE id = ? AND user_id = ?
+         )`,
+        [weaponInstanceId, userId, weaponInstanceId, userId]
+    );
+}
+
+module.exports = { addWeapon, getWeapons, getWeapon, setEquippedWeapon };

--- a/discord-bot/tests/inventory.test.js
+++ b/discord-bot/tests/inventory.test.js
@@ -8,8 +8,14 @@ jest.mock('../src/utils/abilityCardService', () => ({
   getCards: jest.fn(),
   setEquippedCard: jest.fn()
 }));
+jest.mock('../src/utils/weaponService', () => ({
+  getWeapons: jest.fn(),
+  getWeapon: jest.fn(),
+  setEquippedWeapon: jest.fn()
+}));
 const userService = require('../src/utils/userService');
 const abilityCardService = require('../src/utils/abilityCardService');
+const weaponService = require('../src/utils/weaponService');
 const gameData = require('../util/gameData');
 const { allPossibleAbilities } = require('../../backend/game/data');
 
@@ -17,6 +23,8 @@ describe('inventory command', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     gameData.gameData.abilities = new Map(allPossibleAbilities.map(a => [a.id, a]));
+    weaponService.getWeapons.mockResolvedValue([]);
+    weaponService.getWeapon.mockResolvedValue(null);
   });
 
   test('public reply when user has a class', async () => {
@@ -24,6 +32,7 @@ describe('inventory command', () => {
     abilityCardService.getCards.mockResolvedValue([
       { id: 42, ability_id: 3111, charges: 5 }
     ]);
+    weaponService.getWeapons.mockResolvedValue([]);
     const interaction = {
       user: { id: '123', displayAvatarURL: jest.fn().mockReturnValue('https://example.com/avatar.png') },
       options: { getSubcommand: jest.fn().mockReturnValue('show') },
@@ -40,6 +49,7 @@ describe('inventory command', () => {
   test('shows inventory for user with no archetype', async () => {
     userService.getUser.mockResolvedValue({ id: 1, name: 'Tester', class: null, equipped_ability_id: null });
     abilityCardService.getCards.mockResolvedValue([]);
+    weaponService.getWeapons.mockResolvedValue([]);
     const interaction = {
       user: { id: '123', displayAvatarURL: jest.fn().mockReturnValue('https://example.com/avatar.png') },
       options: { getSubcommand: jest.fn().mockReturnValue('show') },
@@ -69,13 +79,14 @@ describe('inventory command', () => {
       { id: 42, ability_id: 3111, charges: 5 },
       { id: 43, ability_id: 3111, charges: 3 }
     ]);
+    weaponService.getWeapons.mockResolvedValue([]);
     const interaction = {
       user: { id: '123', displayAvatarURL: jest.fn().mockReturnValue('https://example.com/avatar.png') },
       options: { getSubcommand: jest.fn().mockReturnValue('show') },
       reply: jest.fn().mockResolvedValue()
     };
     await inventory.execute(interaction);
-    expect(interaction.reply.mock.calls[0][0].embeds[0].data.fields[2].value).toContain('Power Strike');
+    expect(interaction.reply.mock.calls[0][0].embeds[0].data.fields[3].value).toContain('Select a category');
   });
 
   test('set subcommand shows dropdown', async () => {

--- a/discord-bot/tests/weaponService.test.js
+++ b/discord-bot/tests/weaponService.test.js
@@ -1,0 +1,20 @@
+const weaponService = require('../src/utils/weaponService');
+
+jest.mock('../util/database', () => ({
+  query: jest.fn().mockResolvedValue([{ insertId: 1 }])
+}));
+const db = require('../util/database');
+
+describe('weaponService.addWeapon', () => {
+  beforeEach(() => {
+    db.query.mockClear();
+  });
+
+  test('inserts weapon instance for user', async () => {
+    await weaponService.addWeapon(5, 12);
+    expect(db.query).toHaveBeenCalledWith(
+      'INSERT INTO user_weapons (user_id, weapon_id) VALUES (?, ?)',
+      [5, 12]
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- add weapon service for inventory management
- refactor `/inventory show` to include weapons and filtering buttons
- add equip flow for weapons
- implement button handlers for inventory filters
- allow goblins and players to use weapons in `/adventure`
- support weapon loot drops
- add tests for new weapon service and updated flows

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68641ea6c25483279f55a112a5742beb