### PR TITLE
Refactor ping command to use ephemeral flag

### DIFF
--- a/discord-bot/commands/ping.js
+++ b/discord-bot/commands/ping.js
@@ -1,13 +1,12 @@
-const { MessageFlags } = require('discord.js');
 const { SlashCommandBuilder } = require('discord.js');
 const { simple } = require('../src/utils/embedBuilder');
 
 module.exports = {
-    data: new SlashCommandBuilder()
-        .setName('ping')
-        .setDescription('Replies with Pong!'),
-    async execute(interaction) {
-        const embed = simple('Pong!');
-        await interaction.reply({ embeds: [embed], flags: [MessageFlags.Ephemeral] });
-    },
+  data: new SlashCommandBuilder()
+    .setName('ping')
+    .setDescription('Replies with Pong!'),
+  async execute(interaction) {
+    const embed = simple('Pong!');
+    await interaction.reply({ embeds: [embed], ephemeral: true });
+  },
 };

--- a/discord-bot/tests/ping.test.js
+++ b/discord-bot/tests/ping.test.js
@@ -1,7 +1,9 @@
 const ping = require('../commands/ping');
 
 test('ping command replies', async () => {
-  const interaction = { reply: jest.fn().mockResolvedValue(), flags: [] };
+  const interaction = { reply: jest.fn().mockResolvedValue() };
   await ping.execute(interaction);
-  expect(interaction.reply).toHaveBeenCalled();
+  expect(interaction.reply).toHaveBeenCalledWith(
+    expect.objectContaining({ ephemeral: true })
+  );
 });


### PR DESCRIPTION
## Summary
- remove `MessageFlags` usage from ping command
- reply to ping with ephemeral message
- update ping tests accordingly

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_686c60d2bd6083279cda80a723a088a1