### PR TITLE
Add React replay viewer

### DIFF
--- a/auto-battler-react/README.md
+++ b/auto-battler-react/README.md
@@ -26,3 +26,12 @@ This installs `@eslint/js` and the other development dependencies required for l
 npm run dev   # start the Vite dev server
 npm run lint  # run ESLint
 ```
+
+## Replay Viewer
+
+A simple replay viewer is included for inspecting saved battle logs.
+Run the dev server and navigate to `http://localhost:5173/replay?id=sample` to load the example `public/sample_replay.json`.
+When connected to the backend you can replace `sample` with an actual replay id and the viewer will fetch `/api/replays/{id}`.
+
+The viewer is composed of `ReplayHeader`, `CombatantPanel`, `HPBar` and `TimelineControls` components.
+Use the play/pause and step buttons to advance through turns.

--- a/auto-battler-react/public/sample_replay.json
+++ b/auto-battler-react/public/sample_replay.json
@@ -1,0 +1,14 @@
+{
+  "battleId": 1,
+  "date": "2024-06-01T12:00:00Z",
+  "result": "Victory",
+  "combatants": [
+    {"id":"player-hero-0","team":"player","name":"Recruit","currentHp":22,"maxHp":22,"art":"https://placehold.co/100x150?text=Recruit"},
+    {"id":"enemy-hero-0","team":"enemy","name":"Goblin","currentHp":15,"maxHp":15,"art":"https://placehold.co/100x150?text=Goblin"}
+  ],
+  "events": [
+    {"turn":1,"actor":"player-hero-0","target":"enemy-hero-0","damage":6,"message":"Recruit hits Goblin for 6 damage."},
+    {"turn":1,"actor":"enemy-hero-0","target":"player-hero-0","damage":4,"message":"Goblin hits Recruit for 4 damage."},
+    {"turn":2,"actor":"player-hero-0","target":"enemy-hero-0","damage":9,"message":"Recruit hits Goblin for 9 damage."}
+  ]
+}

