### PR TITLE
Add inventory and equip commands

### DIFF
--- a/discord-bot/README.md
+++ b/discord-bot/README.md
@@ -21,11 +21,13 @@ The bot will log into Discord and connect to the database on start.
 
 ## Commands
 
-Three slash commands are available:
+Five slash commands are available:
 
 - `/ping` – check that the bot is responsive
 - `/help` – display an ephemeral list of commands
 - `/character create` – start a new character profile
+- `/inventory` – view your equipped items and backpack
+- `/equip` – equip a weapon, armor piece or ability card you own
 
 Running the command launches a short setup sequence:
 1. **Choose your faction** – pick either **Iron Accord** or **Neon Dharma**.
@@ -41,6 +43,9 @@ The schema defined in `db-schema.sql` creates the following tables:
 - `mission_log` – records mission attempts for each player
 - `codex_entries` – tracks which lore entries a player has unlocked
 - `user_stats` – six core stats for each player with default values
+- `user_weapons` – weapons owned by each player
+- `user_armors` – armor pieces owned by each player
+- `user_ability_cards` – ability cards owned by each player
 
 `codex_entries` is new in this version. Re-run `db-schema.sql` on your MySQL server to create the table or apply the included `ALTER` statements if you are migrating from an older install. Existing installations should drop the old tables listed at the top of the file.
 

--- a/discord-bot/commands/equip.js
+++ b/discord-bot/commands/equip.js
@@ -1,0 +1,71 @@
+const { SlashCommandBuilder } = require('discord.js');
+const db = require('../util/database');
+const { simple } = require('../src/utils/embedBuilder');
+
+module.exports = {
+  data: new SlashCommandBuilder()
+    .setName('equip')
+    .setDescription('Equip an owned item')
+    .addStringOption(opt =>
+      opt.setName('type')
+        .setDescription('Item type')
+        .setRequired(true)
+        .addChoices(
+          { name: 'Weapon', value: 'weapon' },
+          { name: 'Armor', value: 'armor' },
+          { name: 'Ability', value: 'ability' }
+        )
+    )
+    .addIntegerOption(opt =>
+      opt.setName('id')
+        .setDescription('Item ID')
+        .setRequired(true)
+    ),
+  async execute(interaction) {
+    const type = interaction.options.getString('type');
+    const itemId = interaction.options.getInteger('id');
+    const discordId = interaction.user.id;
+
+    const { rows: players } = await db.query(
+      'SELECT id FROM players WHERE discord_id = ?',
+      [discordId]
+    );
+    if (players.length === 0) {
+      const embed = simple('Character not found.');
+      await interaction.reply({ embeds: [embed], ephemeral: true });
+      return;
+    }
+    const playerId = players[0].id;
+
+    let table;
+    let column;
+    if (type === 'weapon') {
+      table = 'user_weapons';
+      column = 'equipped_weapon_id';
+    } else if (type === 'armor') {
+      table = 'user_armors';
+      column = 'equipped_armor_id';
+    } else {
+      table = 'user_ability_cards';
+      column = 'equipped_ability_id';
+    }
+
+    const { rows: items } = await db.query(
+      `SELECT id FROM ${table} WHERE id = ? AND player_id = ?`,
+      [itemId, playerId]
+    );
+    if (items.length === 0) {
+      const embed = simple('You do not own that item.');
+      await interaction.reply({ embeds: [embed], ephemeral: true });
+      return;
+    }
+
+    await db.query(
+      `UPDATE players SET ${column} = ? WHERE id = ?`,
+      [itemId, playerId]
+    );
+
+    const embed = simple('Item equipped!');
+    await interaction.reply({ embeds: [embed], ephemeral: true });
+  }
+};

--- a/discord-bot/commands/inventory.js
+++ b/discord-bot/commands/inventory.js
@@ -1,0 +1,63 @@
+const { SlashCommandBuilder } = require('discord.js');
+const db = require('../util/database');
+const { simple } = require('../src/utils/embedBuilder');
+
+module.exports = {
+  data: new SlashCommandBuilder()
+    .setName('inventory')
+    .setDescription('Show equipped items and backpack contents'),
+  async execute(interaction) {
+    const discordId = interaction.user.id;
+
+    const { rows: players } = await db.query(
+      'SELECT id, equipped_weapon_id, equipped_armor_id, equipped_ability_id FROM players WHERE discord_id = ?',
+      [discordId]
+    );
+    if (players.length === 0) {
+      const embed = simple('No character found.');
+      await interaction.reply({ embeds: [embed], ephemeral: true });
+      return;
+    }
+
+    const player = players[0];
+    const playerId = player.id;
+
+    const { rows: weapons } = await db.query(
+      'SELECT id, name FROM user_weapons WHERE player_id = ?',
+      [playerId]
+    );
+    const { rows: armors } = await db.query(
+      'SELECT id, name FROM user_armors WHERE player_id = ?',
+      [playerId]
+    );
+    const { rows: abilities } = await db.query(
+      'SELECT id, name FROM user_ability_cards WHERE player_id = ?',
+      [playerId]
+    );
+
+    const equippedWeapon = weapons.find(w => w.id === player.equipped_weapon_id);
+    const equippedArmor = armors.find(a => a.id === player.equipped_armor_id);
+    const equippedAbility = abilities.find(a => a.id === player.equipped_ability_id);
+
+    const fields = [
+      { name: 'Weapon', value: equippedWeapon ? equippedWeapon.name : 'None', inline: true },
+      { name: 'Armor', value: equippedArmor ? equippedArmor.name : 'None', inline: true },
+      { name: 'Ability', value: equippedAbility ? equippedAbility.name : 'None', inline: true },
+    ];
+
+    const backpack = [...weapons, ...armors, ...abilities]
+      .filter(i => ![
+        player.equipped_weapon_id,
+        player.equipped_armor_id,
+        player.equipped_ability_id
+      ].includes(i.id))
+      .map(i => i.name)
+      .join(', ');
+    if (backpack) {
+      fields.push({ name: 'Backpack', value: backpack });
+    }
+
+    const embed = simple('Inventory', fields);
+    await interaction.reply({ embeds: [embed], ephemeral: true });
+  }
+};

