### PR TITLE
Add unit tests for character creation workflow

### DIFF
--- a/discord-bot/index.js
+++ b/discord-bot/index.js
@@ -8,6 +8,14 @@ const { setInitialStats } = require('./src/services/playerService');
 const client = new Client({ intents: [GatewayIntentBits.Guilds] });
 client.commands = new Collection();
 
+async function handleStatSelectMenu(interaction) {
+  await setInitialStats(interaction.user.id, interaction.values);
+  const embed = simple('Starting stats saved!', [
+    { name: 'Selected', value: interaction.values.join(', ') }
+  ]);
+  await interaction.reply({ embeds: [embed], ephemeral: true });
+}
+
 const commandsPath = path.join(__dirname, 'commands');
 for (const file of fs.readdirSync(commandsPath)) {
   if (!file.endsWith('.js')) continue;
@@ -35,11 +43,7 @@ client.on(Events.InteractionCreate, async interaction => {
   } else if (interaction.isStringSelectMenu()) {
     if (interaction.customId === 'character_stat_select') {
       try {
-        await setInitialStats(interaction.user.id, interaction.values);
-        const embed = simple('Starting stats saved!', [
-          { name: 'Selected', value: interaction.values.join(', ') }
-        ]);
-        await interaction.reply({ embeds: [embed], ephemeral: true });
+        await handleStatSelectMenu(interaction);
       } catch (error) {
         console.error('Error setting initial stats:', error);
         await interaction.reply({ content: 'There was an error saving your stats.', ephemeral: true });
@@ -48,4 +52,8 @@ client.on(Events.InteractionCreate, async interaction => {
   }
 });
 
-client.login(config.DISCORD_TOKEN);
+if (process.env.NODE_ENV !== 'test') {
+  client.login(config.DISCORD_TOKEN);
+}
+
+module.exports = { handleStatSelectMenu };

--- a/discord-bot/tests/character.test.js
+++ b/discord-bot/tests/character.test.js
@@ -1,0 +1,65 @@
+jest.mock('../util/database', () => ({ query: jest.fn() }));
+const db = require('../util/database');
+
+const character = require('../commands/character');
+
+describe('character create', () => {
+  beforeEach(() => {
+    db.query.mockReset();
+  });
+  test('inserts new player and replies with stat menu', async () => {
+    db.query
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ insertId: 1, rows: [] });
+
+    const interaction = {
+      options: {
+        getSubcommand: jest.fn().mockReturnValue('create'),
+        getString: jest.fn().mockReturnValue('Iron Accord')
+      },
+      user: { id: '123', username: 'tester' },
+      reply: jest.fn().mockResolvedValue()
+    };
+
+    await character.execute(interaction);
+
+    expect(db.query).toHaveBeenNthCalledWith(
+      1,
+      'SELECT id FROM players WHERE discord_id = ?',
+      ['123']
+    );
+    expect(db.query).toHaveBeenNthCalledWith(
+      2,
+      'INSERT INTO players (discord_id, name) VALUES (?, ?)',
+      ['123', 'tester']
+    );
+
+    const replyArg = interaction.reply.mock.calls[0][0];
+    expect(replyArg.ephemeral).toBe(true);
+    expect(replyArg.components[0].components[0].data.custom_id).toBe('stat_select');
+  });
+
+  test('reply when character exists', async () => {
+    db.query.mockResolvedValueOnce({ rows: [{}] });
+
+    const interaction = {
+      options: {
+        getSubcommand: jest.fn().mockReturnValue('create'),
+        getString: jest.fn().mockReturnValue('Iron Accord')
+      },
+      user: { id: '123', username: 'tester' },
+      reply: jest.fn().mockResolvedValue()
+    };
+
+    await character.execute(interaction);
+
+    expect(db.query).toHaveBeenCalledWith(
+      'SELECT id FROM players WHERE discord_id = ?',
+      ['123']
+    );
+    expect(db.query).toHaveBeenCalledTimes(1);
+    expect(interaction.reply).toHaveBeenCalledWith(
+      expect.objectContaining({ ephemeral: true })
+    );
+  });
+});

--- a/discord-bot/tests/interactionHandler.test.js
+++ b/discord-bot/tests/interactionHandler.test.js
@@ -1,0 +1,20 @@
+jest.mock('../src/services/playerService', () => ({ setInitialStats: jest.fn() }));
+jest.mock('../src/utils/embedBuilder', () => ({ simple: jest.fn(() => 'embed') }));
+
+const { handleStatSelectMenu } = require('../index');
+const playerService = require('../src/services/playerService');
+const embeds = require('../src/utils/embedBuilder');
+
+test('handleStatSelectMenu sets stats and replies', async () => {
+  const interaction = {
+    user: { id: '123' },
+    values: ['MGT'],
+    reply: jest.fn().mockResolvedValue()
+  };
+
+  await handleStatSelectMenu(interaction);
+
+  expect(playerService.setInitialStats).toHaveBeenCalledWith('123', ['MGT']);
+  expect(embeds.simple).toHaveBeenCalledWith('Starting stats saved!', [{ name: 'Selected', value: 'MGT' }]);
+  expect(interaction.reply).toHaveBeenCalledWith({ embeds: ['embed'], ephemeral: true });
+});

--- a/discord-bot/tests/playerService.test.js
+++ b/discord-bot/tests/playerService.test.js
@@ -1,5 +1,5 @@
-const db = require('../util/database');
 jest.mock('../util/database', () => ({ query: jest.fn() }));
+const db = require('../util/database');
 
 const { setInitialStats } = require('../src/services/playerService');
 


### PR DESCRIPTION
## Summary
- add `handleStatSelectMenu` helper and export from `index.js`
- skip client login during tests
- test playerService with proper mocks
- add tests for character command user creation flow
- cover select menu handler logic

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686c5d8203808327a868ae864eb64148