### PR TITLE
Add equip/inventory commands

### DIFF
--- a/discord-bot/commands/equip.js
+++ b/discord-bot/commands/equip.js
@@ -1,0 +1,64 @@
+const { SlashCommandBuilder } = require('discord.js');
+const db = require('../util/database');
+const { simple } = require('../src/utils/embedBuilder');
+
+module.exports = {
+  data: new SlashCommandBuilder()
+    .setName('equip')
+    .setDescription('Equip an item by ID')
+    .addStringOption(opt =>
+      opt
+        .setName('type')
+        .setDescription('Item type')
+        .setRequired(true)
+        .addChoices(
+          { name: 'Weapon', value: 'weapon' },
+          { name: 'Armor', value: 'armor' },
+          { name: 'Ability', value: 'ability' }
+        )
+    )
+    .addIntegerOption(opt =>
+      opt.setName('item_id').setDescription('ID of the item').setRequired(true)
+    ),
+  async execute(interaction) {
+    const type = interaction.options.getString('type');
+    const itemId = interaction.options.getInteger('item_id');
+    const { rows: playerRows } = await db.query(
+      'SELECT id FROM players WHERE discord_id = ?',
+      [interaction.user.id]
+    );
+    if (playerRows.length === 0) {
+      const embed = simple('You have no character.');
+      await interaction.reply({ embeds: [embed], ephemeral: true });
+      return;
+    }
+    const playerId = playerRows[0].id;
+    let table;
+    let column;
+    if (type === 'weapon') {
+      table = 'user_weapons';
+      column = 'equipped_weapon_id';
+    } else if (type === 'armor') {
+      table = 'user_armors';
+      column = 'equipped_armor_id';
+    } else {
+      table = 'user_ability_cards';
+      column = 'equipped_ability_id';
+    }
+    const { rows: owned } = await db.query(
+      `SELECT name FROM ${table} WHERE id = ? AND player_id = ?`,
+      [itemId, playerId]
+    );
+    if (owned.length === 0) {
+      const embed = simple('You do not own that item.');
+      await interaction.reply({ embeds: [embed], ephemeral: true });
+      return;
+    }
+    await db.query(
+      `UPDATE players SET ${column} = ? WHERE id = ?`,
+      [itemId, playerId]
+    );
+    const embed = simple(`Equipped ${owned[0].name}!`);
+    await interaction.reply({ embeds: [embed], ephemeral: true });
+  }
+};

--- a/discord-bot/commands/inventory.js
+++ b/discord-bot/commands/inventory.js
@@ -1,0 +1,43 @@
+const { SlashCommandBuilder } = require('discord.js');
+const db = require('../util/database');
+const { simple } = require('../src/utils/embedBuilder');
+
+module.exports = {
+  data: new SlashCommandBuilder()
+    .setName('inventory')
+    .setDescription('View your equipped items and backpack'),
+  async execute(interaction) {
+    const discordId = interaction.user.id;
+    const { rows: playerRows } = await db.query(
+      'SELECT id, equipped_weapon_id, equipped_armor_id, equipped_ability_id FROM players WHERE discord_id = ?',
+      [discordId]
+    );
+    if (playerRows.length === 0) {
+      const embed = simple('You have no character.');
+      await interaction.reply({ embeds: [embed], ephemeral: true });
+      return;
+    }
+    const player = playerRows[0];
+    const playerId = player.id;
+    const [weaponRes, armorRes, abilityRes] = await Promise.all([
+      db.query('SELECT id, name FROM user_weapons WHERE player_id = ?', [playerId]),
+      db.query('SELECT id, name FROM user_armors WHERE player_id = ?', [playerId]),
+      db.query('SELECT id, name FROM user_ability_cards WHERE player_id = ?', [playerId])
+    ]);
+    const weapons = weaponRes.rows;
+    const armors = armorRes.rows;
+    const abilities = abilityRes.rows;
+    const equippedWeapon = weapons.find(w => w.id === player.equipped_weapon_id);
+    const equippedArmor = armors.find(a => a.id === player.equipped_armor_id);
+    const equippedAbility = abilities.find(a => a.id === player.equipped_ability_id);
+    const embed = simple('Inventory', [
+      { name: 'Equipped Weapon', value: equippedWeapon ? equippedWeapon.name : 'None', inline: true },
+      { name: 'Equipped Armor', value: equippedArmor ? equippedArmor.name : 'None', inline: true },
+      { name: 'Equipped Ability', value: equippedAbility ? equippedAbility.name : 'None', inline: true },
+      { name: 'Weapons', value: weapons.map(w => w.name).join(', ') || 'None' },
+      { name: 'Armors', value: armors.map(a => a.name).join(', ') || 'None' },
+      { name: 'Ability Cards', value: abilities.map(a => a.name).join(', ') || 'None' }
+    ]);
+    await interaction.reply({ embeds: [embed], ephemeral: true });
+  }
+};

--- a/discord-bot/db-schema.sql
+++ b/discord-bot/db-schema.sql
@@ -20,6 +20,9 @@ CREATE TABLE IF NOT EXISTS players (
     gold INT DEFAULT 0,
     xp INT DEFAULT 0,
     level INT DEFAULT 1,
+    equipped_weapon_id INT DEFAULT NULL,
+    equipped_armor_id INT DEFAULT NULL,
+    equipped_ability_id INT DEFAULT NULL,
     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
 );
 
