### PR TITLE
Update town command to use ephemeral flag

### DIFF
--- a/discord-bot/commands/town.js
+++ b/discord-bot/commands/town.js
@@ -1,4 +1,4 @@
-const { SlashCommandBuilder, ActionRowBuilder, ButtonBuilder, ButtonStyle, EmbedBuilder } = require('discord.js');
+const { SlashCommandBuilder, ActionRowBuilder, ButtonBuilder, ButtonStyle, EmbedBuilder, MessageFlags } = require('discord.js');
 
 module.exports = {
     data: new SlashCommandBuilder()
@@ -8,7 +8,7 @@ module.exports = {
         const embed = new EmbedBuilder()
             .setTitle('Welcome to the Town')
             .setDescription('The bustling town is full of adventurers. What would you like to do?')
-            .setImage('https://i.imgur.com/pB33g2h.png');
+            .setImage('https://i.imgur.com/2pCIH22.png');
 
         const row = new ActionRowBuilder().addComponents(
             new ButtonBuilder()
@@ -36,7 +36,7 @@ module.exports = {
         await interaction.reply({
             embeds: [embed],
             components: [row],
-            ephemeral: true
+            flags: [MessageFlags.Ephemeral]
         });
     }
 };

--- a/discord-bot/tests/town.test.js
+++ b/discord-bot/tests/town.test.js
@@ -1,9 +1,10 @@
 const town = require('../commands/town');
+const { MessageFlags } = require('discord.js');
 
 test('replies with town hub embed', async () => {
   const interaction = { reply: jest.fn().mockResolvedValue() };
   await town.execute(interaction);
   expect(interaction.reply).toHaveBeenCalledWith(
-    expect.objectContaining({ embeds: expect.any(Array), components: expect.any(Array), ephemeral: true })
+    expect.objectContaining({ embeds: expect.any(Array), components: expect.any(Array), flags: [MessageFlags.Ephemeral] })
   );
 });


### PR DESCRIPTION
## Summary
- point the Town embed at a valid image URL
- swap `ephemeral: true` for `flags: [MessageFlags.Ephemeral]`
- update the town command test accordingly

## Testing
- `npm test` in `discord-bot`
- `npm test` in `backend`


------
https://chatgpt.com/codex/tasks/task_e_6864283642c08327a19974c9b8cb9e00