### PR TITLE
Fix path setup and imports for Discord bot

### DIFF
--- a/ironaccord-bot/bot.py
+++ b/ironaccord-bot/bot.py
@@ -1,20 +1,21 @@
 import os
-from pathlib import Path
-from dotenv import load_dotenv
+import sys
+import asyncio
 import discord
 from discord.ext import commands
+from dotenv import load_dotenv
 
-# Load environment from the project root
-ROOT_DIR = Path(__file__).resolve().parent.parent
-load_dotenv(ROOT_DIR / ".env")
+# --- Path and Environment Setup ---
+
+project_root = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+sys.path.insert(0, project_root)
+sys.path.insert(0, os.path.dirname(__file__))
+
+dotenv_path = os.path.join(project_root, ".env")
+load_dotenv(dotenv_path=dotenv_path)
 
 TOKEN = os.getenv("DISCORD_TOKEN")
-GUILD_ID = os.getenv("GUILD_ID")
-
-if not TOKEN:
-    raise RuntimeError(
-        "DISCORD_TOKEN environment variable is missing. Did you copy .env.example to .env?"
-    )
+GUILD_ID = os.getenv("DISCORD_GUILD_ID")
 
 intents = discord.Intents.default()
 intents.message_content = True
@@ -22,16 +23,57 @@ intents.members = True
 
 bot = commands.Bot(command_prefix="!", intents=intents)
 
+
+async def load_cogs():
+    """Dynamically loads all command cogs from the /cogs directory."""
+    print("─" * 20)
+    print("Loading cogs...")
+    cogs_dir = os.path.join(os.path.dirname(__file__), "cogs")
+    for filename in os.listdir(cogs_dir):
+        if filename.endswith(".py") and not filename.startswith("__"):
+            try:
+                await bot.load_extension(f"cogs.{filename[:-3]}")
+                print(f"  ✅ Loaded cog: {filename}")
+            except Exception as e:
+                print(f"  ❌ Failed to load cog {filename}: {e}")
+    print("─" * 20)
+
+
 @bot.event
 async def on_ready():
-    print(f"Logged in as {bot.user} (ID: {bot.user.id})")
-    print("------")
+    """Event handler for when the bot logs in and is ready."""
+    print(f"\nLogged in as {bot.user} (ID: {bot.user.id})")
+    print("─" * 20)
 
-# Load all cogs from the cogs directory
-for path in Path("cogs").glob("*.py"):
-    if path.stem.startswith("_"):
-        continue
-    module_name = f"cogs.{path.stem}"
-    bot.load_extension(module_name)
+    print("Syncing application commands...")
+    try:
+        if GUILD_ID:
+            guild = discord.Object(id=GUILD_ID)
+            bot.tree.copy_global_to(guild=guild)
+            synced = await bot.tree.sync(guild=guild)
+        else:
+            synced = await bot.tree.sync()
 
-bot.run(TOKEN)
+        print(f"  ✅ Synced {len(synced)} application commands.")
+    except Exception as e:
+        print(f"  ❌ Failed to sync commands: {e}")
+    print("─" * 20)
+    print("🤖 Bot is online and ready.")
+
+
+async def main():
+    """Main function to load cogs and run the bot."""
+    if not TOKEN:
+        print("❌ ERROR: DISCORD_TOKEN is not set. Please check your .env file.")
+        return
+
+    async with bot:
+        await load_cogs()
+        await bot.start(TOKEN)
+
+
+if __name__ == "__main__":
+    try:
+        asyncio.run(main())
+    except KeyboardInterrupt:
+        print("\n🤖 Bot shutting down.")

--- a/ironaccord-bot/cogs/character.py
+++ b/ironaccord-bot/cogs/character.py
@@ -2,9 +2,9 @@ import discord
 from discord import app_commands
 from discord.ext import commands
 
-from ..models import database as db
-from ..models import character_service
-from ..utils.embed import simple
+from models import database as db
+from models import character_service
+from utils.embed import simple
 
 class CharacterCog(commands.Cog):
     def __init__(self, bot: commands.Bot):

--- a/ironaccord-bot/cogs/codex.py
+++ b/ironaccord-bot/cogs/codex.py
@@ -2,9 +2,9 @@ import discord
 from discord import app_commands
 from discord.ext import commands
 
-from ..models import database as db
-from ..utils.embed import simple
-from ..ai.mixtral_agent import MixtralAgent
+from models import database as db
+from utils.embed import simple
+from ai.mixtral_agent import MixtralAgent
 
 class CodexCog(commands.Cog):
     def __init__(self, bot: commands.Bot):
