### PR TITLE
Refactor town hub response

### DIFF
--- a/discord-bot/commands/town.js
+++ b/discord-bot/commands/town.js
@@ -1,7 +1,48 @@
-const { SlashCommandBuilder, ActionRowBuilder, ButtonBuilder, ButtonStyle, EmbedBuilder, MessageFlags } = require('discord.js');
+const { SlashCommandBuilder, ActionRowBuilder, ButtonBuilder, ButtonStyle, EmbedBuilder } = require('discord.js');
 const userService = require('../src/utils/userService');
 
-const IMAGE_URL = 'YOUR_IMAGE_URL_HERE';
+const IMAGE_URL = 'https://i.imgur.com/2pCIH22.png';
+
+/**
+ * Builds the embed and components for the town hub message.
+ * This function is reusable and separate from the interaction reply.
+ * @returns {{embeds: EmbedBuilder[], components: ActionRowBuilder[], ephemeral: boolean}}
+ */
+function buildTownHubResponse() {
+  const embed = new EmbedBuilder()
+    .setTitle('Welcome to Portal\'s Rest')
+    .setDescription('The bustling town is full of adventurers. What would you like to do?')
+    .setImage(IMAGE_URL);
+
+  const row = new ActionRowBuilder().addComponents(
+    new ButtonBuilder()
+      .setCustomId('town-adventure')
+      .setLabel('Go on an Adventure')
+      .setStyle(ButtonStyle.Success)
+      .setEmoji('⚔️'),
+    new ButtonBuilder()
+      .setCustomId('town-inventory')
+      .setLabel('Check Inventory')
+      .setStyle(ButtonStyle.Secondary)
+      .setEmoji('🎒'),
+    new ButtonBuilder()
+      .setCustomId('town-leaderboard')
+      .setLabel('View Leaderboard')
+      .setStyle(ButtonStyle.Primary)
+      .setEmoji('🏆'),
+    new ButtonBuilder()
+      .setCustomId('town-auctionhouse')
+      .setLabel('Visit Auction House')
+      .setStyle(ButtonStyle.Primary)
+      .setEmoji('💰')
+  );
+
+  return {
+    embeds: [embed],
+    components: [row],
+    ephemeral: true
+  };
+}
 
 module.exports = {
     data: new SlashCommandBuilder()
@@ -9,38 +50,14 @@ module.exports = {
         .setDescription('Visit the town to prepare for your next adventure.'),
     async execute(interaction) {
         await userService.setUserLocation(interaction.user.id, 'town');
-        const embed = new EmbedBuilder()
-            .setTitle('Welcome to Portal\'s Rest')
-            .setDescription('The bustling town is full of adventurers. What would you like to do?')
-            .setImage(IMAGE_URL.startsWith('http') ? IMAGE_URL : 'https://i.imgur.com/2pCIH22.png');
+        const responsePayload = buildTownHubResponse();
 
-        const row = new ActionRowBuilder().addComponents(
-            new ButtonBuilder()
-                .setCustomId('town-adventure')
-                .setLabel('Go on an Adventure')
-                .setStyle(ButtonStyle.Success)
-                .setEmoji('⚔️'),
-            new ButtonBuilder()
-                .setCustomId('town-inventory')
-                .setLabel('Check Inventory')
-                .setStyle(ButtonStyle.Secondary)
-                .setEmoji('🎒'),
-            new ButtonBuilder()
-                .setCustomId('town-leaderboard')
-                .setLabel('View Leaderboard')
-                .setStyle(ButtonStyle.Primary)
-                .setEmoji('🏆'),
-            new ButtonBuilder()
-                .setCustomId('town-auctionhouse')
-                .setLabel('Visit Auction House')
-                .setStyle(ButtonStyle.Primary)
-                .setEmoji('💰')
-        );
+        if (interaction.replied || interaction.deferred) {
+            await interaction.followUp(responsePayload);
+        } else {
+            await interaction.reply(responsePayload);
+        }
+    },
 
-        await interaction.reply({
-            embeds: [embed],
-            components: [row],
-            flags: [MessageFlags.Ephemeral]
-        });
-    }
+    buildTownHubResponse
 };

--- a/discord-bot/src/utils/interactionRouter.js
+++ b/discord-bot/src/utils/interactionRouter.js
@@ -1,5 +1,6 @@
 const userService = require('./userService');
 const settingsCommand = require('../../commands/settings');
+const { buildTownHubResponse } = require('../../commands/town');
 const feedback = require('./feedback');
 
 // Handles interactions for active users
@@ -64,24 +65,15 @@ async function routeInteraction(interaction) {
   let user = await userService.getUser(interaction.user.id);
   if (!user) {
     // --- MODIFICATION START ---
-    // New users should skip the tutorial and start in town. The old
-    // tutorial logic is kept below in comments for easy reversion.
+    // New users should skip the tutorial and start in town.
     user = await userService.createUser(interaction.user.id, interaction.user.username);
     await userService.setUserState(interaction.user.id, 'active');
     await userService.setUserLocation(interaction.user.id, 'town');
 
-    // Greet the user and show them the town command
-    const townCommand = interaction.client.commands.get('town');
-    if (townCommand) {
-      await feedback.sendInfo(
-        interaction,
-        'Welcome, Adventurer!',
-        "You have arrived at Portal's Rest. Use the buttons below to explore."
-      );
-      return townCommand.execute(interaction);
-    }
-    // Fallback if town command isn't available
-    return feedback.sendInfo(interaction, 'Welcome!', 'Your adventure begins!');
+    const townPayload = buildTownHubResponse();
+    townPayload.content = "Welcome, Adventurer! You have arrived at Portal's Rest.";
+
+    return interaction.reply(townPayload);
 
     /*
     // --- OLD TUTORIAL LOGIC (DISABLED) ---

--- a/discord-bot/tests/town.test.js
+++ b/discord-bot/tests/town.test.js
@@ -1,5 +1,5 @@
 const town = require('../commands/town');
-const { MessageFlags } = require('discord.js');
+
 
 jest.mock('../src/utils/userService', () => ({ setUserLocation: jest.fn() }));
 const userService = require('../src/utils/userService');
@@ -9,6 +9,6 @@ test('replies with town hub embed', async () => {
   await town.execute(interaction);
   expect(userService.setUserLocation).toHaveBeenCalledWith('1', 'town');
   expect(interaction.reply).toHaveBeenCalledWith(
-    expect.objectContaining({ embeds: expect.any(Array), components: expect.any(Array), flags: [MessageFlags.Ephemeral] })
+    expect.objectContaining({ embeds: expect.any(Array), components: expect.any(Array), ephemeral: true })
   );
 });


### PR DESCRIPTION
## Summary
- make town hub reusable with `buildTownHubResponse`
- use new builder in `interactionRouter`
- adjust tests for updated response payload

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6865f839c1a0832781456e0e7d044fa7