### PR TITLE
Add player state and repair command

### DIFF
--- a/discord-bot/README.md
+++ b/discord-bot/README.md
@@ -22,11 +22,12 @@ The bot will log into Discord and connect to the database on start.
 
 ## Commands
 
-Three slash commands are available:
+Four slash commands are available:
 
 - `/ping` – check that the bot is responsive
 - `/help` – display an ephemeral list of commands
 - `/character create` – start a new character profile
+- `/repair` – restore your equipped gear to full durability
 
 Running the command launches a short setup sequence:
 1. **Choose your faction** – pick either **Iron Accord** or **Neon Dharma**.
@@ -37,7 +38,7 @@ After confirming your choices the bot stores the character in the database and y
 
 The schema defined in `db-schema.sql` creates the following tables:
 
-- `players` – stores Discord IDs, names, class and progression stats
+- `players` – stores Discord IDs, names, class, current state and progression stats
 - `missions` – mission definitions and rewards
 - `mission_log` – records mission attempts for each player
 - `codex_entries` – tracks which lore entries a player has unlocked
@@ -84,6 +85,12 @@ CREATE TABLE user_flags (
   PRIMARY KEY (player_id, flag),
   FOREIGN KEY (player_id) REFERENCES players(id)
 );
+```
+
+Add the new `state` column to track a player's current location:
+
+```sql
+ALTER TABLE players ADD COLUMN state VARCHAR(20) DEFAULT 'idle';
 ```
 
 ## Running Tests

--- a/discord-bot/commands/repair.js
+++ b/discord-bot/commands/repair.js
@@ -1,0 +1,32 @@
+const { SlashCommandBuilder } = require('discord.js');
+const db = require('../util/database');
+const { simple } = require('../src/utils/embedBuilder');
+const missionService = require('../src/services/missionService');
+const playerService = require('../src/services/playerService');
+
+module.exports = {
+  data: new SlashCommandBuilder()
+    .setName('repair')
+    .setDescription('Repair all of your gear'),
+  async execute(interaction) {
+    const playerId = await missionService.getPlayerId(interaction.user.id);
+    if (!playerId) {
+      await interaction.reply({ embeds: [simple('You have no character.')], ephemeral: true });
+      return;
+    }
+
+    const state = await playerService.getPlayerState(playerId);
+    if (state !== 'idle') {
+      await interaction.reply({ embeds: [simple('You are busy and cannot repair right now.')], ephemeral: true });
+      return;
+    }
+
+    await Promise.all([
+      db.query('UPDATE user_weapons SET durability = 100 WHERE player_id = ?', [playerId]),
+      db.query('UPDATE user_armors SET durability = 100 WHERE player_id = ?', [playerId]),
+      db.query('UPDATE user_ability_cards SET durability = 100 WHERE player_id = ?', [playerId])
+    ]);
+
+    await interaction.reply({ embeds: [simple('All equipment repaired!')], ephemeral: true });
+  }
+};

--- a/discord-bot/db-schema.sql
+++ b/discord-bot/db-schema.sql
@@ -21,6 +21,7 @@ CREATE TABLE IF NOT EXISTS players (
     gold INT DEFAULT 0,
     xp INT DEFAULT 0,
     level INT DEFAULT 1,
+    state VARCHAR(20) DEFAULT 'idle',
     equipped_weapon_id INT DEFAULT NULL,
     equipped_armor_id INT DEFAULT NULL,
     equipped_ability_id INT DEFAULT NULL,

--- a/discord-bot/migrations/001_add_player_state.sql
+++ b/discord-bot/migrations/001_add_player_state.sql
@@ -1,0 +1,1 @@
+ALTER TABLE players ADD COLUMN state VARCHAR(20) DEFAULT 'idle';

--- a/discord-bot/src/services/missionService.js
+++ b/discord-bot/src/services/missionService.js
@@ -1,4 +1,5 @@
 const db = require('../../util/database');
+const playerService = require('./playerService');
 
 const activeMissions = new Map();
 
@@ -13,6 +14,7 @@ async function startMission(playerId, missionId) {
     [missionId, playerId]
   );
   activeMissions.set(insertId, { choices: [], durability: 3 });
+  await playerService.setPlayerState(playerId, 'mission');
   return insertId;
 }
 
@@ -44,6 +46,7 @@ async function completeMission(logId, outcomeTier, rewards = {}, codexKey, playe
   }
 
   activeMissions.delete(logId);
+  await playerService.setPlayerState(playerId, 'idle');
 }
 
 module.exports = { getPlayerId, startMission, recordChoice, completeMission };

--- a/discord-bot/src/services/playerService.js
+++ b/discord-bot/src/services/playerService.js
@@ -15,4 +15,13 @@ async function storeStatSelection(discordId, values) {
   ]);
 }
 
-module.exports = { storeStatSelection };
+async function getPlayerState(playerId) {
+  const { rows } = await db.query('SELECT state FROM players WHERE id = ?', [playerId]);
+  return rows[0] ? rows[0].state : null;
+}
+
+async function setPlayerState(playerId, state) {
+  await db.query('UPDATE players SET state = ? WHERE id = ?', [state, playerId]);
+}
+
+module.exports = { storeStatSelection, getPlayerState, setPlayerState };

--- a/discord-bot/tests/missionService.test.js
+++ b/discord-bot/tests/missionService.test.js
@@ -1,10 +1,15 @@
 jest.mock('../util/database', () => ({ query: jest.fn() }));
+jest.mock('../src/services/playerService', () => ({ setPlayerState: jest.fn() }));
 const db = require('../util/database');
+const playerService = require('../src/services/playerService');
 
 const service = require('../src/services/missionService');
 
 describe('missionService', () => {
-  beforeEach(() => { db.query.mockReset(); });
+  beforeEach(() => {
+    db.query.mockReset();
+    playerService.setPlayerState.mockReset();
+  });
 
   test('startMission inserts log', async () => {
     db.query.mockResolvedValueOnce({ insertId: 5 });
@@ -13,6 +18,7 @@ describe('missionService', () => {
       'INSERT INTO mission_log (mission_id, player_id) VALUES (?, ?)',
       [2, 1]
     );
+    expect(playerService.setPlayerState).toHaveBeenCalledWith(1, 'mission');
     expect(id).toBe(5);
   });
 
@@ -41,5 +47,6 @@ describe('missionService', () => {
       'INSERT IGNORE INTO codex_entries (player_id, entry_key) VALUES (?, ?)',
       [1, 'frag']
     );
+    expect(playerService.setPlayerState).toHaveBeenCalledWith(1, 'idle');
   });
 });

--- a/discord-bot/tests/playerService.test.js
+++ b/discord-bot/tests/playerService.test.js
@@ -1,7 +1,7 @@
 jest.mock('../util/database', () => ({ query: jest.fn() }));
 const db = require('../util/database');
 
-const { storeStatSelection } = require('../src/services/playerService');
+const { storeStatSelection, getPlayerState, setPlayerState } = require('../src/services/playerService');
 
 test('storeStatSelection updates player stats', async () => {
   await storeStatSelection('123', ['str']);
@@ -9,4 +9,16 @@ test('storeStatSelection updates player stats', async () => {
     'UPDATE players SET starting_stats = ? WHERE discord_id = ?',
     [JSON.stringify(['str']), '123']
   );
+});
+
+test('getPlayerState queries state', async () => {
+  db.query.mockResolvedValueOnce({ rows: [{ state: 'idle' }] });
+  const state = await getPlayerState(1);
+  expect(db.query).toHaveBeenCalledWith('SELECT state FROM players WHERE id = ?', [1]);
+  expect(state).toBe('idle');
+});
+
+test('setPlayerState updates state', async () => {
+  await setPlayerState(2, 'mission');
+  expect(db.query).toHaveBeenCalledWith('UPDATE players SET state = ? WHERE id = ?', ['mission', 2]);
 });

--- a/discord-bot/tests/repair.test.js
+++ b/discord-bot/tests/repair.test.js
@@ -1,0 +1,36 @@
+jest.mock('../util/database', () => ({ query: jest.fn() }));
+jest.mock('../src/services/missionService', () => ({ getPlayerId: jest.fn() }));
+jest.mock('../src/services/playerService', () => ({ getPlayerState: jest.fn() }));
+
+const db = require('../util/database');
+const missionService = require('../src/services/missionService');
+const playerService = require('../src/services/playerService');
+const repair = require('../commands/repair');
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+test('repairs when idle', async () => {
+  missionService.getPlayerId.mockResolvedValue(1);
+  playerService.getPlayerState.mockResolvedValue('idle');
+  db.query.mockResolvedValue({});
+  const interaction = { user: { id: '1' }, reply: jest.fn().mockResolvedValue() };
+
+  await repair.execute(interaction);
+
+  expect(db.query).toHaveBeenNthCalledWith(1, 'UPDATE user_weapons SET durability = 100 WHERE player_id = ?', [1]);
+  expect(db.query).toHaveBeenNthCalledWith(2, 'UPDATE user_armors SET durability = 100 WHERE player_id = ?', [1]);
+  expect(interaction.reply).toHaveBeenCalledWith(expect.objectContaining({ ephemeral: true }));
+});
+
+test('blocks repair when busy', async () => {
+  missionService.getPlayerId.mockResolvedValue(1);
+  playerService.getPlayerState.mockResolvedValue('mission');
+  const interaction = { user: { id: '1' }, reply: jest.fn().mockResolvedValue() };
+
+  await repair.execute(interaction);
+
+  expect(db.query).not.toHaveBeenCalled();
+  expect(interaction.reply).toHaveBeenCalledWith(expect.objectContaining({ ephemeral: true }));
+});


### PR DESCRIPTION
## Summary
- track player state/location in `players` table
- create migration for the new column
- expose `getPlayerState`/`setPlayerState` helpers
- update mission flow to set player state
- add `/repair` command which checks state
- document new command and schema change
- test all new functionality

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686c70c84c848327a80bb404041b1e69