### PR TITLE
Improve narrative onboarding via /start

### DIFF
--- a/docs/iron_accord_mvp_story.md
+++ b/docs/iron_accord_mvp_story.md
@@ -7,7 +7,7 @@
 - **Starting Location:** Brasshaven — Tier 3 Safeforge
 - **Initial Stats:** 1 point in each stat, plus 1 bonus stat
 - **Neutral Gear:** patched coat, standard breather, ration x1, wrench
-- **Commands:** `/character`, `/mission`, `/scavenge`, `/rest`, `/codex`, `/repair`
+- **Commands:** `/start`, `/mission`, `/scavenge`, `/rest`, `/codex`, `/repair`
 
 ## Mainline Quest Flow
 

--- a/ironaccord-bot/cogs/start.py
+++ b/ironaccord-bot/cogs/start.py
@@ -15,12 +15,19 @@ class StartCog(commands.Cog):
 
     @app_commands.command(name="start", description="Begin your adventure")
     async def start(self, interaction: discord.Interaction):
-        # Generate a short intro using the Mixtral agent
+        # Generate a rich intro using the Mixtral agent
         agent = MixtralAgent()
         loop = asyncio.get_running_loop()
-        intro = await loop.run_in_executor(None, agent.query,
-                                            "Provide a one sentence intro to welcome a new player.")
-        embed = simple(intro)
+        prompt = (
+            "You are the Game Master for a gritty, steampunk survival game called "
+            "Iron Accord. A new player has just joined. Write a single, compelling "
+            "paragraph that sets the scene. The player is in the city of Brasshaven, "
+            "a place of soot-stained pipes and roaring forges. They should feel the "
+            "weight of this world and the constant struggle for survival. End with "
+            "a question that prompts them to begin their journey."
+        )
+        intro = await loop.run_in_executor(None, agent.query, prompt)
+        embed = simple("The World You've Entered...", description=intro)
         view = IntroView(interaction.user)
         await interaction.response.send_message(embed=embed, view=view, ephemeral=True)
 

--- a/ironaccord-bot/utils/embed.py
+++ b/ironaccord-bot/utils/embed.py
@@ -2,8 +2,10 @@ from typing import List, Dict, Optional
 import discord
 
 
-def simple(title: str, fields: Optional[List[Dict[str, str]]] = None, thumbnail_url: Optional[str] = None) -> discord.Embed:
-    embed = discord.Embed(title=title, colour=0x29B6F6)
+def simple(title: str, fields: Optional[List[Dict[str, str]]] = None,
+           thumbnail_url: Optional[str] = None,
+           description: Optional[str] = None) -> discord.Embed:
+    embed = discord.Embed(title=title, description=description, colour=0x29B6F6)
     embed.set_footer(text="Auto-Battler Bot")
     if fields:
         for f in fields:


### PR DESCRIPTION
## Summary
- expand `simple()` embed helper to support a description field
- enhance `/start` command to generate a longer intro paragraph
- document the new entry command in the Iron Accord MVP story

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686d668f9d5c832799d6ceacc9106543