### PR TITLE
Constrain GM narration length

### DIFF
--- a/ironaccord-bot/cogs/gm.py
+++ b/ironaccord-bot/cogs/gm.py
@@ -80,10 +80,16 @@ class GmCog(commands.Cog):
         await interaction.response.defer(ephemeral=True, thinking=True)
 
         agent = MixtralAgent()
+
+        # Append a hard limit instruction so the LLM keeps responses short.
+        constrained_prompt = (
+            f"{prompt}\n\n(IMPORTANT: Your response must be two paragraphs maximum.)"
+        )
+
         try:
             # Run the blocking request in a thread so the bot stays responsive.
             loop = asyncio.get_running_loop()
-            text = await loop.run_in_executor(None, agent.query, prompt)
+            text = await loop.run_in_executor(None, agent.query, constrained_prompt)
         except requests.exceptions.ConnectionError:
             print("LOG: Failed to connect to the Mixtral/LLM server.")
             text = (


### PR DESCRIPTION
## Summary
- ensure Mixtral prompts warn the LLM to respond with two paragraphs max

## Testing
- `npm test`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686d519b93f483278ff2d9766f4a2e75