### PR TITLE
Update mission_engine import path

### DIFF
--- a/ironaccord-bot/utils/mission_engine.py
+++ b/ironaccord-bot/utils/mission_engine.py
@@ -1,7 +1,7 @@
 import random
 from typing import Dict, Any
 
-from ..models import database as db
+from models import database as db
 from .items import BY_NAME
 
 async def resolve_choice(player_id: int, choice: Dict[str, Any]) -> Dict[str, Any]:


### PR DESCRIPTION
## Summary
- fix relative import path in `mission_engine`
- ensure utils consistently import the database module

## Testing
- `pip install -r requirements.txt`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686d4902811c8327ab962d63e73d3188