### PR TITLE
Expand XP system through level 10

### DIFF
--- a/discord-bot/commands/inventory.js
+++ b/discord-bot/commands/inventory.js
@@ -105,7 +105,7 @@ async function execute(interaction) {
     }
 
     let xpDisplay = 'MAX LEVEL';
-    if (user.level < 4) {
+    if (XP_THRESHOLDS[user.level] !== Infinity) {
       const nextLevelXp = XP_THRESHOLDS[user.level];
       const prevLevelXp = XP_THRESHOLDS[user.level - 1] || 0;
       const currentLevelProgress = user.xp - prevLevelXp;

--- a/discord-bot/src/utils/userService.js
+++ b/discord-bot/src/utils/userService.js
@@ -11,7 +11,13 @@ const XP_THRESHOLDS = {
   1: 5000,
   2: 12500,
   3: 22500,
-  4: Infinity // Level cap
+  4: 35000,
+  5: 50000,
+  6: 67500,
+  7: 87500,
+  8: 110000,
+  9: 135000,
+  10: Infinity // Level cap
 };
 
 async function getUser(discordId) {
@@ -66,8 +72,9 @@ async function addGold(userId, amount) {
 async function addXp(userId, amount) {
   const [rows] = await db.query('SELECT id, level, xp FROM users WHERE id = ?', [userId]);
   const user = rows[0];
-  if (!user || user.level >= 4) {
-    return { leveledUp: false, newLevel: user ? user.level : undefined };
+  if (!user) return null;
+  if (user.level >= 10) {
+    return { leveledUp: false, newLevel: user.level };
   }
 
   const newXp = user.xp + amount;

--- a/discord-bot/tests/inventory.test.js
+++ b/discord-bot/tests/inventory.test.js
@@ -3,7 +3,18 @@ const inventory = require('../commands/inventory');
 jest.mock('../src/utils/userService', () => ({
   getUser: jest.fn(),
   createUser: jest.fn(),
-  XP_THRESHOLDS: { 1: 5000, 2: 12500, 3: 22500, 4: Infinity }
+  XP_THRESHOLDS: {
+    1: 5000,
+    2: 12500,
+    3: 22500,
+    4: 35000,
+    5: 50000,
+    6: 67500,
+    7: 87500,
+    8: 110000,
+    9: 135000,
+    10: Infinity
+  }
 }));
 jest.mock('../src/utils/abilityCardService', () => ({
   getCards: jest.fn(),

--- a/discord-bot/tests/userService.test.js
+++ b/discord-bot/tests/userService.test.js
@@ -52,10 +52,10 @@ describe('userService.addXp', () => {
   });
 
   test('no xp when at level cap', async () => {
-    db.query.mockResolvedValueOnce([[{ id: 1, level: 4, xp: 22500 }]]);
+    db.query.mockResolvedValueOnce([[{ id: 1, level: 10, xp: 135000 }]]);
 
     const result = await userService.addXp(1, 10);
     expect(db.query).toHaveBeenCalledTimes(1);
-    expect(result).toEqual({ leveledUp: false, newLevel: 4 });
+    expect(result).toEqual({ leveledUp: false, newLevel: 10 });
   });
 });


### PR DESCRIPTION
## Summary
- extend XP table in `userService` up to level 10
- allow leveling past 4 and enforce cap at level 10
- show XP progress until level 10 in inventory display
- update tests for new levels

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6864d50d29b48327b1f8d5fe73afb854