### PR TITLE
Improve GM narration prompt

### DIFF
--- a/ironaccord-bot/cogs/gm.py
+++ b/ironaccord-bot/cogs/gm.py
@@ -81,9 +81,11 @@ class GmCog(commands.Cog):
 
         agent = MixtralAgent()
 
-        # Append a hard limit instruction so the LLM keeps responses short.
+        # Append a strict instruction so the LLM replies with only one concise paragraph.
         constrained_prompt = (
-            f"{prompt}\n\n(IMPORTANT: Your response must be two paragraphs maximum.)"
+            f"{prompt}\n\n"
+            f"(IMPORTANT: Your entire response MUST be a single, concise paragraph. "
+            f"Do not write a second paragraph.)"
         )
 
         try:


### PR DESCRIPTION
## Summary
- ensure `gm narrate` command asks for a single concise paragraph

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686d557962f883278abdd5a9af4a87a3