### PR TITLE
Fix Discord bot replay link

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -22,4 +22,4 @@ PVP_CHANNEL_ID=1389239394812170410
 PORT=3000
 
 # Base URL for the web app (used in replay links)
-WEB_APP_URL=https://your-app.vercel.app
+WEB_APP_URL=http://game.strahde.com

--- a/PROJECT_HISTORY.md
+++ b/PROJECT_HISTORY.md
@@ -4,7 +4,7 @@ This document summarizes notable features and infrastructure changes implemented
 
 ## July 3, 2025
 - Added a static battle-state renderer to the React client for easier replay visualization.
-- Introduced URL-based replay fetching and a new `/replay/:id` API endpoint.
+- Introduced URL-based replay fetching and a new `/api/replay.php?id=` endpoint.
 - The adventure flow now includes "link to replay" buttons so users can share past battles.
 - Discord bot updated to store replay logs, enabling post-battle review across platforms.
 

--- a/auto-battler-react/src/App.jsx
+++ b/auto-battler-react/src/App.jsx
@@ -104,10 +104,9 @@ export default function App() {
 
   // Load a replay if the URL includes a battle ID
   useEffect(() => {
-    const path = window.location.pathname;
-    const match = path.match(/^\/replay\/(\d+)/);
-    if (match) {
-      const battleId = match[1];
+    const params = new URLSearchParams(window.location.search);
+    const battleId = params.get('id');
+    if (battleId) {
       console.log(`[App] Found replay ID in URL: ${battleId}`);
       fetchReplay(battleId);
     }
@@ -179,7 +178,7 @@ export default function App() {
 
   return (
     <Routes>
-      <Route path="/replay/:id" element={<ReplayViewer />} />
+      <Route path="/replay" element={<ReplayViewer />} />
       <Route
         path="*"
         element={(

--- a/auto-battler-react/src/components/ReplayViewer.jsx
+++ b/auto-battler-react/src/components/ReplayViewer.jsx
@@ -1,16 +1,16 @@
 import React, { useEffect } from 'react'
-import { useParams } from 'react-router-dom'
 import { useGameStore } from '../store.js'
 
 export default function ReplayViewer() {
-  const { id } = useParams()
+  const params = new URLSearchParams(window.location.search)
+  const id = params.get('id')
   const setBattleLog = useGameStore(state => state.setBattleLog)
   const battleLog = useGameStore(state => state.battleLog)
 
   useEffect(() => {
     async function fetchReplay() {
       try {
-        const res = await fetch(`/api/replays/${id}`)
+        const res = await fetch(`/api/replay.php?id=${id}`)
         if (!res.ok) return
         const data = await res.json()
         setBattleLog(data)

--- a/auto-battler-react/src/store.js
+++ b/auto-battler-react/src/store.js
@@ -99,7 +99,7 @@ export const useGameStore = createWithEqualityFn(
   fetchReplay: async id => {
     set({ isLoading: true, error: null });
     try {
-      const res = await fetch(`/api/replays/${id}`);
+      const res = await fetch(`/api/replay.php?id=${id}`);
       if (!res.ok) {
         throw new Error(`Failed to fetch replay ${id}`);
       }

--- a/discord-bot/src/commands/adventure.js
+++ b/discord-bot/src/commands/adventure.js
@@ -263,7 +263,7 @@ async function execute(interaction) {
   // --- MODIFICATION START: Add a button linking to the replay ---
   // Note: You will need to add a WEB_APP_URL to your .env file.
   const webAppUrl = config.WEB_APP_URL || 'http://localhost:5173'; // Fallback for local testing
-  const replayUrl = `${webAppUrl}/replay/${battleId}`;
+  const replayUrl = `${webAppUrl}/api/replay.php?id=${battleId}`;
 
   const row = new ActionRowBuilder().addComponents(
     new ButtonBuilder()

--- a/discord-bot/src/commands/challenge.js
+++ b/discord-bot/src/commands/challenge.js
@@ -239,7 +239,7 @@ async function handleAccept(interaction) {
       new ButtonBuilder()
         .setStyle(ButtonStyle.Link)
         .setLabel('View Battle Replay')
-        .setURL(`${config.WEB_APP_URL}/replay/${replayId ?? ''}`)
+        .setURL(`${config.WEB_APP_URL}/api/replay.php?id=${replayId ?? ''}`)
     );
     await channel.send({ content: victoryMessage, components: [row] });
   } catch (e) {

--- a/discord-bot/tests/adventure.test.js
+++ b/discord-bot/tests/adventure.test.js
@@ -97,7 +97,7 @@ describe('adventure command', () => {
     );
     const components = summaryCall[0].components[0].components;
     expect(components).toHaveLength(2);
-    expect(components[0].data.url).toContain('/replay/');
+    expect(components[0].data.url).toContain('/api/replay.php?id=');
     expect(components[1].data.custom_id).toBe(`continue-adventure:${interaction.user.id}`);
     expect(db.query).toHaveBeenCalledWith(
       'INSERT INTO battle_replays (battle_log) VALUES (?)',


### PR DESCRIPTION
## Summary
- link battle replays directly to `api/replay.php?id=`
- update replay button tests
- parse replay ID from query string in React app
- use PHP endpoint for replay fetches
- document updated WEB_APP_URL and endpoint

## Testing
- `npm test` in `discord-bot`
- `npm test` in `backend`


------
https://chatgpt.com/codex/tasks/task_e_6866bc923a508327b31711782087fa77