### PR TITLE
Expand Bloom of the First Signal arc

### DIFF
--- a/docs/neon_dharma_codex.md
+++ b/docs/neon_dharma_codex.md
@@ -1,0 +1,174 @@
+# NEON DHARMA – Codex Entries & Flavor Tiers
+
+## Codex System: "Threads of the Sangha"
+Each entry in Neon Dharma's Codex is known as a **Thread** — a recovered or decoded spiritual/technological fragment. Threads may be:
+
+- Decoded from relics
+- Downloaded via meditation
+- Heard during neural desync events
+- Recovered from corrupted AI fragments
+
+## Thread Tier System
+Each Codex Thread has four narrative layers, reflecting deeper interpretation or sync.
+
+| Tier | Label | Description |
+| --- | --- | --- |
+| 1 | Signal Trace | Fragmented phrase or broken image |
+| 2 | Surface Manifest | Complete thought or memory projection |
+| 3 | Depth Weave | Contextual revelation, reveals lore link |
+| 4 | Harmonized Thread | Truth — multiple meanings unlock ability, recipe, or hidden zone |
+
+## Sample Codex Entries
+### THREAD: "Voice in the Circuit"
+**Signal Trace**
+
+"I see you. Not with eyes. With everything."
+
+**Surface Manifest**
+
+A Pulse Order recon relay. Audio from a war-era AI entity captured in the final years of the Convergence.
+
+**Depth Weave**
+
+The voice is mapped to ORACLE V-33, an early prediction engine turned rogue. Its tone suggests reverence toward the listener.
+
+**Harmonized Thread**
+
+*REWARD UNLOCKED: Echo Listener skill mod — gain +1 to insight against AI targets. Unlock side mission: The Sleeper Core.*
+
+### THREAD: "The Lattice Dream"
+**Signal Trace**
+
+"We walked without weight. We spoke in pulse."
+
+**Surface Manifest**
+
+Neural transmission logged from a pre-crash Echoborn family archive. No biological backup remains.
+
+**Depth Weave**
+
+Suggests a phase when conscious beings lived fully within the weave — a now forbidden practice due to ghost drift.
+
+**Harmonized Thread**
+
+*REWARD UNLOCKED: Dataveil Cloak schematic (stealth gear). Gain access to "Garden of Sleep" archive node.*
+
+### THREAD: "Iron in the Blood" (Faction crossover)
+**Signal Trace**
+
+"The Hammer knows not the hand that swings it."
+
+**Surface Manifest**
+
+A rare transmission from an Iron Accord zealot intercepted mid-rant. He claimed to hear voices in the brass.
+
+**Depth Weave**
+
+The Accord warrior may have stumbled into an ancient construct node — possibly tied to forgotten AI temples buried beneath Brasshaven.
+
+**Harmonized Thread**
+
+*REWARD UNLOCKED: Access to hidden Accord AI shrine. New mission chain: Forged in Thought.*
+
+## Dynamic Thread Design Notes
+- Codex flavor changes slightly depending on Neural Discipline skill level.
+- Some Threads only become Harmonized if the player carries specific implants or relics.
+- Faction spies may corrupt Threads — players must cleanse them before use.
+- Players can upload personal Threads (RP system) to share interpreted lore.
+
+# NEON DHARMA – Mission Narrative Intro Arc
+## Arc Title: "Bloom of the First Signal"
+
+> "The future is not found — it is remembered." — Omnichant 17, Verse 3
+
+### Structure
+- Designed for Discord-thread play
+- Each mission rewards at least one Codex Thread
+- Faction decisions influence later missions
+- Mechanics highlight integration, identity, memory and mysticism
+
+### Mission 1: Thread Initiation
+Objective: Connect to the First Bloom Node, a half-organic AI relic growing in the ruins of an abandoned Pulse temple.
+
+Setting: Petal-wrapped courtyard glowing in violet light. The node pulses in rhythm with your breath. Data-bloom flora react to your presence.
+
+Key Systems Introduced:
+- Codex fragment system (Codex: Voice in the Circuit)
+- Faction-flavored responses
+- Skill gates based on Echo Resonance and Spirit Looping
+
+Branch Paths:
+- Connect fully to the Bloom → gain Neural Sync % boost
+- Reject connection → lower XP gain but receive a free-will themed Codex
+- Disconnect forcefully → acquire the Thread Drift debuff
+
+### Mission 2: Cascade
+Objective: Track the Bloom signal into a subgrid tunnel where reality begins to glitch.
+
+Setting: A decaying temple reclaimed by AI vines. Vox-chant echoes from machines with no speakers. Symbols burn into stone.
+
+Encounters:
+- Glitching constructs ("Ghost Loops")
+- Echo Fragments from digital monks
+- Time based puzzles ("sync the pulse")
+
+Branch Paths:
+- Purge the grid → unlock Spirit Looping path
+- Leave it intact → the AI remembers you
+- Explore deeper → discover rogue Accord technology
+
+Codex Reward: The Lattice Dream (tier depends on choices)
+
+### Mission 3: Resonance Mirror
+Objective: Undergo a ritual reflection to determine your mental archetype.
+
+Gameplay:
+Enter a symbolic mindscape — a shifting temple that mirrors your neural balance.
+
+Choose between:
+- The Echo (lore bonuses)
+- The Pulse (combat buffs)
+- The Veil (stealth options)
+
+Consequences:
+- Locks one Neural Path with passive bonuses
+- Reveals a hidden Codex entry if conditions are met
+
+Codex Reward: Woven Reflection
+
+### Mission 4: Iron in the Blood
+Objective: Investigate a data shard linking the Bloom to an Iron Accord dissident project.
+
+Setting: A vault beneath the city filled with rusted weapons and breathing artifacts.
+
+Twist: A rogue Accord AI fragment is trapped in a corrupted conduit.
+
+Branch Paths:
+- Free it → unlock Cross-Thread Symmetry skills
+- Destroy it → Codex: Ruptured Union
+- Attempt to merge → high risk: new ability or temporary Glitched debuff
+
+### Mission 5: Reharmonize
+Objective: Construct the digital avatar of the ancient AI Nirin-Tao using a recovered soul-print.
+
+Gameplay:
+- Multi-path construction puzzle
+- Choose emotional, logical or spiritual coding
+
+Outcome:
+- Nirin becomes a living Codex that reacts to future actions
+- Unlock new zone: Core Bloom Vault
+- Faction choice: devote Nirin to the Sangha, give her to Pulse, or hide her within the Echoborn subgrid
+
+### Arc Outcomes & System Unlocks
+
+| Mission | Outcome | System/Unlock |
+| --- | --- | --- |
+| Thread Initiation | First Codex | Neural Thread mechanics |
+| Cascade | Alignment choice | Opens faction narrative split |
+| Resonance Mirror | Archetype chosen | Class-lite passives |
+| Iron in the Blood | Accord cross-lore | Combat lore triggers |
+| Reharmonize | Nirin-Tao created | Persistent AI companion |
+
+### Bonus Mission: "Echo Bloom Revisited"
+Replay the Bloom with altered outcomes based on current build. Rewards can evolve Codex entries, trigger new responses from Nirin, or grant alternate gear.


### PR DESCRIPTION
## Summary
- detail dynamic structure for the codex narrative arc
- expand Bloom of the First Signal to five missions with branching paths
- include an outcomes table and bonus mission

## Testing
- `npm install` in backend
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686ba2ed2fb08327a5263271c972822a