### PR TITLE
Fix tutorial flags undefined in battle loop

### DIFF
--- a/discord-bot/src/utils/battleRunner.js
+++ b/discord-bot/src/utils/battleRunner.js
@@ -58,6 +58,9 @@ async function runBattleLoop(interaction, engine, { waitMs = 1000, isTutorial = 
   const fullLog = [];
   const user = await userService.getUser(interaction.user.id);
   const verbosity = user?.log_verbosity || 'summary';
+  if (isTutorial && !engine.tutorialFlags) {
+    engine.tutorialFlags = { energyExplained: false, abilityReady: false };
+  }
   let lastEmbed = null;
   for (const step of engine.runGameSteps()) {
     if (step.type === 'PAUSE') {


### PR DESCRIPTION
## Summary
- ensure engine.tutorialFlags is initialized when starting a tutorial battle

## Testing
- `npm test --prefix backend` *(fails: jest not found)*
- `npm test --prefix discord-bot` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6865e0bae5ac8327bf038d1b5ab4091b