### PR TITLE
Remove adventure pause

### DIFF
--- a/backend/game/engine.js
+++ b/backend/game/engine.js
@@ -28,6 +28,7 @@ class GameEngine {
         this.procEngine = new ProcEngine(this.battleLog);
         this.narrativeMode = options.isNarrative || false;
         this.playerName = options.playerName || (this.combatants.find(c => c.team === 'player')?.name);
+        this.isTutorial = options.isTutorial || false;
         this.abilityPauseShown = false;
         this.pendingPause = null;
     }
@@ -522,6 +523,7 @@ class GameEngine {
        if (this.checkVictory()) return;
        attacker.currentEnergy = (attacker.currentEnergy || 0) + 1;
        if (
+           this.isTutorial &&
            attacker.team === 'player' &&
            attacker.abilityData &&
            attacker.abilityCharges > 0 &&
@@ -531,7 +533,7 @@ class GameEngine {
            this.pendingPause = { type: 'PAUSE', reason: 'ABILITY_READY' };
            this.abilityPauseShown = true;
        }
-   }
+  }
 
 
 

--- a/discord-bot/commands/tutorial.js
+++ b/discord-bot/commands/tutorial.js
@@ -132,7 +132,10 @@ async function runTutorial(interaction, archetype) {
     );
   await interaction.followUp({ embeds: [startEmbed], ephemeral: true });
 
-  const engine = new GameEngine([player, goblin], { isNarrative: true, playerName: interaction.user.username });
+  const engine = new GameEngine(
+    [player, goblin],
+    { isNarrative: true, playerName: interaction.user.username, isTutorial: true }
+  );
   const { runBattleLoop } = require('../src/utils/battleRunner');
   await runBattleLoop(interaction, engine, { waitMs: 1000 });
 


### PR DESCRIPTION
## Summary
- add `isTutorial` option to GameEngine so ability pauses only happen in tutorials
- pass `isTutorial: true` from the tutorial command
- gate pause logic on this flag so adventure battles run uninterrupted

## Testing
- `npm test` in `backend` *(fails: Energy gain at combat start etc.)*
- `npm test` in `discord-bot`

------
https://chatgpt.com/codex/tasks/task_e_68658eee4df08327a9b545067195a9de