### PR TITLE
Add character command and tests

### DIFF
--- a/discord-bot/commands/character.js
+++ b/discord-bot/commands/character.js
@@ -1,0 +1,36 @@
+const { SlashCommandBuilder, ActionRowBuilder, StringSelectMenuBuilder } = require('discord.js');
+const db = require('../util/database');
+const { simple } = require('../src/utils/embedBuilder');
+
+async function execute(interaction) {
+  const discordId = interaction.user.id;
+  const name = interaction.user.username;
+  const { rows } = await db.query('SELECT * FROM players WHERE discord_id = ?', [discordId]);
+  if (rows.length === 0) {
+    await db.query('INSERT INTO players (discord_id, name) VALUES (?, ?)', [discordId, name]);
+    const embed = simple('Character created! Choose your class:');
+    const menu = new StringSelectMenuBuilder()
+      .setCustomId('class-select')
+      .setPlaceholder('Select your class')
+      .addOptions([
+        { label: 'Warrior', value: 'Warrior' },
+        { label: 'Mage', value: 'Mage' }
+      ]);
+    const row = new ActionRowBuilder().addComponents(menu);
+    await interaction.reply({ embeds: [embed], components: [row], ephemeral: true });
+  } else {
+    const embed = simple('You already have a character.');
+    await interaction.reply({ embeds: [embed], ephemeral: true });
+  }
+}
+
+async function handleClassSelect(interaction) {
+  const selected = interaction.values[0];
+  await interaction.reply({ content: `Class selected: ${selected}`, ephemeral: true });
+}
+
+module.exports = {
+  data: new SlashCommandBuilder().setName('character').setDescription('Create your character'),
+  execute,
+  handleClassSelect
+};

--- a/discord-bot/tests/character.test.js
+++ b/discord-bot/tests/character.test.js
@@ -1,0 +1,39 @@
+const character = require('../commands/character');
+const db = require('../util/database');
+
+jest.mock('../util/database');
+
+function createInteraction() {
+  return {
+    user: { id: '123', username: 'Tester' },
+    reply: jest.fn().mockResolvedValue(),
+  };
+}
+
+describe('character command', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('creates a new user when none exists', async () => {
+    db.query
+      .mockResolvedValueOnce({ rows: [] }) // select
+      .mockResolvedValueOnce({ insertId: 1 }); // insert
+
+    const interaction = createInteraction();
+    await character.execute(interaction);
+
+    expect(db.query).toHaveBeenCalledWith('SELECT * FROM players WHERE discord_id = ?', ['123']);
+    expect(db.query).toHaveBeenCalledWith('INSERT INTO players (discord_id, name) VALUES (?, ?)', ['123', 'Tester']);
+    expect(interaction.reply).toHaveBeenCalled();
+  });
+
+  test('handles class select menu', async () => {
+    const interaction = {
+      values: ['Warrior'],
+      reply: jest.fn().mockResolvedValue(),
+    };
+    await character.handleClassSelect(interaction);
+    expect(interaction.reply).toHaveBeenCalledWith({ content: 'Class selected: Warrior', ephemeral: true });
+  });
+});


### PR DESCRIPTION
## Summary
- implement basic `character` command with select menu
- add Jest test suite for user creation flow and select menu handler

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686c5b86f1448327b7897b67a2603543