### PR TITLE
Fix tutorial goblin name

### DIFF
--- a/discord-bot/commands/tutorial.js
+++ b/discord-bot/commands/tutorial.js
@@ -45,6 +45,7 @@ async function execute(interaction) {
 
     const goblin = {
       id: 'enemy-0',
+      name: 'Tutorial Goblin',
       heroData: { name: 'Tutorial Goblin', hp: 10, attack: 1, speed: 1, defense: 0 },
       weaponData: rustyKnife,
       armorData: null,


### PR DESCRIPTION
## Summary
- fix tutorial goblin `name` property so logs show **Tutorial Goblin**

## Testing
- `npm install` in `discord-bot`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6864d08cf44c83278602eab8abd1db0f