### PR TITLE
Update documentation for trimmed Discord bot

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,127 +1,13 @@
-# Auto Battler Prototypes
+# Auto Battler
 
-This repository contains a series of HTML and JavaScript prototypes for a card based auto‑battler.  The most complete browser implementation now lives in the `auto-battler-react/` folder, while the root directory holds several earlier proof‑of‑concept files.
-
-For details on the current prototype and its user interface, see [auto-battler-react/README.md](auto-battler-react/README.md).
+This repository houses the Discord bot used for the auto battler experiments along with various design documents and legacy HTML prototypes. The previous React client and Express server have been removed.
 
 ## Repository Layout
 
-- `auto-battler-react/` – React-based prototype with modular scenes and battle logic.
-- `index.html`, `poc2` – Stand‑alone HTML prototypes kept for reference.
-- `docs/` – Game design documents and technical notes.
-- `backend/` – Basic Express server used for local development.
+- `discord-bot/` – Node.js bot and MySQL schema.
+- `docs/` – design notes and lore.
+- `index.html`, `poc2/` – early browser prototypes kept for reference.
 
-## Running the Game
+## Setup
 
-The React prototype is built with Vite. From the repository root run:
-
-```bash
-cd auto-battler-react
-npm install
-npm run dev
-```
-
-This starts the Vite development server (usually on `http://localhost:5173`).
-
-Once running you can view saved battle replays by navigating to
-`http://localhost:5173/replay?id=<battleId>`. The React `ReplayViewer`
-will fetch the battle log from `/api/replay.php` and animate each turn.
-
-## Running the Backend
-
-The `backend` directory contains a simple Express server. Start it with:
-
-```bash
-npm install
-npm start
-```
-
-By default it runs on `http://localhost:3000` and prints `Server is running!` to the console.
-
-### Running Tests
-
-Install dependencies in the `backend` directory before executing the Jest suite:
-
-```bash
-cd backend
-npm install
-npm test
-```
-
-`npm test` invokes Jest. The tests will fail to run if the dependencies have not been installed.
-
-## Environment Setup
-
-Before running the Discord bot or backend, copy `.env.example` in the repository root to `.env` and fill in the required variables. The `.env` file is excluded from version control by `.gitignore` so your credentials remain private.
-
-
-## Documentation
-
-Documentation for the previous prototypes has been moved to
-[docs/archive](docs/archive/). New design notes will live in
-[docs/README.md](docs/README.md) and the work-in-progress
-[docs/gdd.md](docs/gdd.md).
-
-
-## Discord Bot
-
-The Discord bot resides in the `discord-bot/` directory and requires a `.env` file for secrets.
-Copy the `.env.example` file in the repository root to `.env` and populate the following variables:
-
-- `DISCORD_TOKEN` – your bot token.
-- `APP_ID` and `GUILD_ID` – used when deploying slash commands.
-- `DB_HOST`, `DB_USER`, `DB_PASSWORD`, `DB_DATABASE` – credentials for the MySQL database. `DB_HOST` must be the remote host address provided by GoDaddy.
-- `PVP_CHANNEL_ID` – Discord channel ID used for challenge announcements.
-
-Install the dependencies and start the bot:
-
-```bash
-cd discord-bot
-npm install
-node index.js
-```
-
-When configured correctly the bot logs a `Database connection successful` message on start.
-
-### Inventory Commands & Charge System
-
-The bot includes a simple `/inventory` command for viewing your backpack. Once the ability card system is implemented it will also support `/inventory set` to choose which ability card is active.  The design for this charge-based system is documented in [docs/archive/ability_card_charge_gdd.md](docs/archive/ability_card_charge_gdd.md).
-
-## Deployment
-
-Follow these steps to host the app on your GoDaddy server:
-
-1. **Build the frontend**
-   ```bash
-   cd auto-battler-react
-   npm install
-   npm run build
-   ```
-   Upload the resulting `dist/` folder to your hosting space.
-
-2. **Start the backend**
-   ```bash
-   cd backend
-   npm install
-   npm start
-   ```
-   Use a tool such as `pm2` if you want the server to run continuously.
-
-3. **Environment variables**
-   Copy `.env.example` to `.env` and set `WEB_APP_URL` to your production domain.
-   The replay buttons in `/challenge` and `/adventure` will point to this URL.
-
-
-## PHP Backend Setup
-
-We host our replay API on GoDaddy shared hosting under `public_html/api/`.
-
-- **Replay Endpoint**  
-  `GET http://game.strahde.com/api/replay.php?id={id}`  
-  Returns stored JSON battle_log or `{"error":"Not found"}`.
-
-- **Health Check**  
-  `GET http://game.strahde.com/api/health.php` → `{"status":"OK"}`.
-
-- **CORS**  
-  Both endpoints allow origin `http://game.strahde.com`.
+Copy `.env.example` to `.env` and provide your Discord token and database credentials. See [discord-bot/README.md](discord-bot/README.md) for details on running the bot and migrating the database schema.

