### PR TITLE
Improve replay fetching and error handling

### DIFF
--- a/auto-battler-react/src/ErrorBoundary.jsx
+++ b/auto-battler-react/src/ErrorBoundary.jsx
@@ -1,0 +1,28 @@
+import React from 'react'
+
+export default class ErrorBoundary extends React.Component {
+  constructor(props) {
+    super(props)
+    this.state = { hasError: false }
+  }
+
+  static getDerivedStateFromError() {
+    return { hasError: true }
+  }
+
+  componentDidCatch(error, info) {
+    console.error('ErrorBoundary caught an error', error, info)
+  }
+
+  render() {
+    if (this.state.hasError) {
+      return (
+        <div className="p-4 text-center">
+          <h1 className="text-2xl font-bold mb-2">Something went wrong.</h1>
+          <p>Please try again later.</p>
+        </div>
+      )
+    }
+    return this.props.children
+  }
+}

--- a/auto-battler-react/src/components/ReplayViewer.jsx
+++ b/auto-battler-react/src/components/ReplayViewer.jsx
@@ -14,16 +14,24 @@ export default function ReplayViewer() {
   const [current, setCurrent] = useState(0)
   const [isPlaying, setIsPlaying] = useState(false)
   const timerRef = useRef(null)
+  const [loadError, setLoadError] = useState(false)
 
   useEffect(() => {
     async function fetchReplay() {
       try {
         const res = await fetch(`/api/replay.php?id=${id}`)
         if (!res.ok) throw new Error('Failed')
-        const data = await res.json()
+        const text = await res.text()
+        let data
+        try {
+          data = JSON.parse(text)
+        } catch {
+          throw new Error('Invalid JSON')
+        }
         setBattleLog(data)
       } catch (err) {
         console.error('Failed to fetch replay', err)
+        setLoadError(true)
       }
     }
     if (id) fetchReplay()
@@ -59,6 +67,10 @@ export default function ReplayViewer() {
   const handlePlayPause = () => setIsPlaying(p => !p)
   const handleNext = () => setCurrent(c => Math.min(c + 1, snapshots.length - 1))
   const handlePrev = () => setCurrent(c => Math.max(c - 1, 0))
+
+  if (loadError) {
+    return <div className="scene">Could not load replay.</div>
+  }
 
   if (!battleLog) {
     return <div className="scene"><div className="text-xl">Loading...</div></div>

--- a/auto-battler-react/src/main.jsx
+++ b/auto-battler-react/src/main.jsx
@@ -4,13 +4,16 @@ import './index.css'
 import './style.css'
 import { initBackgroundAnimation } from './background-animation.js'
 import App from './App.jsx'
+import ErrorBoundary from './ErrorBoundary.jsx'
 import { BrowserRouter } from 'react-router-dom'
 
 createRoot(document.getElementById('root')).render(
   <StrictMode>
-    <BrowserRouter>
-      <App />
-    </BrowserRouter>
+    <ErrorBoundary>
+      <BrowserRouter>
+        <App />
+      </BrowserRouter>
+    </ErrorBoundary>
   </StrictMode>,
 )
 

--- a/auto-battler-react/src/scenes/BattleScene.jsx
+++ b/auto-battler-react/src/scenes/BattleScene.jsx
@@ -26,8 +26,6 @@ export default function BattleScene() {
     playbackSpeed: state.playbackSpeed,
     setPlaybackSpeed: state.setPlaybackSpeed,
   }));
-  const event = battleLog?.events?.[currentEventIndex];
-  // TODO: apply `event` effects to the scene state
 
   if (!battleLog || !Array.isArray(battleLog.events)) {
     return <div className="error-message">⚠️ Unable to play this replay.</div>;

--- a/auto-battler-react/src/shims/discord-sdk.js
+++ b/auto-battler-react/src/shims/discord-sdk.js
@@ -1,6 +1,7 @@
 // stub for @discord/embedded-app-sdk
 export class DiscordSDK {
-  constructor(_clientId) {
+  constructor(clientId) {
+    this.clientId = clientId;
     console.warn('DiscordSDK stub initialized');
   }
   ready() {

--- a/auto-battler-react/src/store.js
+++ b/auto-battler-react/src/store.js
@@ -103,7 +103,13 @@ export const useGameStore = createWithEqualityFn(
       if (!res.ok) {
         throw new Error(`Failed to fetch replay ${id}`);
       }
-      const data = await res.json();
+      const text = await res.text();
+      let data;
+      try {
+        data = JSON.parse(text);
+      } catch {
+        throw new Error('Invalid JSON');
+      }
       set({ battleLog: data, isLoading: false });
     } catch (err) {
       console.error('[store] fetchReplay error', err);

--- a/auto-battler-react/vite.config.js
+++ b/auto-battler-react/vite.config.js
@@ -33,5 +33,12 @@ export default defineConfig({
       // For older browsers, though CSP is preferred
       'X-Frame-Options': 'ALLOW-FROM *.discord.com',
     },
+    proxy: {
+      '/api': {
+        target: 'http://game.strahde.com',
+        changeOrigin: true,
+        secure: false,
+      },
+    },
   },
 })


### PR DESCRIPTION
## Summary
- add ErrorBoundary and wrap App with it
- proxy /api requests to the PHP backend
- improve replay JSON parsing and show an inline error
- remove unused vars and stub field usage

## Testing
- `npm run lint`
- `npm test` in `backend`
- `npm test` in `discord-bot`


------
https://chatgpt.com/codex/tasks/task_e_6866d43c2150832788f2bbafc809c6b3