### PR TITLE
Add base items module and integrate with mission engine

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ This repository houses the Discord bot used for the auto battler experiments alo
 - `discord-bot/` – Node.js bot and MySQL schema.
 - `docs/` – design notes and lore.
 - `index.html`, `poc2/` – early browser prototypes kept for reference.
+- `discord-bot/src/data/items.js` – base item definitions consumed by missions and rewards.
 
 ## Setup
 
@@ -21,3 +22,7 @@ This repository houses the Discord bot used for the auto battler experiments alo
    ```
 
 See [discord-bot/README.md](discord-bot/README.md) for additional details on running tests and migrating the database schema.
+
+## Item Data
+
+Base item properties live in `discord-bot/src/data/items.js`. The mission engine and other services import this file to look up item bonuses when applying rewards or combat modifiers.

--- a/discord-bot/src/data/items.js
+++ b/discord-bot/src/data/items.js
@@ -1,0 +1,14 @@
+// Base item definitions used throughout the bot
+
+const ITEMS = [
+  { id: 'sword', type: 'weapon', name: 'Sword', bonus: 1 },
+  { id: 'plate_armor', type: 'armor', name: 'Plate Armor', bonus: 2 },
+  { id: 'fireball_card', type: 'ability', name: 'Fireball', bonus: 2 }
+];
+
+const BY_NAME = {};
+for (const item of ITEMS) {
+  BY_NAME[item.name] = item;
+}
+
+module.exports = { ITEMS, BY_NAME };

--- a/discord-bot/src/utils/missionEngine.js
+++ b/discord-bot/src/utils/missionEngine.js
@@ -1,4 +1,5 @@
 const db = require('../../util/database');
+const { BY_NAME } = require('../data/items');
 
 function rollD20() {
   return Math.floor(Math.random() * 20) + 1;
@@ -26,8 +27,10 @@ async function loadEquipped(playerId) {
 
 async function loadBonus(table, id) {
   if (!id) return 0;
-  const { rows } = await db.query(`SELECT bonus FROM ${table} WHERE id = ?`, [id]);
-  return rows[0] && typeof rows[0].bonus === 'number' ? rows[0].bonus : 0;
+  const { rows } = await db.query(`SELECT name FROM ${table} WHERE id = ?`, [id]);
+  if (rows.length === 0) return 0;
+  const item = BY_NAME[rows[0].name];
+  return item && typeof item.bonus === 'number' ? item.bonus : 0;
 }
 
 /**

--- a/discord-bot/tests/missionEngine.test.js
+++ b/discord-bot/tests/missionEngine.test.js
@@ -16,16 +16,16 @@ describe('missionEngine.resolveChoice', () => {
     db.query
       .mockResolvedValueOnce({ rows: [{ stat: 'MGT', value: 3 }] })
       .mockResolvedValueOnce({ rows: [{ equipped_weapon_id: 2, equipped_armor_id: 3, equipped_ability_id: null }] })
-      .mockResolvedValueOnce({ rows: [{ bonus: 1 }] })
-      .mockResolvedValueOnce({ rows: [{ bonus: 2 }] })
+      .mockResolvedValueOnce({ rows: [{ name: 'Sword' }] })
+      .mockResolvedValueOnce({ rows: [{ name: 'Plate Armor' }] })
       .mockResolvedValueOnce({ rows: [] });
 
     const res = await resolveChoice(1, { dc: 15, stat: 'MGT', rewards: { gold: 2 } });
 
     expect(db.query).toHaveBeenNthCalledWith(1, 'SELECT stat, value FROM user_stats WHERE player_id = ?', [1]);
     expect(db.query).toHaveBeenNthCalledWith(2, 'SELECT equipped_weapon_id, equipped_armor_id, equipped_ability_id FROM players WHERE id = ?', [1]);
-    expect(db.query).toHaveBeenNthCalledWith(3, 'SELECT bonus FROM user_weapons WHERE id = ?', [2]);
-    expect(db.query).toHaveBeenNthCalledWith(4, 'SELECT bonus FROM user_armors WHERE id = ?', [3]);
+    expect(db.query).toHaveBeenNthCalledWith(3, 'SELECT name FROM user_weapons WHERE id = ?', [2]);
+    expect(db.query).toHaveBeenNthCalledWith(4, 'SELECT name FROM user_armors WHERE id = ?', [3]);
     expect(res.tier).toBe('success');
     expect(res.rewards).toEqual({ gold: 2 });
   });


### PR DESCRIPTION
## Summary
- define base item data in `src/data/items.js`
- look up gear bonuses from the new data when resolving missions
- adjust tests for the new lookup behaviour
- document the item data module in the README

## Testing
- `npm --prefix discord-bot install`
- `npm --prefix discord-bot test`

------
https://chatgpt.com/codex/tasks/task_e_686c752a4854832786fce4bf68827657