### PR TITLE
Add town command hub

### DIFF
--- a/discord-bot/commands/town.js
+++ b/discord-bot/commands/town.js
@@ -1,0 +1,42 @@
+const { SlashCommandBuilder, ActionRowBuilder, ButtonBuilder, ButtonStyle, EmbedBuilder } = require('discord.js');
+
+module.exports = {
+    data: new SlashCommandBuilder()
+        .setName('town')
+        .setDescription('Visit the town to prepare for your next adventure.'),
+    async execute(interaction) {
+        const embed = new EmbedBuilder()
+            .setTitle('Welcome to the Town')
+            .setDescription('The bustling town is full of adventurers. What would you like to do?')
+            .setImage('https://i.imgur.com/pB33g2h.png');
+
+        const row = new ActionRowBuilder().addComponents(
+            new ButtonBuilder()
+                .setCustomId('town-adventure')
+                .setLabel('Go on an Adventure')
+                .setStyle(ButtonStyle.Success)
+                .setEmoji('⚔️'),
+            new ButtonBuilder()
+                .setCustomId('town-inventory')
+                .setLabel('Check Inventory')
+                .setStyle(ButtonStyle.Secondary)
+                .setEmoji('🎒'),
+            new ButtonBuilder()
+                .setCustomId('town-leaderboard')
+                .setLabel('View Leaderboard')
+                .setStyle(ButtonStyle.Primary)
+                .setEmoji('🏆'),
+            new ButtonBuilder()
+                .setCustomId('town-auctionhouse')
+                .setLabel('Visit Auction House')
+                .setStyle(ButtonStyle.Primary)
+                .setEmoji('💰')
+        );
+
+        await interaction.reply({
+            embeds: [embed],
+            components: [row],
+            ephemeral: true
+        });
+    }
+};

--- a/discord-bot/deploy-commands.js
+++ b/discord-bot/deploy-commands.js
@@ -12,6 +12,7 @@ const commandDirs = [
   path.join(__dirname, 'commands/tutorial.js'),
   path.join(__dirname, 'commands/leaderboard.js'),
   path.join(__dirname, 'commands/auctionhouse.js'),
+  path.join(__dirname, 'commands/town.js'),
   path.join(__dirname, 'src/commands/adventure.js'),
   path.join(__dirname, 'src/commands/challenge.js'),
   path.join(__dirname, 'src/commands/practice.js')

--- a/discord-bot/index.js
+++ b/discord-bot/index.js
@@ -109,6 +109,28 @@ client.on(Events.InteractionCreate, async interaction => {
       await auctionHandlers.handleSellButton(interaction);
     } else if (interaction.customId === 'ah-buy-start') {
       await auctionHandlers.handleBuyButton(interaction);
+    } else if (interaction.customId === 'town-adventure') {
+      const adventureCommand = client.commands.get('adventure');
+      if (adventureCommand) {
+        await interaction.deferUpdate();
+        await adventureCommand.execute(interaction);
+      }
+    } else if (interaction.customId === 'town-inventory') {
+      const inventoryCommand = client.commands.get('inventory');
+      if (inventoryCommand) {
+        interaction.options = { getSubcommand: () => 'show' };
+        await inventoryCommand.execute(interaction);
+      }
+    } else if (interaction.customId === 'town-leaderboard') {
+      const leaderboardCommand = client.commands.get('leaderboard');
+      if (leaderboardCommand) {
+        await leaderboardCommand.execute(interaction);
+      }
+    } else if (interaction.customId === 'town-auctionhouse') {
+      const auctionhouseCommand = client.commands.get('auctionhouse');
+      if (auctionhouseCommand) {
+        await auctionhouseCommand.execute(interaction);
+      }
     }
   } else if (interaction.isModalSubmit()) {
     if (interaction.customId.startsWith('ah-sell-modal:')) {

--- a/discord-bot/tests/town.test.js
+++ b/discord-bot/tests/town.test.js
@@ -1,0 +1,9 @@
+const town = require('../commands/town');
+
+test('replies with town hub embed', async () => {
+  const interaction = { reply: jest.fn().mockResolvedValue() };
+  await town.execute(interaction);
+  expect(interaction.reply).toHaveBeenCalledWith(
+    expect.objectContaining({ embeds: expect.any(Array), components: expect.any(Array), ephemeral: true })
+  );
+});


### PR DESCRIPTION
## Summary
- add `/town` command to act as a hub for other commands
- register new command in deploy script
- handle new button interactions in `index.js`
- test coverage for the new command

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6864238c81dc83278b6e9cc3e636c681