### PR TITLE
Update proc system documentation

### DIFF
--- a/docs/proc_system.md
+++ b/docs/proc_system.md
@@ -1,37 +1,82 @@
 # Proc System
 
-This document explains how passive procs are defined in the prototype and how the battle engine applies them during combat.
+The combat engine supports data-driven "procs" – conditional effects attached to equipment. Weapons and armor may include a `procs` array and each entry in that array describes when the proc triggers and what it does.
 
-## Proc Object Structure
-A proc object describes a conditional effect that may occur when a specific trigger fires. It is typically attached to a weapon via the `passiveEffect` field.
-
-Example from `backend/game/data.js`:
+## Procs Array Structure
+A proc object is a plain JSON record placed inside an item's `procs` array. An example from `backend/game/data.js`:
 ```javascript
-{ trigger: 'on_auto_attack', chance: 0.25, effect: 'Poison', duration: 2 }
+{ trigger: 'on_attack', effect: 'bonus_damage', value: 2, condition: { target_hp_below: 0.5 } }
 ```
 
-The object fields are:
+Common fields are:
+- **trigger** – event name that causes the proc to be evaluated.
+- **effect** – identifier for the action or status to apply.
+- **value** – numeric amount used by many effects (damage, stat bonus, etc.).
+- **status** – status name when the effect applies a condition.
+- **duration** – how many turns the status lasts.
+- **chance** – optional probability (0–1) the proc activates.
+- **condition** – object with additional requirements (see below).
+- **target**, **stat**, **permanent**, **once_per_combat**, **damage_type** – extra keys used by specific effects.
 
-- **trigger** – event name that causes the proc to be evaluated. The current implementation uses `on_auto_attack`.
-- **chance** – number between `0` and `1` representing the probability that the proc activates when its trigger occurs.
-- **effect** – name of the effect to apply. Common effects include `Poison`, `Slow`, `Armor Break`, `Stun`, `BonusDamagePoisoned`, `BonusDamageIfFaster`, `AttackDownIfLast`, `CannotBeEvaded`, `HealOnAbility`, `AbilityDamageBoost`, `ExtraEnergy`, `GainDefenseOnStart`, `Guardian`, and `StunOnFirstHit`.
-- **duration** – optional number of turns that a status effect lasts.
-- **amount** – optional numeric value used by some effects (for example bonus damage or defense gained).
+## Supported Triggers
+The current data defines the following trigger strings:
+- `on_combat_start`
+- `on_attack`
+- `on_hit`
+- `on_attacked`
+- `on_ability_used`
+- `on_ability_targeted`
+- `on_kill`
+- `on_status_applied`
 
-Some effect names encode additional conditions (e.g. `IfFaster` or `OnFirstHit`). These are interpreted by the battle engine as bespoke rules when implemented.
+`GameEngine` presently fires `on_combat_start`, `on_attack`, `on_hit`, `on_attacked` and `on_ability_used`. Other triggers are reserved for future expansion.
 
-## Battle Engine Processing
-During a turn the engine resolves each combatant's auto‑attack. After dealing damage it checks the attacker’s weapon for a `passiveEffect`. If the trigger matches and a random roll is less than the listed `chance`, the effect is applied to the defender.
-
-Snippet from `engine.js` demonstrating this logic:
+## Condition Processing
+When `ProcEngine.trigger()` runs, it scans the attacker and defender's equipment for procs matching the event name. For each candidate proc it calls `checkConditions` to verify optional rules:
 ```javascript
-const weapon = attacker.weaponData;
-if (weapon && weapon.passiveEffect && weapon.passiveEffect.trigger === 'on_auto_attack') {
-    if (Math.random() < weapon.passiveEffect.chance) {
-        const eff = weapon.passiveEffect;
-        this.applyStatusEffect(targetEnemy, eff.effect, eff.duration, { amount: eff.amount });
-    }
+if (proc.condition.first_attack && (attacker.attacksMade || 0) > 0) return false;
+if (proc.condition.target_hp_below && (defender.currentHp / defender.maxHp) >= proc.condition.target_hp_below) return false;
+if (proc.condition.attacker_is_faster && attacker.speed <= defender.speed) return false;
+if (proc.condition.target_has_status) {
+    const hasStatus = proc.condition.target_has_status.some(status =>
+        defender.statusEffects.some(e => e.name === status)
+    );
+    if (!hasStatus) return false;
 }
 ```
+Only when all conditions pass does the proc's effect activate.
 
-Effects resolved here typically add a status effect to the target via `applyStatusEffect`, after which they are processed like any other status during subsequent turns.
+## Effect Resolution
+`executeEffect` performs the proc action. A summary of the implemented handlers:
+```javascript
+switch (proc.effect) {
+    case 'cleave':
+        const others = allCombatants.filter(c => c.team !== attacker.team && c.id !== defender.id && c.currentHp > 0);
+        for (const enemy of others) {
+            context.applyDamage(attacker, enemy, proc.value);
+        }
+        break;
+    case 'apply_status':
+        if (!proc.chance || Math.random() < proc.chance) {
+            context.applyStatus(defender, proc.status, proc.duration, { damage: proc.value });
+        }
+        break;
+    case 'bonus_damage':
+        if (!proc.chance || Math.random() < proc.chance) {
+            context.applyDamage(attacker, defender, proc.value);
+        }
+        break;
+    case 'apply_status_to_attacker':
+        if (!proc.chance || Math.random() < proc.chance) {
+            context.applyStatus(attacker, proc.status, proc.duration, { damage: proc.value });
+        }
+        break;
+    default:
+        if (!proc.chance || Math.random() < proc.chance) {
+            context.applyStatus(defender, proc.effect, proc.duration, { amount: proc.amount });
+        }
+        break;
+}
+```
+Unrecognised effect names fall through to the `default` case and are treated as status effects on the defender.
+


### PR DESCRIPTION
## Summary
- document the current `procs` array layout and supported trigger names
- explain how `ProcEngine` checks conditions and runs effects

## Testing
- `npm install --silent` in `backend`
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68654a3ecc6c83279cdc13e590ef4e15