### PR TITLE
Add role selection tutorial

### DIFF
--- a/discord-bot/commands/tutorial.js
+++ b/discord-bot/commands/tutorial.js
@@ -1,6 +1,13 @@
-const { SlashCommandBuilder, EmbedBuilder } = require('discord.js');
+const {
+  SlashCommandBuilder,
+  EmbedBuilder,
+  ActionRowBuilder,
+  ButtonBuilder,
+  ButtonStyle
+} = require('discord.js');
 const userService = require('../src/utils/userService');
 const weaponService = require('../src/utils/weaponService');
+const abilityCardService = require('../src/utils/abilityCardService');
 const { buildBattleEmbed } = require('../src/utils/embedBuilder');
 const GameEngine = require('../../backend/game/engine');
 const { createCombatant } = require('../../backend/game/utils');
@@ -36,119 +43,103 @@ async function execute(interaction) {
     return;
   }
 
+  const embed = new EmbedBuilder()
+    .setTitle('Choose Your Starting Archetype')
+    .setDescription('Select a role that matches your preferred playstyle. This choice will grant you a hero and a powerful ability.');
 
-  try {
-    const baseHero = allPossibleHeroes.find(h => h.isBase) || allPossibleHeroes[0];
-    const player = createCombatant({ hero_id: baseHero.id }, 'player', 0);
+  const row = new ActionRowBuilder().addComponents(
+    new ButtonBuilder().setCustomId('tutorial_select_tank').setLabel('Stalwart Defender').setEmoji('🛡️').setStyle(ButtonStyle.Primary),
+    new ButtonBuilder().setCustomId('tutorial_select_dps').setLabel('Raging Fighter').setEmoji('⚔️').setStyle(ButtonStyle.Primary),
+    new ButtonBuilder().setCustomId('tutorial_select_healer').setLabel('Divine Healer').setEmoji('❤️‍🩹').setStyle(ButtonStyle.Primary),
+    new ButtonBuilder().setCustomId('tutorial_select_support').setLabel('Inspiring Artist').setEmoji('🎶').setStyle(ButtonStyle.Primary)
+  );
 
-    const rustyKnife = allPossibleWeapons.find(w => w.name === 'Rusty Knife');
-
-    const goblin = {
-      id: 'enemy-0',
-      name: 'Tutorial Goblin',
-      heroData: { name: 'Tutorial Goblin', hp: 10, attack: 1, speed: 1, defense: 0 },
-      weaponData: rustyKnife,
-      armorData: null,
-      abilityData: null,
-      abilityCharges: 0,
-      deck: [],
-      team: 'enemy',
-      position: 0,
-      currentHp: 10,
-      maxHp: 10,
-      currentEnergy: 0,
-      statusEffects: [],
-      hp: 10,
-      attack: 1 + (rustyKnife ? rustyKnife.statBonuses.ATK || 0 : 0),
-      speed: 1,
-      defense: 0
-    };
-
-
-
-    const engine = new GameEngine([player, goblin]);
-    const wait = ms => new Promise(r => setTimeout(r, ms));
-    let logText = '';
-    let battleMessage;
-    for (const step of engine.runGameSteps()) {
-      const lines = step.log.map(formatLog);
-      logText = [logText, ...lines].filter(Boolean).join('\n');
-      const embed = buildBattleEmbed(step.combatants, logText);
-      if (!battleMessage) {
-        battleMessage = await interaction.reply({
-          embeds: [embed],
-          ephemeral: true
-        });
-      } else {
-        console.log(
-          `Editing tutorial message for interaction ${interaction.id} (user ${interaction.user.id})`
-        );
-        await wait(1000);
-        await battleMessage.edit({ embeds: [embed] });
-      }
-    }
-
-    const commonOffenseAbilities = allPossibleAbilities.filter(
-      a =>
-        a.rarity === 'Common' &&
-        a.category === 'Offense' &&
-        a.class === baseHero.class
-    );
-    const abilityDrop =
-      commonOffenseAbilities[Math.floor(Math.random() * commonOffenseAbilities.length)];
-
-    await userService.addAbility(interaction.user.id, abilityDrop.id);
-    if (rustyKnife) {
-      await weaponService.addWeapon(user.id, rustyKnife.id);
-    }
-
-    const lootMessage = rustyKnife
-      ? `The Tutorial Goblin dropped a **${rustyKnife.name}** and **${abilityDrop.name}**.`
-      : `The Tutorial Goblin dropped **${abilityDrop.name}**.`;
-
-    const summaryEmbed = new EmbedBuilder()
-      .setColor('#57F287')
-      .setDescription(`Victory! ${lootMessage}`);
-    await interaction.followUp({ embeds: [summaryEmbed], ephemeral: true });
-
-    interaction.followUp({
-      content:
-        "Congratulations on your victory! You've found your first Ability Card. Use the /inventory show command to see what's in your backpack.",
-      ephemeral: true
-    });
-
-    setTimeout(() => {
-      interaction.followUp({
-        content: `Now, equip your new ability using the command: /inventory set ability:${abilityDrop.name}`,
-        ephemeral: true
-      });
-    }, 5000);
-
-    setTimeout(() => {
-      interaction.followUp({
-        content:
-          "**Tip:** The bot will sometimes send you DMs with full battle logs or new items you've found. If you find this too noisy, you can turn them off!\n\n" +
-          '• Use `/settings battle_logs enabled:False` to disable battle log DMs.\n' +
-          '• Use `/settings item_drops enabled:False` to disable new item DMs.',
-        ephemeral: true
-      });
-    }, 10000);
-
-    setTimeout(async () => {
-      await interaction.followUp({
-        content:
-          'You can now use /adventure to battle monsters, /challenge @user to duel other players, and /who @user to inspect a character.',
-        ephemeral: true
-      });
-      await userService.markTutorialComplete(interaction.user.id);
-    }, 15000);
-  } catch (error) {
-    console.error(`Tutorial failed for ${interaction.user.tag}.`, error);
-    await interaction.followUp({
-      content: 'An error occurred while running the tutorial. Please try again later.',
-      ephemeral: true
-    });
-  }
+  await interaction.reply({ embeds: [embed], components: [row], ephemeral: true });
 }
 
