### PR TITLE
Add Iron Accord world bible prompt injection

### DIFF
--- a/ironaccord-bot/ai/mixtral_agent.py
+++ b/ironaccord-bot/ai/mixtral_agent.py
@@ -1,6 +1,20 @@
 import os
 import requests
 
+# --- THE WORLD BIBLE ---
+# This text contains the unbreakable rules of the Iron Accord universe.
+# It is sent with EVERY prompt to ensure narrative consistency.
+WORLD_BIBLE = """
+You are the Game Master and narrator for 'Iron Accord'. Adhere to these core truths at all times:
+- The world is a harsh, post-apocalyptic steampunk setting that resulted from a war with AI.
+- The Iron Accord faction rejects all digital tech. They worship steam, steel, and flame. Their culture is rigid, reverent, and industrial.
+- Permitted technology: Gears, steam, pressure systems, mechanical automatons.
+- Forbidden technology: Processors, AI, neural networks, digital screens, anything "smart".
+- Key location: Brasshaven, a soot-stained industrial megacity.
+- Core philosophy: "Progress killed the world. Simplicity will rebuild it."
+- Tone: Gritty, reverent, somber. The world is dangerous and survival is a struggle.
+"""
+
 class MixtralAgent:
     """Simple client for querying a local Mixtral LLM endpoint."""
 
@@ -9,10 +23,11 @@ class MixtralAgent:
 
     def query(self, prompt: str, max_tokens: int = 200) -> str:
         """Send a prompt to the Mixtral API and return the generated text."""
+        final_prompt = f"{WORLD_BIBLE}\n\nTASK: {prompt}"
         url = self.base_url.rstrip("/") + "/chat/completions"
         payload = {
             "model": "mixtral",
-            "messages": [{"role": "user", "content": prompt}],
+            "messages": [{"role": "user", "content": final_prompt}],
             "max_tokens": max_tokens,
         }
         response = requests.post(url, json=payload, timeout=30)


### PR DESCRIPTION
## Summary
- define WORLD_BIBLE describing the immutable Iron Accord lore
- inject this constant before every Mixtral LLM prompt

## Testing
- `pytest -q`
- `python - <<'PY'
import sys
sys.path.append('ironaccord-bot')
from ai.mixtral_agent import MixtralAgent
agent = MixtralAgent()
try:
    print(agent.query("Describe a citizen using a personal data screen."))
except Exception as e:
    print('error', e)
PY`
- `python - <<'PY'
import sys
sys.path.append('ironaccord-bot')
from ai.mixtral_agent import MixtralAgent
agent = MixtralAgent()
try:
    print(agent.query("Describe a lively, happy festival in Brasshaven."))
except Exception as e:
    print('error', e)
PY`


------
https://chatgpt.com/codex/tasks/task_e_686d62d807448327aeb6cd05452af41e