### PR TITLE
Expand proc engine and tests

### DIFF
--- a/backend/game/procEngine.js
+++ b/backend/game/procEngine.js
@@ -31,7 +31,10 @@ class ProcEngine {
                     if (proc.once_per_combat && this.onceMap.has(key)) continue;
                     if (proc.once_per_combat) this.onceMap.add(key);
 
-                    this.executeEffect(proc, { ...context, owner: combatant });
+                    const prevOwner = context.owner;
+                    context.owner = combatant;
+                    this.executeEffect(proc, context);
+                    context.owner = prevOwner;
                 }
             }
         }


### PR DESCRIPTION
## Summary
- fix procEngine to update shared context so cancel flags work
- adjust proc system tests to use engine combatants
- add coverage for ignore block, aura buffs, and block ability

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68654d9800fc8327922df32f8cf054b6