### PR TITLE
Add shared config for PHP API

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,18 @@ Follow these steps to host the app on your GoDaddy server:
 
 We host the replay API on our GoDaddy shared hosting account under `public_html/api/`.
 
+Create a `config.php` file in that directory containing your MySQL credentials:
+
+```php
+<?php
+define('DB_HOST', 'your_host');
+define('DB_NAME', 'your_db');
+define('DB_USER', 'your_user');
+define('DB_PASS', 'your_pass');
+```
+
+`replay.php` includes this file so you only update one place when the database settings change.
+
 - **Replay Endpoint**
   `GET http://game.strahde.com/api/replay.php?id={id}`
   returns the stored JSON `battle_log` for that id or `{"error":"Not found"}`.

--- a/public_html/api/config.php
+++ b/public_html/api/config.php
@@ -1,0 +1,8 @@
+<?php
+// Database connection settings for the replay API
+// Update these values with your GoDaddy MySQL credentials
+
+define('DB_HOST', 'your_host');
+define('DB_NAME', 'your_db');
+define('DB_USER', 'your_user');
+define('DB_PASS', 'your_pass');

--- a/public_html/api/replay.php
+++ b/public_html/api/replay.php
@@ -1,4 +1,5 @@
 <?php
+require __DIR__ . '/config.php';
 header('Content-Type: application/json');
 header('Access-Control-Allow-Origin: http://game.strahde.com');
 
@@ -10,9 +11,9 @@ if ($id < 1) {
 
 try {
   $pdo = new PDO(
-    'mysql:host=' . getenv('DB_HOST') . ';dbname=' . getenv('DB_DATABASE') . ';charset=utf8mb4',
-    getenv('DB_USER'),
-    getenv('DB_PASSWORD'),
+    'mysql:host=' . DB_HOST . ';dbname=' . DB_NAME . ';charset=utf8mb4',
+    DB_USER,
+    DB_PASS,
     [PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION]
   );
 } catch (PDOException $e) {


### PR DESCRIPTION
## Summary
- create `public_html/api/config.php` with database constants
- use `config.php` in `public_html/api/replay.php`
- document config file usage in README

## Testing
- `npm install` in `backend`
- `npm test` in `backend`


------
https://chatgpt.com/codex/tasks/task_e_6866b8ff2ee0832798b5657fa4d2c46c