### PR TITLE
Add base item data module

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ This repository houses the Discord bot used for the auto battler experiments alo
 - `discord-bot/` – Node.js bot and MySQL schema.
 - `docs/` – design notes and lore.
 - `index.html`, `poc2/` – early browser prototypes kept for reference.
+- `discord-bot/src/data/items.js` – base item definitions used by the bot.
 
 ## Setup
 

--- a/discord-bot/README.md
+++ b/discord-bot/README.md
@@ -86,6 +86,12 @@ CREATE TABLE user_flags (
 );
 ```
 
+## Item Data
+
+Base item definitions live in `src/data/items.js`. Services that need item
+properties should import this module and call `getBaseItem` from
+`src/services/itemService` to retrieve details by key.
+
 ## Running Tests
 
 A small Jest test suite lives in `tests/`. Node 20 or newer is required. Run it with:

--- a/discord-bot/src/data/items.js
+++ b/discord-bot/src/data/items.js
@@ -1,0 +1,32 @@
+module.exports = {
+  weapons: {
+    sword: {
+      name: 'Sword',
+      type: 'weapon',
+      rarity: 'common',
+      statBonuses: { MGT: 1 }
+    },
+    axe: {
+      name: 'Axe',
+      type: 'weapon',
+      rarity: 'common',
+      statBonuses: { MGT: 2 }
+    }
+  },
+  armors: {
+    leather: {
+      name: 'Leather Armor',
+      type: 'armor',
+      rarity: 'common',
+      statBonuses: { FOR: 1 }
+    }
+  },
+  abilities: {
+    fireball: {
+      name: 'Fireball',
+      type: 'ability',
+      rarity: 'common',
+      effect: 'Deal fire damage.'
+    }
+  }
+};

--- a/discord-bot/src/services/itemService.js
+++ b/discord-bot/src/services/itemService.js
@@ -1,4 +1,11 @@
 const db = require('../../util/database');
+const baseItems = require('../data/items');
+
+const CATEGORY_MAP = {
+  weapon: 'weapons',
+  armor: 'armors',
+  ability: 'abilities'
+};
 
 /**
  * Reduce durability on all equipped items for a player.
@@ -47,4 +54,10 @@ async function reduceDurability(playerId, amount) {
   await Promise.all(queries);
 }
 
-module.exports = { reduceDurability };
+function getBaseItem(type, key) {
+  const cat = CATEGORY_MAP[type];
+  if (!cat) return null;
+  return baseItems[cat][key] || null;
+}
+
+module.exports = { reduceDurability, getBaseItem };

--- a/discord-bot/src/utils/interactionRouter.js
+++ b/discord-bot/src/utils/interactionRouter.js
@@ -28,14 +28,22 @@ async function applyChoiceResults(playerId, result) {
     const { items, codex } = result.rewards;
     if (Array.isArray(items)) {
       for (const item of items) {
-        if (!item || !item.type || !item.name) continue;
+        if (!item || !item.type) continue;
         let table;
         if (item.type === 'weapon') table = 'user_weapons';
         else if (item.type === 'armor') table = 'user_armors';
         else if (item.type === 'ability') table = 'user_ability_cards';
         else continue;
+
+        let name = item.name;
+        if (!name && item.key) {
+          const base = itemService.getBaseItem(item.type, item.key);
+          name = base && base.name;
+        }
+        if (!name) continue;
+
         tasks.push(
-          db.query(`INSERT INTO ${table} (player_id, name) VALUES (?, ?)`, [playerId, item.name])
+          db.query(`INSERT INTO ${table} (player_id, name) VALUES (?, ?)`, [playerId, name])
         );
       }
     }

--- a/discord-bot/tests/interactionRouter.test.js
+++ b/discord-bot/tests/interactionRouter.test.js
@@ -1,5 +1,8 @@
 jest.mock('../util/database', () => ({ query: jest.fn() }));
-jest.mock('../src/services/itemService', () => ({ reduceDurability: jest.fn() }));
+jest.mock('../src/services/itemService', () => ({
+  reduceDurability: jest.fn(),
+  getBaseItem: jest.fn()
+}));
 jest.mock('../src/services/userService', () => ({ addFlag: jest.fn() }));
 
 const db = require('../util/database');
@@ -21,11 +24,17 @@ describe('interactionRouter.applyChoiceResults', () => {
   });
 
   test('adds loot items and codex fragments', async () => {
+    itemService.getBaseItem.mockImplementation((type, key) => {
+      if (key === 'sword') return { name: 'Sword' };
+      if (key === 'fireball') return { name: 'Fireball' };
+      return null;
+    });
+
     await applyChoiceResults(2, {
       rewards: {
         items: [
-          { type: 'weapon', name: 'Sword' },
-          { type: 'ability', name: 'Fireball' }
+          { type: 'weapon', key: 'sword' },
+          { type: 'ability', key: 'fireball' }
         ],
         codex: 'frag1'
       }


### PR DESCRIPTION
## Summary
- define core items in `src/data/items.js`
- expose `getBaseItem` helper in itemService
- resolve items by key in interactionRouter
- update README docs
- adjust tests for new behavior

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_686c70c9dd0c8327940de548654c24fd