### PR TITLE
Refactor discord bot tutorial interaction routing

### DIFF
--- a/discord-bot/index.js
+++ b/discord-bot/index.js
@@ -5,7 +5,6 @@ const config = require('./util/config');
 const gameData = require('./util/gameData');
 const { routeInteraction } = require('./src/utils/interactionRouter');
 const feedback = require('./src/utils/feedback');
-const userService = require('./src/utils/userService');
 
 const client = new Client({ intents: [GatewayIntentBits.Guilds] });
 client.commands = new Collection();
@@ -34,40 +33,6 @@ client.once(Events.ClientReady, async () => {
 
 client.on(Events.InteractionCreate, async interaction => {
   try {
-    if (typeof interaction.isStringSelectMenu === 'function' && interaction.isStringSelectMenu()) {
-      if (interaction.customId === 'tutorial_archetype_select') {
-        const selectedArchetype = interaction.values[0];
-        const tutorialCommand = client.commands.get('tutorial');
-        if (tutorialCommand) {
-          await tutorialCommand.showArchetypePreview(
-            interaction,
-            selectedArchetype
-          );
-        }
-        return;
-      }
-    } else if (typeof interaction.isButton === 'function' && interaction.isButton()) {
-      if (interaction.customId === 'tutorial_loot_weapon') {
-        const tutorialCommand = client.commands.get('tutorial');
-        if (tutorialCommand) {
-          await tutorialCommand.handleLootChoice(interaction, 'weapon');
-        }
-        return;
-      } else if (interaction.customId === 'tutorial_loot_ability') {
-        const tutorialCommand = client.commands.get('tutorial');
-        if (tutorialCommand) {
-          await tutorialCommand.handleLootChoice(interaction, 'ability');
-        }
-        return;
-      } else if (interaction.customId === 'tutorial_go_to_town') {
-        await userService.completeTutorial(interaction.user.id);
-        const townCommand = client.commands.get('town');
-        if (townCommand) {
-          await townCommand.execute(interaction);
-        }
-        return;
-      }
-    }
     await routeInteraction(interaction);
   } catch (error) {
     console.error(`Unhandled error during interaction routing:`, error);

--- a/discord-bot/tests/index.test.js
+++ b/discord-bot/tests/index.test.js
@@ -64,3 +64,36 @@ test('errors from router are handled', async () => {
     expect.objectContaining({ embeds: expect.any(Array), ephemeral: true })
   );
 });
+
+test('tutorial button interaction routed to router', async () => {
+  const client = discord.__clients[0];
+  const handler = client.listeners('interactionCreate')[0];
+  const interaction = {
+    isButton: () => true,
+    isStringSelectMenu: () => false,
+    customId: 'tutorial_loot_weapon',
+    replied: false,
+    deferred: false,
+    reply: jest.fn(),
+    followUp: jest.fn()
+  };
+  await handler(interaction);
+  expect(routeInteraction).toHaveBeenCalledWith(interaction);
+});
+
+test('tutorial select menu interaction routed to router', async () => {
+  const client = discord.__clients[0];
+  const handler = client.listeners('interactionCreate')[0];
+  const interaction = {
+    isButton: () => false,
+    isStringSelectMenu: () => true,
+    values: ['Stalwart Defender'],
+    customId: 'tutorial_archetype_select',
+    replied: false,
+    deferred: false,
+    reply: jest.fn(),
+    followUp: jest.fn()
+  };
+  await handler(interaction);
+  expect(routeInteraction).toHaveBeenCalledWith(interaction);
+});


### PR DESCRIPTION
## Summary
- remove hardcoded tutorial interaction handling from `discord-bot/index.js`
- rely on `interactionRouter` and tutorial command for all tutorial interactions
- extend index tests to ensure button and select menu interactions are routed

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6865d2492268832794f204e0e6f4181f