### PR TITLE
Add mission engine with tests

### DIFF
--- a/discord-bot/commands/mission.js
+++ b/discord-bot/commands/mission.js
@@ -3,6 +3,7 @@ const fs = require('fs');
 const path = require('path');
 const { simple } = require('../src/utils/embedBuilder');
 const missionService = require('../src/services/missionService');
+const { resolveChoice } = require('../src/utils/missionEngine');
 
 const missionsPath = path.join(__dirname, '../src/data/missions');
 
@@ -54,9 +55,14 @@ module.exports = {
       const opts = round.options.map((o, idx) => `${idx + 1}. ${o.text}`).join('\n');
       await thread.send(`${round.text}\n${opts}`);
       const choice = 0; // auto-select first option
-      const delta = round.options[choice].durability || 0;
+      const option = round.options[choice];
+      const result = await resolveChoice(playerId, option);
+      const delta = option.durability || 0;
       missionService.recordChoice(logId, i, choice, delta);
       durability += delta;
+      if (result.tier) {
+        await thread.send(`Outcome: ${result.tier}`);
+      }
     }
     const outcome = durability > 0 ? 'success' : 'fail';
     await missionService.completeMission(logId, outcome, mission.rewards, mission.codexFragment, playerId);

--- a/discord-bot/src/utils/missionEngine.js
+++ b/discord-bot/src/utils/missionEngine.js
@@ -1,0 +1,73 @@
+const db = require('../../util/database');
+
+function rollD20() {
+  return Math.floor(Math.random() * 20) + 1;
+}
+
+async function loadStats(playerId) {
+  const { rows } = await db.query(
+    'SELECT stat, value FROM user_stats WHERE player_id = ?',
+    [playerId]
+  );
+  const stats = {};
+  for (const row of rows) {
+    stats[row.stat] = row.value;
+  }
+  return stats;
+}
+
+async function loadEquipped(playerId) {
+  const { rows } = await db.query(
+    'SELECT equipped_weapon_id, equipped_armor_id, equipped_ability_id FROM players WHERE id = ?',
+    [playerId]
+  );
+  return rows[0] || {};
+}
+
+async function loadBonus(table, id) {
+  if (!id) return 0;
+  const { rows } = await db.query(`SELECT bonus FROM ${table} WHERE id = ?`, [id]);
+  return rows[0] && typeof rows[0].bonus === 'number' ? rows[0].bonus : 0;
+}
+
+/**
+ * Resolve a player's mission choice.
+ *
+ * @param {number} playerId
+ * @param {object} choice
+ * @returns {Promise<{tier: string, rewards?: object, penalties?: object}>}
+ */
+async function resolveChoice(playerId, choice) {
+  const stats = await loadStats(playerId);
+  const equipped = await loadEquipped(playerId);
+
+  const [weaponBonus, armorBonus, abilityBonus] = await Promise.all([
+    loadBonus('user_weapons', equipped.equipped_weapon_id),
+    loadBonus('user_armors', equipped.equipped_armor_id),
+    loadBonus('user_ability_cards', equipped.equipped_ability_id)
+  ]);
+  const gearBonus = weaponBonus + armorBonus + abilityBonus;
+
+  const statBonus = choice.stat ? stats[choice.stat] || 0 : 0;
+  const roll = rollD20();
+  const total = roll + statBonus + gearBonus;
+  const dc = choice.dc || 10;
+
+  let tier;
+  if (roll === 1) tier = 'critical_fail';
+  else if (roll === 20) tier = 'critical_success';
+  else if (total >= dc) tier = 'success';
+  else tier = 'fail';
+
+  const result = { tier };
+  if (choice.rewards && tier === 'success') result.rewards = choice.rewards;
+  if (choice.penalties && tier === 'fail') result.penalties = choice.penalties;
+  if (choice.outcomes && choice.outcomes[tier]) {
+    const o = choice.outcomes[tier];
+    if (o.rewards) result.rewards = o.rewards;
+    if (o.penalties) result.penalties = o.penalties;
+  }
+  return result;
+}
+
+module.exports = { resolveChoice };

--- a/discord-bot/tests/mission.test.js
+++ b/discord-bot/tests/mission.test.js
@@ -5,14 +5,17 @@ jest.mock('../src/services/missionService', () => ({
   recordChoice: jest.fn(),
   completeMission: jest.fn()
 }));
+jest.mock('../src/utils/missionEngine', () => ({ resolveChoice: jest.fn() }));
 
 const fs = require('fs');
 const missionService = require('../src/services/missionService');
+const missionEngine = require('../src/utils/missionEngine');
 const mission = require('../commands/mission');
 
 describe('mission command', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    missionEngine.resolveChoice.mockResolvedValue({ tier: 'success' });
   });
 
   test('creates thread and progresses rounds', async () => {
@@ -51,7 +54,7 @@ describe('mission command', () => {
     await mission.execute(interaction);
 
     expect(create).toHaveBeenCalled();
-    expect(send).toHaveBeenCalledTimes(data.rounds.length + 2);
+    expect(send).toHaveBeenCalledTimes(data.rounds.length * 2 + 2);
     expect(missionService.recordChoice).toHaveBeenCalledTimes(data.rounds.length);
     expect(missionService.completeMission).toHaveBeenCalledWith(
       20,

--- a/discord-bot/tests/missionEngine.test.js
+++ b/discord-bot/tests/missionEngine.test.js
@@ -1,0 +1,32 @@
+jest.mock('../util/database', () => ({ query: jest.fn() }));
+const db = require('../util/database');
+const { resolveChoice } = require('../src/utils/missionEngine');
+
+describe('missionEngine.resolveChoice', () => {
+  beforeEach(() => {
+    db.query.mockReset();
+    jest.spyOn(Math, 'random').mockReturnValue(0.5); // roll 11
+  });
+
+  afterEach(() => {
+    Math.random.mockRestore();
+  });
+
+  test('applies stats and gear bonuses', async () => {
+    db.query
+      .mockResolvedValueOnce({ rows: [{ stat: 'MGT', value: 3 }] })
+      .mockResolvedValueOnce({ rows: [{ equipped_weapon_id: 2, equipped_armor_id: 3, equipped_ability_id: null }] })
+      .mockResolvedValueOnce({ rows: [{ bonus: 1 }] })
+      .mockResolvedValueOnce({ rows: [{ bonus: 2 }] })
+      .mockResolvedValueOnce({ rows: [] });
+
+    const res = await resolveChoice(1, { dc: 15, stat: 'MGT', rewards: { gold: 2 } });
+
+    expect(db.query).toHaveBeenNthCalledWith(1, 'SELECT stat, value FROM user_stats WHERE player_id = ?', [1]);
+    expect(db.query).toHaveBeenNthCalledWith(2, 'SELECT equipped_weapon_id, equipped_armor_id, equipped_ability_id FROM players WHERE id = ?', [1]);
+    expect(db.query).toHaveBeenNthCalledWith(3, 'SELECT bonus FROM user_weapons WHERE id = ?', [2]);
+    expect(db.query).toHaveBeenNthCalledWith(4, 'SELECT bonus FROM user_armors WHERE id = ?', [3]);
+    expect(res.tier).toBe('success');
+    expect(res.rewards).toEqual({ gold: 2 });
+  });
+});


### PR DESCRIPTION
## Summary
- implement `missionEngine.resolveChoice` to evaluate mission choices
- show round outcomes in `mission` command using the new engine
- test mission engine logic and update mission command test

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686c69ad0a1083279412045afadd8350