### PR TITLE
Fix audit logging function typo

### DIFF
--- a/discord-bot/commands/gm.js
+++ b/discord-bot/commands/gm.js
@@ -2,7 +2,7 @@ const { SlashCommandBuilder } = require('discord.js');
 const db = require('../util/database');
 const { simple } = require('../src/utils/embedBuilder');
 const { isGM } = require('../util/auth');
-const { logGMAcion } = require('../src/utils/auditService');
+const { logGMAction } = require('../src/utils/auditService');
 
 module.exports = {
   data: new SlashCommandBuilder()
@@ -81,7 +81,7 @@ async function handleReset(interaction) {
   }
   await db.query('DELETE FROM players WHERE id = ?', [playerId]);
   await interaction.reply({ embeds: [simple('Player reset.')], ephemeral: true });
-  await logGMAcion(interaction.user.username, target.username, 'reset', target.id);
+  await logGMAction(interaction.user.username, target.username, 'reset', target.id);
 }
 
 async function handleCodexUnlock(interaction) {
@@ -102,7 +102,7 @@ async function handleCodexUnlock(interaction) {
     [playerId, entry]
   );
   await interaction.reply({ embeds: [simple('Codex updated.')], ephemeral: true });
-  await logGMAcion(interaction.user.username, target.username, 'codex unlock', entry);
+  await logGMAction(interaction.user.username, target.username, 'codex unlock', entry);
 }
 
 async function handleFlagSet(interaction) {
@@ -123,5 +123,5 @@ async function handleFlagSet(interaction) {
     [playerId, flagId]
   );
   await interaction.reply({ embeds: [simple('Flag applied.')], ephemeral: true });
-  await logGMAcion(interaction.user.username, target.username, 'flag set', flagId);
+  await logGMAction(interaction.user.username, target.username, 'flag set', flagId);
 }

--- a/discord-bot/src/utils/auditService.js
+++ b/discord-bot/src/utils/auditService.js
@@ -1,6 +1,6 @@
 const db = require('../../util/database');
 
-async function logGMAcion(adminUser, targetUser, action, details) {
+async function logGMAction(adminUser, targetUser, action, details) {
   console.log(`[GM] ${adminUser} -> ${targetUser}: ${action} ${details}`);
   await db.query(
     'INSERT INTO gm_audit_log (admin_user, target_user, action, details) VALUES (?, ?, ?, ?)',
@@ -8,4 +8,4 @@ async function logGMAcion(adminUser, targetUser, action, details) {
   );
 }
 
-module.exports = { logGMAcion };
+module.exports = { logGMAction };

--- a/discord-bot/tests/gm.test.js
+++ b/discord-bot/tests/gm.test.js
@@ -1,12 +1,12 @@
 jest.mock('../util/database', () => ({ query: jest.fn() }));
-jest.mock('../src/utils/auditService', () => ({ logGMAcion: jest.fn() }));
+jest.mock('../src/utils/auditService', () => ({ logGMAction: jest.fn() }));
 const db = require('../util/database');
 const audit = require('../src/utils/auditService');
 const gm = require('../commands/gm');
 
 beforeEach(() => {
   db.query.mockReset();
-  audit.logGMAcion.mockReset();
+  audit.logGMAction.mockReset();
 });
 
 test('reset deletes player data', async () => {
@@ -29,6 +29,6 @@ test('reset deletes player data', async () => {
 
   expect(db.query).toHaveBeenCalledWith('SELECT id FROM players WHERE discord_id = ?', ['5']);
   expect(db.query).toHaveBeenCalledWith('DELETE FROM players WHERE id = ?', [2]);
-  expect(audit.logGMAcion).toHaveBeenCalled();
+  expect(audit.logGMAction).toHaveBeenCalled();
   expect(interaction.reply).toHaveBeenCalledWith(expect.objectContaining({ ephemeral: true }));
 });


### PR DESCRIPTION
## Summary
- fix typo in `auditService.logGMAction`
- update gm command to use the renamed function
- adjust gm tests for the new function name

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686d641431f4832794cb2d204e92883e