### PR TITLE
Add dynamic tutorial archetype selection

### DIFF
--- a/discord-bot/index.js
+++ b/discord-bot/index.js
@@ -33,6 +33,19 @@ client.once(Events.ClientReady, async () => {
 
 client.on(Events.InteractionCreate, async interaction => {
   try {
+    if (typeof interaction.isStringSelectMenu === 'function' && interaction.isStringSelectMenu()) {
+      if (interaction.customId === 'tutorial_archetype_select') {
+        const selectedArchetype = interaction.values[0];
+        const tutorialCommand = client.commands.get('tutorial');
+        if (tutorialCommand) {
+          await tutorialCommand.showArchetypePreview(
+            interaction,
+            selectedArchetype
+          );
+        }
+        return;
+      }
+    }
     await routeInteraction(interaction);
   } catch (error) {
     console.error(`Unhandled error during interaction routing:`, error);


### PR DESCRIPTION
## Summary
- add dropdown selection for tutorial archetype
- preview selection through new `showArchetypePreview`
- handle select menu events in `index.js`
- support tutorial pauses in `runBattleLoop`

## Testing
- `npm test` within `discord-bot`
- `npm test` within `backend` *(fails: Data-Driven Proc System tests)*

------
https://chatgpt.com/codex/tasks/task_e_6865bbd4d6cc83278ea8f847b9410fbe