### PR TITLE
Fix tutorial follow-up

### DIFF
--- a/discord-bot/commands/tutorial.js
+++ b/discord-bot/commands/tutorial.js
@@ -23,7 +23,9 @@ async function startTutorial(interaction) {
   await userService.setUserState(interaction.user.id, 'in_tutorial');
   await userService.setTutorialStep(interaction.user.id, 'town');
 
-  await interaction.reply({ content: 'https://youtu.be/mnOVJ-ucQPM', ephemeral: true });
+  // The initial welcome reply is sent by the interaction router. Use followUp
+  // for all subsequent tutorial messages to avoid InteractionAlreadyReplied.
+  await interaction.followUp({ content: 'https://youtu.be/mnOVJ-ucQPM', ephemeral: true });
 
   const introEmbed = new EmbedBuilder()
     .setTitle('Edgar Pain')


### PR DESCRIPTION
## Summary
- avoid double reply in tutorial and use `followUp` for initial messages

## Testing
- `cd backend && npm install && npm test` *(fails: Data-Driven Proc System tests)*
- `cd discord-bot && npm install && npm test`

------
https://chatgpt.com/codex/tasks/task_e_6865c3491390832781cc4cc2db8dc180