### PR TITLE
Add tutorial confirm archetype test

### DIFF
--- a/discord-bot/commands/tutorial.js
+++ b/discord-bot/commands/tutorial.js
@@ -28,7 +28,9 @@ async function handleInteraction(interaction, userState) {
   }
 
   if (interaction.isButton()) {
-    if (interaction.customId.startsWith('tutorial_select_') && typeof module.exports.runTutorial === 'function') {
+    if ((interaction.customId.startsWith('tutorial_select_') ||
+         interaction.customId.startsWith('tutorial_confirm_archetype')) &&
+        typeof module.exports.runTutorial === 'function') {
       // This interaction customId might need to be updated if it's from the StringSelectMenu
       // For now, assuming it's a button press that directly gives a class name or similar.
       // The execute() function now handles archetype selection via a StringSelectMenu,

--- a/discord-bot/tests/tutorial.test.js
+++ b/discord-bot/tests/tutorial.test.js
@@ -72,6 +72,22 @@ describe('tutorial command', () => {
     expect(userService.setTutorialStep).toHaveBeenCalledWith('1', 'archetype_selection_prompt');
   });
 
+  test('pressing confirm archetype starts tutorial battle', async () => {
+    const runSpy = jest.spyOn(tutorial, 'runTutorial').mockResolvedValue();
+    const interaction = {
+      isChatInputCommand: () => false,
+      isButton: () => true,
+      isStringSelectMenu: () => false,
+      customId: 'tutorial_confirm_archetype:Stalwart Defender',
+      user: { id: '1' }
+    };
+
+    await tutorial.handleInteraction(interaction, {});
+
+    expect(runSpy).toHaveBeenCalledWith(interaction, 'Stalwart Defender');
+    runSpy.mockRestore();
+  });
+
   test('runTutorial presents loot choice', async () => {
     userService.getUser.mockResolvedValue({ id: 1 });
     const interaction = { user: { id: '1', username: 'Tester' }, followUp: jest.fn() };


### PR DESCRIPTION
## Summary
- test that confirming an archetype calls `runTutorial`
- handle `tutorial_confirm_archetype` customId in tutorial command

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6865d2491d308327896af16db1089775