### PR TITLE
Add mission command

### DIFF
--- a/discord-bot/commands/mission.js
+++ b/discord-bot/commands/mission.js
@@ -1,0 +1,66 @@
+const { SlashCommandBuilder } = require('discord.js');
+const fs = require('fs');
+const path = require('path');
+const { simple } = require('../src/utils/embedBuilder');
+const missionService = require('../src/services/missionService');
+
+const missionsPath = path.join(__dirname, '../src/data/missions');
+
+function loadMission(name) {
+  const file = path.join(missionsPath, `${name}.json`);
+  if (!fs.existsSync(file)) return null;
+  return JSON.parse(fs.readFileSync(file, 'utf8'));
+}
+
+module.exports = {
+  data: new SlashCommandBuilder()
+    .setName('mission')
+    .setDescription('Mission commands')
+    .addSubcommand(sub =>
+      sub
+        .setName('start')
+        .setDescription('Start a mission')
+        .addStringOption(opt =>
+          opt.setName('name').setDescription('Mission name').setRequired(true)
+        )
+    ),
+
+  async execute(interaction) {
+    if (interaction.options.getSubcommand() !== 'start') return;
+
+    const missionName = interaction.options.getString('name');
+    const mission = loadMission(missionName);
+    if (!mission) {
+      await interaction.reply({ embeds: [simple('Mission not found.')], ephemeral: true });
+      return;
+    }
+
+    const playerId = await missionService.getPlayerId(interaction.user.id);
+    if (!playerId) {
+      await interaction.reply({ embeds: [simple('You have no character.')], ephemeral: true });
+      return;
+    }
+
+    const thread = await interaction.channel.threads.create({
+      name: mission.name,
+      autoArchiveDuration: 60
+    });
+
+    await thread.send(mission.intro);
+    const logId = await missionService.startMission(playerId, mission.id);
+    let durability = 3;
+    for (let i = 0; i < mission.rounds.length; i++) {
+      const round = mission.rounds[i];
+      const opts = round.options.map((o, idx) => `${idx + 1}. ${o.text}`).join('\n');
+      await thread.send(`${round.text}\n${opts}`);
+      const choice = 0; // auto-select first option
+      const delta = round.options[choice].durability || 0;
+      missionService.recordChoice(logId, i, choice, delta);
+      durability += delta;
+    }
+    const outcome = durability > 0 ? 'success' : 'fail';
+    await missionService.completeMission(logId, outcome, mission.rewards, mission.codexFragment, playerId);
+    await thread.send(`Mission complete with outcome: ${outcome}`);
+    await interaction.reply({ embeds: [simple('Mission started! Check the thread.')], ephemeral: true });
+  }
+};

--- a/discord-bot/src/data/missions/test.json
+++ b/discord-bot/src/data/missions/test.json
@@ -1,0 +1,12 @@
+{
+  "id": 1,
+  "name": "test",
+  "intro": "Test mission start",
+  "rounds": [
+    { "text": "Round 1", "options": [ { "text": "A", "durability": -1 }, { "text": "B", "durability": -2 } ] },
+    { "text": "Round 2", "options": [ { "text": "A", "durability": -1 }, { "text": "B", "durability": 0 } ] },
+    { "text": "Round 3", "options": [ { "text": "A", "durability": 0 }, { "text": "B", "durability": 0 } ] }
+  ],
+  "rewards": { "gold": 5 },
+  "codexFragment": "test_fragment"
+}

--- a/discord-bot/src/services/missionService.js
+++ b/discord-bot/src/services/missionService.js
@@ -1,0 +1,49 @@
+const db = require('../../util/database');
+
+const activeMissions = new Map();
+
+async function getPlayerId(discordId) {
+  const { rows } = await db.query('SELECT id FROM players WHERE discord_id = ?', [discordId]);
+  return rows[0] ? rows[0].id : null;
+}
+
+async function startMission(playerId, missionId) {
+  const { insertId } = await db.query(
+    'INSERT INTO mission_log (mission_id, player_id) VALUES (?, ?)',
+    [missionId, playerId]
+  );
+  activeMissions.set(insertId, { choices: [], durability: 3 });
+  return insertId;
+}
+
+function recordChoice(logId, roundIdx, choiceIdx, durabilityDelta = 0) {
+  const m = activeMissions.get(logId);
+  if (!m) return;
+  m.choices[roundIdx] = choiceIdx;
+  m.durability += durabilityDelta;
+}
+
+async function completeMission(logId, outcomeTier, rewards = {}, codexKey, playerId) {
+  const m = activeMissions.get(logId) || { choices: [] };
+  const log = JSON.stringify({ choices: m.choices, outcome_tier: outcomeTier });
+
+  if (rewards.gold) {
+    await db.query('UPDATE players SET gold = gold + ? WHERE id = ?', [rewards.gold, playerId]);
+  }
+
+  await db.query(
+    'UPDATE mission_log SET status = ?, completed_at = NOW(), log = ? WHERE id = ?',
+    ['completed', log, logId]
+  );
+
+  if (codexKey) {
+    await db.query(
+      'INSERT IGNORE INTO codex_entries (player_id, entry_key) VALUES (?, ?)',
+      [playerId, codexKey]
+    );
+  }
+
+  activeMissions.delete(logId);
+}
+
+module.exports = { getPlayerId, startMission, recordChoice, completeMission };

