### PR TITLE
Refactor player stat saving function

### DIFF
--- a/discord-bot/index.js
+++ b/discord-bot/index.js
@@ -3,13 +3,18 @@ const fs = require('node:fs');
 const path = require('node:path');
 const config = require('./util/config');
 const { simple } = require('./src/utils/embedBuilder');
-const { setInitialStats } = require('./src/services/playerService');
+const { storeStatSelection } = require('./src/services/playerService');
 
 const client = new Client({ intents: [GatewayIntentBits.Guilds] });
 client.commands = new Collection();
 
+/**
+ * Handle a selection menu where players choose bonus stats.
+ *
+ * @param {import('discord.js').StringSelectMenuInteraction} interaction
+ */
 async function handleStatSelectMenu(interaction) {
-  await setInitialStats(interaction.user.id, interaction.values);
+  await storeStatSelection(interaction.user.id, interaction.values);
   const embed = simple('Starting stats saved!', [
     { name: 'Selected', value: interaction.values.join(', ') }
   ]);

--- a/discord-bot/src/services/playerService.js
+++ b/discord-bot/src/services/playerService.js
@@ -1,14 +1,18 @@
 const db = require('../../util/database');
 
 /**
- * Store the player's initial stat selection.
- * @param {string} discordId - The ID of the Discord user.
- * @param {string[]} values - The values selected from the menu.
+ * Persist a player's selected starting stats.
+ *
+ * @param {string} discordId The ID of the Discord user.
+ * @param {string[]} values The values selected from the menu.
  */
-async function setInitialStats(discordId, values) {
+async function storeStatSelection(discordId, values) {
   const statsJson = JSON.stringify(values);
   // Persist selection in database if supported
-  await db.query('UPDATE players SET starting_stats = ? WHERE discord_id = ?', [statsJson, discordId]);
+  await db.query('UPDATE players SET starting_stats = ? WHERE discord_id = ?', [
+    statsJson,
+    discordId
+  ]);
 }
 
-module.exports = { setInitialStats };
+module.exports = { storeStatSelection };

--- a/discord-bot/tests/interactionHandler.test.js
+++ b/discord-bot/tests/interactionHandler.test.js
@@ -1,4 +1,4 @@
-jest.mock('../src/services/playerService', () => ({ setInitialStats: jest.fn() }));
+jest.mock('../src/services/playerService', () => ({ storeStatSelection: jest.fn() }));
 jest.mock('../src/utils/embedBuilder', () => ({ simple: jest.fn(() => 'embed') }));
 
 const { handleStatSelectMenu } = require('../index');
@@ -14,7 +14,7 @@ test('handleStatSelectMenu sets stats and replies', async () => {
 
   await handleStatSelectMenu(interaction);
 
-  expect(playerService.setInitialStats).toHaveBeenCalledWith('123', ['MGT']);
+  expect(playerService.storeStatSelection).toHaveBeenCalledWith('123', ['MGT']);
   expect(embeds.simple).toHaveBeenCalledWith('Starting stats saved!', [{ name: 'Selected', value: 'MGT' }]);
   expect(interaction.reply).toHaveBeenCalledWith({ embeds: ['embed'], ephemeral: true });
 });

--- a/discord-bot/tests/playerService.test.js
+++ b/discord-bot/tests/playerService.test.js
@@ -1,10 +1,10 @@
 jest.mock('../util/database', () => ({ query: jest.fn() }));
 const db = require('../util/database');
 
-const { setInitialStats } = require('../src/services/playerService');
+const { storeStatSelection } = require('../src/services/playerService');
 
-test('setInitialStats updates player stats', async () => {
-  await setInitialStats('123', ['str']);
+test('storeStatSelection updates player stats', async () => {
+  await storeStatSelection('123', ['str']);
   expect(db.query).toHaveBeenCalledWith(
     'UPDATE players SET starting_stats = ? WHERE discord_id = ?',
     [JSON.stringify(['str']), '123']


### PR DESCRIPTION
## Summary
- rename `setInitialStats` to `storeStatSelection`
- update imports in bot and tests
- document the new function and menu handler

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686c60d5940083278985851ddb434595