### PR TITLE
Enable iframe embedding in Vite dev server

### DIFF
--- a/auto-battler-react/vite.config.js
+++ b/auto-battler-react/vite.config.js
@@ -8,4 +8,16 @@ export default defineConfig({
     react(),
     basicSsl() // <-- ADD THE PLUGIN HERE
   ],
+  server: {
+    port: 5173,
+    // Allow the server to be accessed from your local network
+    host: true,
+    // Explicitly set headers to allow embedding
+    headers: {
+      // Allow discord.com to embed this page
+      'Content-Security-Policy': "frame-ancestors 'self' *.discord.com",
+      // For older browsers, though CSP is preferred
+      'X-Frame-Options': 'ALLOW-FROM *.discord.com',
+    },
+  },
 })


### PR DESCRIPTION
## Summary
- configure `vite.config.js` in React app so Discord can embed the app in an iframe

## Testing
- `npm test` in `discord-bot`
- `npm run lint` in `auto-battler-react`


------
https://chatgpt.com/codex/tasks/task_e_6866024973c88327a23b060ef30f2159