### PR TITLE
Add battle log playback controls

### DIFF
--- a/auto-battler-react/src/hooks/useBattleLogic.js
+++ b/auto-battler-react/src/hooks/useBattleLogic.js
@@ -1,39 +1,93 @@
-import { useState, useRef, useCallback, useEffect } from 'react';
-import GameEngine from '../game/engine.js';
+import { useState, useRef, useCallback, useEffect } from 'react'
+import GameEngine from '../game/engine.js'
 
-export default function useBattleLogic(initialCombatants = []) {
-  const engineRef = useRef(null);
-  const iteratorRef = useRef(null);
+function computeWinner(combatants = []) {
+  const playerAlive = combatants.some(c => c.team === 'player' && c.currentHp > 0)
+  const enemyAlive = combatants.some(c => c.team === 'enemy' && c.currentHp > 0)
+  if (!playerAlive || !enemyAlive) return playerAlive ? 'player' : 'enemy'
+  return null
+}
 
-  const [battleState, setBattleState] = useState(() => initialCombatants.map(c => ({ ...c })));
-  const [battleLog, setBattleLog] = useState([]);
-  const [isBattleOver, setIsBattleOver] = useState(false);
-  const [winner, setWinner] = useState(null);
+export default function useBattleLogic(initialCombatants = [], options = {}, existingLog) {
+  const engineRef = useRef(null)
+  const iteratorRef = useRef(null)
+
+  const [battleState, setBattleState] = useState(() =>
+    (existingLog && existingLog[0]?.combatants)
+      ? existingLog[0].combatants.map(c => ({ ...c }))
+      : initialCombatants.map(c => ({ ...c }))
+  )
+  const [battleLog, setBattleLog] = useState(() => (existingLog && existingLog[0]?.log) ? [...existingLog[0].log] : [])
+  const [isBattleOver, setIsBattleOver] = useState(() => (existingLog ? existingLog.length <= 1 : false))
+  const [winner, setWinner] = useState(() => (existingLog && existingLog[0]?.combatants ? computeWinner(existingLog[0].combatants) : null))
+  const [stepIndex, setStepIndex] = useState(0)
+  const [isPlaying, setIsPlaying] = useState(!existingLog)
 
   useEffect(() => {
-    engineRef.current = new GameEngine(initialCombatants);
-    iteratorRef.current = engineRef.current.runGameSteps();
-    const first = iteratorRef.current.next().value;
-    if (first && first.combatants) {
-      setBattleState(first.combatants);
-      setBattleLog(first.log);
+    if (existingLog && existingLog.length > 0) {
+      setBattleState(existingLog[0].combatants.map(c => ({ ...c })))
+      setBattleLog(existingLog[0].log || [])
+      setIsBattleOver(existingLog.length === 1)
+      setWinner(computeWinner(existingLog[0].combatants))
+      setStepIndex(0)
+      engineRef.current = null
+      iteratorRef.current = null
     } else {
-      setBattleState(initialCombatants.map(c => ({ ...c })));
+      engineRef.current = new GameEngine(initialCombatants, options)
+      iteratorRef.current = engineRef.current.runGameSteps()
+      const first = iteratorRef.current.next().value
+      if (first && first.combatants) {
+        setBattleState(first.combatants)
+        setBattleLog(first.log)
+      } else {
+        setBattleState(initialCombatants.map(c => ({ ...c })))
+      }
+      setIsBattleOver(engineRef.current.isBattleOver)
+      setWinner(engineRef.current.winner)
+      setStepIndex(0)
     }
-    setIsBattleOver(engineRef.current.isBattleOver);
-    setWinner(engineRef.current.winner);
-  }, [initialCombatants]);
+  }, [initialCombatants, options, existingLog])
 
   const processTurn = useCallback(() => {
-    if (!iteratorRef.current || engineRef.current.isBattleOver) return;
-    const step = iteratorRef.current.next().value;
-    if (!step) return;
-    if (step.type === 'PAUSE') return;
-    if (step.combatants) setBattleState(step.combatants);
-    if (step.log) setBattleLog((log) => [...log, ...step.log]);
-    setIsBattleOver(engineRef.current.isBattleOver);
-    setWinner(engineRef.current.winner);
-  }, []);
+    if (existingLog) {
+      if (stepIndex >= existingLog.length - 1) return
+      const nextIndex = stepIndex + 1
+      const step = existingLog[nextIndex]
+      if (step.combatants) setBattleState(step.combatants)
+      if (step.log) setBattleLog(log => [...log, ...step.log])
+      setStepIndex(nextIndex)
+      if (nextIndex === existingLog.length - 1) {
+        setIsBattleOver(true)
+        setWinner(computeWinner(step.combatants))
+        setIsPlaying(false)
+      }
+      return
+    }
 
-  return { battleState, battleLog, isBattleOver, winner, processTurn };
+    if (!iteratorRef.current || engineRef.current.isBattleOver) return
+    const step = iteratorRef.current.next().value
+    if (!step) return
+    if (step.type === 'PAUSE') return
+    if (step.combatants) setBattleState(step.combatants)
+    if (step.log) setBattleLog(log => [...log, ...step.log])
+    setIsBattleOver(engineRef.current.isBattleOver)
+    setWinner(engineRef.current.winner)
+    setStepIndex(i => i + 1)
+  }, [existingLog, stepIndex])
+
+  const play = () => setIsPlaying(true)
+  const pause = () => setIsPlaying(false)
+
+  return {
+    battleState,
+    battleLog,
+    isBattleOver,
+    winner,
+    processTurn,
+    play,
+    pause,
+    isPlaying,
+    stepIndex,
+    totalSteps: existingLog ? existingLog.length : null
+  }
 }

