### PR TITLE
Add pytest tests for ironaccord bot

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,3 +46,15 @@ A small Python prototype is also provided. Environment variables match the Node.
 ## Item Data
 
 Base item properties live in `discord-bot/src/data/items.js`. The mission engine and other services import this file to look up item bonuses when applying rewards or combat modifiers.
+
+## Running Python Tests
+
+The repository includes pytest suites for both the legacy prototype and the new
+Iron Accord bot. After installing the requirements from `requirements.txt` and
+`ironaccord-bot/requirements.txt`, execute the tests from the project root:
+
+```bash
+pip install -r requirements.txt
+pip install -r ironaccord-bot/requirements.txt
+pytest
+```

--- a/ironaccord-bot/tests/conftest.py
+++ b/ironaccord-bot/tests/conftest.py
@@ -1,0 +1,18 @@
+import sys
+import importlib
+from pathlib import Path
+
+# Ensure project root is on sys.path
+ROOT = Path(__file__).resolve().parents[2]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+PKG_DIR = ROOT / "ironaccord-bot"
+if str(PKG_DIR) not in sys.path:
+    sys.path.insert(0, str(PKG_DIR))
+
+# Alias the hyphenated package name so `import ironaccord_bot` works
+try:
+    pkg = importlib.import_module('ironaccord-bot')
+    sys.modules['ironaccord_bot'] = pkg
+except Exception:
+    pass

--- a/ironaccord-bot/tests/test_database.py
+++ b/ironaccord-bot/tests/test_database.py
@@ -1,0 +1,76 @@
+import types
+import pytest
+
+from ironaccord_bot.models import database
+
+class DummyCursor:
+    def __init__(self, rows=None, description=True, lastrowid=1):
+        self.rows = rows or []
+        self.description = description
+        self.lastrowid = lastrowid
+        self.sql = None
+        self.params = None
+
+    async def execute(self, sql, params):
+        self.sql = sql
+        self.params = params
+
+    async def fetchall(self):
+        return self.rows
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        pass
+
+class DummyConnection:
+    def __init__(self, cursor):
+        self._cursor = cursor
+
+    def cursor(self, _):
+        class Ctx:
+            async def __aenter__(self_inner):
+                return self._cursor
+            async def __aexit__(self_inner, exc_type, exc, tb):
+                pass
+        return Ctx()
+
+class DummyPool:
+    def __init__(self, cursor):
+        self._cursor = cursor
+    def acquire(self):
+        class Ctx:
+            async def __aenter__(self_inner):
+                return DummyConnection(self._cursor)
+            async def __aexit__(self_inner, exc_type, exc, tb):
+                pass
+        return Ctx()
+
+@pytest.mark.asyncio
+async def test_query_fetches_rows(monkeypatch):
+    database._pool = None
+    cur = DummyCursor(rows=[{"x": 1}], description=True, lastrowid=42)
+    pool = DummyPool(cur)
+    async def fake_create_pool(**kwargs):
+        return pool
+    monkeypatch.setattr(database.aiomysql, "create_pool", fake_create_pool)
+
+    result = await database.query("SELECT 1", [1])
+
+    assert result == {"insertId": 42, "rows": [{"x": 1}]}
+    assert cur.sql == "SELECT 1"
+    assert cur.params == [1]
+
+@pytest.mark.asyncio
+async def test_query_handles_no_rows(monkeypatch):
+    database._pool = None
+    cur = DummyCursor(rows=[], description=None, lastrowid=3)
+    pool = DummyPool(cur)
+    async def fake_create_pool(**kwargs):
+        return pool
+    monkeypatch.setattr(database.aiomysql, "create_pool", fake_create_pool)
+
+    result = await database.query("UPDATE", None)
+
+    assert result == {"insertId": 3, "rows": []}

--- a/ironaccord-bot/tests/test_ping_cog.py
+++ b/ironaccord-bot/tests/test_ping_cog.py
@@ -1,0 +1,26 @@
+import pytest
+import discord
+from discord.ext import commands
+
+from ironaccord_bot.cogs import ping
+
+class DummySend:
+    def __init__(self):
+        self.called = False
+        self.kwargs = None
+    async def send_message(self, **kwargs):
+        self.called = True
+        self.kwargs = kwargs
+
+class DummyInteraction:
+    def __init__(self):
+        self.response = DummySend()
+
+@pytest.mark.asyncio
+async def test_ping_cog_reply():
+    bot = commands.Bot(command_prefix="!", intents=discord.Intents.none())
+    cog = ping.PingCog(bot)
+    interaction = DummyInteraction()
+    await cog.ping.callback(cog, interaction)
+    assert interaction.response.called
+    assert interaction.response.kwargs.get("ephemeral") is True

--- a/ironaccord-bot/tests/test_player_service.py
+++ b/ironaccord-bot/tests/test_player_service.py
@@ -1,0 +1,28 @@
+import pytest
+
+from ironaccord_bot.models import player_service
+
+class DummyDB:
+    def __init__(self):
+        self.calls = []
+    async def query(self, sql, params=None):
+        self.calls.append((sql, params))
+        if sql.startswith('SELECT'):
+            return {'rows': [{'state': 'idle'}]}
+        return {'rows': [], 'insertId': 1}
+
+db = DummyDB()
+
+@pytest.mark.asyncio
+async def test_set_player_state(monkeypatch):
+    monkeypatch.setattr(player_service, 'db', db)
+    db.calls.clear()
+    await player_service.set_player_state(5, 'busy')
+    assert db.calls[0] == ('UPDATE players SET state = %s WHERE id = %s', ['busy', 5])
+
+@pytest.mark.asyncio
+async def test_get_player_state(monkeypatch):
+    monkeypatch.setattr(player_service, 'db', db)
+    state = await player_service.get_player_state(1)
+    assert state == 'idle'
+


### PR DESCRIPTION
## Summary
- add pytest test suite under `ironaccord-bot/tests`
- cover DB query helpers and ping cog
- document running pytest in `README.md`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686d6416f3748327a7264a97ec07a5c0