### PR TITLE
Implement SDK init and Activity launcher

### DIFF
--- a/auto-battler-react/src/App.jsx
+++ b/auto-battler-react/src/App.jsx
@@ -1,4 +1,5 @@
-import React from 'react'
+import React, { useEffect } from 'react'
+import { DiscordSDK } from '@discord/embedded-app-sdk'
 import { useGameStore } from './store.js'
 import AnimatedBackground from './components/AnimatedBackground.jsx'
 import DebugMenu from './components/DebugMenu.jsx'
@@ -13,8 +14,24 @@ import TournamentEndScene from './scenes/TournamentEndScene.jsx'
 
 import './style.css'
 
+// --- New SDK Setup ---
+const discordSdk = new DiscordSDK(import.meta.env.VITE_DISCORD_CLIENT_ID)
+
+async function setupDiscordSdk() {
+  await discordSdk.ready()
+  console.log("Discord SDK is ready and connected.")
+}
+// --- End SDK Setup ---
+
 export default function App() {
   const gamePhase = useGameStore(state => state.gamePhase)
+
+  // --- New useEffect for SDK ---
+  useEffect(() => {
+    // Run the setup function when the component mounts
+    setupDiscordSdk()
+  }, [])
+  // --- End useEffect ---
   let scene = null
   switch (gamePhase) {
     case 'PACK':

--- a/discord-bot/tests/practice.test.js
+++ b/discord-bot/tests/practice.test.js
@@ -1,51 +1,32 @@
 const practice = require('../src/commands/practice');
 
-jest.mock('../src/utils/userService', () => ({
-  getUser: jest.fn(),
-  createUser: jest.fn()
-}));
-jest.mock('../src/utils/abilityCardService', () => ({
-  getCards: jest.fn()
-}));
-jest.mock('../../backend/game/engine');
-
-const userService = require('../src/utils/userService');
-const abilityCardService = require('../src/utils/abilityCardService');
-const GameEngine = require('../../backend/game/engine');
-const utils = require('../../backend/game/utils');
-const gameData = require('../util/gameData');
-const { allPossibleHeroes, allPossibleAbilities } = require('../../backend/game/data');
-
-jest.spyOn(utils, 'createCombatant');
-
 beforeEach(() => {
   jest.clearAllMocks();
-  gameData.gameData.heroes = new Map(allPossibleHeroes.map(h => [h.id, h]));
-  gameData.gameData.abilities = new Map(allPossibleAbilities.map(a => [a.id, a]));
-  GameEngine.mockImplementation(() => ({
-    runGameSteps: function* () {
-      yield { combatants: [], log: [{ round: 1, type: 'info', level: 'summary', message: 'log' }] };
-    },
-    runFullGame: jest.fn(),
-    winner: 'player',
-    finalPlayerState: {}
-  }));
+  process.env.APP_ID = '123456';
 });
 
-test('follow up when battle log DM fails', async () => {
-  userService.getUser.mockResolvedValue({
-    id: 1,
-    class: 'Warrior',
-    equipped_ability_id: 50,
-    dm_battle_logs_enabled: true
-  });
-  abilityCardService.getCards.mockResolvedValue([{ id: 50, ability_id: 3111, charges: 5 }]);
+test('errors when user not in voice channel', async () => {
   const interaction = {
-    user: { id: '123', username: 'tester', send: jest.fn().mockRejectedValue(new Error('fail')) },
+    member: { voice: { channel: null } },
     reply: jest.fn().mockResolvedValue(),
-    followUp: jest.fn().mockResolvedValue()
   };
   await practice.execute(interaction);
-  const ephemerals = interaction.followUp.mock.calls.filter(c => c[0].ephemeral);
-  expect(ephemerals.length).toBeGreaterThan(0);
+  expect(interaction.reply).toHaveBeenCalledWith(
+    expect.objectContaining({ ephemeral: true })
+  );
+});
+
+test('creates invite and replies with link', async () => {
+  const createInvite = jest.fn().mockResolvedValue({ code: 'abc123' });
+  const interaction = {
+    member: { voice: { channel: { createInvite } } },
+    reply: jest.fn().mockResolvedValue(),
+  };
+
+  await practice.execute(interaction);
+
+  expect(createInvite).toHaveBeenCalled();
+  expect(interaction.reply).toHaveBeenCalledWith(
+    expect.objectContaining({ ephemeral: true })
+  );
 });


### PR DESCRIPTION
## Summary
- initialize Discord SDK in React app on mount
- refactor `/practice` command to create a voice Activity invite
- update tests for new practice command behaviour

## Testing
- `npm test` in `backend`
- `npm test` in `discord-bot`


------
https://chatgpt.com/codex/tasks/task_e_6865e99fb0b48327a7750bb3fa7c62f3