### PR TITLE
Add backend replay endpoint

### DIFF
--- a/backend/index.js
+++ b/backend/index.js
@@ -1,6 +1,6 @@
 const express = require('express');
 const cors = require('cors');
-const db = require('../discord-bot/util/database');
+const db = require('./util/database');
 
 const app = express();
 const port = process.env.PORT || 3000;
@@ -13,15 +13,22 @@ app.get('/', (req, res) => {
 });
 
 app.get('/api/replays/:id', async (req, res) => {
+  const { id } = req.params;
   try {
-    const [rows] = await db.query('SELECT battle_log FROM battle_replays WHERE id = ?', [req.params.id]);
+    const [rows] = await db.query(
+      'SELECT battle_log FROM battle_replays WHERE id = ?',
+      [id]
+    );
+
     if (rows.length === 0) {
-      return res.status(404).json({ error: 'Not Found' });
+      return res.status(404).json({ error: 'Replay not found' });
     }
-    res.json(rows[0].battle_log);
+
+    const battleLog = JSON.parse(rows[0].battle_log);
+    res.json(battleLog);
   } catch (err) {
-    console.error('Failed to fetch replay:', err);
-    res.status(500).json({ error: 'Server Error' });
+    console.error(`Error fetching replay ${id}:`, err);
+    res.status(500).json({ error: 'Internal Server Error' });
   }
 });
 

--- a/backend/tests/replayApi.test.js
+++ b/backend/tests/replayApi.test.js
@@ -1,10 +1,10 @@
 const request = require('supertest');
 
-jest.mock('../../discord-bot/util/database', () => ({
+jest.mock('../util/database', () => ({
   query: jest.fn(),
 }));
 
-const db = require('../../discord-bot/util/database');
+const db = require('../util/database');
 const app = require('../index');
 
 describe('GET /api/replays/:id', () => {
@@ -14,7 +14,7 @@ describe('GET /api/replays/:id', () => {
 
   test('returns battle log when replay exists', async () => {
     const log = { turns: [] };
-    db.query.mockResolvedValue([[{ battle_log: log }]]);
+    db.query.mockResolvedValue([[{ battle_log: JSON.stringify(log) }]]);
     const res = await request(app).get('/api/replays/1');
     expect(res.statusCode).toBe(200);
     expect(res.body).toEqual(log);
@@ -28,6 +28,6 @@ describe('GET /api/replays/:id', () => {
     db.query.mockResolvedValue([[]]);
     const res = await request(app).get('/api/replays/999');
     expect(res.statusCode).toBe(404);
-    expect(res.body).toEqual({ error: 'Not Found' });
+    expect(res.body).toEqual({ error: 'Replay not found' });
   });
 });

--- a/backend/util/config.js
+++ b/backend/util/config.js
@@ -1,0 +1,14 @@
+const dotenv = require('dotenv');
+dotenv.config();
+
+module.exports = {
+  get DISCORD_TOKEN() { return process.env.DISCORD_TOKEN; },
+  get DB_HOST() { return process.env.DB_HOST; },
+  get DB_USER() { return process.env.DB_USER; },
+  get DB_PASSWORD() { return process.env.DB_PASSWORD; },
+  get DB_DATABASE() { return process.env.DB_DATABASE; },
+  get APP_ID() { return process.env.APP_ID; },
+  get GUILD_ID() { return process.env.GUILD_ID; },
+  get PVP_CHANNEL_ID() { return process.env.PVP_CHANNEL_ID; },
+  get WEB_APP_URL() { return process.env.WEB_APP_URL || 'https://example.com'; }
+};

--- a/backend/util/database.js
+++ b/backend/util/database.js
@@ -1,0 +1,18 @@
+const mysql = require('mysql2');
+const config = require('./config');
+
+const pool = mysql.createPool({
+  host: config.DB_HOST,
+  user: config.DB_USER,
+  password: config.DB_PASSWORD,
+  database: config.DB_DATABASE,
+  waitForConnections: true,
+  connectionLimit: 10,
+  queueLimit: 0
+});
+
+const promisePool = pool.promise();
+
+console.log('✅ Database connection pool created.');
+
+module.exports = promisePool;


### PR DESCRIPTION
## Summary
- create `backend/util` and copy `database` and `config` helpers
- expose `/api/replays/:id` on the backend
- update replay tests for new location and JSON storage

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68668faf06cc8327a258166bf7f123fb