### PR TITLE
Add Python versions of bot data

### DIFF
--- a/ironaccord-bot/data/codex.py
+++ b/ironaccord-bot/data/codex.py
@@ -1,0 +1,12 @@
+CODEX = {
+    "ancient-tech": {
+        "name": "Ancient Tech",
+        "emoji": "📜",
+        "statBonuses": {"ING": 2},
+    },
+    "martial-training": {
+        "name": "Martial Training",
+        "emoji": "⚔️",
+        "statBonuses": {"MGT": 1},
+    },
+}

--- a/ironaccord-bot/data/flags.py
+++ b/ironaccord-bot/data/flags.py
@@ -1,0 +1,12 @@
+FLAGS = {
+    "Injured": {
+        "name": "Injured",
+        "emoji": "🤕",
+        "statBonuses": {"FOR": -1},
+    },
+    "Well-Fed": {
+        "name": "Well-Fed",
+        "emoji": "🍗",
+        "statBonuses": {"MGT": 1},
+    },
+}

--- a/ironaccord-bot/data/items.py
+++ b/ironaccord-bot/data/items.py
@@ -1,0 +1,7 @@
+ITEMS = [
+    {"id": "sword", "type": "weapon", "name": "Sword", "bonus": 1},
+    {"id": "plate_armor", "type": "armor", "name": "Plate Armor", "bonus": 2},
+    {"id": "fireball_card", "type": "ability", "name": "Fireball", "bonus": 2},
+]
+
+BY_NAME = {item["name"]: item for item in ITEMS}

--- a/ironaccord-bot/data/missions/test.py
+++ b/ironaccord-bot/data/missions/test.py
@@ -1,0 +1,96 @@
+MISSION = {
+    "id": 1,
+    "name": "test",
+    "intro": "Test mission start",
+    "rounds": [
+        {
+            "text": "Round 1",
+            "options": [
+                {
+                    "text": "A",
+                    "durability": -1,
+                    "combat": True,
+                    "dc": 12,
+                    "outcomes": {
+                        "Operational Success": {"loot": {"gold": 1}},
+                        "System Degraded": {
+                            "penalty": {"durability_loss": 5, "add_flag": "Injured"}
+                        },
+                    },
+                },
+                {
+                    "text": "B",
+                    "durability": -2,
+                    "combat": True,
+                    "dc": 12,
+                    "outcomes": {
+                        "Operational Success": {"loot": {"gold": 2}},
+                        "System Degraded": {
+                            "penalty": {"durability_loss": 5, "add_flag": "Injured"}
+                        },
+                    },
+                },
+            ],
+        },
+        {
+            "text": "Round 2",
+            "options": [
+                {
+                    "text": "A",
+                    "durability": -1,
+                    "combat": True,
+                    "dc": 10,
+                    "outcomes": {
+                        "Operational Success": {"loot": {"gold": 1}},
+                        "System Degraded": {
+                            "penalty": {"durability_loss": 5, "add_flag": "Injured"}
+                        },
+                    },
+                },
+                {
+                    "text": "B",
+                    "durability": 0,
+                    "combat": True,
+                    "dc": 10,
+                    "outcomes": {
+                        "Operational Success": {"loot": {"gold": 1}},
+                        "System Degraded": {
+                            "penalty": {"durability_loss": 5, "add_flag": "Injured"}
+                        },
+                    },
+                },
+            ],
+        },
+        {
+            "text": "Round 3",
+            "options": [
+                {
+                    "text": "A",
+                    "durability": 0,
+                    "combat": True,
+                    "dc": 8,
+                    "outcomes": {
+                        "Operational Success": {"loot": {"gold": 2}},
+                        "System Degraded": {
+                            "penalty": {"durability_loss": 5, "add_flag": "Injured"}
+                        },
+                    },
+                },
+                {
+                    "text": "B",
+                    "durability": 0,
+                    "combat": True,
+                    "dc": 8,
+                    "outcomes": {
+                        "Operational Success": {"loot": {"gold": 3}},
+                        "System Degraded": {
+                            "penalty": {"durability_loss": 5, "add_flag": "Injured"}
+                        },
+                    },
+                },
+            ],
+        },
+    ],
+    "rewards": {"gold": 5},
+    "codexFragment": "test_fragment",
+}


### PR DESCRIPTION
## Summary
- mirror discord bot data in Python
- provide mission data as a Python dict

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686c9219725c8327b17dae7ec9fe6f18