### PR TITLE
Handle once_per_combat procs

### DIFF
--- a/backend/game/procEngine.js
+++ b/backend/game/procEngine.js
@@ -9,6 +9,21 @@ class ProcEngine {
             battleLog.push({ round: this.roundCounter, level, ...entry });
         };
         this.roundCounter = 0;
+        this.usedProcs = new Map();
+    }
+
+    hasProcTriggered(combatant, proc) {
+        const set = this.usedProcs.get(combatant.id);
+        return set ? set.has(proc) : false;
+    }
+
+    markProcTriggered(combatant, proc) {
+        let set = this.usedProcs.get(combatant.id);
+        if (!set) {
+            set = new Set();
+            this.usedProcs.set(combatant.id, set);
+        }
+        set.add(proc);
     }
 
     // A central function to check for any procs that should activate.
@@ -24,7 +39,13 @@ class ProcEngine {
 
                 for (const proc of item.procs) {
                     if (proc.trigger === eventName && this.checkConditions(proc, context)) {
+                        if (proc.once_per_combat && this.hasProcTriggered(combatant, proc)) {
+                            continue;
+                        }
                         this.executeEffect(proc, context);
+                        if (proc.once_per_combat) {
+                            this.markProcTriggered(combatant, proc);
+                        }
                     }
                 }
             }

--- a/backend/tests/procSystem.test.js
+++ b/backend/tests/procSystem.test.js
@@ -60,4 +60,21 @@ describe('Data-Driven Proc System', () => {
     const updatedDefender = engine.combatants.find(c => c.id === defender.id);
     expect(updatedDefender.currentHp).toBe(initialDefenderHp - (baseDamage + 2));
   });
+
+  test('Once per combat procs trigger only once', () => {
+    const attacker = createCombatant({ hero_id: 1 }, 'player', 0);
+    const defender = createCombatant({ hero_id: 2001 }, 'enemy', 0);
+    attacker.weaponData = {
+      name: 'Test Weapon',
+      procs: [{ trigger: 'on_attack', effect: 'bonus_damage', value: 1, once_per_combat: true }]
+    };
+    const engine = new GameEngine([attacker, defender]);
+    engine.turnQueue = [attacker];
+    engine.processTurn();
+    engine.turnQueue = [attacker];
+    engine.processTurn();
+
+    const logOccurrences = engine.battleLog.filter(l => l.message.includes('bonus_damage procs!')).length;
+    expect(logOccurrences).toBe(1);
+  });
 });


### PR DESCRIPTION
## Summary
- track procs that are only allowed to fire once per combat
- skip once-per-combat procs after they've triggered
- test that once-per-combat procs are only logged the first time

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68654a4015588327a23cf116332afd93