### PR TITLE
Handle gm narration asynchronously

### DIFF
--- a/python_bot/tests/conftest.py
+++ b/python_bot/tests/conftest.py
@@ -2,6 +2,6 @@ import sys
 from pathlib import Path
 
 # Ensure the project root is on the path so `import python_bot` works
-ROOT = Path(__file__).resolve().parents[1]
+ROOT = Path(__file__).resolve().parents[2]
 if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))


### PR DESCRIPTION
## Summary
- improve gm `narrate` command to defer interaction and run LLM query off the main thread
- add connection error handling for the Mixtral server
- fix `python_bot` tests importing by correcting the path

## Testing
- `pytest -q`
- `npm test --prefix discord-bot`

------
https://chatgpt.com/codex/tasks/task_e_686d4cb521348327ae4f7cbea8b90b06