### PR TITLE
Implement loot choice step in tutorial

### DIFF
--- a/discord-bot/index.js
+++ b/discord-bot/index.js
@@ -5,6 +5,7 @@ const config = require('./util/config');
 const gameData = require('./util/gameData');
 const { routeInteraction } = require('./src/utils/interactionRouter');
 const feedback = require('./src/utils/feedback');
+const userService = require('./src/utils/userService');
 
 const client = new Client({ intents: [GatewayIntentBits.Guilds] });
 client.commands = new Collection();
@@ -42,6 +43,27 @@ client.on(Events.InteractionCreate, async interaction => {
             interaction,
             selectedArchetype
           );
+        }
+        return;
+      }
+    } else if (typeof interaction.isButton === 'function' && interaction.isButton()) {
+      if (interaction.customId === 'tutorial_loot_weapon') {
+        const tutorialCommand = client.commands.get('tutorial');
+        if (tutorialCommand) {
+          await tutorialCommand.handleLootChoice(interaction, 'weapon');
+        }
+        return;
+      } else if (interaction.customId === 'tutorial_loot_ability') {
+        const tutorialCommand = client.commands.get('tutorial');
+        if (tutorialCommand) {
+          await tutorialCommand.handleLootChoice(interaction, 'ability');
+        }
+        return;
+      } else if (interaction.customId === 'tutorial_go_to_town') {
+        await userService.completeTutorial(interaction.user.id);
+        const townCommand = client.commands.get('town');
+        if (townCommand) {
+          await townCommand.execute(interaction);
         }
         return;
       }

--- a/discord-bot/tests/index.test.js
+++ b/discord-bot/tests/index.test.js
@@ -9,6 +9,8 @@ jest.mock('fs', () => ({
 
 jest.mock('../util/config', () => ({ DISCORD_TOKEN: 'token' }));
 
+jest.mock('../src/utils/userService', () => ({ completeTutorial: jest.fn() }));
+
 jest.mock('../src/utils/interactionRouter', () => ({ routeInteraction: jest.fn() }));
 const { routeInteraction } = require('../src/utils/interactionRouter');
 

--- a/discord-bot/tests/tutorial.test.js
+++ b/discord-bot/tests/tutorial.test.js
@@ -72,18 +72,32 @@ describe('tutorial command', () => {
     expect(userService.setTutorialStep).toHaveBeenCalledWith('1', 'archetype_selection_prompt');
   });
 
-  test('runTutorial awards items and marks completion', async () => {
+  test('runTutorial presents loot choice', async () => {
     userService.getUser.mockResolvedValue({ id: 1 });
-    abilityCardService.addCard.mockResolvedValue(10);
-    weaponService.addWeapon.mockResolvedValue(5);
     const interaction = { user: { id: '1', username: 'Tester' }, followUp: jest.fn() };
     await tutorial.runTutorial(interaction, 'Stalwart Defender');
-    expect(abilityCardService.addCard).toHaveBeenCalled();
-    expect(weaponService.addWeapon).toHaveBeenCalled();
-    expect(userService.setActiveAbility).toHaveBeenCalled();
-    expect(weaponService.setEquippedWeapon).toHaveBeenCalled();
     expect(userService.setUserClass).toHaveBeenCalledWith('1', 'Stalwart Defender');
-    jest.runAllTimers();
-    await Promise.resolve();
+    expect(userService.setTutorialStep).toHaveBeenCalledWith('1', 'loot_choice');
+    const call = interaction.followUp.mock.calls.find(c => c[0].embeds);
+    expect(call).toBeDefined();
+  });
+
+  test('handleLootChoice awards weapon', async () => {
+    userService.getUser.mockResolvedValue({ id: 1 });
+    const interaction = { user: { id: '1' }, update: jest.fn() };
+    await tutorial.handleLootChoice(interaction, 'weapon');
+    expect(weaponService.addWeapon).toHaveBeenCalled();
+    expect(weaponService.setEquippedWeapon).toHaveBeenCalled();
+    expect(userService.setTutorialStep).toHaveBeenCalledWith('1', 'town_arrival');
+    expect(interaction.update).toHaveBeenCalled();
+  });
+
+  test('handleLootChoice awards ability', async () => {
+    userService.getUser.mockResolvedValue({ id: 1 });
+    const interaction = { user: { id: '1' }, update: jest.fn() };
+    await tutorial.handleLootChoice(interaction, 'ability');
+    expect(abilityCardService.addCard).toHaveBeenCalled();
+    expect(userService.setTutorialStep).toHaveBeenCalledWith('1', 'town_arrival');
+    expect(interaction.update).toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary
- add a loot-choice phase to the tutorial run flow
- handle weapon or ability reward buttons and final town transition
- update index interaction handler for new tutorial buttons
- extend tutorial tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6865bff1e1708327903776b483eb0dcd