### PR TITLE
Add interactive replay viewer

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,10 @@ npm run dev
 
 This starts the Vite development server (usually on `http://localhost:5173`).
 
+Once running you can view saved battle replays by navigating to
+`http://localhost:5173/replay?id=<battleId>`. The React `ReplayViewer`
+will fetch the battle log from `/api/replay.php` and animate each turn.
+
 ## Running the Backend
 
 The `backend` directory contains a simple Express server. Start it with:

--- a/auto-battler-react/README.md
+++ b/auto-battler-react/README.md
@@ -26,3 +26,9 @@ This installs `@eslint/js` and the other development dependencies required for l
 npm run dev   # start the Vite dev server
 npm run lint  # run ESLint
 ```
+
+## Viewing Battle Replays
+
+Run the Vite dev server and open `/replay?id=<battleId>` in the browser to see an animated replay.
+The viewer fetches data from `/api/replay.php` and steps through each turn using the
+components under `src/components/replay/`.

--- a/auto-battler-react/src/components/ReplayViewer.jsx
+++ b/auto-battler-react/src/components/ReplayViewer.jsx
@@ -1,5 +1,8 @@
-import React, { useEffect } from 'react'
+import React, { useEffect, useState, useRef } from 'react'
 import { useGameStore } from '../store.js'
+import ReplayHeader from './replay/ReplayHeader.jsx'
+import CombatantPanel from './replay/CombatantPanel.jsx'
+import TimelineControls from './replay/TimelineControls.jsx'
 
 export default function ReplayViewer() {
   const params = new URLSearchParams(window.location.search)
@@ -7,24 +10,100 @@ export default function ReplayViewer() {
   const setBattleLog = useGameStore(state => state.setBattleLog)
   const battleLog = useGameStore(state => state.battleLog)
 
+  const [snapshots, setSnapshots] = useState([])
+  const [current, setCurrent] = useState(0)
+  const [isPlaying, setIsPlaying] = useState(false)
+  const timerRef = useRef(null)
+
   useEffect(() => {
     async function fetchReplay() {
       try {
         const res = await fetch(`/api/replay.php?id=${id}`)
-        if (!res.ok) return
+        if (!res.ok) throw new Error('Failed')
         const data = await res.json()
         setBattleLog(data)
       } catch (err) {
         console.error('Failed to fetch replay', err)
       }
     }
-    fetchReplay()
+    if (id) fetchReplay()
   }, [id, setBattleLog])
 
+  useEffect(() => {
+    if (!battleLog) return
+    let snaps = []
+    if (Array.isArray(battleLog.snapshots)) {
+      snaps = battleLog.snapshots
+    } else if (Array.isArray(battleLog.events)) {
+      let state = battleLog.events[0]?.combatants || []
+      if (state.length) snaps.push(JSON.parse(JSON.stringify(state)))
+      for (const ev of battleLog.events) {
+        if (ev.combatants) state = ev.combatants
+        snaps.push(JSON.parse(JSON.stringify(state)))
+      }
+    }
+    setSnapshots(snaps)
+    setCurrent(0)
+  }, [battleLog])
+
+  useEffect(() => {
+    if (!isPlaying) return
+    if (current >= snapshots.length - 1) {
+      setIsPlaying(false)
+      return
+    }
+    timerRef.current = setTimeout(() => setCurrent(c => Math.min(c + 1, snapshots.length - 1)), 1000)
+    return () => clearTimeout(timerRef.current)
+  }, [isPlaying, current, snapshots.length])
+
+  const handlePlayPause = () => setIsPlaying(p => !p)
+  const handleNext = () => setCurrent(c => Math.min(c + 1, snapshots.length - 1))
+  const handlePrev = () => setCurrent(c => Math.max(c - 1, 0))
+
+  if (!battleLog) {
+    return <div className="scene"><div className="text-xl">Loading...</div></div>
+  }
+
+  if (!snapshots.length) {
+    return <div className="scene">No replay data.</div>
+  }
+
+  const snapshot = snapshots[current]
+  const prevSnapshot = current > 0 ? snapshots[current - 1] : null
+  const playerSide = snapshot.filter(c => c.team === 'player')
+  const enemySide = snapshot.filter(c => c.team !== 'player')
+
+  const meta = {
+    battleId: id,
+    date: battleLog.created_at,
+    playerName: battleLog.playerName || playerSide.map(c => c.name).join(', '),
+    enemyName: battleLog.enemyName || enemySide.map(c => c.name).join(', '),
+    result: battleLog.result,
+  }
+
   return (
-    <div>
-      <h2>Replay Viewer</h2>
-      <pre>{JSON.stringify(battleLog, null, 2)}</pre>
+    <div className="replay-viewer container mx-auto p-4">
+      <ReplayHeader meta={meta} />
+      <div className="battlefield grid grid-cols-2 gap-4 mb-4">
+        <div className="player-side flex flex-col items-center gap-4">
+          {playerSide.map(c => (
+            <CombatantPanel key={c.id} combatant={c} prev={prevSnapshot?.find(p => p.id === c.id)} />
+          ))}
+        </div>
+        <div className="enemy-side flex flex-col items-center gap-4">
+          {enemySide.map(c => (
+            <CombatantPanel key={c.id} combatant={c} prev={prevSnapshot?.find(p => p.id === c.id)} />
+          ))}
+        </div>
+      </div>
+      <TimelineControls
+        isPlaying={isPlaying}
+        onPlayPause={handlePlayPause}
+        onNext={handleNext}
+        onPrev={handlePrev}
+        currentTurn={current}
+        totalTurns={snapshots.length - 1}
+      />
     </div>
   )
 }

--- a/auto-battler-react/src/components/replay/CombatantPanel.jsx
+++ b/auto-battler-react/src/components/replay/CombatantPanel.jsx
@@ -1,0 +1,29 @@
+import React, { useEffect, useState } from 'react'
+import Card from '../Card.jsx'
+
+export default function CombatantPanel({ combatant, prev }) {
+  const [delta, setDelta] = useState(0)
+  useEffect(() => {
+    if (!prev) return
+    const diff = combatant.currentHp - prev.currentHp
+    if (diff !== 0) {
+      setDelta(diff)
+      const t = setTimeout(() => setDelta(0), 800)
+      return () => clearTimeout(t)
+    }
+  }, [combatant.currentHp, prev])
+
+  return (
+    <div className="combatant-panel relative">
+      <Card item={combatant} view="compact" />
+      {delta !== 0 && (
+        <span
+          className={`combat-text-popup ${delta < 0 ? 'damage' : 'heal'}`}
+          style={{ pointerEvents: 'none' }}
+        >
+          {delta > 0 ? `+${delta}` : `${delta}`}
+        </span>
+      )}
+    </div>
+  )
+}

--- a/auto-battler-react/src/components/replay/ReplayHeader.jsx
+++ b/auto-battler-react/src/components/replay/ReplayHeader.jsx
@@ -1,0 +1,20 @@
+import React from 'react'
+
+export default function ReplayHeader({ meta }) {
+  if (!meta) return null
+  const { battleId, date, playerName, enemyName, result } = meta
+  const formatted = date ? new Date(date).toLocaleString() : ''
+  const resultClass = result === 'Victory' ? 'text-green-400' : 'text-red-400'
+  return (
+    <div className="replay-header text-center mb-4">
+      <h2 className="text-2xl font-cinzel">Battle #{battleId}</h2>
+      <div className="text-sm opacity-80">{formatted}</div>
+      <div className="flex items-center justify-center gap-2 mt-2">
+        <span className="font-semibold">{playerName}</span>
+        <span className="text-gray-400">vs.</span>
+        <span className="font-semibold">{enemyName}</span>
+        {result && <span className={`ml-4 font-bold ${resultClass}`}>{result}</span>}
+      </div>
+    </div>
+  )
+}

--- a/auto-battler-react/src/components/replay/TimelineControls.jsx
+++ b/auto-battler-react/src/components/replay/TimelineControls.jsx
@@ -1,0 +1,14 @@
+import React from 'react'
+
+export default function TimelineControls({ isPlaying, onPlayPause, onNext, onPrev, currentTurn, totalTurns }) {
+  return (
+    <div className="timeline-controls flex items-center justify-center gap-2 mt-4">
+      <button onClick={onPrev} aria-label="Previous Turn" className="px-2 py-1 bg-gray-700 rounded">Prev</button>
+      <button onClick={onPlayPause} aria-label="Play or Pause" className="px-3 py-1 bg-gray-700 rounded">
+        {isPlaying ? 'Pause' : 'Play'}
+      </button>
+      <button onClick={onNext} aria-label="Next Turn" className="px-2 py-1 bg-gray-700 rounded">Next</button>
+      <span className="ml-2 text-sm">Turn {currentTurn} of {totalTurns}</span>
+    </div>
+  )
+}

--- a/auto-battler-react/src/style.css
+++ b/auto-battler-react/src/style.css
@@ -2260,3 +2260,9 @@ button:disabled {
     margin-top: 1rem;
     font-weight: bold;
 }
+
+/* Replay Viewer */
+.replay-header h2 { margin-bottom: 0.25rem; }
+.battlefield { min-height: 200px; }
+.timeline-controls button { background-color: #374151; }
+.timeline-controls button:hover { background-color: #4b5563; }


### PR DESCRIPTION
## Summary
- implement new ReplayViewer with animated turn playback
- show per-turn combatants using CombatantPanel and ReplayHeader
- add timeline controls for play/pause and navigation
- style the new replay viewer
- document replay usage in READMEs

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: package.json missing)*
- `npm test` in backend *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6866cb8ca91c83279bebccb72acdfd6b