### PR TITLE
Add replay viewer routing

### DIFF
--- a/auto-battler-react/package-lock.json
+++ b/auto-battler-react/package-lock.json
@@ -11,6 +11,7 @@
         "prop-types": "^15.8.1",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
+        "react-router-dom": "^7.6.3",
         "use-sync-external-store": "^1.5.0",
         "zustand": "^5.0.5"
       },
@@ -1984,6 +1985,14 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/cookie": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.0.2.tgz",
+      "integrity": "sha512-9Kr/j4O16ISv8zBBhJoi4bXOYNTkFLOqSL3UDB0njXxCXNezjeyVrJyGOWtgfs/q2km1gwBcfH8q1yEGoMYunA==",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
@@ -3252,6 +3261,42 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/react-router": {
+      "version": "7.6.3",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.6.3.tgz",
+      "integrity": "sha512-zf45LZp5skDC6I3jDLXQUu0u26jtuP4lEGbc7BbdyxenBN1vJSTA18czM2D+h5qyMBuMrD+9uB+mU37HIoKGRA==",
+      "dependencies": {
+        "cookie": "^1.0.1",
+        "set-cookie-parser": "^2.6.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-router-dom": {
+      "version": "7.6.3",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.6.3.tgz",
+      "integrity": "sha512-DiWJm9qdUAmiJrVWaeJdu4TKu13+iB/8IEi0EW/XgaHCjW/vWGrwzup0GVvaMteuZjKnh5bEvJP/K0MDnzawHw==",
+      "dependencies": {
+        "react-router": "7.6.3"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
+      }
+    },
     "node_modules/resolve-from": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
@@ -3317,6 +3362,11 @@
       "bin": {
         "semver": "bin/semver.js"
       }
+    },
+    "node_modules/set-cookie-parser": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.1.tgz",
+      "integrity": "sha512-IOc8uWeOZgnb3ptbCURJWNjWUPcO3ZnTTdzsurqERrP6nPyv+paC55vJM0LpOlT2ne+Ix+9+CRG1MNLlyZ4GjQ=="
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",

--- a/auto-battler-react/package.json
+++ b/auto-battler-react/package.json
@@ -13,6 +13,7 @@
     "prop-types": "^15.8.1",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
+    "react-router-dom": "^7.6.3",
     "use-sync-external-store": "^1.5.0",
     "zustand": "^5.0.5"
   },

--- a/auto-battler-react/src/App.jsx
+++ b/auto-battler-react/src/App.jsx
@@ -1,11 +1,13 @@
 import React, { useEffect } from 'react'
 import { DiscordSDK } from '@discord/embedded-app-sdk'
+import { Routes, Route } from 'react-router-dom'
 
 // Log when the script is loaded to verify iframe execution
 console.log('[React App] App.jsx script loaded.');
 import { useGameStore } from './store.js'
 import AnimatedBackground from './components/AnimatedBackground.jsx'
 import DebugMenu from './components/DebugMenu.jsx'
+import ReplayViewer from './components/ReplayViewer.jsx'
 
 import PackScene from './scenes/PackScene.jsx'
 import RevealScene from './scenes/RevealScene.jsx'
@@ -143,10 +145,18 @@ export default function App() {
   }
 
   return (
-    <>
-      <AnimatedBackground isSpeedActive={false} />
-      {scene}
-      {import.meta.env.DEV && <DebugMenu />}
-    </>
+    <Routes>
+      <Route path="/replay/:id" element={<ReplayViewer />} />
+      <Route
+        path="*"
+        element={(
+          <>
+            <AnimatedBackground isSpeedActive={false} />
+            {scene}
+            {import.meta.env.DEV && <DebugMenu />}
+          </>
+        )}
+      />
+    </Routes>
   )
 }

--- a/auto-battler-react/src/components/ReplayViewer.jsx
+++ b/auto-battler-react/src/components/ReplayViewer.jsx
@@ -1,0 +1,30 @@
+import React, { useEffect } from 'react'
+import { useParams } from 'react-router-dom'
+import { useGameStore } from '../store.js'
+
+export default function ReplayViewer() {
+  const { id } = useParams()
+  const setReplayLog = useGameStore(state => state.setReplayLog)
+  const replayLog = useGameStore(state => state.replayLog)
+
+  useEffect(() => {
+    async function fetchReplay() {
+      try {
+        const res = await fetch(`/api/replays/${id}`)
+        if (!res.ok) return
+        const data = await res.json()
+        setReplayLog(data)
+      } catch (err) {
+        console.error('Failed to fetch replay', err)
+      }
+    }
+    fetchReplay()
+  }, [id, setReplayLog])
+
+  return (
+    <div>
+      <h2>Replay Viewer</h2>
+      <pre>{JSON.stringify(replayLog, null, 2)}</pre>
+    </div>
+  )
+}

--- a/auto-battler-react/src/main.jsx
+++ b/auto-battler-react/src/main.jsx
@@ -4,10 +4,13 @@ import './index.css'
 import './style.css'
 import { initBackgroundAnimation } from './background-animation.js'
 import App from './App.jsx'
+import { BrowserRouter } from 'react-router-dom'
 
 createRoot(document.getElementById('root')).render(
   <StrictMode>
-    <App />
+    <BrowserRouter>
+      <App />
+    </BrowserRouter>
   </StrictMode>,
 )
 

--- a/auto-battler-react/src/store.js
+++ b/auto-battler-react/src/store.js
@@ -74,6 +74,7 @@ export const useGameStore = createWithEqualityFn(
   packChoices: [],
   revealedCards: [],
   combatants: [],
+  replayLog: [],
   isSpeedLinesActive: false,
   // Add these new properties to your initial store state
   playerRole: 'guest', // Default to 'guest'
@@ -81,6 +82,8 @@ export const useGameStore = createWithEqualityFn(
 
   advanceGamePhase: newPhase => set({ gamePhase: newPhase }),
   setSpeedLines: isActive => set({ isSpeedLinesActive: isActive }),
+
+  setReplayLog: log => set({ replayLog: log }),
 
   // Add this new action to your store
   setMultiplayerState: (role, participants) => set({ playerRole: role, participants }),


### PR DESCRIPTION
## Summary
- install react-router-dom
- wrap `<App />` with `<BrowserRouter>` in `main.jsx`
- define `/replay/:id` route in `App.jsx`
- add `ReplayViewer` component to load replay log
- store replay log in Zustand

## Testing
- `npm run lint`
- `npm test` in `backend`


------
https://chatgpt.com/codex/tasks/task_e_6866264c31f08327a794275ef6df3de4