--- a/discord-bot/tests/mission.test.js
+++ b/discord-bot/tests/mission.test.js
@@ -1,0 +1,64 @@
+jest.mock('fs');
+jest.mock('../src/services/missionService', () => ({
+  getPlayerId: jest.fn(),
+  startMission: jest.fn(),
+  recordChoice: jest.fn(),
+  completeMission: jest.fn()
+}));
+
+const fs = require('fs');
+const missionService = require('../src/services/missionService');
+const mission = require('../commands/mission');
+
+describe('mission command', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('creates thread and progresses rounds', async () => {
+    const data = {
+      id: 1,
+      name: 'test',
+      intro: 'Intro',
+      rounds: [
+        { text: 'r1', options: [{ text: 'a', durability: -1 }, { text: 'b' }] },
+        { text: 'r2', options: [{ text: 'a' }, { text: 'b' }] },
+        { text: 'r3', options: [{ text: 'a' }, { text: 'b' }] }
+      ],
+      rewards: { gold: 5 },
+      codexFragment: 'frag'
+    };
+
+    fs.existsSync.mockReturnValue(true);
+    fs.readFileSync.mockReturnValue(JSON.stringify(data));
+
+    missionService.getPlayerId.mockResolvedValue(10);
+    missionService.startMission.mockResolvedValue(20);
+
+    const send = jest.fn().mockResolvedValue();
+    const create = jest.fn().mockResolvedValue({ send });
+
+    const interaction = {
+      options: {
+        getSubcommand: jest.fn().mockReturnValue('start'),
+        getString: jest.fn().mockReturnValue('test')
+      },
+      user: { id: 'u1' },
+      channel: { threads: { create } },
+      reply: jest.fn().mockResolvedValue()
+    };
+
+    await mission.execute(interaction);
+
+    expect(create).toHaveBeenCalled();
+    expect(send).toHaveBeenCalledTimes(data.rounds.length + 2);
+    expect(missionService.recordChoice).toHaveBeenCalledTimes(data.rounds.length);
+    expect(missionService.completeMission).toHaveBeenCalledWith(
+      20,
+      expect.any(String),
+      data.rewards,
+      data.codexFragment,
+      10
+    );
+  });
+});

--- a/discord-bot/tests/missionService.test.js
+++ b/discord-bot/tests/missionService.test.js
@@ -1,0 +1,45 @@
+jest.mock('../util/database', () => ({ query: jest.fn() }));
+const db = require('../util/database');
+
+const service = require('../src/services/missionService');
+
+describe('missionService', () => {
+  beforeEach(() => { db.query.mockReset(); });
+
+  test('startMission inserts log', async () => {
+    db.query.mockResolvedValueOnce({ insertId: 5 });
+    const id = await service.startMission(1, 2);
+    expect(db.query).toHaveBeenCalledWith(
+      'INSERT INTO mission_log (mission_id, player_id) VALUES (?, ?)',
+      [2, 1]
+    );
+    expect(id).toBe(5);
+  });
+
+  test('completeMission updates log and rewards', async () => {
+    db.query
+      .mockResolvedValueOnce({ insertId: 1 })
+      .mockResolvedValue({});
+
+    const logId = await service.startMission(1, 2);
+    service.recordChoice(logId, 0, 1, -1);
+
+    await service.completeMission(logId, 'success', { gold: 2 }, 'frag', 1);
+
+    expect(db.query).toHaveBeenNthCalledWith(
+      2,
+      'UPDATE players SET gold = gold + ? WHERE id = ?',
+      [2, 1]
+    );
+    const updateCall = db.query.mock.calls[2];
+    expect(updateCall[0]).toMatch(/UPDATE mission_log/);
+    const log = JSON.parse(updateCall[1][1]);
+    expect(log.choices).toEqual([1]);
+    expect(log.outcome_tier).toBe('success');
+    expect(db.query).toHaveBeenNthCalledWith(
+      4,
+      'INSERT IGNORE INTO codex_entries (player_id, entry_key) VALUES (?, ?)',
+      [1, 'frag']
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- add `/mission start` command for launching missions
- implement new mission service to track progress
- include example mission data
- test mission command and mission service

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686c67a7080c832785221d5be2e4cdda