### PR TITLE
Add GM audit logging with auth fail tracking

### DIFF
--- a/ironaccord-bot/cogs/gm.py
+++ b/ironaccord-bot/cogs/gm.py
@@ -3,6 +3,7 @@ from discord import app_commands
 from discord.ext import commands
 
 from models import database as db
+from models.audit_service import log_auth_fail
 from utils.embed import simple
 from ai.mixtral_agent import MixtralAgent
 
@@ -27,6 +28,7 @@ class GmCog(commands.Cog):
 
     async def reset(self, interaction: discord.Interaction, player: discord.User):
         if not self.is_gm(interaction):
+            await log_auth_fail(interaction.user, 'gm reset')
             await interaction.response.send_message('Unauthorized.', ephemeral=True)
             return
         rows = await db.query('SELECT id FROM players WHERE discord_id = %s', [str(player.id)])
@@ -42,6 +44,7 @@ class GmCog(commands.Cog):
 
     async def codex_unlock(self, interaction: discord.Interaction, player: discord.User, entry: str):
         if not self.is_gm(interaction):
+            await log_auth_fail(interaction.user, 'gm codex unlock')
             await interaction.response.send_message('Unauthorized.', ephemeral=True)
             return
         rows = await db.query('SELECT id FROM players WHERE discord_id = %s', [str(player.id)])
@@ -54,6 +57,7 @@ class GmCog(commands.Cog):
 
     async def flag_set(self, interaction: discord.Interaction, player: discord.User, flag_id: str):
         if not self.is_gm(interaction):
+            await log_auth_fail(interaction.user, 'gm flag set')
             await interaction.response.send_message('Unauthorized.', ephemeral=True)
             return
         rows = await db.query('SELECT id FROM players WHERE discord_id = %s', [str(player.id)])
@@ -66,6 +70,7 @@ class GmCog(commands.Cog):
 
     async def narrate(self, interaction: discord.Interaction, prompt: str):
         if not self.is_gm(interaction):
+            await log_auth_fail(interaction.user, 'gm narrate')
             await interaction.response.send_message('Unauthorized.', ephemeral=True)
             return
         agent = MixtralAgent()

--- a/ironaccord-bot/models/audit_service.py
+++ b/ironaccord-bot/models/audit_service.py
@@ -1,0 +1,18 @@
+from . import database as db
+
+async def log_gm_action(admin_user: str, target_user: str, action: str, details: str) -> None:
+    """Record an administrative action to the gm_audit_log table."""
+    print(f"[GM] {admin_user} -> {target_user}: {action} {details}")
+    await db.query(
+        'INSERT INTO gm_audit_log (admin_user, target_user, action, details) VALUES (%s, %s, %s, %s)',
+        [admin_user, target_user, action, details]
+    )
+
+async def log_auth_fail(user, command: str) -> None:
+    """Log a failed authorization attempt."""
+    user_str = f"{user.name} ({user.id})"
+    print(f"[AUTH_FAIL] {user_str} - {command}")
+    await db.query(
+        'INSERT INTO gm_audit_log (admin_user, target_user, action, details) VALUES (%s, %s, %s, %s)',
+        [user_str, 'N/A', 'AUTH_FAIL', command]
+    )


### PR DESCRIPTION
## Summary
- add `audit_service.py` with logging helpers
- record GM auth failures in the gm commands

## Testing
- `PYTHONPATH=. pytest -q`
- `cd discord-bot && npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_686d490559f48327aaf3cc348fbbf338