### PR TITLE
Display final battle state from stored logs

### DIFF
--- a/auto-battler-react/src/App.jsx
+++ b/auto-battler-react/src/App.jsx
@@ -88,6 +88,7 @@ async function setupDiscordSdk() {
 
 export default function App() {
   const gamePhase = useGameStore(state => state.gamePhase)
+  const storedLog = useGameStore(state => state.battleLog)
 
   // Setup Discord SDK and multiplayer logic
   useEffect(() => {
@@ -124,7 +125,7 @@ export default function App() {
       scene = <DraftScene />
       break
     case 'BATTLE':
-      scene = <BattleScene />
+      scene = <BattleScene storedLog={storedLog} />
       break
     case 'RECAP_1':
       scene = <RecapScene />

--- a/auto-battler-react/src/store.js
+++ b/auto-battler-react/src/store.js
@@ -74,6 +74,7 @@ export const useGameStore = createWithEqualityFn(
   packChoices: [],
   revealedCards: [],
   combatants: [],
+  battleLog: [],
   isSpeedLinesActive: false,
   // Add these new properties to your initial store state
   playerRole: 'guest', // Default to 'guest'
@@ -289,7 +290,7 @@ export const useGameStore = createWithEqualityFn(
       const enemy1 = createCombatant(enemyHero1, enemyWeapon1, enemyArmor1, enemyAbility1, 'enemy', 0)
       const enemy2 = createCombatant(enemyHero2, enemyWeapon2, enemyArmor2, enemyAbility2, 'enemy', 1)
 
-      return { combatants: [player1, player2, enemy1, enemy2], gamePhase: 'BATTLE' }
+      return { combatants: [player1, player2, enemy1, enemy2], gamePhase: 'BATTLE', battleLog: [] }
     }),
 
   openPack: () =>


### PR DESCRIPTION
## Summary
- track battle logs in store and reset them when battles start
- forward the stored log to `BattleScene`
- derive final combatant state from the stored log
- show cards and final result using that state

## Testing
- `npm run lint` in `auto-battler-react`
- `npm test` in `backend`

------
https://chatgpt.com/codex/tasks/task_e_6866264a8c348327a150aaacfdaf5028