### PR TITLE
Add animated replay playback controls

### DIFF
--- a/auto-battler-react/src/components/ReplayViewer.jsx
+++ b/auto-battler-react/src/components/ReplayViewer.jsx
@@ -4,8 +4,8 @@ import { useGameStore } from '../store.js'
 
 export default function ReplayViewer() {
   const { id } = useParams()
-  const setReplayLog = useGameStore(state => state.setReplayLog)
-  const replayLog = useGameStore(state => state.replayLog)
+  const setBattleLog = useGameStore(state => state.setBattleLog)
+  const battleLog = useGameStore(state => state.battleLog)
 
   useEffect(() => {
     async function fetchReplay() {
@@ -13,18 +13,18 @@ export default function ReplayViewer() {
         const res = await fetch(`/api/replays/${id}`)
         if (!res.ok) return
         const data = await res.json()
-        setReplayLog(data)
+        setBattleLog(data)
       } catch (err) {
         console.error('Failed to fetch replay', err)
       }
     }
     fetchReplay()
-  }, [id, setReplayLog])
+  }, [id, setBattleLog])
 
   return (
     <div>
       <h2>Replay Viewer</h2>
-      <pre>{JSON.stringify(replayLog, null, 2)}</pre>
+      <pre>{JSON.stringify(battleLog, null, 2)}</pre>
     </div>
   )
 }

--- a/auto-battler-react/src/hooks/useReplay.js
+++ b/auto-battler-react/src/hooks/useReplay.js
@@ -1,0 +1,23 @@
+import { useEffect } from 'react';
+import { useGameStore } from '../store.js';
+
+export function useReplay() {
+  const {
+    isReplaying,
+    currentEventIndex,
+    playbackSpeed,
+    nextEvent,
+    battleLog,
+  } = useGameStore();
+
+  useEffect(() => {
+    if (!isReplaying) return;
+    if (currentEventIndex >= battleLog.events.length) {
+      useGameStore.getState().pauseReplay();
+      return;
+    }
+    const timer = setTimeout(nextEvent, playbackSpeed);
+    return () => clearTimeout(timer);
+  }, [isReplaying, currentEventIndex, playbackSpeed, battleLog.events.length, nextEvent]);
+}
+

--- a/auto-battler-react/src/scenes/BattleScene.jsx
+++ b/auto-battler-react/src/scenes/BattleScene.jsx
@@ -1,16 +1,33 @@
 import React from 'react';
 import Card from '../components/Card.jsx';
 import BattleLog from '../components/BattleLog.jsx';
