### PR TITLE
Implement Edgar Pain tutorial intro

### DIFF
--- a/discord-bot/src/utils/embedBuilder.js
+++ b/discord-bot/src/utils/embedBuilder.js
@@ -131,4 +131,29 @@ async function sendItemDM(user, item) {
   await user.send({ embeds: [embed] });
 }
 
-module.exports = { simple, sendCardDM, buildCardEmbed, buildBattleEmbed, sendWeaponDM, buildWeaponEmbed, buildItemEmbed, sendItemDM };
+/**
+ * Creates a standardized embed for dialogue from the NPC guide, Edgar Pain.
+ * @param {string} title The title of the dialogue moment.
+ * @param {string} dialogue The text Edgar is saying.
+ * @returns {EmbedBuilder}
+ */
+function edgarPainEmbed(title, dialogue) {
+  return new EmbedBuilder()
+    .setColor('#8B4513')
+    .setTitle(title)
+    .setThumbnail('https://i.imgur.com/pB32Jfs.png')
+    .setDescription(dialogue)
+    .setFooter({ text: 'Edgar Pain', iconURL: 'https://i.imgur.com/pB32Jfs.png' });
+}
+
+module.exports = {
+  simple,
+  sendCardDM,
+  buildCardEmbed,
+  buildBattleEmbed,
+  sendWeaponDM,
+  buildWeaponEmbed,
+  buildItemEmbed,
+  sendItemDM,
+  edgarPainEmbed
+};

--- a/discord-bot/tests/adventure.test.js
+++ b/discord-bot/tests/adventure.test.js
@@ -315,8 +315,9 @@ describe('adventure command', () => {
       followUp: jest.fn().mockResolvedValue()
     };
     await adventure.execute(interaction);
-    const ephemerals = interaction.followUp.mock.calls.filter(c => c[0].ephemeral);
-    expect(ephemerals.length).toBeGreaterThan(0);
+    const replyEphemerals = interaction.reply.mock.calls.filter(c => c[0].ephemeral);
+    const followEphemerals = interaction.followUp.mock.calls.filter(c => c[0].ephemeral);
+    expect(replyEphemerals.length + followEphemerals.length).toBeGreaterThan(0);
     Math.random.mockRestore();
   });
 });

--- a/discord-bot/tests/index.test.js
+++ b/discord-bot/tests/index.test.js
@@ -28,6 +28,15 @@ jest.mock('discord.js', () => {
     Collection: Map,
     GatewayIntentBits: { Guilds: 0 },
     Events: { ClientReady: 'ready', InteractionCreate: 'interactionCreate' },
+    EmbedBuilder: class {
+      setColor() { return this; }
+      setTitle() { return this; }
+      setDescription() { return this; }
+      setTimestamp() { return this; }
+      setFooter() { return this; }
+      setThumbnail() { return this; }
+      addFields() { return this; }
+    },
     __clients: clients
   };
 });
@@ -49,5 +58,7 @@ test('errors from router are handled', async () => {
   const interaction = { replied: false, deferred: false, reply: jest.fn(), followUp: jest.fn() };
   routeInteraction.mockRejectedValueOnce(new Error('fail'));
   await handler(interaction);
-  expect(interaction.reply).toHaveBeenCalledWith(expect.objectContaining({ content: 'An unexpected error occurred.' }));
+  expect(interaction.reply).toHaveBeenCalledWith(
+    expect.objectContaining({ embeds: expect.any(Array), ephemeral: true })
+  );
 });

--- a/discord-bot/tests/tutorial.test.js
+++ b/discord-bot/tests/tutorial.test.js
@@ -49,9 +49,12 @@ describe('tutorial command', () => {
 
   test('creates a user when none exists', async () => {
     userService.getUser.mockResolvedValue(null);
-    const interaction = { user: { id: '1', username: 'Tester' }, reply: jest.fn(), followUp: jest.fn() };
+    userService.createUser.mockResolvedValue({ id: 1, tutorial_completed: 0 });
+    const interaction = { user: { id: '1', username: 'Tester' }, reply: jest.fn() };
     await tutorial.execute(interaction);
     expect(userService.createUser).toHaveBeenCalledWith('1', 'Tester');
+    expect(userService.setUserState).toHaveBeenCalledWith('1', 'in_tutorial');
+    expect(interaction.reply).toHaveBeenCalledWith(expect.objectContaining({ embeds: expect.any(Array) }));
   });
 
   test('replies when already completed', async () => {
@@ -61,11 +64,12 @@ describe('tutorial command', () => {
     expect(interaction.reply).toHaveBeenCalledWith(expect.objectContaining({ ephemeral: true }));
   });
 
-  test('sends selection embed with buttons', async () => {
+  test('sends ambush embed and sets step', async () => {
     userService.getUser.mockResolvedValue({ id: 1, tutorial_completed: 0 });
-    const interaction = { user: { id: '1', username: 'Tester' }, reply: jest.fn(), followUp: jest.fn() };
+    const interaction = { user: { id: '1', username: 'Tester' }, reply: jest.fn() };
     await tutorial.execute(interaction);
-    expect(interaction.followUp).toHaveBeenCalledWith(expect.objectContaining({ components: expect.any(Array) }));
+    expect(interaction.reply).toHaveBeenCalledWith(expect.objectContaining({ embeds: expect.any(Array), ephemeral: true }));
+    expect(userService.setTutorialStep).toHaveBeenCalledWith('1', 'archetype_selection_prompt');
   });
 
   test('runTutorial awards items and marks completion', async () => {


### PR DESCRIPTION
## Summary
- add `edgarPainEmbed` for consistent Edgar embeds
- rework `/tutorial` command to start ambush scene
- adjust tests for new tutorial flow and feedback format
- update mocks in `index.test.js`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6865b92bc9948327b939d2aed7cd0e88