### PR TITLE
Add stub for Discord SDK and Vite alias

### DIFF
--- a/auto-battler-react/src/shims/discord-sdk.js
+++ b/auto-battler-react/src/shims/discord-sdk.js
@@ -1,0 +1,9 @@
+// stub for @discord/embedded-app-sdk
+export class DiscordSDK {
+  constructor(_clientId) {
+    console.warn('DiscordSDK stub initialized');
+  }
+  ready() {
+    return Promise.resolve();
+  }
+}

--- a/auto-battler-react/vite.config.js
+++ b/auto-battler-react/vite.config.js
@@ -1,6 +1,10 @@
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
 import basicSsl from '@vitejs/plugin-basic-ssl' // <-- IMPORT THE PLUGIN
+import path from 'path'
+import { fileURLToPath } from 'url'
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
 
 // https://vite.dev/config/
 export default defineConfig({
@@ -8,6 +12,16 @@ export default defineConfig({
     react(),
     basicSsl() // <-- ADD THE PLUGIN HERE
   ],
+  resolve: {
+    alias: {
+      '@discord/embedded-app-sdk': path.resolve(__dirname, 'src/shims/discord-sdk.js')
+    }
+  },
+  build: {
+    rollupOptions: {
+      external: ['@discord/embedded-app-sdk']
+    }
+  },
   server: {
     port: 5173,
     // Allow the server to be accessed from your local network


### PR DESCRIPTION
## Summary
- stub out `@discord/embedded-app-sdk` so Vite build works
- wire the stub via alias and externalize the module in `vite.config.js`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6866a99796fc83278a10a7e9bbd0975a