### PR TITLE
Implement /character view command

### DIFF
--- a/discord-bot/commands/character.js
+++ b/discord-bot/commands/character.js
@@ -1,6 +1,7 @@
 const { SlashCommandBuilder, ActionRowBuilder, StringSelectMenuBuilder } = require('discord.js');
 const db = require('../util/database');
 const { simple } = require('../src/utils/embedBuilder');
+const characterService = require('../src/utils/characterService');
 
 module.exports = {
   data: new SlashCommandBuilder()
@@ -16,41 +17,75 @@ module.exports = {
             .setRequired(true)
             .addChoices({ name: 'Iron Accord', value: 'Iron Accord' })
         )
+    )
+    .addSubcommand(sub =>
+      sub
+        .setName('view')
+        .setDescription('View your character stats')
     ),
 
   async execute(interaction) {
-    if (interaction.options.getSubcommand() !== 'create') return;
+    const sub = interaction.options.getSubcommand();
 
-    const faction = interaction.options.getString('faction');
-    const discordId = interaction.user.id;
-    const name = interaction.user.username;
+    if (sub === 'create') {
+      const faction = interaction.options.getString('faction');
+      const discordId = interaction.user.id;
+      const name = interaction.user.username;
 
-    const { rows } = await db.query('SELECT id FROM players WHERE discord_id = ?', [discordId]);
-    if (rows.length > 0) {
-      const embed = simple('Character already exists.');
+      const { rows } = await db.query('SELECT id FROM players WHERE discord_id = ?', [discordId]);
+      if (rows.length > 0) {
+        const embed = simple('Character already exists.');
+        await interaction.reply({ embeds: [embed], ephemeral: true });
+        return;
+      }
+
+      await db.query('INSERT INTO players (discord_id, name) VALUES (?, ?)', [discordId, name]);
+
+      const embed = simple(`Welcome to the ${faction}!`, [
+        { name: 'Next Step', value: 'Select one stat to increase by +1.' }
+      ]);
+
+      const menu = new StringSelectMenuBuilder()
+        .setCustomId('stat_select')
+        .setPlaceholder('Choose a stat')
+        .addOptions(
+          { label: 'Might', value: 'MGT' },
+          { label: 'Agility', value: 'AGI' },
+          { label: 'Fortitude', value: 'FOR' },
+          { label: 'Intuition', value: 'INTU' },
+          { label: 'Resolve', value: 'RES' },
+          { label: 'Ingenuity', value: 'ING' }
+        );
+
+      const row = new ActionRowBuilder().addComponents(menu);
+      await interaction.reply({ embeds: [embed], components: [row], ephemeral: true });
+    } else if (sub === 'view') {
+      const sheet = await characterService.getCharacterSheet(interaction.user.id);
+      if (!sheet) {
+        await interaction.reply({ embeds: [simple('You have no character.')], ephemeral: true });
+        return;
+      }
+
+      const stats = Object.entries(sheet.stats)
+        .map(([s, v]) => `${s}: ${v}`)
+        .join('\n');
+      const gear = [
+        `🗡️ ${sheet.gear.weapon || 'None'}`,
+        `🛡️ ${sheet.gear.armor || 'None'}`,
+        `📜 ${sheet.gear.ability || 'None'}`
+      ].join('\n');
+      const flags = sheet.flags.join(', ') || 'None';
+      const codex = sheet.codex.join(', ') || 'None';
+
+      const embed = simple('Character Sheet', [
+        { name: 'Level', value: String(sheet.level), inline: true },
+        { name: 'Stats', value: stats },
+        { name: 'Equipped Gear', value: gear },
+        { name: 'Active Effects', value: flags },
+        { name: 'Codex', value: codex }
+      ]);
+
       await interaction.reply({ embeds: [embed], ephemeral: true });
-      return;
     }
-
-    await db.query('INSERT INTO players (discord_id, name) VALUES (?, ?)', [discordId, name]);
-
-    const embed = simple(`Welcome to the ${faction}!`, [
-      { name: 'Next Step', value: 'Select one stat to increase by +1.' }
-    ]);
-
-    const menu = new StringSelectMenuBuilder()
-      .setCustomId('stat_select')
-      .setPlaceholder('Choose a stat')
-      .addOptions(
-        { label: 'Might', value: 'MGT' },
-        { label: 'Agility', value: 'AGI' },
-        { label: 'Fortitude', value: 'FOR' },
-        { label: 'Intuition', value: 'INTU' },
-        { label: 'Resolve', value: 'RES' },
-        { label: 'Ingenuity', value: 'ING' }
-      );
-
-    const row = new ActionRowBuilder().addComponents(menu);
-    await interaction.reply({ embeds: [embed], components: [row], ephemeral: true });
   }
 };

--- a/discord-bot/src/data/codex.js
+++ b/discord-bot/src/data/codex.js
@@ -1,0 +1,12 @@
+module.exports = {
+  'ancient-tech': {
+    name: 'Ancient Tech',
+    emoji: '📜',
+    statBonuses: { ING: 2 }
+  },
+  'martial-training': {
+    name: 'Martial Training',
+    emoji: '⚔️',
+    statBonuses: { MGT: 1 }
+  }
+};