--- a/discord-bot/README.md
+++ b/discord-bot/README.md
@@ -1,139 +1,46 @@
 # Discord Bot
 
-This folder contains the Node.js bot that powers the game's Discord integration.
+This folder contains the Node.js bot that powers the Discord integration.
 
 ## Prerequisites
 
-1. Copy `.env.example` from the repository root to `.env` and fill in your settings.
-   The file is ignored by Git so your credentials remain private. The bot requires a Discord token and MySQL credentials:
-   - `DISCORD_TOKEN` – your bot token.
-   - `DB_HOST`, `DB_USER`, `DB_PASSWORD`, `DB_DATABASE` – location and credentials for the database.
-   - `APP_ID` and `GUILD_ID` are needed when running `deploy-commands.js`.
-
-The bot reads these variables using `util/config.js`. Import this module wherever
-configuration values are needed instead of referencing `process.env` directly.
-
-## Running the Bot
+1. Copy `.env.example` from the repository root to `.env` and fill in the following values:
+   - `DISCORD_TOKEN` – your bot token
+   - `APP_ID` and `GUILD_ID` – required when running `deploy-commands.js`
+   - `DB_HOST`, `DB_USER`, `DB_PASSWORD`, `DB_DATABASE` – MySQL connection details
+2. Install dependencies and register the slash commands:
 
 ```bash
 cd discord-bot
 npm install
-node deploy-commands.js  # registers the slash commands (re-run when deploying)
-node index.js            # starts the bot
+node deploy-commands.js
+node index.js
 ```
 
-The bot connects to the database on start and should log `Database connection successful`.
+The bot will log into Discord and connect to the database on start.
 
-## Using `/begin`
+## Commands
 
-The `/begin` command launches the onboarding flow for new players. The flow guides you
-through drafting a starter champion:
+Only two slash commands are currently available:
 
-1. **Choose a hero** – pick a starter hero to establish your initial stats.
-2. **Select an ability** – equip one starting ability.
-3. **Pick a weapon** – add a weapon for attack bonuses.
-4. **Choose armor** – round out your defenses.
-5. **Confirm** – review the recap embed and finalize your champion.
+- `/ping` – check that the bot is responsive
+- `/help` – display an ephemeral list of commands
 
-After confirmation the champion is saved to your roster and you can explore the rest of the commands.
+## Database Schema
 
-## Using `/game`
+The schema defined in `db-schema.sql` creates the following tables:
 
-`/game` provides a quick introduction battle and hands you a starter ability card. When you confirm the prompt the bot equips that ability and launches a short fight against a goblin. Your hero is chosen dynamically based on the ability's **archetype** and rarity. You can rerun `/game` to try a different ability – swapping abilities changes which hero you field.
+- `players` – stores Discord IDs, names, class and progression stats
+- `missions` – mission definitions and rewards
+- `mission_log` – records mission attempts for each player
+- `codex_entries` – tracks which lore entries a player has unlocked
 
