### PR TITLE
Move game engine to React client

### DIFF
--- a/auto-battler-react/src/App.jsx
+++ b/auto-battler-react/src/App.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useCallback } from 'react' // Import useCallback
+import React, { useEffect } from 'react' 
 import { DiscordSDK } from '@discord/embedded-app-sdk'
 import { useGameStore } from './store.js'
 import AnimatedBackground from './components/AnimatedBackground.jsx'

--- a/auto-battler-react/src/game/engine.js
+++ b/auto-battler-react/src/game/engine.js
@@ -4,17 +4,6 @@ import { allPossibleMinions } from '../data/data.js';
 import { STATUS_EFFECTS } from './statusEffects.js';
 import ProcEngine from './procEngine.js';
 
-// let abilityCardService;
-// try {
-//     abilityCardService = require('../../discord-bot/src/utils/abilityCardService');
-// } catch (e) {
-//     abilityCardService = { decrementCharge: () => {}, deleteCard: () => {} };
-// }
-// Stubbing out abilityCardService as per instructions
-const abilityCardService = {
-    decrementCharge: () => { console.warn("abilityCardService.decrementCharge called but is stubbed"); },
-    deleteCard: () => { console.warn("abilityCardService.deleteCard called but is stubbed"); }
-};
 
 class GameEngine {
     constructor(combatants, options = {}) {
@@ -498,13 +487,6 @@ class GameEngine {
                    });
                    attacker.currentEnergy -= cost;
                    attacker.abilityCharges -= 1;
-                   if (ability.cardId && !ability.isPractice) {
-                       try { abilityCardService.decrementCharge(ability.cardId); } catch(e) { /* ignore */ }
-                   }
-                   if (attacker.abilityCharges <= 0 && ability.cardId && !ability.isPractice) {
-                       this.log({ type: 'info', message: `${attacker.name}'s ${ability.name} card has run out of charges and crumbled to dust.` });
-                       try { abilityCardService.deleteCard(ability.cardId); } catch(e) { /* ignore in engine */ }
-                   }
                    if (attacker.abilityCharges <= 0) {
                        const idx = attacker.deck.findIndex(a => a.charges > 0);
                        if (idx !== -1) {

--- a/auto-battler-react/src/hooks/useBattleLogic.js
+++ b/auto-battler-react/src/hooks/useBattleLogic.js
@@ -1,284 +1,39 @@
-import { useState, useCallback, useEffect } from 'react';
-import { allPossibleMinions } from '../data/data.js';
+import { useState, useRef, useCallback, useEffect } from 'react';
+import GameEngine from '../game/engine.js';
 
-const MAX_ENERGY = 10;
+export default function useBattleLogic(initialCombatants = []) {
+  const engineRef = useRef(null);
+  const iteratorRef = useRef(null);
 
-function getEffectiveSpeed(combatant) {
-  let spd = combatant.speed || 0;
-  combatant.statusEffects.forEach((s) => {
-    if (s.name === 'Slow') spd -= 1;
-  });
-  return spd;
-}
-
-function computeTurnQueue(state) {
-  return state
-    .filter((c) => c.currentHp > 0)
-    .sort((a, b) => getEffectiveSpeed(b) - getEffectiveSpeed(a))
-    .map((c) => c.id);
-}
-
-function applyStatus(target, statusName, turns, log) {
-  const existing = target.statusEffects.find((s) => s.name === statusName);
-  if (existing) existing.turnsRemaining += turns;
-  else target.statusEffects.push({ name: statusName, turnsRemaining: turns });
-  if (log) log(`${target.name} is afflicted with ${statusName}!`);
-}
-
-function calculateDamage(attacker, target, baseDamage) {
-  let dmg = baseDamage;
-  if (attacker.statusEffects.some((s) => s.name === 'Attack Up')) dmg += 2;
-
-  let block = target.block || 0;
-  if (target.statusEffects.some((s) => s.name === 'Defense Down')) block = Math.max(0, block - 1);
-  if (target.statusEffects.some((s) => s.name === 'Burn')) block = Math.max(0, block - 1);
-  dmg = Math.max(1, dmg - block);
-
-  if (target.statusEffects.some((s) => s.name === 'Vulnerable')) dmg += 1;
-  return dmg;
-}
-
-export default function useBattleLogic(initialCombatants = [], eventHandlers = {}) {
-  const { onAttack } = eventHandlers
-  const [battleState, setBattleState] = useState(() =>
-    initialCombatants.map(c => ({ ...c }))
-  );
-  const [turnQueue, setTurnQueue] = useState(() => computeTurnQueue(initialCombatants));
-
-  useEffect(() => {
-    setBattleState(initialCombatants.map(c => ({ ...c })))
-    setTurnQueue(computeTurnQueue(initialCombatants))
-  }, [initialCombatants])
+  const [battleState, setBattleState] = useState(() => initialCombatants.map(c => ({ ...c })));
   const [battleLog, setBattleLog] = useState([]);
   const [isBattleOver, setIsBattleOver] = useState(false);
   const [winner, setWinner] = useState(null);
 
-  const log = useCallback((msg) => setBattleLog((l) => [...l, msg]), []);
-
-  const removeFromQueue = (id, queue) => queue.filter((q) => q !== id);
-
-  const applyDamage = (attacker, target, baseDamage, queue) => {
-    const dmg = calculateDamage(attacker, target, baseDamage)
-
-    if (onAttack) onAttack(attacker.id, target.id, dmg)
-
-    target.currentHp = Math.max(0, target.currentHp - dmg)
-    const aName = attacker.heroData?.name || attacker.name
-    const tName = target.heroData?.name || target.name
-    log(`${aName} hits ${tName} for ${dmg} damage.`)
-    if (target.currentHp <= 0) {
-      log(`${tName} is defeated.`)
-      queue = removeFromQueue(target.id, queue)
+  useEffect(() => {
+    engineRef.current = new GameEngine(initialCombatants);
+    iteratorRef.current = engineRef.current.runGameSteps();
+    const first = iteratorRef.current.next().value;
+    if (first && first.combatants) {
+      setBattleState(first.combatants);
+      setBattleLog(first.log);
+    } else {
+      setBattleState(initialCombatants.map(c => ({ ...c })));
     }
-    return queue
-  }
-
-  const processStatuses = (combatant) => {
-    let skip = false;
-
-    combatant.statusEffects.forEach((s) => {
-      switch (s.name) {
-        case 'Poison':
-          combatant.currentHp = Math.max(0, combatant.currentHp - 2);
-          log(`${combatant.name} suffers 2 poison damage.`);
-          break;
-        case 'Bleed':
-          combatant.currentHp = Math.max(0, combatant.currentHp - 2);
-          log(`${combatant.name} suffers 2 bleed damage.`);
-          break;
-        case 'Burn':
-          combatant.currentHp = Math.max(0, combatant.currentHp - 2);
-          log(`${combatant.name} suffers 2 burn damage.`);
-          break;
-        default:
-          break;
-      }
-    });
-
-    if (combatant.statusEffects.some((s) => s.name === 'Stun')) {
-      log(`${combatant.name} is stunned and misses the turn.`);
-      skip = true;
-    }
-
-    if (combatant.statusEffects.some((s) => s.name === 'Root')) {
-      log(`${combatant.name} is rooted and cannot act.`);
-      skip = true;
-    }
-
-    if (!skip && combatant.statusEffects.some((s) => s.name === 'Confuse') && Math.random() < 0.5) {
-      log(`${combatant.name} is confused and fumbles their turn.`);
-      skip = true;
-    }
-
-    combatant.statusEffects = combatant.statusEffects
-      .map((s) => ({ ...s, turnsRemaining: s.turnsRemaining - 1 }))
-      .filter((s) => s.turnsRemaining > 0);
-
-    return skip;
-  };
-
-  const checkVictory = (state) => {
-    const playerAlive = state.some((c) => c.team === 'player' && c.currentHp > 0);
-    const enemyAlive = state.some((c) => c.team === 'enemy' && c.currentHp > 0);
-    if (!playerAlive || !enemyAlive) {
-      setIsBattleOver(true);
-      setWinner(playerAlive ? 'player' : 'enemy');
-      log(`${playerAlive ? 'Player' : 'Enemy'} team wins the battle!`);
-      return true;
-    }
-    return false;
-  };
+    setIsBattleOver(engineRef.current.isBattleOver);
+    setWinner(engineRef.current.winner);
+  }, [initialCombatants]);
 
   const processTurn = useCallback(() => {
-    if (isBattleOver) return;
-
-    setBattleState((prevState) => {
-      const state = prevState.map((c) => ({ ...c, statusEffects: [...c.statusEffects] }));
-      let queue = [...turnQueue];
-      if (queue.length === 0) queue = computeTurnQueue(state);
-
-      let attackerId = queue.shift();
-      let attacker = state.find((c) => c.id === attackerId);
-      while (attacker && attacker.currentHp <= 0 && queue.length) {
-        attackerId = queue.shift();
-        attacker = state.find((c) => c.id === attackerId);
-      }
-      if (!attacker || attacker.currentHp <= 0) {
-        setTurnQueue(queue);
-        return state;
-      }
-
-      const skip = processStatuses(attacker);
-      if (attacker.currentHp <= 0) {
-        queue = removeFromQueue(attacker.id, queue);
-        setTurnQueue(queue);
-        return state;
-      }
-      if (!skip) {
-        const targets = state.filter((c) => c.team !== attacker.team && c.currentHp > 0);
-        if (targets.length === 0) {
-          setTurnQueue(queue);
-          return state;
-        }
-        const ability = attacker.abilityData;
-        let usedAbility = false;
-        if (ability && attacker.currentEnergy >= ability.energyCost) {
-          usedAbility = true;
-          attacker.currentEnergy -= ability.energyCost;
-
-          const shocked = attacker.statusEffects.some((s) => s.name === 'Shock') && Math.random() < 0.5;
-          if (shocked) {
-            log(`${attacker.name}'s ability fizzles due to shock!`);
-          } else {
-            log(`${attacker.name} uses ${ability.name}!`);
-
-            if (ability.summons) {
-              const summonList = Array.isArray(ability.summons) ? ability.summons : [ability.summons];
-              summonList.forEach((key) => {
-                const minionData = allPossibleMinions[key];
-                if (minionData) {
-                  const id = `${attacker.team}-minion-${Date.now()}-${Math.floor(Math.random() * 10000)}`;
-                  const newUnit = {
-                    id,
-                    heroData: { ...minionData },
-                    weaponData: null,
-                    armorData: null,
-                    abilityData: null,
-                    team: attacker.team,
-                    position: state.filter((c) => c.team === attacker.team).length,
-                    currentHp: minionData.hp,
-                    maxHp: minionData.hp,
-                    attack: minionData.attack,
-                    speed: minionData.speed,
-                    block: 0,
-                    evasion: 0,
-                    magicResist: 0,
-                    currentEnergy: 0,
-                    statusEffects: [],
-                  };
-                  state.push(newUnit);
-                }
-              });
-              queue = computeTurnQueue(state).filter((id) => id !== attacker.id);
-            }
-
-            const dmgMatch = ability.effect.match(/(\d+)/);
-            const base = dmgMatch ? parseInt(dmgMatch[1], 10) : attacker.attack;
-            if (ability.target === 'ENEMIES') {
-              targets.forEach((t) => {
-                queue = applyDamage(attacker, t, base, queue);
-                if (ability.name === 'Firestorm') applyStatus(t, 'Burn', 2, log);
-              });
-            } else if (targets.length) {
-              const target = targets[0];
-              queue = applyDamage(attacker, target, base, queue);
-              if (ability.name === 'Shield Bash') {
-                applyStatus(target, 'Stun', 1, log);
-              } else if (['Elemental Rift', 'Frozen Grasp', 'Entangle'].includes(ability.name)) {
-                applyStatus(target, 'Root', 1, log);
-              } else if (ability.name === 'Judgment') {
-                applyStatus(target, 'Defense Down', 2, log);
-              }
-            }
-
-            if (ability.summons) {
-              const keys = Array.isArray(ability.summons)
-                ? ability.summons
-                : [ability.summons];
-              const newMinions = [];
-              keys.forEach((key) => {
-                const template = allPossibleMinions[key];
-                if (!template) return;
-                const id = `${attacker.id}-minion-${
-                  Math.random().toString(36).slice(2, 9)
-                }`;
-                const minion = {
-                  id,
-                  heroData: template,
-                  team: attacker.team,
-                  position: state.length,
-                  currentHp: template.hp,
-                  maxHp: template.hp,
-                  currentEnergy: 0,
-                  attack: template.attack,
-                  speed: template.speed,
-                  block: template.block || 0,
-                  evasion: template.evasion || 0,
-                  magicResist: template.magicResist || 0,
-                  statusEffects: [],
-                  isMinion: true,
-                  name: template.name,
-                  art: template.art,
-                  rarity: template.rarity,
-                  abilityData: null,
-                };
-                state.push(minion);
-                newMinions.push(minion);
-                log(`${attacker.name} summons a ${template.name}!`);
-              });
-              if (newMinions.length) {
-                const remaining = queue
-                  .map((id) => state.find((c) => c.id === id))
-                  .filter(Boolean);
-                queue = computeTurnQueue([...remaining, ...newMinions]);
-              }
-            }
-          }
-        }
-
-        if (!usedAbility) {
-          const target = targets[0];
-          queue = applyDamage(attacker, target, attacker.attack, queue);
-        }
-        attacker.currentEnergy = Math.min(MAX_ENERGY, attacker.currentEnergy + 1);
-      }
-
-      setTurnQueue(queue);
-      checkVictory(state);
-      return state;
-    });
-  }, [turnQueue, isBattleOver, log]);
+    if (!iteratorRef.current || engineRef.current.isBattleOver) return;
+    const step = iteratorRef.current.next().value;
+    if (!step) return;
+    if (step.type === 'PAUSE') return;
+    if (step.combatants) setBattleState(step.combatants);
+    if (step.log) setBattleLog((log) => [...log, ...step.log]);
+    setIsBattleOver(engineRef.current.isBattleOver);
+    setWinner(engineRef.current.winner);
+  }, []);
 
   return { battleState, battleLog, isBattleOver, winner, processTurn };
 }
-


### PR DESCRIPTION
## Summary
- copy backend game engine to `src/game` and convert to ES modules
- remove abilityCardService dependencies from the engine
- implement `useBattleLogic` using the client-side game engine
- fix an ESLint issue by removing an unused import

## Testing
- `npm run lint` in `auto-battler-react`
- `npm test` in `backend`

------
https://chatgpt.com/codex/tasks/task_e_6865fa96f224832784511f9c36ff1834