--- a/discord-bot/src/data/flags.js
+++ b/discord-bot/src/data/flags.js
@@ -1,0 +1,12 @@
+module.exports = {
+  Injured: {
+    name: 'Injured',
+    emoji: '🤕',
+    statBonuses: { FOR: -1 }
+  },
+  'Well-Fed': {
+    name: 'Well-Fed',
+    emoji: '🍗',
+    statBonuses: { MGT: 1 }
+  }
+};

--- a/discord-bot/tests/character.test.js
+++ b/discord-bot/tests/character.test.js
@@ -1,5 +1,7 @@
 jest.mock('../util/database', () => ({ query: jest.fn() }));
+jest.mock('../src/utils/characterService', () => ({ getCharacterSheet: jest.fn() }));
 const db = require('../util/database');
+const characterService = require('../src/utils/characterService');
 
 const character = require('../commands/character');
 
@@ -58,6 +60,51 @@ describe('character create', () => {
       ['123']
     );
     expect(db.query).toHaveBeenCalledTimes(1);
+    expect(interaction.reply).toHaveBeenCalledWith(
+      expect.objectContaining({ ephemeral: true })
+    );
+  });
+});
+
+describe('character view', () => {
+  beforeEach(() => {
+    characterService.getCharacterSheet.mockReset();
+  });
+
+  test('displays character sheet when found', async () => {
+    characterService.getCharacterSheet.mockResolvedValue({
+      level: 2,
+      stats: { MGT: 2 },
+      gear: { weapon: 'Sword', armor: null, ability: 'Fireball' },
+      flags: ['Injured'],
+      codex: []
+    });
+
+    const interaction = {
+      options: { getSubcommand: jest.fn().mockReturnValue('view') },
+      user: { id: '1' },
+      reply: jest.fn().mockResolvedValue()
+    };
+
+    await character.execute(interaction);
+
+    expect(characterService.getCharacterSheet).toHaveBeenCalledWith('1');
+    expect(interaction.reply).toHaveBeenCalledWith(
+      expect.objectContaining({ ephemeral: true })
+    );
+  });
+
+  test('handles missing character', async () => {
+    characterService.getCharacterSheet.mockResolvedValue(undefined);
+
+    const interaction = {
+      options: { getSubcommand: jest.fn().mockReturnValue('view') },
+      user: { id: '2' },
+      reply: jest.fn().mockResolvedValue()
+    };
+
+    await character.execute(interaction);
+
     expect(interaction.reply).toHaveBeenCalledWith(
       expect.objectContaining({ ephemeral: true })
     );

--- a/discord-bot/tests/characterService.test.js
+++ b/discord-bot/tests/characterService.test.js
@@ -1,0 +1,40 @@
+jest.mock('../util/database', () => ({ query: jest.fn() }));
+const db = require('../util/database');
+
+const { getCharacterSheet } = require('../src/utils/characterService');
+
+beforeEach(() => {
+  db.query.mockReset();
+});
+
+test('returns undefined when player missing', async () => {
+  db.query.mockResolvedValueOnce({ rows: [] });
+  const sheet = await getCharacterSheet('1');
+  expect(sheet).toBeUndefined();
+  expect(db.query).toHaveBeenCalledWith(
+    'SELECT id, level, equipped_weapon_id, equipped_armor_id, equipped_ability_id FROM players WHERE discord_id = ?',
+    ['1']
+  );
+});
+
+test('aggregates data and applies bonuses', async () => {
+  db.query
+    .mockResolvedValueOnce({ rows: [{ id: 2, level: 1, equipped_weapon_id: 5, equipped_armor_id: null, equipped_ability_id: 6 }] })
+    .mockResolvedValueOnce({ rows: [{ stat: 'MGT', value: 1 }, { stat: 'FOR', value: 1 }] })
+    .mockResolvedValueOnce({ rows: [{ flag: 'Injured' }] })
+    .mockResolvedValueOnce({ rows: [{ entry_key: 'ancient-tech' }] })
+    .mockResolvedValueOnce({ rows: [{ name: 'Sword' }] })
+    .mockResolvedValueOnce({ rows: [{ name: 'Fireball' }] });
+
+  const sheet = await getCharacterSheet('user');
+
+  expect(db.query).toHaveBeenCalledTimes(6);
+  expect(sheet.level).toBe(1);
+  expect(sheet.stats.MGT).toBe(1); // no bonuses
+  expect(sheet.stats.FOR).toBe(0); // 1 base + (-1 flag)
+  expect(sheet.stats.ING).toBe(2); // from codex
+  expect(sheet.gear.weapon).toBe('Sword');
+  expect(sheet.gear.ability).toBe('Fireball');
+  expect(sheet.flags).toEqual(['Injured']);
+  expect(sheet.codex).toEqual(['ancient-tech']);
+});


### PR DESCRIPTION
## Summary
- extend `/character` command with new `view` subcommand
- implement `characterService.getCharacterSheet` aggregator
- add static codex and flag data
- show formatted character sheet embed
- test character view command and service logic

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686c75131ce08327aeea32d5c20e0166