### PR TITLE
Add event-driven battle animations

### DIFF
--- a/auto-battler-react/src/style.css
+++ b/auto-battler-react/src/style.css
@@ -528,6 +528,7 @@ button:disabled {
 }
 .combat-text-popup.damage { color: #ef4444; }
 .combat-text-popup.heal { color: #22c55e; }
+.combat-text-popup.status { color: #e0f2fe; }
 .combat-text-popup.energy {
     color: #60a5fa;
     text-shadow: 1px 1px 3px #1e3a8a;


### PR DESCRIPTION
## Summary
- enhance `BattleScene.jsx` with event parsing and animation triggers
- flash status icons and show damage/heal popups based on log events
- add status text color style for combat popups

## Testing
- `npm test --silent --prefix backend`
- `npm run lint --silent --prefix auto-battler-react`

------
https://chatgpt.com/codex/tasks/task_e_68662648c63c8327a3158232f5db3ebc