--- a/discord-bot/db-schema.sql
+++ b/discord-bot/db-schema.sql
@@ -20,6 +20,9 @@ CREATE TABLE IF NOT EXISTS players (
     gold INT DEFAULT 0,
     xp INT DEFAULT 0,
     level INT DEFAULT 1,
+    equipped_weapon_id INT DEFAULT NULL,
+    equipped_armor_id INT DEFAULT NULL,
+    equipped_ability_id INT DEFAULT NULL,
     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
 );
 
@@ -64,5 +67,27 @@ CREATE TABLE IF NOT EXISTS user_stats (
     intuition INT DEFAULT 1,
     resolve INT DEFAULT 1,
     ingenuity INT DEFAULT 1,
+    FOREIGN KEY (player_id) REFERENCES players(id)
+);
+
+-- User inventory tables
+CREATE TABLE IF NOT EXISTS user_weapons (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    player_id INT NOT NULL,
+    name VARCHAR(255) NOT NULL,
+    FOREIGN KEY (player_id) REFERENCES players(id)
+);
+
+CREATE TABLE IF NOT EXISTS user_armors (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    player_id INT NOT NULL,
+    name VARCHAR(255) NOT NULL,
+    FOREIGN KEY (player_id) REFERENCES players(id)
+);
+
+CREATE TABLE IF NOT EXISTS user_ability_cards (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    player_id INT NOT NULL,
+    name VARCHAR(255) NOT NULL,
     FOREIGN KEY (player_id) REFERENCES players(id)
 );

--- a/discord-bot/tests/equip.test.js
+++ b/discord-bot/tests/equip.test.js
@@ -1,0 +1,59 @@
+jest.mock('../util/database', () => ({ query: jest.fn() }));
+const db = require('../util/database');
+const equip = require('../commands/equip');
+
+describe('equip command', () => {
+  beforeEach(() => { db.query.mockReset(); });
+
+  test('equips owned item', async () => {
+    db.query
+      .mockResolvedValueOnce({ rows: [{ id: 1 }] })
+      .mockResolvedValueOnce({ rows: [{ id: 5 }] })
+      .mockResolvedValueOnce({ rows: [] });
+
+    const interaction = {
+      options: {
+        getString: jest.fn().mockReturnValue('weapon'),
+        getInteger: jest.fn().mockReturnValue(5)
+      },
+      user: { id: '123' },
+      reply: jest.fn().mockResolvedValue()
+    };
+
+    await equip.execute(interaction);
+
+    expect(db.query).toHaveBeenNthCalledWith(1,
+      'SELECT id FROM players WHERE discord_id = ?',
+      ['123']
+    );
+    expect(db.query).toHaveBeenNthCalledWith(2,
+      'SELECT id FROM user_weapons WHERE id = ? AND player_id = ?',
+      [5, 1]
+    );
+    expect(db.query).toHaveBeenNthCalledWith(3,
+      'UPDATE players SET equipped_weapon_id = ? WHERE id = ?',
+      [5, 1]
+    );
+    expect(interaction.reply).toHaveBeenCalledWith(expect.objectContaining({ ephemeral: true }));
+  });
+
+  test('rejects unowned item', async () => {
+    db.query
+      .mockResolvedValueOnce({ rows: [{ id: 1 }] })
+      .mockResolvedValueOnce({ rows: [] });
+
+    const interaction = {
+      options: {
+        getString: jest.fn().mockReturnValue('weapon'),
+        getInteger: jest.fn().mockReturnValue(5)
+      },
+      user: { id: '123' },
+      reply: jest.fn().mockResolvedValue()
+    };
+
+    await equip.execute(interaction);
+
+    expect(db.query).toHaveBeenCalledTimes(2);
+    expect(interaction.reply).toHaveBeenCalledWith(expect.objectContaining({ ephemeral: true }));
+  });
+});

--- a/discord-bot/tests/inventory.test.js
+++ b/discord-bot/tests/inventory.test.js
@@ -1,0 +1,24 @@
+jest.mock('../util/database', () => ({ query: jest.fn() }));
+const db = require('../util/database');
+const inventory = require('../commands/inventory');
+
+describe('inventory command', () => {
+  beforeEach(() => {
+    db.query.mockReset();
+  });
+
+  test('shows equipped items', async () => {
+    db.query
+      .mockResolvedValueOnce({ rows: [{ id: 1, equipped_weapon_id: 2, equipped_armor_id: 3, equipped_ability_id: 4 }] })
+      .mockResolvedValueOnce({ rows: [{ id: 2, name: 'Sword' }] })
+      .mockResolvedValueOnce({ rows: [{ id: 3, name: 'Leather' }] })
+      .mockResolvedValueOnce({ rows: [{ id: 4, name: 'Fireball' }] });
+
+    const interaction = { user: { id: '123' }, reply: jest.fn().mockResolvedValue() };
+
+    await inventory.execute(interaction);
+
+    expect(db.query).toHaveBeenCalledTimes(4);
+    expect(interaction.reply).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- expand MySQL schema with equipment columns and inventory tables
- document new commands and tables in README
- implement `/inventory` command
- implement `/equip` command
- test equip and inventory logic

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686c60d638e0832780b057a65769f889