### PR TITLE
Add combat data to missions

### DIFF
--- a/discord-bot/src/data/missions/test.json
+++ b/discord-bot/src/data/missions/test.json
@@ -3,9 +3,81 @@
   "name": "test",
   "intro": "Test mission start",
   "rounds": [
-    { "text": "Round 1", "options": [ { "text": "A", "durability": -1 }, { "text": "B", "durability": -2 } ] },
-    { "text": "Round 2", "options": [ { "text": "A", "durability": -1 }, { "text": "B", "durability": 0 } ] },
-    { "text": "Round 3", "options": [ { "text": "A", "durability": 0 }, { "text": "B", "durability": 0 } ] }
+    {
+      "text": "Round 1",
+      "options": [
+        {
+          "text": "A",
+          "durability": -1,
+          "combat": true,
+          "dc": 12,
+          "outcomes": {
+            "Operational Success": { "loot": { "gold": 1 } },
+            "System Degraded": { "penalty": { "durability_loss": 5, "add_flag": "Injured" } }
+          }
+        },
+        {
+          "text": "B",
+          "durability": -2,
+          "combat": true,
+          "dc": 12,
+          "outcomes": {
+            "Operational Success": { "loot": { "gold": 2 } },
+            "System Degraded": { "penalty": { "durability_loss": 5, "add_flag": "Injured" } }
+          }
+        }
+      ]
+    },
+    {
+      "text": "Round 2",
+      "options": [
+        {
+          "text": "A",
+          "durability": -1,
+          "combat": true,
+          "dc": 10,
+          "outcomes": {
+            "Operational Success": { "loot": { "gold": 1 } },
+            "System Degraded": { "penalty": { "durability_loss": 5, "add_flag": "Injured" } }
+          }
+        },
+        {
+          "text": "B",
+          "durability": 0,
+          "combat": true,
+          "dc": 10,
+          "outcomes": {
+            "Operational Success": { "loot": { "gold": 1 } },
+            "System Degraded": { "penalty": { "durability_loss": 5, "add_flag": "Injured" } }
+          }
+        }
+      ]
+    },
+    {
+      "text": "Round 3",
+      "options": [
+        {
+          "text": "A",
+          "durability": 0,
+          "combat": true,
+          "dc": 8,
+          "outcomes": {
+            "Operational Success": { "loot": { "gold": 2 } },
+            "System Degraded": { "penalty": { "durability_loss": 5, "add_flag": "Injured" } }
+          }
+        },
+        {
+          "text": "B",
+          "durability": 0,
+          "combat": true,
+          "dc": 8,
+          "outcomes": {
+            "Operational Success": { "loot": { "gold": 3 } },
+            "System Degraded": { "penalty": { "durability_loss": 5, "add_flag": "Injured" } }
+          }
+        }
+      ]
+    }
   ],
   "rewards": { "gold": 5 },
   "codexFragment": "test_fragment"

--- a/docs/README.md
+++ b/docs/README.md
@@ -14,3 +14,25 @@ The MVP story walkthrough, including mission flow and Codex integration, is
 documented in [iron_accord_mvp_story.md](iron_accord_mvp_story.md).
 The phased rollout strategy is outlined in [iron_accord_mvp_rollout.md](iron_accord_mvp_rollout.md).
 
+
+## Mission Data Fields
+
+Mission JSON files are stored in `discord-bot/src/data/missions`. Each mission defines several rounds of player choices. Choice objects support additional fields used during combat:
+
+- `combat` – boolean indicating that selecting the choice triggers a combat roll.
+- `dc` – numeric difficulty class for that roll.
+- `outcomes` – maps result tiers (e.g. `Operational Success`, `System Degraded`) to either `loot` or `penalty` data.
+
+An example snippet:
+
+```json
+{
+  "text": "A",
+  "combat": true,
+  "dc": 12,
+  "outcomes": {
+    "Operational Success": { "loot": { "gold": 1 } },
+    "System Degraded": { "penalty": { "durability_loss": 5, "add_flag": "Injured" } }
+  }
+}
+```


### PR DESCRIPTION
## Summary
- flesh out the example mission with combat options
- explain new combat-related fields in docs

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686c69abfe3c83278c2ceb0b275368db