@@ -61,5 +64,27 @@ CREATE TABLE IF NOT EXISTS user_stats (
     stat VARCHAR(10) NOT NULL,
     value INT DEFAULT 1,
     PRIMARY KEY (player_id, stat),
+    FOREIGN KEY (player_id) REFERENCES players(id)
+);
+
+-- Player inventory tables
+CREATE TABLE IF NOT EXISTS user_weapons (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    player_id INT NOT NULL,
+    name VARCHAR(255) NOT NULL,
+    FOREIGN KEY (player_id) REFERENCES players(id)
+);
+
+CREATE TABLE IF NOT EXISTS user_armors (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    player_id INT NOT NULL,
+    name VARCHAR(255) NOT NULL,
+    FOREIGN KEY (player_id) REFERENCES players(id)
+);
+
+CREATE TABLE IF NOT EXISTS user_ability_cards (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    player_id INT NOT NULL,
+    name VARCHAR(255) NOT NULL,
     FOREIGN KEY (player_id) REFERENCES players(id)
 );

--- a/discord-bot/tests/equip.test.js
+++ b/discord-bot/tests/equip.test.js
@@ -1,0 +1,60 @@
+jest.mock('../util/database', () => ({ query: jest.fn() }));
+const db = require('../util/database');
+const equip = require('../commands/equip');
+
+beforeEach(() => {
+  db.query.mockReset();
+});
+
+test('equips owned weapon', async () => {
+  db.query
+    .mockResolvedValueOnce({ rows: [{ id: 1 }] })
+    .mockResolvedValueOnce({ rows: [{ name: 'Sword' }] })
+    .mockResolvedValueOnce({});
+
+  const interaction = {
+    options: {
+      getString: jest.fn().mockReturnValue('weapon'),
+      getInteger: jest.fn().mockReturnValue(5)
+    },
+    user: { id: '1' },
+    reply: jest.fn().mockResolvedValue()
+  };
+
+  await equip.execute(interaction);
+
+  expect(db.query).toHaveBeenNthCalledWith(
+    1,
+    'SELECT id FROM players WHERE discord_id = ?',
+    ['1']
+  );
+  expect(db.query).toHaveBeenNthCalledWith(
+    2,
+    'SELECT name FROM user_weapons WHERE id = ? AND player_id = ?',
+    [5, 1]
+  );
+  expect(db.query).toHaveBeenNthCalledWith(
+    3,
+    'UPDATE players SET equipped_weapon_id = ? WHERE id = ?',
+    [5, 1]
+  );
+  expect(interaction.reply).toHaveBeenCalledWith(expect.objectContaining({ ephemeral: true }));
+});
+
+test('errors when item not owned', async () => {
+  db.query
+    .mockResolvedValueOnce({ rows: [{ id: 1 }] })
+    .mockResolvedValueOnce({ rows: [] });
+
+  const interaction = {
+    options: {
+      getString: jest.fn().mockReturnValue('armor'),
+      getInteger: jest.fn().mockReturnValue(2)
+    },
+    user: { id: '1' },
+    reply: jest.fn().mockResolvedValue()
+  };
+
+  await equip.execute(interaction);
+  expect(interaction.reply).toHaveBeenCalledWith(expect.objectContaining({ ephemeral: true }));
+});

--- a/discord-bot/tests/interactionHandler.test.js
+++ b/discord-bot/tests/interactionHandler.test.js
@@ -49,6 +49,7 @@ test('interactionCreate calls handleStatSelectMenu for stat_select menu', async 
       setDescription() { return this; }
       addSubcommand() { return this; }
       addStringOption() { return this; }
+      addIntegerOption() { return this; }
     },
     ActionRowBuilder: class { addComponents() { return this; } },
     StringSelectMenuBuilder: class {
@@ -71,5 +72,5 @@ test('interactionCreate calls handleStatSelectMenu for stat_select menu', async 
 
   await interactionHandler(interaction);
 
-  expect(playerService.setInitialStats).toHaveBeenCalledWith('1', []);
+  expect(playerService.storeStatSelection).toHaveBeenCalledWith('1', []);
 });

--- a/discord-bot/tests/inventory.test.js
+++ b/discord-bot/tests/inventory.test.js
@@ -1,0 +1,33 @@
+jest.mock('../util/database', () => ({ query: jest.fn() }));
+const db = require('../util/database');
+const inventory = require('../commands/inventory');
+
+beforeEach(() => {
+  db.query.mockReset();
+});
+
+test('replies with inventory for existing player', async () => {
+  db.query
+    .mockResolvedValueOnce({ rows: [{ id: 1, equipped_weapon_id: 2, equipped_armor_id: null, equipped_ability_id: 3 }] })
+    .mockResolvedValueOnce({ rows: [{ id: 2, name: 'Sword' }] })
+    .mockResolvedValueOnce({ rows: [] })
+    .mockResolvedValueOnce({ rows: [{ id: 3, name: 'Fireball' }] });
+
+  const interaction = { user: { id: '1' }, reply: jest.fn().mockResolvedValue() };
+  await inventory.execute(interaction);
+
+  expect(db.query).toHaveBeenNthCalledWith(
+    1,
+    'SELECT id, equipped_weapon_id, equipped_armor_id, equipped_ability_id FROM players WHERE discord_id = ?',
+    ['1']
+  );
+  expect(db.query).toHaveBeenCalledTimes(4);
+  expect(interaction.reply).toHaveBeenCalledWith(expect.objectContaining({ ephemeral: true }));
+});
+
+test('replies when player missing', async () => {
+  db.query.mockResolvedValueOnce({ rows: [] });
+  const interaction = { user: { id: '2' }, reply: jest.fn().mockResolvedValue() };
+  await inventory.execute(interaction);
+  expect(interaction.reply).toHaveBeenCalledWith(expect.objectContaining({ ephemeral: true }));
+});


### PR DESCRIPTION
## Summary
- expand schema with equipment columns and tables
- add `/equip` and `/inventory` commands
- show equipped items and backpack
- allow equipping items you own
- test new commands and update interaction handler test

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686c62c807c483279d5476bd916f2792