### PR TITLE
Add Continue Adventuring button

### DIFF
--- a/discord-bot/index.js
+++ b/discord-bot/index.js
@@ -80,7 +80,21 @@ client.on(Events.InteractionCreate, async interaction => {
       await auctionHandlers.handleBuySelect(interaction);
     }
   } else if (interaction.isButton()) {
-    if (interaction.customId === 'inventory-equip-start') {
+    const [customId, targetUserId] = interaction.customId.split(':');
+
+    if (targetUserId && interaction.user.id !== targetUserId) {
+      return interaction.reply({ content: "This isn't your adventure!", ephemeral: true });
+    }
+
+    if (customId === 'continue-adventure') {
+      await interaction.update({ content: 'Delving deeper into the caves...', components: [] });
+      const command = client.commands.get('adventure');
+      if (command) {
+        await command.execute(interaction);
+      }
+    } else if (customId === 'back-to-town') {
+      await interaction.update({ content: 'You head back to the relative safety of the town.', components: [] });
+    } else if (customId === 'inventory-equip-start') {
       await inventoryHandlers.handleEquipButton(interaction);
     } else if (interaction.customId === 'inventory-merge-start') {
       await inventoryHandlers.handleMergeButton(interaction);

--- a/discord-bot/tests/adventure.test.js
+++ b/discord-bot/tests/adventure.test.js
@@ -93,8 +93,10 @@ describe('adventure command', () => {
     const summaryCall = interaction.followUp.mock.calls.find(c => Array.isArray(c[0].components));
     expect(summaryCall).toBeDefined();
     expect(summaryCall[0]).toEqual(expect.objectContaining({ embeds: expect.any(Array), components: expect.any(Array) }));
-    const components = summaryCall[0].components;
-    expect(components[0].components[0].data.custom_id).toBe('nav-town');
+    const components = summaryCall[0].components[0].components;
+    expect(components).toHaveLength(2);
+    expect(components[0].data.custom_id).toBe('back-to-town');
+    expect(components[1].data.custom_id).toBe(`continue-adventure:${interaction.user.id}`);
   });
 
   test('warns when equipped ability has no charges', async () => {

--- a/discord-bot/tests/index.test.js
+++ b/discord-bot/tests/index.test.js
@@ -73,3 +73,22 @@ test('nav-town button calls town command', async () => {
   await handler(interaction);
   expect(town.execute).toHaveBeenCalledWith(interaction);
 });
+
+test('continue-adventure button calls adventure command', async () => {
+  const client = discord.__clients[0];
+  const handler = client.listeners('interactionCreate')[0];
+  const adventure = { execute: jest.fn() };
+  client.commands.set('adventure', adventure);
+  const interaction = {
+    isChatInputCommand: jest.fn(() => false),
+    isAutocomplete: jest.fn(() => false),
+    isStringSelectMenu: jest.fn(() => false),
+    isButton: jest.fn(() => true),
+    customId: 'continue-adventure:123',
+    user: { id: '123' },
+    update: jest.fn().mockResolvedValue()
+  };
+  await handler(interaction);
+  expect(interaction.update).toHaveBeenCalled();
+  expect(adventure.execute).toHaveBeenCalledWith(interaction);
+});


### PR DESCRIPTION
## Summary
- support starting an adventure again from the victory message
- update the adventure command to show Back to Town and Continue buttons
- handle the new buttons in the interaction handler
- adjust tests for updated button layout and add coverage for the Continue button

## Testing
- `npm test --silent --prefix discord-bot`

------
https://chatgpt.com/codex/tasks/task_e_6864659388d08327b99464c131634e20