+import { useReplay } from '../hooks/useReplay.js';
 import { useGameStore } from '../store.js';
 
 export default function BattleScene() {
-  // Get the combatants and the full replay log from the store.
-  // In this new model, 'combatants' will hold the state for a single moment in time,
-  // and 'replayLog' holds the entire script of the battle.
-  const { combatants, replayLog } = useGameStore(state => ({
+  useReplay();
+
+  const {
+    combatants,
+    battleLog,
+    currentEventIndex,
+    isReplaying,
+    startReplay,
+    pauseReplay,
+    playbackSpeed,
+    setPlaybackSpeed,
+  } = useGameStore(state => ({
     combatants: state.combatants,
-    replayLog: state.replayLog,
+    battleLog: state.battleLog,
+    currentEventIndex: state.currentEventIndex,
+    isReplaying: state.isReplaying,
+    startReplay: state.startReplay,
+    pauseReplay: state.pauseReplay,
+    playbackSpeed: state.playbackSpeed,
+    setPlaybackSpeed: state.setPlaybackSpeed,
   }));
+
+  const _event = battleLog?.events?.[currentEventIndex]; // apply this event to scene state
 
   // If there's no data yet, show a loading or empty state.
   if (!combatants || combatants.length === 0) {
@@ -18,6 +35,12 @@ export default function BattleScene() {
       <div className="scene">
         <h1 className="text-4xl font-cinzel">Preparing for battle...</h1>
       </div>
+    );
+  }
+
+  if (!battleLog || !Array.isArray(battleLog.events)) {
+    return (
+      <div className="error-message">\n        ⚠️ Unable to play this replay.\n      </div>
     );
   }
 
@@ -56,8 +79,25 @@ export default function BattleScene() {
         </div>
       </div>
       
-      {/* The BattleLog component will now display the full log from the replay */}
-      <BattleLog battleLog={replayLog || []} />
+      {/* The BattleLog component shows events up to the current index */}
+      <BattleLog battleLog={battleLog.events.slice(0, currentEventIndex + 1)} />
+
+      <div className="replay-controls">
+        <button onClick={() => (isReplaying ? pauseReplay() : startReplay())}>
+          {isReplaying ? 'Pause' : 'Play'}
+        </button>
+        <select
+          value={playbackSpeed}
+          onChange={e => setPlaybackSpeed(Number(e.target.value))}
+        >
+          <option value={2000}>×0.5</option>
+          <option value={1000}>×1</option>
+          <option value={500}>×2</option>
+        </select>
+        <span>
+          Event {currentEventIndex + 1} / {battleLog.events.length}
+        </span>
+      </div>
     </div>
   );
 }

--- a/auto-battler-react/src/store.js
+++ b/auto-battler-react/src/store.js
@@ -74,20 +74,28 @@ export const useGameStore = createWithEqualityFn(
   packChoices: [],
   revealedCards: [],
   combatants: [],
-  replayLog: [],
+  battleLog: { events: [] },
   isLoading: false,
   error: null,
   isSpeedLinesActive: false,
   // Add these new properties to your initial store state
   playerRole: 'guest', // Default to 'guest'
   participants: [],
+  currentEventIndex: 0,
+  isReplaying: false,
+  playbackSpeed: 1000,
 
   advanceGamePhase: newPhase => set({ gamePhase: newPhase }),
   setSpeedLines: isActive => set({ isSpeedLinesActive: isActive }),
 
-  setReplayLog: log => set({ replayLog: log }),
+  startReplay: () => set({ isReplaying: true, currentEventIndex: 0 }),
+  pauseReplay: () => set({ isReplaying: false }),
+  nextEvent: () => set(state => ({ currentEventIndex: state.currentEventIndex + 1 })),
+  setPlaybackSpeed: ms => set({ playbackSpeed: ms }),
 
-  // Fetch a battle replay by ID and store it in replayLog
+  setBattleLog: log => set({ battleLog: log }),
+
+  // Fetch a battle replay by ID and store it in battleLog
   fetchReplay: async id => {
     set({ isLoading: true, error: null });
     try {
@@ -96,7 +104,7 @@ export const useGameStore = createWithEqualityFn(
         throw new Error(`Failed to fetch replay ${id}`);
       }
       const data = await res.json();
-      set({ replayLog: data, isLoading: false });
+      set({ battleLog: data, isLoading: false });
     } catch (err) {
       console.error('[store] fetchReplay error', err);
       set({ error: err.message || 'Failed to load replay', isLoading: false });

--- a/auto-battler-react/src/style.css
+++ b/auto-battler-react/src/style.css
@@ -2247,3 +2247,17 @@ button:disabled {
 .debug-btn:hover {
     background-color: #6b7280;
 }
+
+.replay-controls {
+    margin-top: 1rem;
+    display: flex;
+    gap: 1rem;
+    align-items: center;
+}
+
+.error-message {
+    color: #f87171;
+    font-weight: bold;
+    text-align: center;
+    padding: 2rem;
+}


### PR DESCRIPTION
## Summary
- extend Zustand store for replay playback state
- fetch battle logs into new `battleLog` state and add actions for replay playback
- implement `useReplay` hook to automatically advance events
- wire up playback controls in `BattleScene`
- adjust `ReplayViewer` to use new store methods
- style replay controls and error message

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6866a2eda07c8327a90a8de00b6f2e79