### PR TITLE
Improve battle log clarity

### DIFF
--- a/backend/game/engine.js
+++ b/backend/game/engine.js
@@ -182,36 +182,36 @@ class GameEngine {
            const healing = parseInt(hotMatch[1], 10);
            const turns = parseInt(hotMatch[2], 10);
            target.statusEffects.push({ name: 'Regrowth', healing, turnsRemaining: turns, sourceAbility: ability.name });
-           this.log({ type: 'status', message: `↳ ${target.name} is blessed with Regrowth.` });
+           this.log({ type: 'status', message: `💚 ${target.name} gains Regrowth (${healing} HP/turn for ${turns} turns) from ${attacker.name}'s [${ability.name}].` });
        }
 
-       const poisonMatchDetailed = ability.effect.match(/apply Poison \((\d+) dmg\/turn for (\d+) turns\)/i);
-       const poisonMatchSimple = ability.effect.match(/poison .* for (\d+) turns/i);
-       if (poisonMatchDetailed || poisonMatchSimple) {
-           const damage = poisonMatchDetailed ? parseInt(poisonMatchDetailed[1], 10) : 1;
-           const turns = poisonMatchDetailed ? parseInt(poisonMatchDetailed[2], 10) : parseInt(poisonMatchSimple[1], 10);
-           target.statusEffects.push({ name: 'Poison', damage, turnsRemaining: turns, sourceAbility: ability.name });
-           this.log({ type: 'status', message: `↳ ${target.name} is poisoned.` });
-       }
+        const poisonMatchDetailed = ability.effect.match(/apply Poison \((\d+) dmg\/turn for (\d+) turns\)/i);
+        const poisonMatchSimple = ability.effect.match(/poison .* for (\d+) turns/i);
+        if (poisonMatchDetailed || poisonMatchSimple) {
+            const damage = poisonMatchDetailed ? parseInt(poisonMatchDetailed[1], 10) : 1;
+            const turns = poisonMatchDetailed ? parseInt(poisonMatchDetailed[2], 10) : parseInt(poisonMatchSimple[1], 10);
+            target.statusEffects.push({ name: 'Poison', damage, turnsRemaining: turns, sourceAbility: ability.name });
+            this.log({ type: 'status', message: `☣️ ${target.name} is afflicted with Poison (${damage} dmg/turn for ${turns} turns) from ${attacker.name}'s [${ability.name}].` });
+        }
 
-       if (/confuse/i.test(ability.effect)) {
-           target.statusEffects.push({ name: 'Confuse', turnsRemaining: 1, sourceAbility: ability.name });
-           this.log({ type: 'status', message: `↳ ${target.name} is confused.` });
-       }
+        if (/confuse/i.test(ability.effect)) {
+            target.statusEffects.push({ name: 'Confuse', turnsRemaining: 1, sourceAbility: ability.name });
+            this.log({ type: 'status', message: `❓ ${target.name} is afflicted with Confuse from ${attacker.name}'s [${ability.name}].` });
+        }
 
-       if (/Armor Break/i.test(ability.effect)) {
-           const match = ability.effect.match(/(\d+) turns?/i);
-           const turns = match ? parseInt(match[1], 10) : 2;
-           target.statusEffects.push({ name: 'Armor Break', bonusDamage: 1, turnsRemaining: turns, sourceAbility: ability.name });
-           this.log({ type: 'status', message: `↳ ${target.name} suffers Armor Break.` });
-       }
+        if (/Armor Break/i.test(ability.effect)) {
+            const match = ability.effect.match(/(\d+) turns?/i);
+            const turns = match ? parseInt(match[1], 10) : 2;
+            target.statusEffects.push({ name: 'Armor Break', bonusDamage: 1, turnsRemaining: turns, sourceAbility: ability.name });
+            this.log({ type: 'status', message: `🛡️ ${target.name} suffers Armor Break for ${turns} turns from ${attacker.name}'s [${ability.name}].` });
+        }
 
-       if (/Defense Down/i.test(ability.effect)) {
-           const match = ability.effect.match(/Defense Down for (\d+) turns?/i);
-           const turns = match ? parseInt(match[1], 10) : 2;
-           target.statusEffects.push({ name: 'Defense Down', turnsRemaining: turns, sourceAbility: ability.name });
-           this.log({ type: 'status', message: `↳ ${target.name} suffers Defense Down.` });
-       }
+        if (/Defense Down/i.test(ability.effect)) {
+            const match = ability.effect.match(/Defense Down for (\d+) turns?/i);
+            const turns = match ? parseInt(match[1], 10) : 2;
+            target.statusEffects.push({ name: 'Defense Down', turnsRemaining: turns, sourceAbility: ability.name });
+            this.log({ type: 'status', message: `🛡️ ${target.name} suffers Defense Down for ${turns} turns from ${attacker.name}'s [${ability.name}].` });
+        }
 
        if (ability.summons) {
            const summonKeys = Array.isArray(ability.summons) ? ability.summons : [ability.summons];

--- a/backend/game/procEngine.js
+++ b/backend/game/procEngine.js
@@ -31,7 +31,7 @@ class ProcEngine {
                     if (proc.once_per_combat && this.onceMap.has(key)) continue;
                     if (proc.once_per_combat) this.onceMap.add(key);
 
-                    this.executeEffect(proc, { ...context, owner: combatant });
+                    this.executeEffect(proc, { ...context, owner: combatant, item });
                 }
             }
         }
@@ -63,10 +63,11 @@ class ProcEngine {
 
     // Executes the proc's effect.
     executeEffect(proc, context) {
-        const { attacker, defender, allCombatants, owner } = context;
+        const { attacker, defender, allCombatants, owner, item } = context;
         const actor = owner || attacker;
 
-        this.log({ type: 'proc', message: `✨ ${actor.name}'s ${proc.effect} procs!` }, 'summary');
+        const itemName = item ? `[${item.name}]` : 'Unknown Item';
+        this.log({ type: 'proc', message: `✨ ${itemName} on ${actor.name} procs ${proc.effect}!` }, 'summary');
 
         switch (proc.effect) {
             case 'cleave': {


### PR DESCRIPTION
## Summary
- show which item triggers procs
- include ability and duration when applying status effects

## Testing
- `npm test` *(fails: Thorns proc reflects damage on hit, log string expectations)*

------
https://chatgpt.com/codex/tasks/task_e_6865502d33c083278726bc557bc30b2f