### PR TITLE
Add nav-town handler and test

### DIFF
--- a/discord-bot/index.js
+++ b/discord-bot/index.js
@@ -131,6 +131,11 @@ client.on(Events.InteractionCreate, async interaction => {
       if (auctionhouseCommand) {
         await auctionhouseCommand.execute(interaction);
       }
+    } else if (interaction.customId === 'nav-town') {
+      const townCommand = client.commands.get('town');
+      if (townCommand) {
+        await townCommand.execute(interaction);
+      }
     }
   } else if (interaction.isModalSubmit()) {
     if (interaction.customId.startsWith('ah-sell-modal:')) {

--- a/discord-bot/tests/index.test.js
+++ b/discord-bot/tests/index.test.js
@@ -1,0 +1,75 @@
+const EventEmitter = require('events');
+
+jest.mock('node:fs', () => ({
+  existsSync: jest.fn(() => false),
+  readdirSync: jest.fn(() => [])
+}));
+jest.mock('fs', () => ({
+  existsSync: jest.fn(() => false),
+  readdirSync: jest.fn(() => [])
+}));
+
+jest.mock('../util/config', () => ({ DISCORD_TOKEN: 'token' }));
+
+jest.mock('discord.js', () => {
+  const { EventEmitter } = require('events');
+  const clients = [];
+  class MockClient extends EventEmitter {
+    constructor() {
+      super();
+      this.commands = new Map();
+      this.login = jest.fn();
+      clients.push(this);
+    }
+  }
+  class StubBuilder {
+    constructor() {
+      const proxy = new Proxy(this, {
+        get: (target, prop) => {
+          if (prop === 'toJSON') return () => ({})
+          return function(...args) {
+            if (typeof args[0] === 'function') {
+              args[0](new StubBuilder());
+            }
+            return proxy;
+          };
+        }
+      });
+      return proxy;
+    }
+  }
+  return {
+    Client: MockClient,
+    Collection: Map,
+    GatewayIntentBits: { Guilds: 0 },
+    Events: { ClientReady: 'ready', InteractionCreate: 'interactionCreate' },
+    SlashCommandBuilder: StubBuilder,
+    ActionRowBuilder: StubBuilder,
+    ButtonBuilder: StubBuilder,
+    StringSelectMenuBuilder: StubBuilder,
+    EmbedBuilder: StubBuilder,
+    ButtonStyle: { Primary: 1, Secondary: 2, Success: 3 },
+    MessageFlags: { Ephemeral: 64 },
+    __clients: clients
+  };
+});
+
+const discord = require('discord.js');
+
+require('../index.js');
+
+test('nav-town button calls town command', async () => {
+  const client = discord.__clients[0];
+  const handler = client.listeners('interactionCreate')[0];
+  const town = { execute: jest.fn() };
+  client.commands.set('town', town);
+  const interaction = {
+    isChatInputCommand: jest.fn(() => false),
+    isAutocomplete: jest.fn(() => false),
+    isStringSelectMenu: jest.fn(() => false),
+    isButton: jest.fn(() => true),
+    customId: 'nav-town'
+  };
+  await handler(interaction);
+  expect(town.execute).toHaveBeenCalledWith(interaction);
+});


### PR DESCRIPTION
## Summary
- add `nav-town` handler to bot
- test that `nav-town` triggers the town command

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68642cbcaf3c83279717a887c43ad421