### PR TITLE
Add interactive /start command

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,9 +39,10 @@ A small Python prototype is also provided. Environment variables match the Node.
    ```
 4. Deploy commands and start the bot:
    ```bash
-   python deploy_commands.py
-   python bot.py
-   ```
+  python deploy_commands.py
+  python bot.py
+  ```
+5. Once the bot is online, use `/start` in your Discord server to begin character creation.
 
 ## Item Data
 

--- a/ironaccord-bot/cogs/help.py
+++ b/ironaccord-bot/cogs/help.py
@@ -11,6 +11,7 @@ class HelpCog(commands.Cog):
     @app_commands.command(name="help", description="List available commands")
     async def help(self, interaction: discord.Interaction):
         embed = simple("Available Commands", [
+            {"name": "/start", "value": "Create your character"},
             {"name": "/ping", "value": "Check bot responsiveness"},
             {"name": "/help", "value": "Show this help message"}
         ])

--- a/ironaccord-bot/cogs/start.py
+++ b/ironaccord-bot/cogs/start.py
@@ -1,0 +1,101 @@
+import asyncio
+import discord
+from discord import app_commands
+from discord.ext import commands
+
+from ai.mixtral_agent import MixtralAgent
+from utils.embed import simple
+from models import database as db
+from models import player_service
+
+
+class StartCog(commands.Cog):
+    def __init__(self, bot: commands.Bot) -> None:
+        self.bot = bot
+
+    @app_commands.command(name="start", description="Begin your adventure")
+    async def start(self, interaction: discord.Interaction):
+        # Generate a short intro using the Mixtral agent
+        agent = MixtralAgent()
+        loop = asyncio.get_running_loop()
+        intro = await loop.run_in_executor(None, agent.query,
+                                            "Provide a one sentence intro to welcome a new player.")
+        embed = simple(intro)
+        view = IntroView(interaction.user)
+        await interaction.response.send_message(embed=embed, view=view, ephemeral=True)
+
+
+class IntroView(discord.ui.View):
+    def __init__(self, user: discord.User) -> None:
+        super().__init__()
+        self.user = user
+
+    @discord.ui.button(label="Begin", style=discord.ButtonStyle.primary)
+    async def begin(self, interaction: discord.Interaction, button: discord.ui.Button):
+        if interaction.user.id != self.user.id:
+            await interaction.response.send_message("This is not your prompt.", ephemeral=True)
+            return
+        embed = simple("Choose your faction")
+        view = FactionView(self.user)
+        await interaction.response.edit_message(embed=embed, view=view)
+
+
+class FactionView(discord.ui.View):
+    def __init__(self, user: discord.User) -> None:
+        super().__init__()
+        self.user = user
+
+    async def _set_faction(self, interaction: discord.Interaction, faction: str):
+        discord_id = str(self.user.id)
+        name = self.user.name
+        res = await db.query('SELECT id FROM players WHERE discord_id = %s', [discord_id])
+        if res['rows']:
+            await player_service.store_faction(discord_id, faction)
+        else:
+            await db.query(
+                'INSERT INTO players (discord_id, name, faction) VALUES (%s, %s, %s)',
+                [discord_id, name, faction]
+            )
+        embed = simple(f"Welcome to the {faction}!", [{"name": "Next Step", "value": "Select one stat to increase."}])
+        view = StatSelectView(self.user)
+        await interaction.response.edit_message(embed=embed, view=view)
+
+    @discord.ui.button(label="Iron Accord", style=discord.ButtonStyle.primary)
+    async def iron(self, interaction: discord.Interaction, button: discord.ui.Button):
+        await self._set_faction(interaction, "Iron Accord")
+
+    @discord.ui.button(label="Neon Dharma", style=discord.ButtonStyle.secondary)
+    async def neon(self, interaction: discord.Interaction, button: discord.ui.Button):
+        await self._set_faction(interaction, "Neon Dharma")
+
+
+class StatSelect(discord.ui.Select):
+    def __init__(self, user: discord.User) -> None:
+        options = [
+            discord.SelectOption(label='Might', value='MGT'),
+            discord.SelectOption(label='Agility', value='AGI'),
+            discord.SelectOption(label='Fortitude', value='FOR'),
+            discord.SelectOption(label='Intuition', value='INTU'),
+            discord.SelectOption(label='Resolve', value='RES'),
+            discord.SelectOption(label='Ingenuity', value='ING'),
+        ]
+        super().__init__(custom_id='stat_select', placeholder='Choose a stat', min_values=1, max_values=1, options=options)
+        self.user = user
+
+    async def callback(self, interaction: discord.Interaction):
+        if interaction.user.id != self.user.id:
+            await interaction.response.send_message("This menu isn't for you.", ephemeral=True)
+            return
+        await player_service.store_stat_selection(str(self.user.id), list(self.values))
+        embed = simple('Character creation complete!', [{"name": "Commands", "value": "Use /help to view commands."}])
+        await interaction.response.edit_message(embed=embed, view=None)
+
+
+class StatSelectView(discord.ui.View):
+    def __init__(self, user: discord.User) -> None:
+        super().__init__()
+        self.add_item(StatSelect(user))
+
+
+async def setup(bot: commands.Bot):
+    await bot.add_cog(StartCog(bot))

--- a/ironaccord-bot/models/player_service.py
+++ b/ironaccord-bot/models/player_service.py
@@ -12,3 +12,7 @@ async def store_stat_selection(discord_id: str, values: list[str]) -> None:
     stats_json = json.dumps(values)
     await db.query('UPDATE players SET starting_stats = %s WHERE discord_id = %s', [stats_json, discord_id])
 
+async def store_faction(discord_id: str, faction: str) -> None:
+    """Persist the player's chosen faction."""
+    await db.query('UPDATE players SET faction = %s WHERE discord_id = %s', [faction, discord_id])
+


### PR DESCRIPTION
## Summary
- add `StartCog` for guided character creation
- persist faction and stat selection in `player_service`
- expose `/start` in help text and README

## Testing
- `npm test` *(fails: jest not found)*
- `pytest -q` *(fails: missing asyncio plugin)*

------
https://chatgpt.com/codex/tasks/task_e_686d6413abd483278abd04e704e46175