### PR TITLE
Add Back to Town button in adventure summary

### DIFF
--- a/discord-bot/src/commands/adventure.js
+++ b/discord-bot/src/commands/adventure.js
@@ -10,6 +10,7 @@ const abilityCardService = require('../utils/abilityCardService');
 const weaponService = require('../utils/weaponService');
 const { sendCardDM } = require('../utils/embedBuilder');
 const { runBattleLoop, sendBattleLogDM, formatLog } = require('../utils/battleRunner');
+const { createBackToTownRow } = require('../utils/navigation');
 
 const GameEngine = require('../../../backend/game/engine');
 const { createCombatant } = require('../../../backend/game/utils');
@@ -209,7 +210,7 @@ async function execute(interaction) {
     .setColor(engine.winner === 'player' ? '#57F287' : '#ED4245')
     .setDescription(narrativeDescription);
 
-  await interaction.followUp({ embeds: [summaryEmbed] });
+  await interaction.followUp({ embeds: [summaryEmbed], components: [createBackToTownRow()] });
 
   if (engine.finalPlayerState.equipped_ability_id) {
     await userService.setActiveAbility(

--- a/discord-bot/src/utils/navigation.js
+++ b/discord-bot/src/utils/navigation.js
@@ -1,0 +1,12 @@
+const { ActionRowBuilder, ButtonBuilder, ButtonStyle } = require('discord.js');
+
+function createBackToTownRow() {
+  return new ActionRowBuilder().addComponents(
+    new ButtonBuilder()
+      .setCustomId('nav-town')
+      .setLabel('Back to Town')
+      .setStyle(ButtonStyle.Secondary)
+  );
+}
+
+module.exports = { createBackToTownRow };

--- a/discord-bot/tests/adventure.test.js
+++ b/discord-bot/tests/adventure.test.js
@@ -90,7 +90,11 @@ describe('adventure command', () => {
       0
     );
     expect(interaction.reply).toHaveBeenCalledWith(expect.objectContaining({ content: expect.stringContaining('Goblin') }));
-    expect(interaction.followUp).toHaveBeenCalledWith(expect.objectContaining({ embeds: expect.any(Array) }));
+    const summaryCall = interaction.followUp.mock.calls.find(c => Array.isArray(c[0].components));
+    expect(summaryCall).toBeDefined();
+    expect(summaryCall[0]).toEqual(expect.objectContaining({ embeds: expect.any(Array), components: expect.any(Array) }));
+    const components = summaryCall[0].components;
+    expect(components[0].components[0].data.custom_id).toBe('nav-town');
   });
 
   test('warns when equipped ability has no charges', async () => {


### PR DESCRIPTION
## Summary
- create `createBackToTownRow` utility for navigation
- show a Back to Town button when posting battle summary
- test for `nav-town` button on adventure summary

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68642cba14c083279ba199c6008fd70d