--- a/auto-battler-react/src/scenes/BattleScene.jsx
+++ b/auto-battler-react/src/scenes/BattleScene.jsx
@@ -73,15 +73,25 @@ export default function BattleScene() {
     setTimeout(() => popup.remove(), 1200)
   }
 
-  const { battleState, battleLog, isBattleOver, winner, processTurn } =
-    useBattleLogic(combatants, { onAttack: handleAttack })
+  const {
+    battleState,
+    battleLog,
+    isBattleOver,
+    winner,
+    processTurn,
+    play,
+    pause,
+    isPlaying,
+    stepIndex,
+    totalSteps
+  } = useBattleLogic(combatants, { onAttack: handleAttack })
 
   useEffect(() => {
-    if (!isBattleOver) {
+    if (!isBattleOver && isPlaying) {
       const timer = setTimeout(processTurn, 1000)
       return () => clearTimeout(timer)
     }
-  }, [battleLog, isBattleOver, processTurn])
+  }, [battleLog, isBattleOver, processTurn, isPlaying])
 
   useEffect(() => {
     if (isBattleOver) {
@@ -117,6 +127,14 @@ export default function BattleScene() {
         </div>
       </div>
       <BattleLog battleLog={battleLog} />
+      <div className="battle-controls text-center mt-2">
+        <button className="px-2 py-1 bg-gray-700 rounded" onClick={isPlaying ? pause : play}>
+          {isPlaying ? 'Pause' : 'Play'}
+        </button>
+        <span className="ml-2">
+          Step {stepIndex + 1}{totalSteps ? ` / ${totalSteps}` : ''}
+        </span>
+      </div>
       {isBattleOver && (
         <div className="battle-result text-xl text-center mt-4">
           {winner === 'player' ? 'Victory!' : 'Defeat!'}


### PR DESCRIPTION
## Summary
- extend `useBattleLogic` to optionally read from a pre-generated log
- expose play/pause state and step index for UI
- show a play/pause button and step counter in BattleScene

## Testing
- `npm test` in `backend` *(fails: jest not found)*
- `npm test` in `auto-battler-react` *(fails: no test script)*
- `npm run lint` in `auto-battler-react` *(fails: missing ESLint deps)*

------
https://chatgpt.com/codex/tasks/task_e_68662649a5348327addc78a8745a7562