### PR TITLE
Fix pytest imports

### DIFF
--- a/python_bot/tests/conftest.py
+++ b/python_bot/tests/conftest.py
@@ -1,0 +1,7 @@
+import sys
+from pathlib import Path
+
+# Ensure the project root is on the path so `import python_bot` works
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))


### PR DESCRIPTION
## Summary
- ensure `python_bot` can be imported during test collection by creating `conftest.py`

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686c97b1b7388327a09af06171ababcc