### PR TITLE
Add on_status_applied trigger

### DIFF
--- a/backend/game/engine.js
+++ b/backend/game/engine.js
@@ -62,13 +62,20 @@ class GameEngine {
        }
    }
 
-   applyStatusEffect(target, name, duration = 2, extra = {}) {
+   applyStatusEffect(target, name, duration = 2, extra = {}, source = null) {
        const effect = { name, turnsRemaining: duration, ...extra };
        if (name === 'Poison' && effect.damage === undefined) {
            effect.damage = 1;
        }
        target.statusEffects.push(effect);
        this.log({ type: 'status', message: `↳ ${target.name} is ${name.toLowerCase()}.` });
+       this.procEngine.trigger('on_status_applied', {
+           attacker: source,
+           defender: target,
+           allCombatants: this.combatants,
+           applyDamage: this.applyDamage.bind(this),
+           applyStatus: this.applyStatusEffect.bind(this)
+       });
    }
 
    applyDamage(attacker, target, baseDamage, options = {}) {

--- a/backend/game/procEngine.js
+++ b/backend/game/procEngine.js
@@ -69,7 +69,7 @@ class ProcEngine {
             }
             case 'apply_status':
                 if (!proc.chance || Math.random() < proc.chance) {
-                    context.applyStatus(defender, proc.status, proc.duration, { damage: proc.value });
+                    context.applyStatus(defender, proc.status, proc.duration, { damage: proc.value }, attacker);
                 }
                 break;
             case 'bonus_damage':
@@ -79,12 +79,15 @@ class ProcEngine {
                 break;
             case 'apply_status_to_attacker':
                 if (!proc.chance || Math.random() < proc.chance) {
-                    context.applyStatus(attacker, proc.status, proc.duration, { damage: proc.value });
+                    context.applyStatus(attacker, proc.status, proc.duration, { damage: proc.value }, attacker);
                 }
+                break;
+            case 'immune_to_status':
+                defender.statusEffects = defender.statusEffects.filter(s => s.name !== proc.status);
                 break;
             default:
                 if (!proc.chance || Math.random() < proc.chance) {
-                    context.applyStatus(defender, proc.effect, proc.duration, { amount: proc.amount });
+                    context.applyStatus(defender, proc.effect, proc.duration, { amount: proc.amount }, attacker);
                 }
                 break;
             // Add more effect handlers here...

--- a/backend/tests/procSystem.test.js
+++ b/backend/tests/procSystem.test.js
@@ -38,7 +38,7 @@ describe('Data-Driven Proc System', () => {
     const attacker = createCombatant({ hero_id: 1 }, 'enemy', 0);
     const engine = new GameEngine([attacker, defender]);
     
-    engine.applyStatusEffect(defender, 'Stun', 1);
+    engine.applyStatusEffect(defender, 'Stun', 1, {}, attacker);
 
     // The proc engine would need to be triggered on status application to prevent it.
     // This requires a new trigger point 'on_status_applied'.


### PR DESCRIPTION
## Summary
- fire `on_status_applied` after new status effects are added
- pass attacker through proc engine when applying statuses
- handle `immune_to_status` proc
- adjust proc system test

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68654a4043a08327b0b3143b1554e33a