### PR TITLE
Add damage breakdown logging

### DIFF
--- a/backend/tests/statusEffects.test.js
+++ b/backend/tests/statusEffects.test.js
@@ -90,15 +90,15 @@ describe('Status effect processing', () => {
     expect(tgt.statusEffects.some(s => s.name === 'Armor Break')).toBe(true);
 
     const base = atk.attack;
-    const damage1 = engine.applyDamage(atk, tgt, base, { log: false });
-    expect(damage1).toBe(base - tgt.defense + 1);
+    const result1 = engine.applyDamage(atk, tgt, base, { log: false });
+    expect(result1.finalDamage).toBe(base - tgt.defense + 1);
 
     engine.processStatuses(tgt);
-    const damage2 = engine.applyDamage(atk, tgt, base, { log: false });
-    expect(damage2).toBe(base - tgt.defense + 1);
+    const result2 = engine.applyDamage(atk, tgt, base, { log: false });
+    expect(result2.finalDamage).toBe(base - tgt.defense + 1);
 
     engine.processStatuses(tgt);
-    const damage3 = engine.applyDamage(atk, tgt, base, { log: false });
-    expect(damage3).toBe(base - tgt.defense);
+    const result3 = engine.applyDamage(atk, tgt, base, { log: false });
+    expect(result3.finalDamage).toBe(base - tgt.defense);
   });
 });

--- a/discord-bot/src/utils/battleRunner.js
+++ b/discord-bot/src/utils/battleRunner.js
@@ -32,6 +32,12 @@ function buildFinalLog(logEntries) {
         case 'ability-cast':
           message = `✨ ${message}`;
           break;
+        case 'damage_calculation': {
+          const { baseDamage, bonusDamage, defenseMitigation, finalDamage } = entry.details;
+          const attacker = entry.attacker;
+          const target = entry.target;
+          return `${prefix} ${attacker} attacks ${target}! (Base: ${baseDamage}, Buffs: +${bonusDamage}) ➞ (Defense: ${defenseMitigation}) ➞ Final Damage: ${finalDamage}`;
+        }
         case 'defeat':
         case 'victory':
           message = `🏆 ${message} 🏆`;


### PR DESCRIPTION
## Summary
- refactor `applyDamage` to return detailed calculation info
- log damage calculations during each turn
- show granular breakdown in DM logs
- update status effect test

## Testing
- `npm test` *(fails: abilityPattern.test.js, statusEffects.test.js, energy.test.js, procSystem.test.js, abilityEffect.test.js)*

------
https://chatgpt.com/codex/tasks/task_e_68655a92a2fc8327a232fcd4096b737e