### PR TITLE
Handle stat select menus

### DIFF
--- a/discord-bot/index.js
+++ b/discord-bot/index.js
@@ -2,6 +2,8 @@ const { Client, Collection, GatewayIntentBits, Events } = require('discord.js');
 const fs = require('node:fs');
 const path = require('node:path');
 const config = require('./util/config');
+const { simple } = require('./src/utils/embedBuilder');
+const { setInitialStats } = require('./src/services/playerService');
 
 const client = new Client({ intents: [GatewayIntentBits.Guilds] });
 client.commands = new Collection();
@@ -20,16 +22,29 @@ client.once(Events.ClientReady, () => {
 });
 
 client.on(Events.InteractionCreate, async interaction => {
-  if (!interaction.isChatInputCommand()) return;
+  if (interaction.isChatInputCommand()) {
+    const command = interaction.client.commands.get(interaction.commandName);
+    if (!command) return;
 
-  const command = interaction.client.commands.get(interaction.commandName);
-  if (!command) return;
-
-  try {
-    await command.execute(interaction);
-  } catch (error) {
-    console.error('Error executing command:', error);
-    await interaction.reply({ content: 'There was an error executing that command.', ephemeral: true });
+    try {
+      await command.execute(interaction);
+    } catch (error) {
+      console.error('Error executing command:', error);
+      await interaction.reply({ content: 'There was an error executing that command.', ephemeral: true });
+    }
+  } else if (interaction.isStringSelectMenu()) {
+    if (interaction.customId === 'character_stat_select') {
+      try {
+        await setInitialStats(interaction.user.id, interaction.values);
+        const embed = simple('Starting stats saved!', [
+          { name: 'Selected', value: interaction.values.join(', ') }
+        ]);
+        await interaction.reply({ embeds: [embed], ephemeral: true });
+      } catch (error) {
+        console.error('Error setting initial stats:', error);
+        await interaction.reply({ content: 'There was an error saving your stats.', ephemeral: true });
+      }
+    }
   }
 });
 

--- a/discord-bot/src/services/playerService.js
+++ b/discord-bot/src/services/playerService.js
@@ -1,0 +1,14 @@
+const db = require('../../util/database');
+
+/**
+ * Store the player's initial stat selection.
+ * @param {string} discordId - The ID of the Discord user.
+ * @param {string[]} values - The values selected from the menu.
+ */
+async function setInitialStats(discordId, values) {
+  const statsJson = JSON.stringify(values);
+  // Persist selection in database if supported
+  await db.query('UPDATE players SET starting_stats = ? WHERE discord_id = ?', [statsJson, discordId]);
+}
+
+module.exports = { setInitialStats };

--- a/discord-bot/tests/playerService.test.js
+++ b/discord-bot/tests/playerService.test.js
@@ -1,0 +1,12 @@
+const db = require('../util/database');
+jest.mock('../util/database', () => ({ query: jest.fn() }));
+
+const { setInitialStats } = require('../src/services/playerService');
+
+test('setInitialStats updates player stats', async () => {
+  await setInitialStats('123', ['str']);
+  expect(db.query).toHaveBeenCalledWith(
+    'UPDATE players SET starting_stats = ? WHERE discord_id = ?',
+    [JSON.stringify(['str']), '123']
+  );
+});


### PR DESCRIPTION
## Summary
- update interaction listener to handle `character_stat_select`
- store stat choice through new `playerService`
- add test for `setInitialStats`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686c5b8119c08327a31e55d98e7e0bb3