### PR TITLE
Configure production URL and deployment docs

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,25 @@
+# Example environment configuration for the Discord bot and backend
+
+# Discord bot token
+DISCORD_TOKEN=YOUR_DISCORD_TOKEN
+
+# Discord application ID (client ID)
+APP_ID=YOUR_APP_ID
+
+# Discord guild/server ID where commands are deployed
+GUILD_ID=YOUR_GUILD_ID
+
+# MySQL database connection settings
+DB_HOST=localhost
+DB_USER=root
+DB_PASSWORD=password
+DB_DATABASE=auto_battler
+
+# Channel used for announcements
+PVP_CHANNEL_ID=1389239394812170410
+
+# Port for the Express backend (optional)
+PORT=3000
+
+# Base URL for the web app (used in replay links)
+WEB_APP_URL=https://autobattler.example.com

--- a/README.md
+++ b/README.md
@@ -76,3 +76,27 @@ When configured correctly the bot logs a `Database connection successful` messag
 
 The bot includes a simple `/inventory` command for viewing your backpack. Once the ability card system is implemented it will also support `/inventory set` to choose which ability card is active.  The design for this charge-based system is documented in [docs/ability_card_charge_gdd.md](docs/ability_card_charge_gdd.md).
 
+## Deployment
+
+Follow these steps to host the app on your GoDaddy server:
+
+1. **Build the frontend**
+   ```bash
+   cd auto-battler-react
+   npm install
+   npm run build
+   ```
+   Upload the resulting `dist/` folder to your hosting space.
+
+2. **Start the backend**
+   ```bash
+   cd backend
+   npm install
+   npm start
+   ```
+   Use a tool such as `pm2` if you want the server to run continuously.
+
+3. **Environment variables**
+   Copy `.env.example` to `.env` and set `WEB_APP_URL` to your production domain.
+   The replay buttons in `/challenge` and `/adventure` will point to this URL.
+


### PR DESCRIPTION
## Summary
- add `.env` with placeholder production domain
- update challenge command to save replays and link to web app
- mock replay service and ability service in challenge tests
- document GoDaddy deployment steps

## Testing
- `npm test --silent` *(fails: TypeError in challenge.test.js)*


------
https://chatgpt.com/codex/tasks/task_e_686626484e888327bcb5c84bdd98f74b