### PR TITLE
Implement GM commands with audit logging

### DIFF
--- a/discord-bot/commands/gm.js
+++ b/discord-bot/commands/gm.js
@@ -1,0 +1,127 @@
+const { SlashCommandBuilder } = require('discord.js');
+const db = require('../util/database');
+const { simple } = require('../src/utils/embedBuilder');
+const { isGM } = require('../util/auth');
+const { logGMAcion } = require('../src/utils/auditService');
+
+module.exports = {
+  data: new SlashCommandBuilder()
+    .setName('gm')
+    .setDescription('Game master tools')
+    .addSubcommand(sub => {
+      return sub
+        .setName('reset')
+        .setDescription('Reset a player')
+        .addUserOption(opt =>
+          opt.setName('player').setDescription('Target player').setRequired(true)
+        );
+    })
+    .addSubcommandGroup(group => {
+      return group
+        .setName('codex')
+        .setDescription('Codex commands')
+        .addSubcommand(sub => {
+          return sub
+            .setName('unlock')
+            .setDescription('Unlock a codex entry')
+            .addUserOption(opt =>
+              opt.setName('player').setDescription('Target player').setRequired(true)
+            )
+            .addStringOption(opt =>
+              opt.setName('entry').setDescription('Entry key').setRequired(true)
+            );
+        });
+    })
+    .addSubcommandGroup(group => {
+      return group
+        .setName('flag')
+        .setDescription('Flag commands')
+        .addSubcommand(sub => {
+          return sub
+            .setName('set')
+            .setDescription('Apply a status flag')
+            .addUserOption(opt =>
+              opt.setName('player').setDescription('Target player').setRequired(true)
+            )
+            .addStringOption(opt =>
+              opt.setName('flag_id').setDescription('Flag ID').setRequired(true)
+            );
+        });
+    }),
+
+  async execute(interaction) {
+    const group = interaction.options.getSubcommandGroup(false);
+    const sub = interaction.options.getSubcommand();
+
+    if (group === null && sub === 'reset') {
+      await handleReset(interaction);
+    } else if (group === 'codex' && sub === 'unlock') {
+      await handleCodexUnlock(interaction);
+    } else if (group === 'flag' && sub === 'set') {
+      await handleFlagSet(interaction);
+    }
+  }
+};
+
+async function handleReset(interaction) {
+  if (!isGM(interaction)) {
+    await interaction.reply({ content: 'Unauthorized.', ephemeral: true });
+    return;
+  }
+  const target = interaction.options.getUser('player');
+  const { rows } = await db.query('SELECT id FROM players WHERE discord_id = ?', [target.id]);
+  if (rows.length === 0) {
+    await interaction.reply({ embeds: [simple('Player not found.')], ephemeral: true });
+    return;
+  }
+  const playerId = rows[0].id;
+  const tables = ['user_stats', 'user_weapons', 'user_armors', 'user_ability_cards', 'user_flags', 'codex_entries', 'mission_log'];
+  for (const t of tables) {
+    await db.query(`DELETE FROM ${t} WHERE player_id = ?`, [playerId]);
+  }
+  await db.query('DELETE FROM players WHERE id = ?', [playerId]);
+  await interaction.reply({ embeds: [simple('Player reset.')], ephemeral: true });
+  await logGMAcion(interaction.user.username, target.username, 'reset', target.id);
+}
+
+async function handleCodexUnlock(interaction) {
+  if (!isGM(interaction)) {
+    await interaction.reply({ content: 'Unauthorized.', ephemeral: true });
+    return;
+  }
+  const target = interaction.options.getUser('player');
+  const entry = interaction.options.getString('entry');
+  const { rows } = await db.query('SELECT id FROM players WHERE discord_id = ?', [target.id]);
+  if (rows.length === 0) {
+    await interaction.reply({ embeds: [simple('Player not found.')], ephemeral: true });
+    return;
+  }
+  const playerId = rows[0].id;
+  await db.query(
+    'INSERT INTO codex_entries (player_id, entry_key) VALUES (?, ?) ON DUPLICATE KEY UPDATE unlocked_at = NOW()',
+    [playerId, entry]
+  );
+  await interaction.reply({ embeds: [simple('Codex updated.')], ephemeral: true });
+  await logGMAcion(interaction.user.username, target.username, 'codex unlock', entry);
+}
+
+async function handleFlagSet(interaction) {
+  if (!isGM(interaction)) {
+    await interaction.reply({ content: 'Unauthorized.', ephemeral: true });
+    return;
+  }
+  const target = interaction.options.getUser('player');
+  const flagId = interaction.options.getString('flag_id');
+  const { rows } = await db.query('SELECT id FROM players WHERE discord_id = ?', [target.id]);
+  if (rows.length === 0) {
+    await interaction.reply({ embeds: [simple('Player not found.')], ephemeral: true });
+    return;
+  }
+  const playerId = rows[0].id;
+  await db.query(
+    'INSERT INTO user_flags (player_id, flag) VALUES (?, ?) ON DUPLICATE KEY UPDATE timestamp = CURRENT_TIMESTAMP',
+    [playerId, flagId]
+  );
+  await interaction.reply({ embeds: [simple('Flag applied.')], ephemeral: true });
+  await logGMAcion(interaction.user.username, target.username, 'flag set', flagId);
+}

