### PR TITLE
Implement adventure cooldown and improved navigation

### DIFF
--- a/discord-bot/commands/adventure.js
+++ b/discord-bot/commands/adventure.js
@@ -1,0 +1,40 @@
+const { SlashCommandBuilder, EmbedBuilder } = require('discord.js');
+const { createBackToTownRow } = require('../utils/components');
+
+const adventureCooldowns = new Map();
+const COOLDOWN_SECONDS = 30;
+
+module.exports = {
+    data: new SlashCommandBuilder()
+        .setName('adventure')
+        .setDescription('Embark on a daring adventure.'),
+
+    async execute(interaction) {
+        const lastAdventureTime = adventureCooldowns.get(interaction.user.id);
+        if (lastAdventureTime) {
+            const timePassed = (Date.now() - lastAdventureTime) / 1000;
+            if (timePassed < COOLDOWN_SECONDS) {
+                const timeLeft = Math.ceil(COOLDOWN_SECONDS - timePassed);
+                const replyMethod = interaction.isButton() ? 'update' : 'reply';
+                await interaction[replyMethod]({
+                    content: `You need to rest. You can go on another adventure in ${timeLeft} seconds.`,
+                    ephemeral: true,
+                    embeds: [],
+                    components: []
+                });
+                return;
+            }
+        }
+
+        await interaction.reply({ content: 'You venture forth in search of glory...', ephemeral: true });
+
+        const summaryEmbed = new EmbedBuilder()
+            .setColor('#57F287')
+            .setDescription('After a brief skirmish, you return victorious!');
+
+        const backToTownRow = createBackToTownRow(true);
+        await interaction.followUp({ embeds: [summaryEmbed], components: [backToTownRow] });
+
+        adventureCooldowns.set(interaction.user.id, Date.now());
+    }
+};

--- a/discord-bot/index.js
+++ b/discord-bot/index.js
@@ -73,7 +73,9 @@ const BOOSTER_PACKS = {
 
 // Load commands
 const townCommand = require('./commands/town');
+const adventureCommand = require('./commands/adventure');
 client.commands.set(townCommand.data.name, townCommand);
+client.commands.set(adventureCommand.data.name, adventureCommand);
 
 client.once(Events.ClientReady, () => {
     console.log('Bot ready');
@@ -89,6 +91,32 @@ client.on(Events.InteractionCreate, async interaction => {
     }
 
     if (!interaction.isButton()) return;
+
+    // Navigation buttons for returning to town
+    if (interaction.customId === 'nav-town-new') {
+        const townCommand = client.commands.get('town');
+        if (townCommand) {
+            await townCommand.execute(interaction);
+        }
+        return;
+    }
+
+    if (interaction.customId === 'nav-town') {
+        const townEmbed = new EmbedBuilder()
+            .setTitle("Welcome to Portal's Rest")
+            .setDescription('The bustling town is full of adventurers. What would you like to do?')
+            .setImage('https://i.imgur.com/2pCIH22.png');
+
+        const townRow = new ActionRowBuilder().addComponents(
+            new ButtonBuilder().setCustomId('town-adventure').setLabel('Go on an Adventure').setStyle(ButtonStyle.Success).setEmoji('⚔️'),
+            new ButtonBuilder().setCustomId('town-inventory').setLabel('Check Inventory').setStyle(ButtonStyle.Secondary).setEmoji('🎒'),
+            new ButtonBuilder().setCustomId('town-leaderboard').setLabel('View Leaderboard').setStyle(ButtonStyle.Primary).setEmoji('🏆'),
+            new ButtonBuilder().setCustomId('town-auctionhouse').setLabel('Visit Auction House').setStyle(ButtonStyle.Primary).setEmoji('💰')
+        );
+
+        await interaction.update({ content: '', embeds: [townEmbed], components: [townRow] });
+        return;
+    }
 
     const userId = interaction.user.id;
 
@@ -215,6 +243,14 @@ client.on(Events.InteractionCreate, async interaction => {
                 new ButtonBuilder().setCustomId('back_to_town').setLabel('Back to Town').setStyle(ButtonStyle.Secondary).setEmoji('⬅️')
             );
             await interaction.editReply({ embeds: [marketEmbed], components: [storeButton, navigationRow] });
+            break;
+        }
+
+        case interaction.customId === 'town-adventure': {
+            const adventure = client.commands.get('adventure');
+            if (adventure) {
+                await adventure.execute(interaction);
+            }
             break;
         }
 

--- a/discord-bot/utils/components.js
+++ b/discord-bot/utils/components.js
@@ -1,0 +1,19 @@
+const { ActionRowBuilder, ButtonBuilder, ButtonStyle } = require('discord.js');
+
+/**
+ * Creates an ActionRow with a "Back to Town" button.
+ * @param {boolean} [asNewMessage=false] - If true, the button ID triggers a new reply.
+ * @returns {ActionRowBuilder}
+ */
+function createBackToTownRow(asNewMessage = false) {
+    return new ActionRowBuilder()
+        .addComponents(
+            new ButtonBuilder()
+                .setCustomId(asNewMessage ? 'nav-town-new' : 'nav-town')
+                .setLabel('Back to Town')
+                .setStyle(ButtonStyle.Secondary)
+                .setEmoji('🏠')
+        );
+}
+
+module.exports = { createBackToTownRow };


### PR DESCRIPTION
## Summary
- create reusable button row in `utils/components`
- add `/adventure` slash command with 30s cooldown
- load new command and handle new town navigation buttons
- allow adventure button from town menu

## Testing
- `node --check discord-bot/utils/components.js`
- `node --check discord-bot/commands/adventure.js`
- `node --check discord-bot/index.js`


------
https://chatgpt.com/codex/tasks/task_e_6864c232647c8327b772e837f2fe4390