### PR TITLE
Handle mission interaction penalties and rewards

### DIFF
--- a/discord-bot/commands/mission.js
+++ b/discord-bot/commands/mission.js
@@ -4,6 +4,7 @@ const path = require('path');
 const { simple } = require('../src/utils/embedBuilder');
 const missionService = require('../src/services/missionService');
 const { resolveChoice } = require('../src/utils/missionEngine');
+const { applyChoiceResults } = require('../src/utils/interactionRouter');
 
 const missionsPath = path.join(__dirname, '../src/data/missions');
 
@@ -57,6 +58,7 @@ module.exports = {
       const choice = 0; // auto-select first option
       const option = round.options[choice];
       const result = await resolveChoice(playerId, option);
+      await applyChoiceResults(playerId, result);
       const delta = option.durability || 0;
       missionService.recordChoice(logId, i, choice, delta);
       durability += delta;

--- a/discord-bot/src/utils/interactionRouter.js
+++ b/discord-bot/src/utils/interactionRouter.js
@@ -1,0 +1,55 @@
+const db = require('../../util/database');
+const itemService = require('../services/itemService');
+const userService = require('../services/userService');
+
+/**
+ * Apply the outcome of a mission choice to the player's data.
+ *
+ * @param {number} playerId
+ * @param {object} result Result from missionEngine.resolveChoice
+ */
+async function applyChoiceResults(playerId, result) {
+  const tasks = [];
+
+  if (result.penalties) {
+    const { durability_loss, add_flag } = result.penalties;
+    if (durability_loss) {
+      tasks.push(itemService.reduceDurability(playerId, durability_loss));
+    }
+    if (add_flag) {
+      const flags = Array.isArray(add_flag) ? add_flag : [add_flag];
+      for (const flag of flags) {
+        tasks.push(userService.addFlag(playerId, flag));
+      }
+    }
+  }
+
+  if (result.rewards) {
+    const { items, codex } = result.rewards;
+    if (Array.isArray(items)) {
+      for (const item of items) {
+        if (!item || !item.type || !item.name) continue;
+        let table;
+        if (item.type === 'weapon') table = 'user_weapons';
+        else if (item.type === 'armor') table = 'user_armors';
+        else if (item.type === 'ability') table = 'user_ability_cards';
+        else continue;
+        tasks.push(
+          db.query(`INSERT INTO ${table} (player_id, name) VALUES (?, ?)`, [playerId, item.name])
+        );
+      }
+    }
+    if (codex) {
+      const fragments = Array.isArray(codex) ? codex : [codex];
+      for (const frag of fragments) {
+        tasks.push(
+          db.query('INSERT IGNORE INTO codex_entries (player_id, entry_key) VALUES (?, ?)', [playerId, frag])
+        );
+      }
+    }
+  }
+
+  await Promise.all(tasks);
+}
+
+module.exports = { applyChoiceResults };

--- a/discord-bot/tests/interactionRouter.test.js
+++ b/discord-bot/tests/interactionRouter.test.js
@@ -1,0 +1,50 @@
+jest.mock('../util/database', () => ({ query: jest.fn() }));
+jest.mock('../src/services/itemService', () => ({ reduceDurability: jest.fn() }));
+jest.mock('../src/services/userService', () => ({ addFlag: jest.fn() }));
+
+const db = require('../util/database');
+const itemService = require('../src/services/itemService');
+const userService = require('../src/services/userService');
+const { applyChoiceResults } = require('../src/utils/interactionRouter');
+
+describe('interactionRouter.applyChoiceResults', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    db.query.mockResolvedValue({});
+  });
+
+  test('applies durability loss and flag penalties', async () => {
+    await applyChoiceResults(1, { penalties: { durability_loss: 5, add_flag: 'Injured' } });
+
+    expect(itemService.reduceDurability).toHaveBeenCalledWith(1, 5);
+    expect(userService.addFlag).toHaveBeenCalledWith(1, 'Injured');
+  });
+
+  test('adds loot items and codex fragments', async () => {
+    await applyChoiceResults(2, {
+      rewards: {
+        items: [
+          { type: 'weapon', name: 'Sword' },
+          { type: 'ability', name: 'Fireball' }
+        ],
+        codex: 'frag1'
+      }
+    });
+
+    expect(db.query).toHaveBeenNthCalledWith(
+      1,
+      'INSERT INTO user_weapons (player_id, name) VALUES (?, ?)',
+      [2, 'Sword']
+    );
+    expect(db.query).toHaveBeenNthCalledWith(
+      2,
+      'INSERT INTO user_ability_cards (player_id, name) VALUES (?, ?)',
+      [2, 'Fireball']
+    );
+    expect(db.query).toHaveBeenNthCalledWith(
+      3,
+      'INSERT IGNORE INTO codex_entries (player_id, entry_key) VALUES (?, ?)',
+      [2, 'frag1']
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- route mission interaction results through new `applyChoiceResults` utility
- modify mission command to store choice outcomes
- test new interaction router functionality

## Testing
- `npx jest --runInBand --silent`

------
https://chatgpt.com/codex/tasks/task_e_686c6da6a6c88327886a15c6306dd0ab