### PR TITLE
Implement PHP replay API on GoDaddy

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,3 +100,23 @@ Follow these steps to host the app on your GoDaddy server:
    Copy `.env.example` to `.env` and set `WEB_APP_URL` to your production domain.
    The replay buttons in `/challenge` and `/adventure` will point to this URL.
 
+
+## PHP Backend Setup
+
+We host the replay API on our GoDaddy shared hosting account under `public_html/api/`.
+
+- **Replay Endpoint**
+  `GET http://game.strahde.com/api/replay.php?id={id}`
+  returns the stored JSON `battle_log` for that id or `{"error":"Not found"}`.
+
+- **Health Check**
+  `GET http://game.strahde.com/api/health.php` → `{"status":"OK"}`.
+
+Both scripts send the header `Access-Control-Allow-Origin: http://game.strahde.com`.
+
+Example commands:
+
+```bash
+curl http://game.strahde.com/api/health.php
+curl "http://game.strahde.com/api/replay.php?id=1"
+```

--- a/public_html/api/health.php
+++ b/public_html/api/health.php
@@ -1,0 +1,5 @@
+<?php
+header('Content-Type: application/json');
+header('Access-Control-Allow-Origin: http://game.strahde.com');
+
+echo json_encode(['status' => 'OK']);

--- a/public_html/api/replay.php
+++ b/public_html/api/replay.php
@@ -1,0 +1,32 @@
+<?php
+header('Content-Type: application/json');
+header('Access-Control-Allow-Origin: http://game.strahde.com');
+
+$id = isset($_GET['id']) ? intval($_GET['id']) : 0;
+if ($id < 1) {
+  echo json_encode(['error' => 'Not found']);
+  exit;
+}
+
+try {
+  $pdo = new PDO(
+    'mysql:host=' . getenv('DB_HOST') . ';dbname=' . getenv('DB_DATABASE') . ';charset=utf8mb4',
+    getenv('DB_USER'),
+    getenv('DB_PASSWORD'),
+    [PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION]
+  );
+} catch (PDOException $e) {
+  http_response_code(500);
+  echo json_encode(['error' => 'Database connection failed']);
+  exit;
+}
+
+$stmt = $pdo->prepare('SELECT battle_log FROM battle_replays WHERE id = ?');
+$stmt->execute([$id]);
+$row = $stmt->fetch(PDO::FETCH_ASSOC);
+
+if ($row) {
+  echo $row['battle_log'];
+} else {
+  echo json_encode(['error' => 'Not found']);
+}


### PR DESCRIPTION
## Summary
- add simple PHP endpoints for replay logs and health check
- document PHP backend setup in README

## Testing
- `npm test` in `backend`
- `npm test` in `discord-bot`


------
https://chatgpt.com/codex/tasks/task_e_6866b6238bf0832792c1397526186e72