### PR TITLE
Add reusable navigation component

### DIFF
--- a/discord-bot/src/utils/components.js
+++ b/discord-bot/src/utils/components.js
@@ -1,0 +1,13 @@
+const { ActionRowBuilder, ButtonBuilder, ButtonStyle } = require('discord.js');
+
+function createBackToTownRow() {
+  return new ActionRowBuilder().addComponents(
+    new ButtonBuilder()
+      .setCustomId('nav-town')
+      .setLabel('Back to Town')
+      .setStyle(ButtonStyle.Secondary)
+      .setEmoji('🏠')
+  );
+}
+
+module.exports = { createBackToTownRow };


### PR DESCRIPTION
## Summary
- add a `createBackToTownRow` helper to build the Town navigation button

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68642cb9703883279a1f62a50672d77a