### PR TITLE
Enable HTTPS for Vite dev server

### DIFF
--- a/auto-battler-react/package-lock.json
+++ b/auto-battler-react/package-lock.json
@@ -19,6 +19,7 @@
         "@tailwindcss/postcss": "^4.1.10",
         "@types/react": "^19.1.2",
         "@types/react-dom": "^19.1.2",
+        "@vitejs/plugin-basic-ssl": "^2.1.0",
         "@vitejs/plugin-react": "^4.4.1",
         "autoprefixer": "^10.4.21",
         "eslint": "^9.25.0",
@@ -1703,6 +1704,19 @@
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "^19.0.0"
+      }
+    },
+    "node_modules/@vitejs/plugin-basic-ssl": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@vitejs/plugin-basic-ssl/-/plugin-basic-ssl-2.1.0.tgz",
+      "integrity": "sha512-dOxxrhgyDIEUADhb/8OlV9JIqYLgos03YorAueTIeOUskLJSEsfwCByjbu98ctXitUN3znXKp0bYD/WHSudCeA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "peerDependencies": {
+        "vite": "^6.0.0 || ^7.0.0"
       }
     },
     "node_modules/@vitejs/plugin-react": {

--- a/auto-battler-react/package.json
+++ b/auto-battler-react/package.json
@@ -10,17 +10,18 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "prop-types": "^15.8.1",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
     "use-sync-external-store": "^1.5.0",
-    "zustand": "^5.0.5",
-    "prop-types": "^15.8.1"
+    "zustand": "^5.0.5"
   },
   "devDependencies": {
     "@eslint/js": "^9.25.0",
     "@tailwindcss/postcss": "^4.1.10",
     "@types/react": "^19.1.2",
     "@types/react-dom": "^19.1.2",
+    "@vitejs/plugin-basic-ssl": "^2.1.0",
     "@vitejs/plugin-react": "^4.4.1",
     "autoprefixer": "^10.4.21",
     "eslint": "^9.25.0",

--- a/auto-battler-react/vite.config.js
+++ b/auto-battler-react/vite.config.js
@@ -1,7 +1,11 @@
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
+import basicSsl from '@vitejs/plugin-basic-ssl' // <-- IMPORT THE PLUGIN
 
 // https://vite.dev/config/
 export default defineConfig({
-  plugins: [react()],
+  plugins: [
+    react(),
+    basicSsl() // <-- ADD THE PLUGIN HERE
+  ],
 })


### PR DESCRIPTION
Installed @vitejs/plugin-basic-ssl and updated vite.config.js to use it. This allows the Vite development server to serve the application over HTTPS, which is a requirement for Discord Activities.