### PR TITLE
Add XP visibility to adventure and inventory

### DIFF
--- a/discord-bot/commands/inventory.js
+++ b/discord-bot/commands/inventory.js
@@ -7,6 +7,7 @@ const {
 } = require('discord.js');
 const { simple } = require('../src/utils/embedBuilder');
 const userService = require('../src/utils/userService');
+const { XP_THRESHOLDS } = require('../src/utils/userService');
 const abilityCardService = require('../src/utils/abilityCardService');
 const weaponService = require('../src/utils/weaponService');
 const { createBackToTownRow } = require('../src/utils/components');
@@ -103,9 +104,21 @@ async function execute(interaction) {
       }
     }
 
+    let xpDisplay = 'MAX LEVEL';
+    if (user.level < 4) {
+      const nextLevelXp = XP_THRESHOLDS[user.level];
+      const prevLevelXp = XP_THRESHOLDS[user.level - 1] || 0;
+      const currentLevelProgress = user.xp - prevLevelXp;
+      const xpForThisLevel = nextLevelXp - prevLevelXp;
+      xpDisplay = `${currentLevelProgress} / ${xpForThisLevel}`;
+    }
+
     const embed = simple(
       'Player Inventory',
       [
+        { name: 'Player', value: user.name },
+        { name: 'Level', value: `${user.level}`, inline: true },
+        { name: 'XP', value: xpDisplay, inline: true },
         { name: 'Archetype', value: archetype },
         { name: 'Equipped Ability', value: equippedName, inline: true },
         { name: 'Equipped Weapon', value: equippedWeapon ? equippedWeapon.name : 'None', inline: true },

--- a/discord-bot/src/commands/adventure.js
+++ b/discord-bot/src/commands/adventure.js
@@ -165,6 +165,9 @@ async function execute(interaction) {
   if (engine.winner === 'player') {
     await userService.incrementPveWin(user.id);
 
+    const xpGained = 10;
+    const xpResult = await userService.addXp(user.id, xpGained);
+
     let lootMessages = [];
     if (goblinLoot.gold > 0) {
       await userService.addGold(user.id, goblinLoot.gold);
@@ -188,14 +191,14 @@ async function execute(interaction) {
       );
     }
 
+    lootMessages.push(`earned **${xpGained} XP**`);
+
     let lootString = 'and was victorious!';
     if (lootMessages.length > 0) {
       lootString = 'and ' + lootMessages.join(', ') + '!';
     }
 
     narrativeDescription = `${interaction.user.username} defeated the goblin ${lootString}`;
-
-    const xpResult = await userService.addXp(user.id, 10);
     if (xpResult.leveledUp) {
       await interaction.followUp({
         content: `🎉 **Congratulations, ${interaction.user.username}! You have reached Level ${xpResult.newLevel}!** 🎉`

--- a/discord-bot/src/utils/userService.js
+++ b/discord-bot/src/utils/userService.js
@@ -136,6 +136,7 @@ async function setDmPreference(discordId, preferenceKey, isEnabled) {
 }
 
 module.exports = {
+  XP_THRESHOLDS,
   getUser,
   createUser,
   getUserByName,

--- a/discord-bot/tests/inventory.test.js
+++ b/discord-bot/tests/inventory.test.js
@@ -2,7 +2,8 @@ const inventory = require('../commands/inventory');
 
 jest.mock('../src/utils/userService', () => ({
   getUser: jest.fn(),
-  createUser: jest.fn()
+  createUser: jest.fn(),
+  XP_THRESHOLDS: { 1: 5000, 2: 12500, 3: 22500, 4: Infinity }
 }));
 jest.mock('../src/utils/abilityCardService', () => ({
   getCards: jest.fn(),
@@ -42,8 +43,9 @@ describe('inventory command', () => {
     expect(interaction.reply).toHaveBeenCalledWith(expect.objectContaining({ embeds: expect.any(Array) }));
     expect(interaction.reply.mock.calls[0][0].ephemeral).toBe(true);
     const fields = interaction.reply.mock.calls[0][0].embeds[0].data.fields;
-    expect(fields[0].value).toContain('Stalwart Defender (Common)');
-    expect(fields[1].value).toContain('Power Strike');
+    const fieldMap = Object.fromEntries(fields.map(f => [f.name, f.value]));
+    expect(fieldMap.Archetype).toContain('Stalwart Defender (Common)');
+    expect(fieldMap['Equipped Ability']).toContain('Power Strike');
     const navButton = interaction.reply.mock.calls[0][0].components
       .flatMap(r => r.components)
       .find(c => c.data?.custom_id === 'nav-town');
@@ -62,7 +64,8 @@ describe('inventory command', () => {
     await inventory.execute(interaction);
     expect(interaction.reply).toHaveBeenCalledWith(expect.objectContaining({ embeds: expect.any(Array) }));
     const fields = interaction.reply.mock.calls[0][0].embeds[0].data.fields;
-    expect(fields[0].value).toContain('No Archetype Selected');
+    const fieldMap = Object.fromEntries(fields.map(f => [f.name, f.value]));
+    expect(fieldMap.Archetype).toContain('No Archetype Selected');
     const navButton = interaction.reply.mock.calls[0][0].components
       .flatMap(r => r.components)
       .find(c => c.data?.custom_id === 'nav-town');
@@ -98,7 +101,9 @@ describe('inventory command', () => {
       reply: jest.fn().mockResolvedValue()
     };
     await inventory.execute(interaction);
-    expect(interaction.reply.mock.calls[0][0].embeds[0].data.fields[3].value).toContain('Select a category');
+    const fields = interaction.reply.mock.calls[0][0].embeds[0].data.fields;
+    const fieldMap = Object.fromEntries(fields.map(f => [f.name, f.value]));
+    expect(fieldMap.Backpack).toContain('Select a category');
     const navButton = interaction.reply.mock.calls[0][0].components
       .flatMap(r => r.components)
       .find(c => c.data?.custom_id === 'nav-town');


### PR DESCRIPTION
## Summary
- show XP gained in adventure victory text
- expose XP_THRESHOLDS constant from `userService`
- display player XP progress in the `/inventory show` embed
- update inventory tests for new embed fields

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6864620f1efc8327a956d8fd2f445d11