--- a/auto-battler-react/src/App.jsx
+++ b/auto-battler-react/src/App.jsx
@@ -179,6 +179,7 @@ export default function App() {
 
   return (
     <Routes>
+      <Route path="/replay" element={<ReplayViewer />} />
       <Route path="/replay/:id" element={<ReplayViewer />} />
       <Route
         path="*"

--- a/auto-battler-react/src/components/CombatantPanel.jsx
+++ b/auto-battler-react/src/components/CombatantPanel.jsx
@@ -1,0 +1,39 @@
+import React, { useEffect, useState } from 'react'
+import PropTypes from 'prop-types'
+import HPBar from './HPBar.jsx'
+
+export default function CombatantPanel({ combatant, prev }) {
+  const [damage, setDamage] = useState(null)
+
+  useEffect(() => {
+    if (!prev) return
+    const diff = prev.currentHp - combatant.currentHp
+    if (diff > 0) {
+      setDamage(diff)
+      const t = setTimeout(() => setDamage(null), 800)
+      return () => clearTimeout(t)
+    }
+  }, [combatant.currentHp, prev])
+
+  return (
+    <div className="relative flex flex-col items-center w-28">
+      <img
+        src={combatant.art}
+        alt={combatant.name}
+        className="w-24 h-32 object-cover rounded"
+      />
+      <div className="mt-1 text-sm">{combatant.name}</div>
+      <HPBar current={combatant.currentHp} max={combatant.maxHp} />
+      {damage && (
+        <span className="absolute -top-2 text-red-400 font-bold damage-float">
+          -{damage} HP
+        </span>
+      )}
+    </div>
+  )
+}
+
+CombatantPanel.propTypes = {
+  combatant: PropTypes.object.isRequired,
+  prev: PropTypes.object
+}

--- a/auto-battler-react/src/components/HPBar.jsx
+++ b/auto-battler-react/src/components/HPBar.jsx
@@ -1,0 +1,19 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+
+export default function HPBar({ current, max }) {
+  const pct = max ? Math.max(0, (current / max) * 100) : 0
+  return (
+    <div className="w-full h-2 bg-gray-700 rounded overflow-hidden">
+      <div
+        className="bg-green-500 h-full transition-all"
+        style={{ width: `${pct}%` }}
+      />
+    </div>
+  )
+}
+
+HPBar.propTypes = {
+  current: PropTypes.number,
+  max: PropTypes.number
+}

--- a/auto-battler-react/src/components/ReplayHeader.jsx
+++ b/auto-battler-react/src/components/ReplayHeader.jsx
@@ -1,0 +1,24 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+
+export default function ReplayHeader({ meta }) {
+  if (!meta) return null
+  const date = meta.date ? new Date(meta.date) : null
+  return (
+    <div className="mb-4 text-center">
+      <h2 className="text-2xl font-cinzel">Replay #{meta.battleId}</h2>
+      {date && (
+        <p className="text-sm text-gray-400">{date.toLocaleString()}</p>
+      )}
+      {meta.result && (
+        <p className="font-bold mt-1">
+          {meta.result}
+        </p>
+      )}
+    </div>
+  )
+}
+
+ReplayHeader.propTypes = {
+  meta: PropTypes.object
+}

--- a/auto-battler-react/src/components/ReplayViewer.jsx
+++ b/auto-battler-react/src/components/ReplayViewer.jsx
@@ -1,30 +1,112 @@
-import React, { useEffect } from 'react'
-import { useParams } from 'react-router-dom'
-import { useGameStore } from '../store.js'
+import React, { useEffect, useState, useRef } from 'react'
+import { useParams, useLocation } from 'react-router-dom'
+import ReplayHeader from './ReplayHeader.jsx'
+import CombatantPanel from './CombatantPanel.jsx'
+import TimelineControls from './TimelineControls.jsx'
+
+function parseSnapshots(data) {
+  if (!data?.combatants || !Array.isArray(data.events)) return []
+  const state = data.combatants.map(c => ({ ...c }))
+  const snapshots = [state.map(c => ({ ...c }))]
+  for (const ev of data.events) {
+    if (ev.target && typeof ev.damage === 'number') {
+      const t = state.find(c => c.id === ev.target)
+      if (t) t.currentHp = Math.max(0, t.currentHp - ev.damage)
+    }
+    if (ev.target && typeof ev.heal === 'number') {
+      const t = state.find(c => c.id === ev.target)
+      if (t) t.currentHp = Math.min(t.maxHp, t.currentHp + ev.heal)
+    }
+    snapshots.push(state.map(c => ({ ...c })))
+  }
+  return snapshots
+}
 
 export default function ReplayViewer() {
-  const { id } = useParams()
-  const setBattleLog = useGameStore(state => state.setBattleLog)
-  const battleLog = useGameStore(state => state.battleLog)
+  const params = useParams()
+  const location = useLocation()
+  const id = params.id || new URLSearchParams(location.search).get('id')
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState(null)
+  const [data, setData] = useState(null)
+  const [snapshots, setSnapshots] = useState([])
+  const [index, setIndex] = useState(0)
+  const [playing, setPlaying] = useState(false)
+  const timerRef = useRef(null)
 
   useEffect(() => {
-    async function fetchReplay() {
+    async function fetchData() {
+      setLoading(true)
+      setError(null)
       try {
-        const res = await fetch(`/api/replays/${id}`)
-        if (!res.ok) return
-        const data = await res.json()
-        setBattleLog(data)
+        const url = id ? `/api/replays/${id}` : '/sample_replay.json'
+        const res = await fetch(url)
+        if (!res.ok) throw new Error('Failed to fetch replay')
+        const json = await res.json()
+        setData(json)
+        setSnapshots(parseSnapshots(json))
       } catch (err) {
-        console.error('Failed to fetch replay', err)
+        setError(err.message)
+      } finally {
+        setLoading(false)
       }
     }
-    fetchReplay()
-  }, [id, setBattleLog])
+    fetchData()
+  }, [id])
+
+  useEffect(() => {
+    if (!playing) return
+    timerRef.current = setTimeout(() => {
+      setIndex(i => {
+        if (i < snapshots.length - 1) return i + 1
+        setPlaying(false)
+        return i
+      })
+    }, 1000)
+    return () => clearTimeout(timerRef.current)
+  }, [playing, index, snapshots.length])
+
+  if (loading) return <div className="p-4">Loading...</div>
+  if (error) return <div className="p-4 text-red-500">{error}</div>
+  const snapshot = snapshots[index] || []
+  const prev = index > 0 ? snapshots[index - 1] : null
+  const players = snapshot.filter(c => c.team === 'player')
+  const enemies = snapshot.filter(c => c.team === 'enemy')
 
   return (
-    <div>
-      <h2>Replay Viewer</h2>
-      <pre>{JSON.stringify(battleLog, null, 2)}</pre>
+    <div className="p-4">
+      <ReplayHeader meta={data} />
+      <div className="flex flex-col md:flex-row justify-around gap-6">
+        <div className="flex flex-col items-center gap-2">
+          <h3 className="font-cinzel">Player</h3>
+          {players.map(c => (
+            <CombatantPanel
+              key={c.id}
+              combatant={c}
+              prev={prev?.find(p => p.id === c.id)}
+            />
+          ))}
+        </div>
+        <div className="flex flex-col items-center gap-2">
+          <h3 className="font-cinzel">Enemy</h3>
+          {enemies.map(c => (
+            <CombatantPanel
+              key={c.id}
+              combatant={c}
+              prev={prev?.find(p => p.id === c.id)}
+            />
+          ))}
+        </div>
+      </div>
+      <TimelineControls
+        isPlaying={playing}
+        onPlay={() => setPlaying(true)}
+        onPause={() => setPlaying(false)}
+        onPrev={() => setIndex(i => Math.max(0, i - 1))}
+        onNext={() => setIndex(i => Math.min(snapshots.length - 1, i + 1))}
+        current={index}
+        total={snapshots.length - 1}
+      />
     </div>
   )
 }

--- a/auto-battler-react/src/components/TimelineControls.jsx
+++ b/auto-battler-react/src/components/TimelineControls.jsx
@@ -1,0 +1,36 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+
+export default function TimelineControls({
+  isPlaying,
+  onPlay,
+  onPause,
+  onPrev,
+  onNext,
+  current,
+  total
+}) {
+  return (
+    <div className="flex items-center justify-center gap-4 mt-4">
+      <button onClick={onPrev} aria-label="Previous Turn">◀</button>
+      <button
+        onClick={isPlaying ? onPause : onPlay}
+        aria-label={isPlaying ? 'Pause' : 'Play'}
+      >
+        {isPlaying ? 'Pause' : 'Play'}
+      </button>
+      <button onClick={onNext} aria-label="Next Turn">▶</button>
+      <span className="text-sm">Turn {current} of {total}</span>
+    </div>
+  )
+}
+
+TimelineControls.propTypes = {
+  isPlaying: PropTypes.bool,
+  onPlay: PropTypes.func,
+  onPause: PropTypes.func,
+  onPrev: PropTypes.func,
+  onNext: PropTypes.func,
+  current: PropTypes.number,
+  total: PropTypes.number
+}

--- a/auto-battler-react/src/style.css
+++ b/auto-battler-react/src/style.css
@@ -2260,3 +2260,7 @@ button:disabled {
     margin-top: 1rem;
     font-weight: bold;
 }
+
+.damage-float{animation:damage-float 0.8s ease-out;}
+@keyframes damage-float{0%{transform:translateY(0);opacity:1;}100%{transform:translateY(-20px);opacity:0;}}
+


### PR DESCRIPTION
## Summary
- build ReplayViewer with timeline controls and panels
- add small components for HP bars and headers
- include sample replay data and docs

## Testing
- `npm run lint` *(fails: no-unused-vars in unrelated files)*
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6866be9273f0832790df7770f3e7eeb0