### PR TITLE
Fix duplicate proc activation

### DIFF
--- a/backend/game/procEngine.js
+++ b/backend/game/procEngine.js
@@ -31,11 +31,13 @@ class ProcEngine {
                     if (proc.once_per_combat && this.onceMap.has(key)) continue;
                     if (proc.once_per_combat) this.onceMap.add(key);
 
-                    this.executeEffect(proc, { ...context, owner: combatant, item });
                     const prevOwner = context.owner;
+                    const prevItem = context.item;
                     context.owner = combatant;
+                    context.item = item;
                     this.executeEffect(proc, context);
                     context.owner = prevOwner;
+                    context.item = prevItem;
                 }
             }
         }

--- a/backend/tests/procSystem.test.js
+++ b/backend/tests/procSystem.test.js
@@ -14,7 +14,7 @@ describe('Data-Driven Proc System', () => {
 
     const updatedTarget2 = engine.combatants.find(c => c.id === target2.id);
     expect(updatedTarget2.currentHp).toBe(initialHp - 1); // Cleave value is 1
-    expect(engine.battleLog.some(l => l.message.includes('cleave procs!'))).toBe(true);
+    expect(engine.battleLog.some(l => l.message.includes('procs cleave'))).toBe(true);
   });
 
   test('Thorns proc reflects damage on hit', () => {


### PR DESCRIPTION
## Summary
- ensure proc effects only trigger once in `ProcEngine`
- update cleave test expectation for new log wording

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6865d24782388327a6439133bdba5e4b