### PR TITLE
Add aiomysql dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,11 @@ A small Python prototype is also provided. Environment variables match the Node.
    ```bash
    pip install -r requirements.txt
    ```
-3. Deploy commands and start the bot:
+3. Install dependencies for the Iron Accord bot:
+   ```bash
+   pip install -r ironaccord-bot/requirements.txt
+   ```
+4. Deploy commands and start the bot:
    ```bash
    python deploy_commands.py
    python bot.py

--- a/ironaccord-bot/requirements.txt
+++ b/ironaccord-bot/requirements.txt
@@ -1,4 +1,5 @@
 discord.py
 python-dotenv
 mysql-connector-python
+aiomysql
 requests


### PR DESCRIPTION
## Summary
- add `aiomysql` package to Iron Accord bot requirements
- document how to install dependencies for the Iron Accord bot

## Testing
- `PYTHONPATH=$PWD pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686ca16318608327ba1f74df7445694f