### PR TITLE
Add interaction router and related DB updates

### DIFF
--- a/discord-bot/src/services/itemService.js
+++ b/discord-bot/src/services/itemService.js
@@ -1,0 +1,17 @@
+const db = require('../../util/database');
+
+async function reduceDurability(itemId, amount) {
+  await db.query(
+    'UPDATE user_items SET durability = GREATEST(durability - ?, 0) WHERE id = ?',
+    [amount, itemId]
+  );
+}
+
+async function addItem(playerId, itemName) {
+  await db.query(
+    'INSERT INTO user_items (player_id, name) VALUES (?, ?)',
+    [playerId, itemName]
+  );
+}
+
+module.exports = { reduceDurability, addItem };

--- a/discord-bot/src/services/userService.js
+++ b/discord-bot/src/services/userService.js
@@ -1,0 +1,17 @@
+const db = require('../../util/database');
+
+async function addFlag(playerId, flag) {
+  await db.query(
+    'INSERT INTO user_flags (player_id, flag) VALUES (?, ?)',
+    [playerId, flag]
+  );
+}
+
+async function addCodexFragment(playerId, fragment) {
+  await db.query(
+    'INSERT IGNORE INTO codex_entries (player_id, entry_key) VALUES (?, ?)',
+    [playerId, fragment]
+  );
+}
+
+module.exports = { addFlag, addCodexFragment };

--- a/discord-bot/src/utils/interactionRouter.js
+++ b/discord-bot/src/utils/interactionRouter.js
@@ -1,0 +1,40 @@
+const missionEngine = require('./missionEngine');
+const itemService = require('../services/itemService');
+const userService = require('../services/userService');
+
+/**
+ * Resolve a mission choice then persist resulting effects.
+ *
+ * @param {number} playerId
+ * @param {object} choiceData
+ * @returns {Promise<object>} The missionEngine result
+ */
+async function handleChoice(playerId, choiceData) {
+  const result = await missionEngine.resolveChoice(playerId, choiceData);
+
+  if (result.durability_loss && choiceData.item_id) {
+    await itemService.reduceDurability(choiceData.item_id, result.durability_loss);
+  }
+
+  if (Array.isArray(result.flags)) {
+    for (const flag of result.flags) {
+      await userService.addFlag(playerId, flag);
+    }
+  }
+
+  if (Array.isArray(result.loot)) {
+    for (const item of result.loot) {
+      await itemService.addItem(playerId, item);
+    }
+  }
+
+  if (Array.isArray(result.codex)) {
+    for (const frag of result.codex) {
+      await userService.addCodexFragment(playerId, frag);
+    }
+  }
+
+  return result;
+}
+
+module.exports = { handleChoice };

--- a/discord-bot/src/utils/missionEngine.js
+++ b/discord-bot/src/utils/missionEngine.js
@@ -1,0 +1,6 @@
+async function resolveChoice(playerId, choiceData) {
+  // placeholder engine simply echoes the choice data
+  return choiceData.result || {};
+}
+
+module.exports = { resolveChoice };

--- a/discord-bot/tests/interactionRouter.test.js
+++ b/discord-bot/tests/interactionRouter.test.js
@@ -1,0 +1,45 @@
+jest.mock('../src/utils/missionEngine', () => ({ resolveChoice: jest.fn() }));
+jest.mock('../src/services/itemService', () => ({
+  reduceDurability: jest.fn(),
+  addItem: jest.fn()
+}));
+jest.mock('../src/services/userService', () => ({
+  addFlag: jest.fn(),
+  addCodexFragment: jest.fn()
+}));
+
+const missionEngine = require('../src/utils/missionEngine');
+const itemService = require('../src/services/itemService');
+const userService = require('../src/services/userService');
+const { handleChoice } = require('../src/utils/interactionRouter');
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+test('updates db based on missionEngine result', async () => {
+  missionEngine.resolveChoice.mockResolvedValue({
+    durability_loss: 2,
+    flags: ['injured'],
+    loot: ['sword'],
+    codex: ['frag1']
+  });
+
+  await handleChoice(1, { item_id: 10 });
+
+  expect(itemService.reduceDurability).toHaveBeenCalledWith(10, 2);
+  expect(userService.addFlag).toHaveBeenCalledWith(1, 'injured');
+  expect(itemService.addItem).toHaveBeenCalledWith(1, 'sword');
+  expect(userService.addCodexFragment).toHaveBeenCalledWith(1, 'frag1');
+});
+
+test('handles missing optional fields', async () => {
+  missionEngine.resolveChoice.mockResolvedValue({});
+
+  await handleChoice(2, {});
+
+  expect(itemService.reduceDurability).not.toHaveBeenCalled();
+  expect(userService.addFlag).not.toHaveBeenCalled();
+  expect(itemService.addItem).not.toHaveBeenCalled();
+  expect(userService.addCodexFragment).not.toHaveBeenCalled();
+});


### PR DESCRIPTION
## Summary
- add new `itemService` and `userService`
- create `interactionRouter` with hooks to missionEngine
- store mission effects like durability loss, flags, loot and codex fragments
- provide placeholder `missionEngine` implementation
- test new behaviour

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686c69adf3ac8327a4761f87ce609387