### PR TITLE
Update env loading in bot.py

### DIFF
--- a/ironaccord-bot/bot.py
+++ b/ironaccord-bot/bot.py
@@ -4,12 +4,17 @@ from dotenv import load_dotenv
 import discord
 from discord.ext import commands
 
-load_dotenv()
+# Load environment from the project root
+ROOT_DIR = Path(__file__).resolve().parent.parent
+load_dotenv(ROOT_DIR / ".env")
 
 TOKEN = os.getenv("DISCORD_TOKEN")
+GUILD_ID = os.getenv("GUILD_ID")
 
 if not TOKEN:
-    raise RuntimeError("DISCORD_TOKEN not set in environment")
+    raise RuntimeError(
+        "DISCORD_TOKEN environment variable is missing. Did you copy .env.example to .env?"
+    )
 
 intents = discord.Intents.default()
 intents.message_content = True


### PR DESCRIPTION
## Summary
- load `.env` from project root in `ironaccord-bot/bot.py`
- read `GUILD_ID` from the environment
- emit a clearer error if `DISCORD_TOKEN` is missing

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'python_bot')*
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_686ca160be8883279a3de23cebce0d9c