--- a/discord-bot/db-schema.sql
+++ b/discord-bot/db-schema.sql
@@ -102,3 +102,13 @@ CREATE TABLE IF NOT EXISTS user_flags (
     PRIMARY KEY (player_id, flag),
     FOREIGN KEY (player_id) REFERENCES players(id)
 );
+
+-- GM audit log
+CREATE TABLE IF NOT EXISTS gm_audit_log (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    admin_user VARCHAR(255) NOT NULL,
+    target_user VARCHAR(255) NOT NULL,
+    action VARCHAR(50) NOT NULL,
+    details TEXT,
+    timestamp TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);

--- a/discord-bot/migrations/002_create_gm_audit_log.sql
+++ b/discord-bot/migrations/002_create_gm_audit_log.sql
@@ -1,0 +1,8 @@
+CREATE TABLE IF NOT EXISTS gm_audit_log (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    admin_user VARCHAR(255) NOT NULL,
+    target_user VARCHAR(255) NOT NULL,
+    action VARCHAR(50) NOT NULL,
+    details TEXT,
+    timestamp TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);

--- a/discord-bot/src/utils/auditService.js
+++ b/discord-bot/src/utils/auditService.js
@@ -1,0 +1,11 @@
+const db = require('../../util/database');
+
+async function logGMAcion(adminUser, targetUser, action, details) {
+  console.log(`[GM] ${adminUser} -> ${targetUser}: ${action} ${details}`);
+  await db.query(
+    'INSERT INTO gm_audit_log (admin_user, target_user, action, details) VALUES (?, ?, ?, ?)',
+    [adminUser, targetUser, action, details]
+  );
+}
+
+module.exports = { logGMAcion };

--- a/discord-bot/tests/auth.test.js
+++ b/discord-bot/tests/auth.test.js
@@ -1,0 +1,17 @@
+const { isGM } = require('../util/auth');
+
+test('returns true when member has GM role', () => {
+  const interaction = {
+    member: {
+      roles: { cache: new Map([[1, { name: 'GM' }]]) }
+    }
+  };
+  expect(isGM(interaction)).toBe(true);
+});
+
+test('returns false when missing role', () => {
+  const interaction = {
+    member: { roles: { cache: new Map([[1, { name: 'Player' }]]) } }
+  };
+  expect(isGM(interaction)).toBe(false);
+});

--- a/discord-bot/tests/gm.test.js
+++ b/discord-bot/tests/gm.test.js
@@ -1,0 +1,34 @@
+jest.mock('../util/database', () => ({ query: jest.fn() }));
+jest.mock('../src/utils/auditService', () => ({ logGMAcion: jest.fn() }));
+const db = require('../util/database');
+const audit = require('../src/utils/auditService');
+const gm = require('../commands/gm');
+
+beforeEach(() => {
+  db.query.mockReset();
+  audit.logGMAcion.mockReset();
+});
+
+test('reset deletes player data', async () => {
+  db.query
+    .mockResolvedValueOnce({ rows: [{ id: 2 }] })
+    .mockResolvedValue({});
+
+  const interaction = {
+    options: {
+      getSubcommandGroup: jest.fn().mockReturnValue(null),
+      getSubcommand: jest.fn().mockReturnValue('reset'),
+      getUser: jest.fn().mockReturnValue({ id: '5', username: 'target' })
+    },
+    member: { roles: { cache: new Map([[1, { name: 'GM' }]]) } },
+    user: { username: 'admin' },
+    reply: jest.fn().mockResolvedValue()
+  };
+
+  await gm.execute(interaction);
+
+  expect(db.query).toHaveBeenCalledWith('SELECT id FROM players WHERE discord_id = ?', ['5']);
+  expect(db.query).toHaveBeenCalledWith('DELETE FROM players WHERE id = ?', [2]);
+  expect(audit.logGMAcion).toHaveBeenCalled();
+  expect(interaction.reply).toHaveBeenCalledWith(expect.objectContaining({ ephemeral: true }));
+});

--- a/discord-bot/tests/interactionHandler.test.js
+++ b/discord-bot/tests/interactionHandler.test.js
@@ -48,6 +48,7 @@ test('interactionCreate calls handleStatSelectMenu for stat_select menu', async 
       setName() { return this; }
       setDescription() { return this; }
       addSubcommand() { return this; }
+      addSubcommandGroup() { return this; }
       addStringOption() { return this; }
       addIntegerOption() { return this; }
     },

--- a/discord-bot/util/auth.js
+++ b/discord-bot/util/auth.js
@@ -1,0 +1,13 @@
+function isGM(interaction) {
+  const roles = interaction.member && interaction.member.roles;
+  if (!roles) return false;
+  let roleList = [];
+  if (roles.cache) {
+    roleList = Array.from(roles.cache.values());
+  } else if (Array.isArray(roles)) {
+    roleList = roles;
+  }
+  return roleList.some(r => r && (r.name === 'GM' || r.name === 'Developer'));
+}
+
+module.exports = { isGM };


### PR DESCRIPTION
## Summary
- add GM-only command suite for reset, codex unlock and flag set
- protect commands using new `isGM` helper
- log actions using new `auditService`
- add database table `gm_audit_log` and migration
- expand mocked SlashCommandBuilder in tests
- add unit tests for auth and gm reset logic

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686c7d16d93c83278b7000c774cf3a88