-module.exports = { data, execute };
+async function runTutorial(interaction, archetype) {
+  let user = await userService.getUser(interaction.user.id);
+  if (!user) {
+    await userService.createUser(interaction.user.id, interaction.user.username);
+    user = await userService.getUser(interaction.user.id);
+  }
+
+  const hero = allPossibleHeroes.find(h => h.class === archetype && h.isBase);
+  const ability = allPossibleAbilities.find(a => a.class === archetype && a.rarity === 'Common');
+  const rustyKnife = allPossibleWeapons.find(w => w.name === 'Rusty Knife');
+
+  const cardId = await abilityCardService.addCard(user.id, ability.id, 40);
+  const weaponId = rustyKnife ? await weaponService.addWeapon(user.id, rustyKnife.id) : null;
+
+  await userService.setActiveAbility(interaction.user.id, cardId);
+  if (weaponId) {
+    await weaponService.setEquippedWeapon(user.id, weaponId);
+  }
+  await userService.setUserClass(interaction.user.id, archetype);
+
+  const player = createCombatant({ hero_id: hero.id, ability_card: { id: cardId, ability_id: ability.id, charges: 40 }, weapon_id: rustyKnife ? rustyKnife.id : null, name: interaction.user.username }, 'player', 0);
+
+  const goblin = {
+    id: 'enemy-0',
+    name: 'Tutorial Goblin',
+    heroData: { name: 'Tutorial Goblin', hp: 10, attack: 1, speed: 1, defense: 0 },
+    weaponData: rustyKnife,
+    armorData: null,
+    abilityData: null,
+    abilityCharges: 0,
+    deck: [],
+    team: 'enemy',
+    position: 0,
+    currentHp: 10,
+    maxHp: 10,
+    currentEnergy: 0,
+    statusEffects: [],
+    hp: 10,
+    attack: 1 + (rustyKnife ? rustyKnife.statBonuses.ATK || 0 : 0),
+    speed: 1,
+    defense: 0
+  };
+
+  const engine = new GameEngine([player, goblin]);
+  const wait = ms => new Promise(r => setTimeout(r, ms));
+  let logText = '';
+  let battleMessage;
+  for (const step of engine.runGameSteps()) {
+    const lines = step.log.map(formatLog);
+    logText = [logText, ...lines].filter(Boolean).join('\n');
+    const embed = buildBattleEmbed(step.combatants, logText);
+    if (!battleMessage) {
+      battleMessage = await interaction.followUp({ embeds: [embed], ephemeral: true });
+    } else {
+      await wait(1000);
+      await battleMessage.edit({ embeds: [embed] });
+    }
+  }
+
+  const lootMessage = rustyKnife ? `The Tutorial Goblin dropped a **${rustyKnife.name}** and **${ability.name}**.` : `The Tutorial Goblin dropped **${ability.name}**.`;
+
+  const summaryEmbed = new EmbedBuilder().setColor('#57F287').setDescription(`Victory! ${lootMessage}`);
+  await interaction.followUp({ embeds: [summaryEmbed], ephemeral: true });
+
+  await interaction.followUp({ content: "Congratulations on your victory! Use the /inventory show command to see what's in your backpack.", ephemeral: true });
+
+  setTimeout(() => {
+    interaction.followUp({
+      content:
+        '**Tip:** The bot will sometimes send you DMs with full battle logs or new items you\'ve found. If you find this too noisy, you can turn them off!\n\n' +
+        '• Use `/settings battle_logs enabled:False` to disable battle log DMs.\n' +
+        '• Use `/settings item_drops enabled:False` to disable new item DMs.',
+      ephemeral: true
+    });
+  }, 10000);
+
+  setTimeout(async () => {
+    await interaction.followUp({
+      content: 'You can now use /adventure to battle monsters, /challenge @user to duel other players, and /who @user to inspect a character.',
+      ephemeral: true
+    });
+    await userService.markTutorialComplete(interaction.user.id);
+  }, 15000);
+}
+
+module.exports = { data, execute, runTutorial };

