### PR TITLE
Unify flag table name

### DIFF
--- a/discord-bot/src/services/userService.js
+++ b/discord-bot/src/services/userService.js
@@ -8,7 +8,7 @@ const db = require('../../util/database');
  */
 async function addFlag(playerId, flag) {
   await db.query(
-    'INSERT IGNORE INTO player_flags (player_id, flag) VALUES (?, ?)',
+    'INSERT IGNORE INTO user_flags (player_id, flag) VALUES (?, ?)',
     [playerId, flag]
   );
 }

--- a/discord-bot/tests/userService.test.js
+++ b/discord-bot/tests/userService.test.js
@@ -11,7 +11,7 @@ describe('userService.addFlag', () => {
   test('inserts flag for player', async () => {
     await addFlag(2, 'weary');
     expect(db.query).toHaveBeenCalledWith(
-      'INSERT IGNORE INTO player_flags (player_id, flag) VALUES (?, ?)',
+      'INSERT IGNORE INTO user_flags (player_id, flag) VALUES (?, ?)',
       [2, 'weary']
     );
   });


### PR DESCRIPTION
## Summary
- use the `user_flags` table everywhere
- adjust tests for new table name

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686c70c78d5883279b5a87b2b2202822