@@ -35,7 +35,7 @@ class CodexCog(commands.Cog):
         if not check['rows']:
             await interaction.response.send_message(embed=simple('Entry not unlocked.'), ephemeral=True)
             return
-        from ..data.codex import CODEX
+        from data.codex import CODEX
         codex_data = CODEX.get(entry)
         if not codex_data:
             await interaction.response.send_message(embed=simple('Entry not found.'), ephemeral=True)

--- a/ironaccord-bot/cogs/equip.py
+++ b/ironaccord-bot/cogs/equip.py
@@ -2,8 +2,8 @@ import discord
 from discord import app_commands
 from discord.ext import commands
 
-from ..models import database as db
-from ..utils.embed import simple
+from models import database as db
+from utils.embed import simple
 
 class EquipCog(commands.Cog):
     def __init__(self, bot: commands.Bot):

--- a/ironaccord-bot/cogs/gm.py
+++ b/ironaccord-bot/cogs/gm.py
@@ -2,9 +2,9 @@ import discord
 from discord import app_commands
 from discord.ext import commands
 
-from ..models import database as db
-from ..utils.embed import simple
-from ..ai.mixtral_agent import MixtralAgent
+from models import database as db
+from utils.embed import simple
+from ai.mixtral_agent import MixtralAgent
 
 class GmCog(commands.Cog):
     def __init__(self, bot: commands.Bot):

--- a/ironaccord-bot/cogs/help.py
+++ b/ironaccord-bot/cogs/help.py
@@ -2,7 +2,7 @@ import discord
 from discord import app_commands
 from discord.ext import commands
 
-from ..utils.embed import simple
+from utils.embed import simple
 
 class HelpCog(commands.Cog):
     def __init__(self, bot: commands.Bot):

--- a/ironaccord-bot/cogs/inventory.py
+++ b/ironaccord-bot/cogs/inventory.py
@@ -2,8 +2,8 @@ import discord
 from discord import app_commands
 from discord.ext import commands
 
-from ..models import database as db
-from ..utils.embed import simple
+from models import database as db
+from utils.embed import simple
 
 class InventoryCog(commands.Cog):
     def __init__(self, bot: commands.Bot):

--- a/ironaccord-bot/cogs/mission.py
+++ b/ironaccord-bot/cogs/mission.py
@@ -1,13 +1,12 @@
 import json
-import os
 from pathlib import Path
 import discord
 from discord import app_commands
 from discord.ext import commands
 
-from ..utils.embed import simple
-from ..utils.mission_engine import resolve_choice
-from ..models import mission_service
+from utils.embed import simple
+from utils.mission_engine import resolve_choice
+from models import mission_service
 
 MISSIONS_PATH = Path(__file__).parent.parent / 'data' / 'missions'
 

--- a/ironaccord-bot/cogs/ping.py
+++ b/ironaccord-bot/cogs/ping.py
@@ -2,7 +2,7 @@ import discord
 from discord import app_commands
 from discord.ext import commands
 
-from ..utils.embed import simple
+from utils.embed import simple
 
 class PingCog(commands.Cog):
     def __init__(self, bot: commands.Bot):

--- a/ironaccord-bot/cogs/repair.py
+++ b/ironaccord-bot/cogs/repair.py
@@ -2,8 +2,8 @@ import discord
 from discord import app_commands
 from discord.ext import commands
 
-from ..utils.embed import simple
-from ..models import mission_service, player_service, database as db
+from utils.embed import simple
+from models import mission_service, player_service, database as db
 
 class RepairCog(commands.Cog):
     def __init__(self, bot: commands.Bot):

--- a/ironaccord-bot/cogs/use.py
+++ b/ironaccord-bot/cogs/use.py
@@ -2,8 +2,8 @@ import discord
 from discord import app_commands
 from discord.ext import commands
 
-from ..models import mission_service, item_service
-from ..utils.embed import simple
+from models import mission_service, item_service
+from utils.embed import simple
 
 class UseCog(commands.Cog):
     def __init__(self, bot: commands.Bot):

--- a/ironaccord-bot/models/character_service.py
+++ b/ironaccord-bot/models/character_service.py
@@ -1,4 +1,4 @@
-from typing import Dict, Any, List
+from typing import Dict, Any
 
 from . import database as db
 


### PR DESCRIPTION
## Summary
- load `.env` from repo root and start bot with asyncio
- add project paths to `sys.path`
- dynamically load cogs from the cogs directory
- switch all cog imports to use absolute paths
- clean up a few unused imports

## Testing
- `pip install -r requirements.txt`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686ca40b90d08327917564ea932605a7