### PR TITLE
Add long_running_command decorator

### DIFF
--- a/ironaccord-bot/cogs/codex.py
+++ b/ironaccord-bot/cogs/codex.py
@@ -4,6 +4,7 @@ from discord.ext import commands
 
 from models import database as db
 from utils.embed import simple
+from utils.decorators import long_running_command
 from ai.mixtral_agent import MixtralAgent
 
 class CodexCog(commands.Cog):
@@ -25,34 +26,37 @@ class CodexCog(commands.Cog):
         value = ', '.join(entries) if entries else 'None'
         await interaction.response.send_message(embed=simple('Codex', [{"name": 'Entries', "value": value}]), ephemeral=True)
 
+    @long_running_command
     async def view(self, interaction: discord.Interaction, entry: str):
         player_res = await db.query('SELECT id FROM players WHERE discord_id = %s', [str(interaction.user.id)])
         if not player_res['rows']:
-            await interaction.response.send_message(embed=simple('You have no character.'), ephemeral=True)
-            return
+            return simple('You have no character.')
+
         player_id = player_res['rows'][0]['id']
         check = await db.query('SELECT 1 FROM codex_entries WHERE player_id = %s AND entry_key = %s', [player_id, entry])
         if not check['rows']:
-            await interaction.response.send_message(embed=simple('Entry not unlocked.'), ephemeral=True)
-            return
+            return simple('Entry not unlocked.')
+
         from data.codex import CODEX
         codex_data = CODEX.get(entry)
         if not codex_data:
-            await interaction.response.send_message(embed=simple('Entry not found.'), ephemeral=True)
-            return
+            return simple('Entry not found.')
+
         narrative = codex_data.get('narrative', 'No lore available.')
         embed = simple(codex_data['name'], [{"name": "Lore", "value": narrative}])
+
+        agent = MixtralAgent()
+        prompt = (
+            f"As a weary member of the Iron Accord, I'm reading the Codex entry for '{codex_data['name']}'. "
+            f"The entry says: '{narrative}'. Generate a single, short paragraph of my character's personal, gritty thoughts or memories about this."
+        )
         try:
-            agent = MixtralAgent()
-            prompt = (
-                f"As a weary member of the Iron Accord, I'm reading the Codex entry for '{codex_data['name']}'. "
-                f"The entry says: '{narrative}'. Generate a single, short paragraph of my character's personal, gritty thoughts or memories about this."
-            )
             reflection = agent.query(prompt)
             embed.add_field(name="Personal Reflection", value=f"_{reflection}_", inline=False)
         except Exception:
             pass
-        await interaction.response.send_message(embed=embed, ephemeral=True)
+
+        return embed
 
 async def setup(bot: commands.Bot):
     await bot.add_cog(CodexCog(bot))

--- a/ironaccord-bot/utils/decorators.py
+++ b/ironaccord-bot/utils/decorators.py
@@ -1,0 +1,21 @@
+import functools
+import discord
+
+
+def long_running_command(func):
+    """Decorator to handle defer/followup for slow commands."""
+
+    @functools.wraps(func)
+    async def wrapper(cog_instance, interaction: discord.Interaction, *args, **kwargs):
+        await interaction.response.defer(ephemeral=True, thinking=True)
+        try:
+            result = await func(cog_instance, interaction, *args, **kwargs)
+            if isinstance(result, discord.Embed):
+                await interaction.followup.send(embed=result, ephemeral=True)
+            elif isinstance(result, str):
+                await interaction.followup.send(result, ephemeral=True)
+        except Exception as exc:
+            print(f"Error in long_running_command wrapper: {exc}")
+            await interaction.followup.send("An unexpected error occurred.", ephemeral=True)
+
+    return wrapper


### PR DESCRIPTION
## Summary
- implement `long_running_command` decorator to handle Discord interaction deferral
- apply decorator to `codex view` command and simplify command logic

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686d6a96b6348327bb463d8578ab356e