### PR TITLE
Implement /town command for back-to-town button

### DIFF
--- a/discord-bot/index.js
+++ b/discord-bot/index.js
@@ -95,7 +95,10 @@ client.on(Events.InteractionCreate, async interaction => {
         await command.execute(interaction);
       }
     } else if (customId === 'back-to-town') {
-      await interaction.update({ content: 'You head back to the relative safety of the town.', components: [] });
+      const townCommand = client.commands.get('town');
+      if (townCommand) {
+        await townCommand.execute(interaction);
+      }
     } else if (customId === 'inventory-equip-start') {
       await inventoryHandlers.handleEquipButton(interaction);
     } else if (interaction.customId === 'inventory-merge-start') {

--- a/discord-bot/tests/index.test.js
+++ b/discord-bot/tests/index.test.js
@@ -85,6 +85,22 @@ test('nav-town button calls town command', async () => {
   expect(town.execute).toHaveBeenCalledWith(interaction);
 });
 
+test('back-to-town button calls town command', async () => {
+  const client = discord.__clients[0];
+  const handler = client.listeners('interactionCreate')[0];
+  const town = { execute: jest.fn() };
+  client.commands.set('town', town);
+  const interaction = {
+    isChatInputCommand: jest.fn(() => false),
+    isAutocomplete: jest.fn(() => false),
+    isStringSelectMenu: jest.fn(() => false),
+    isButton: jest.fn(() => true),
+    customId: 'back-to-town'
+  };
+  await handler(interaction);
+  expect(town.execute).toHaveBeenCalledWith(interaction);
+});
+
 test('continue-adventure button calls adventure command', async () => {
   const client = discord.__clients[0];
   const handler = client.listeners('interactionCreate')[0];


### PR DESCRIPTION
## Summary
- hook `back-to-town` button into the `/town` command
- test that the new button path triggers the command

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686556128fac83279f3c088b877203e3