### PR TITLE
Improve auction house purchase flow

### DIFF
--- a/discord-bot/src/utils/auctionHouseHandlers.js
+++ b/discord-bot/src/utils/auctionHouseHandlers.js
@@ -9,6 +9,7 @@ const userService = require('./userService');
 const abilityCardService = require('./abilityCardService');
 const auctionService = require('./auctionHouseService');
 const gameData = require('../../util/gameData');
+const { createBackToTownRow } = require('./components');
 
 function getAllAbilities() {
   return Array.from(gameData.gameData.abilities.values());
@@ -125,9 +126,10 @@ async function handleBuySelect(interaction) {
   }
   try {
     const listing = await auctionService.purchaseListing(user.id, listingId, interaction.client);
+    const navigationRow = createBackToTownRow();
     await interaction.update({
-      content: `✅ Purchased ${abilityName(listing.ability_id)} for ${listing.price} gold.`,
-      components: [],
+      content: `✅ You have successfully purchased **${abilityName(listing.ability_id)}** for ${listing.price} gold.`,
+      components: [navigationRow],
       ephemeral: true
     });
   } catch (err) {

--- a/discord-bot/tests/auctionHouseHandlers.test.js
+++ b/discord-bot/tests/auctionHouseHandlers.test.js
@@ -1,5 +1,11 @@
 const auctionHouse = require('../commands/auctionhouse');
 
+jest.mock('../src/utils/userService', () => ({ getUser: jest.fn() }));
+jest.mock('../src/utils/auctionHouseService', () => ({ purchaseListing: jest.fn() }));
+const userService = require('../src/utils/userService');
+const auctionService = require('../src/utils/auctionHouseService');
+const handlers = require('../src/utils/auctionHouseHandlers');
+
 test('command posts welcome message with buy/sell buttons', async () => {
   const interaction = { reply: jest.fn().mockResolvedValue() };
   await auctionHouse.execute(interaction);
@@ -13,5 +19,29 @@ test('command posts welcome message with buy/sell buttons', async () => {
 
   const navButton =
     interaction.reply.mock.calls[0][0].components[1].components[0].toJSON();
+  expect(navButton.custom_id).toBe('nav-town');
+});
+
+test('handleBuySelect posts confirmation with back to town button', async () => {
+  userService.getUser.mockResolvedValue({ id: 1 });
+  auctionService.purchaseListing.mockResolvedValue({ ability_id: 3, price: 20 });
+  const interaction = {
+    values: ['5'],
+    user: { id: '1' },
+    client: {},
+    update: jest.fn().mockResolvedValue()
+  };
+
+  await handlers.handleBuySelect(interaction);
+
+  expect(auctionService.purchaseListing).toHaveBeenCalledWith(1, 5, interaction.client);
+  expect(interaction.update).toHaveBeenCalledWith(
+    expect.objectContaining({
+      content: expect.stringContaining('successfully purchased'),
+      components: expect.any(Array),
+      ephemeral: true
+    })
+  );
+  const navButton = interaction.update.mock.calls[0][0].components[0].components[0].toJSON();
   expect(navButton.custom_id).toBe('nav-town');
 });


### PR DESCRIPTION
## Summary
- add Back to Town row helper import
- show navigation button after buying a card
- test handleBuySelect flow

## Testing
- `npm test --silent --prefix discord-bot`

------
https://chatgpt.com/codex/tasks/task_e_68659ac36dc083278fe5a0f08a227748