### PR TITLE
Add debug logs for Discord Activity launch process

### DIFF
--- a/auto-battler-react/src/App.jsx
+++ b/auto-battler-react/src/App.jsx
@@ -1,5 +1,8 @@
-import React, { useEffect } from 'react' 
+import React, { useEffect } from 'react'
 import { DiscordSDK } from '@discord/embedded-app-sdk'
+
+// Log when the script is loaded to verify iframe execution
+console.log('[React App] App.jsx script loaded.');
 import { useGameStore } from './store.js'
 import AnimatedBackground from './components/AnimatedBackground.jsx'
 import DebugMenu from './components/DebugMenu.jsx'
@@ -18,8 +21,9 @@ import './style.css'
 const discordSdk = new DiscordSDK(import.meta.env.VITE_DISCORD_CLIENT_ID)
 
 async function setupDiscordSdk() {
+  console.log('[React App] Starting Discord SDK setup...');
   await discordSdk.ready();
-  console.log("Discord SDK is ready and connected.");
+  console.log('[React App] Discord SDK is ready!');
 
   // Authenticate to get the current user
   // TODO: This needs a valid OAuth2 access token
@@ -87,6 +91,7 @@ export default function App() {
 
   // Setup Discord SDK and multiplayer logic
   useEffect(() => {
+    console.log('[React App] App component mounted, attempting to set up SDK.');
     setupDiscordSdk();
   }, []);
 

--- a/discord-bot/src/commands/practice.js
+++ b/discord-bot/src/commands/practice.js
@@ -25,11 +25,16 @@ async function execute(interaction) {
       target_type: 2, // Required for Embedded Application invites
     });
 
+    // Log the generated invite code and full URL for debugging
+    console.log(`[Launcher] Generated Activity Invite Code: ${invite.code}`);
+    const activityUrl = `https://discord.com/invite/${invite.code}`;
+    console.log(`[Launcher] Full URL: ${activityUrl}`);
+
     const row = new ActionRowBuilder().addComponents(
       new ButtonBuilder()
         .setLabel('Start Practice Game')
         .setStyle(ButtonStyle.Link)
-        .setURL(`https://discord.com/invite/${invite.code}`)
+        .setURL(activityUrl)
     );
 
     await interaction.reply({


### PR DESCRIPTION
## Summary
- log generated invite URL in `/practice` command
- log React app startup and Discord SDK initialization

## Testing
- `npm test` in `backend`

------
https://chatgpt.com/codex/tasks/task_e_6865fcf5f56883279f405d4a8b42d16b