--- a/discord-bot/index.js
+++ b/discord-bot/index.js
@@ -119,6 +119,30 @@ client.on(Events.InteractionCreate, async interaction => {
       const inventoryCommand = client.commands.get('inventory');
       interaction.options = { getSubcommand: () => 'show' };
       await inventoryCommand.execute(interaction);
+    } else if (interaction.customId === 'tutorial_select_tank') {
+      await interaction.update({ content: 'You have chosen the path of the Stalwart Defender!', components: [] });
+      const tutorial = client.commands.get('tutorial');
+      if (tutorial && typeof tutorial.runTutorial === 'function') {
+        await tutorial.runTutorial(interaction, 'Stalwart Defender');
+      }
+    } else if (interaction.customId === 'tutorial_select_dps') {
+      await interaction.update({ content: 'You have chosen the path of the Raging Fighter!', components: [] });
+      const tutorial = client.commands.get('tutorial');
+      if (tutorial && typeof tutorial.runTutorial === 'function') {
+        await tutorial.runTutorial(interaction, 'Raging Fighter');
+      }
+    } else if (interaction.customId === 'tutorial_select_healer') {
+      await interaction.update({ content: 'You have chosen the path of the Divine Healer!', components: [] });
+      const tutorial = client.commands.get('tutorial');
+      if (tutorial && typeof tutorial.runTutorial === 'function') {
+        await tutorial.runTutorial(interaction, 'Divine Healer');
+      }
+    } else if (interaction.customId === 'tutorial_select_support') {
+      await interaction.update({ content: 'You have chosen the path of the Inspiring Artist!', components: [] });
+      const tutorial = client.commands.get('tutorial');
+      if (tutorial && typeof tutorial.runTutorial === 'function') {
+        await tutorial.runTutorial(interaction, 'Inspiring Artist');
+      }
     } else if (interaction.customId.startsWith('proceed-battle:')) {
       await interaction.update({ content: 'Proceeding to battle...', components: [] });
       const adventureCommand = client.commands.get('adventure');

--- a/discord-bot/tests/index.test.js
+++ b/discord-bot/tests/index.test.js
@@ -120,6 +120,25 @@ test('continue-adventure button calls adventure command', async () => {
   expect(adventure.execute).toHaveBeenCalledWith(interaction);
 });
 
+test('tutorial selection buttons trigger runTutorial', async () => {
+  const client = discord.__clients[0];
+  const handler = client.listeners('interactionCreate')[0];
+  const tutorial = { execute: jest.fn(), runTutorial: jest.fn() };
+  client.commands.set('tutorial', tutorial);
+  const interaction = {
+    isChatInputCommand: jest.fn(() => false),
+    isAutocomplete: jest.fn(() => false),
+    isStringSelectMenu: jest.fn(() => false),
+    isButton: jest.fn(() => true),
+    customId: 'tutorial_select_tank',
+    update: jest.fn().mockResolvedValue(),
+    user: { id: '123' }
+  };
+  await handler(interaction);
+  expect(interaction.update).toHaveBeenCalled();
+  expect(tutorial.runTutorial).toHaveBeenCalledWith(interaction, 'Stalwart Defender');
+});
+
 test('toggle_battle_logs updates preference and refreshes message', async () => {
   const client = discord.__clients[0];
   const handler = client.listeners('interactionCreate')[0];

--- a/discord-bot/tests/tutorial.test.js
+++ b/discord-bot/tests/tutorial.test.js
@@ -3,26 +3,32 @@ const tutorial = require('../commands/tutorial');
 jest.mock('../src/utils/userService', () => ({
   getUser: jest.fn(),
   createUser: jest.fn(),
-  addAbility: jest.fn(),
+  setActiveAbility: jest.fn(),
+  setUserClass: jest.fn(),
   markTutorialComplete: jest.fn()
 }));
 jest.mock('../src/utils/weaponService', () => ({
-  addWeapon: jest.fn()
+  addWeapon: jest.fn(),
+  setEquippedWeapon: jest.fn()
+}));
+jest.mock('../src/utils/abilityCardService', () => ({
+  addCard: jest.fn()
 }));
 jest.mock('../../backend/game/engine');
 
 const userService = require('../src/utils/userService');
 const weaponService = require('../src/utils/weaponService');
+const abilityCardService = require('../src/utils/abilityCardService');
 const GameEngine = require('../../backend/game/engine');
-const utils = require('../../backend/game/utils');
-const {
-  allPossibleAbilities,
-  allPossibleHeroes,
-  allPossibleWeapons
-} = require('../../backend/game/data');
 const gameData = require('../util/gameData');
+const { allPossibleHeroes, allPossibleAbilities, allPossibleWeapons } = require('../../backend/game/data');
 
-jest.spyOn(utils, 'createCombatant');
+GameEngine.mockImplementation(() => ({
+  runGameSteps: function* () {
+    yield { combatants: [], log: [] };
+  },
+  winner: 'player'
+}));
 
 describe('tutorial command', () => {
   beforeEach(() => {
@@ -30,13 +36,7 @@ describe('tutorial command', () => {
     jest.clearAllMocks();
     gameData.gameData.heroes = new Map(allPossibleHeroes.map(h => [h.id, h]));
     gameData.gameData.abilities = new Map(allPossibleAbilities.map(a => [a.id, a]));
-    GameEngine.mockImplementation(() => ({
-      runGameSteps: function* () {
-        yield { combatants: [], log: [{ round: 1, type: 'info', message: 'log' }] };
-      },
-      runFullGame: jest.fn(),
-      winner: 'player'
-    }));
+    gameData.gameData.weapons = new Map(allPossibleWeapons.map(w => [w.id, w]));
   });
 
   afterEach(() => {
@@ -46,74 +46,38 @@ describe('tutorial command', () => {
 
   test('creates a user when none exists', async () => {
     userService.getUser.mockResolvedValueOnce(null).mockResolvedValueOnce({ id: 1 });
-    const interaction = {
-      user: { id: '1', username: 'Tester' },
-      reply: jest.fn().mockResolvedValue(),
-      followUp: jest.fn().mockResolvedValue()
-    };
+    const interaction = { user: { id: '1', username: 'Tester' }, reply: jest.fn() };
     await tutorial.execute(interaction);
     expect(userService.createUser).toHaveBeenCalledWith('1', 'Tester');
   });
 
   test('replies when already completed', async () => {
     userService.getUser.mockResolvedValue({ id: 1, tutorial_completed: 1 });
-    const interaction = {
-      user: { id: '1' },
-      reply: jest.fn().mockResolvedValue()
-    };
+    const interaction = { user: { id: '1' }, reply: jest.fn() };
     await tutorial.execute(interaction);
     expect(interaction.reply).toHaveBeenCalledWith(expect.objectContaining({ ephemeral: true }));
   });
 
-  test('grants a common ability and marks completion', async () => {
+  test('sends selection embed with buttons', async () => {
     userService.getUser.mockResolvedValue({ id: 1, tutorial_completed: 0 });
-    const interaction = {
-      user: { id: '1', username: 'Tester' },
-      reply: jest.fn().mockResolvedValue(),
-      followUp: jest.fn().mockResolvedValue()
-    };
-    jest.spyOn(Math, 'random').mockReturnValue(0);
+    const interaction = { user: { id: '1', username: 'Tester' }, reply: jest.fn() };
     await tutorial.execute(interaction);
-    const abilityId = allPossibleAbilities.filter(
-      a =>
-        a.rarity === 'Common' &&
-        a.category === 'Offense' &&
-        a.class ===
-          (allPossibleHeroes.find(h => h.isBase) || allPossibleHeroes[0]).class
-    )[0].id;
-    expect(userService.addAbility).toHaveBeenCalledWith('1', abilityId);
-    const rustyKnifeId = allPossibleWeapons.find(w => w.name === 'Rusty Knife').id;
-    expect(weaponService.addWeapon).toHaveBeenCalledWith(1, rustyKnifeId);
-    jest.runAllTimers();
-    await Promise.resolve();
-    expect(userService.markTutorialComplete).toHaveBeenCalledWith('1');
-    const ephemeralCalls = interaction.followUp.mock.calls.filter(c => c[0].ephemeral);
-    expect(ephemeralCalls.length).toBeGreaterThan(0);
-    Math.random.mockRestore();
+    expect(interaction.reply).toHaveBeenCalledWith(expect.objectContaining({ components: expect.any(Array) }));
   });
 
-  test('battle log uses single reply edited for each step', async () => {
-    userService.getUser.mockResolvedValue({ id: 1, tutorial_completed: 0 });
-    const editMock = jest.fn().mockResolvedValue();
-    const interaction = {
-      id: 'xyz',
-      user: { id: '1', username: 'Tester', send: jest.fn() },
-      reply: jest.fn().mockResolvedValue({ edit: editMock }),
-      followUp: jest.fn().mockResolvedValue()
-    };
-    GameEngine.mockImplementationOnce(() => ({
-      runGameSteps: function* () {
-        yield { combatants: [], log: [{ round: 1, type: 'info', message: 'one' }] };
-        yield { combatants: [], log: [{ round: 1, type: 'info', message: 'two' }] };
-      },
-      runFullGame: jest.fn(),
-      winner: 'player'
-    }));
-    const exec = tutorial.execute(interaction);
-    await jest.runAllTimersAsync();
-    await exec;
-    expect(interaction.reply).toHaveBeenCalledTimes(1);
-    expect(editMock).toHaveBeenCalledTimes(1);
-    expect(interaction.user.send).not.toHaveBeenCalled();
+  test('runTutorial awards items and marks completion', async () => {
+    userService.getUser.mockResolvedValue({ id: 1 });
+    abilityCardService.addCard.mockResolvedValue(10);
+    weaponService.addWeapon.mockResolvedValue(5);
+    const interaction = { user: { id: '1', username: 'Tester' }, followUp: jest.fn() };
+    await tutorial.runTutorial(interaction, 'Stalwart Defender');
+    expect(abilityCardService.addCard).toHaveBeenCalled();
+    expect(weaponService.addWeapon).toHaveBeenCalled();
+    expect(userService.setActiveAbility).toHaveBeenCalled();
+    expect(weaponService.setEquippedWeapon).toHaveBeenCalled();
+    expect(userService.setUserClass).toHaveBeenCalledWith('1', 'Stalwart Defender');
+    jest.runAllTimers();
+    await Promise.resolve();
+    expect(userService.markTutorialComplete).toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary
- introduce archetype selection UI to `/tutorial`
- handle new tutorial selection buttons in index.js
- implement tutorial battle in `runTutorial`
- update tests for new flow

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68655d6281608327a1cf0b214735ebfa