### PR TITLE
Fix tutorial reply handling

### DIFF
--- a/discord-bot/commands/tutorial.js
+++ b/discord-bot/commands/tutorial.js
@@ -298,7 +298,11 @@ async function execute(interaction, isReprompt = false) {
     await interaction.update(messagePayload);
   } else {
     // For the initial /tutorial command by a new user.
-    await interaction.reply(messagePayload);
+    if (interaction.replied || interaction.deferred) {
+      await interaction.followUp(messagePayload);
+    } else {
+      await interaction.reply(messagePayload);
+    }
   }
 }
 


### PR DESCRIPTION
## Summary
- handle case where /tutorial is called after another reply

## Testing
- `npm test` in `discord-bot`
- `npm install` && `npm test` in `backend` *(fails: expect 44, received 43)*

------
https://chatgpt.com/codex/tasks/task_e_6865cc2db470832795705f05bd322fa2