### PR TITLE
Add item and user services with tests

### DIFF
--- a/discord-bot/src/services/itemService.js
+++ b/discord-bot/src/services/itemService.js
@@ -1,0 +1,50 @@
+const db = require('../../util/database');
+
+/**
+ * Reduce durability on all equipped items for a player.
+ * If an item has no durability column this call will no-op for that table.
+ *
+ * @param {number} playerId
+ * @param {number} amount
+ */
+async function reduceDurability(playerId, amount) {
+  const { rows } = await db.query(
+    'SELECT equipped_weapon_id, equipped_armor_id, equipped_ability_id FROM players WHERE id = ?',
+    [playerId]
+  );
+  if (rows.length === 0) return;
+
+  const player = rows[0];
+  const queries = [];
+
+  if (player.equipped_weapon_id) {
+    queries.push(
+      db.query(
+        'UPDATE user_weapons SET durability = GREATEST(durability - ?, 0) WHERE id = ?',
+        [amount, player.equipped_weapon_id]
+      )
+    );
+  }
+
+  if (player.equipped_armor_id) {
+    queries.push(
+      db.query(
+        'UPDATE user_armors SET durability = GREATEST(durability - ?, 0) WHERE id = ?',
+        [amount, player.equipped_armor_id]
+      )
+    );
+  }
+
+  if (player.equipped_ability_id) {
+    queries.push(
+      db.query(
+        'UPDATE user_ability_cards SET durability = GREATEST(durability - ?, 0) WHERE id = ?',
+        [amount, player.equipped_ability_id]
+      )
+    );
+  }
+
+  await Promise.all(queries);
+}
+
+module.exports = { reduceDurability };

--- a/discord-bot/src/services/userService.js
+++ b/discord-bot/src/services/userService.js
@@ -1,0 +1,16 @@
+const db = require('../../util/database');
+
+/**
+ * Add a status flag to a player if it is not already present.
+ *
+ * @param {number} playerId
+ * @param {string} flag
+ */
+async function addFlag(playerId, flag) {
+  await db.query(
+    'INSERT IGNORE INTO player_flags (player_id, flag) VALUES (?, ?)',
+    [playerId, flag]
+  );
+}
+
+module.exports = { addFlag };

--- a/discord-bot/tests/itemService.test.js
+++ b/discord-bot/tests/itemService.test.js
@@ -1,0 +1,42 @@
+jest.mock('../util/database', () => ({ query: jest.fn() }));
+const db = require('../util/database');
+
+const { reduceDurability } = require('../src/services/itemService');
+
+describe('itemService.reduceDurability', () => {
+  beforeEach(() => {
+    db.query.mockReset();
+  });
+
+  test('updates durability for all equipped items', async () => {
+    db.query.mockResolvedValueOnce({ rows: [{
+      equipped_weapon_id: 5,
+      equipped_armor_id: 6,
+      equipped_ability_id: 7
+    }] });
+
+    await reduceDurability(1, 10);
+
+    expect(db.query).toHaveBeenNthCalledWith(
+      1,
+      'SELECT equipped_weapon_id, equipped_armor_id, equipped_ability_id FROM players WHERE id = ?',
+      [1]
+    );
+
+    expect(db.query).toHaveBeenNthCalledWith(
+      2,
+      'UPDATE user_weapons SET durability = GREATEST(durability - ?, 0) WHERE id = ?',
+      [10, 5]
+    );
+    expect(db.query).toHaveBeenNthCalledWith(
+      3,
+      'UPDATE user_armors SET durability = GREATEST(durability - ?, 0) WHERE id = ?',
+      [10, 6]
+    );
+    expect(db.query).toHaveBeenNthCalledWith(
+      4,
+      'UPDATE user_ability_cards SET durability = GREATEST(durability - ?, 0) WHERE id = ?',
+      [10, 7]
+    );
+  });
+});

--- a/discord-bot/tests/userService.test.js
+++ b/discord-bot/tests/userService.test.js
@@ -1,0 +1,18 @@
+jest.mock('../util/database', () => ({ query: jest.fn() }));
+const db = require('../util/database');
+
+const { addFlag } = require('../src/services/userService');
+
+describe('userService.addFlag', () => {
+  beforeEach(() => {
+    db.query.mockReset();
+  });
+
+  test('inserts flag for player', async () => {
+    await addFlag(2, 'weary');
+    expect(db.query).toHaveBeenCalledWith(
+      'INSERT IGNORE INTO player_flags (player_id, flag) VALUES (?, ?)',
+      [2, 'weary']
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- implement `itemService.reduceDurability` to decrease durability of equipped items
- implement `userService.addFlag` to insert status flags
- create unit tests for both services

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686c69aee21083278befd51164369b9a