-## Ability-Based Archetypes
-
-Abilities belong to themed archetypes such as **Stalwart Defender** or **Raging Fighter**. The rarity of the equipped ability determines which hero from that archetype you control. Equipping a higher rarity card automatically upgrades your hero, while changing to a different archetype swaps you to a completely new hero.
-
-## Using `/who`
-
-`/who` displays a short character sheet for the mentioned player. You must mention the target user:
-
-```bash
-/who @SomePlayer
-```
-
-The command responds with a styled embed showing the player's name, current archetype, base HP and Attack, and the ability they currently have equipped. If the player has not started the game or has no ability equipped, the embed will indicate that instead.
-
-Example output:
-
-```
-Character Sheet
-Player: SomePlayer - Stalwart Defender
-HP: 16
-Attack: 2
-Equipped Ability: Power Strike
-```
-
-## Using `/adventure`
-
-`/adventure` sends your hero into a practice fight against a random goblin. The
-command posts an embed that updates every couple seconds to show remaining HP
-for all combatants. The battle log grows from top to bottom, with new entries
-appended to the bottom of the list. When the fight ends a final embed announces
-**Victory** or **Defeat** and any loot is granted. Victorious players now earn a
-small **gold** reward added directly to their balance.
-
-## Using `/auctionhouse`
-
-`/auctionhouse` now opens a button-driven menu instead of using
-separate subcommands. The reply contains **Buy Cards** and **Sell Cards**
-buttons which guide you through purchasing or listing ability cards.
-
-- **Buying** – Click **Buy Cards** to view the cheapest listings for each
-  ability. Each listing includes a **Purchase** button. Selecting it
-  opens a confirmation modal and, once confirmed, transfers the gold and
-  delivers the card to your backpack.
-- **Selling** – Press **Sell Cards** to open a modal where you choose one
-  of your ability cards and set a price. Submitting creates the
-  listing and removes the card from your inventory until sold.
-
-Listings stay active until another player purchases them or the seller
-cancels the post.
-
-## Settings
-
-The `/settings` command toggles optional preferences for each player.
-
-- `/settings battle_logs` – turn receiving DM battle logs on or off.
-- `/settings item_drops` – enable or disable item drop notifications.
-
-Both preferences default to **enabled** for all players.
-
-## Admin Tools
-
-`/admin grant-ability` lets users with the **Game Master** role grant an ability card to any player. The command requires two options:
-
-```bash
-/admin grant-ability user:@SomePlayer ability:"Power Strike"
-```
-
-The Game Master receives an ephemeral confirmation message while the target player is sent a DM with the standard ability card embed.
-
-## Database Migration
-
-The updated schema introduces a `user_ability_cards` table and a new
-`equipped_ability_id` column on `users`. It also adds an `auction_listings`
-table, an `auction_bids` table and a `soft_currency` column on `users` for
-storing gold balances.
-
-1. Run the statements in `db-schema.sql` against your MySQL database.
-2. For existing installs, create a `user_ability_cards` row for each
-   player's current ability and update `users.equipped_ability_id` to
-   point to that card.
-3. Run the additional statements that create `auction_listings` and
-   `auction_bids` along with the new `soft_currency` column.
-
-New deployments only need to execute the schema file.
+Run the SQL file on your MySQL instance to create or update the tables. Existing installations should drop the old tables listed at the top of the file.
 
 ## Running Tests
 
-The bot includes a Jest test suite located in the `tests/` directory. Install
-dependencies and run the suite with:
+A small Jest test suite lives in `tests/`. Run it with:
 
 ```bash
-npm install
 npm test
 ```
-
-`npm test` runs Jest and executes all tests.


### PR DESCRIPTION
## Summary
- strip React and Express references from root README
- rewrite Discord bot README for minimal command set

## Testing
- `npm install` and `npm test` in `discord-bot`

------
https://chatgpt.com/codex/tasks/task_e_686c54ba84488327a2b3ce4911684317