### PR TITLE
Implement run_blocking helper

### DIFF
--- a/ironaccord-bot/cogs/codex.py
+++ b/ironaccord-bot/cogs/codex.py
@@ -5,6 +5,7 @@ from discord.ext import commands
 from models import database as db
 from utils.embed import simple
 from utils.decorators import long_running_command
+from utils.async_utils import run_blocking
 from ai.mixtral_agent import MixtralAgent
 
 class CodexCog(commands.Cog):
@@ -51,7 +52,7 @@ class CodexCog(commands.Cog):
             f"The entry says: '{narrative}'. Generate a single, short paragraph of my character's personal, gritty thoughts or memories about this."
         )
         try:
-            reflection = agent.query(prompt)
+            reflection = await run_blocking(agent.query, prompt)
             embed.add_field(name="Personal Reflection", value=f"_{reflection}_", inline=False)
         except Exception:
             pass

--- a/ironaccord-bot/cogs/gm.py
+++ b/ironaccord-bot/cogs/gm.py
@@ -1,8 +1,9 @@
 import discord
 from discord import app_commands
 from discord.ext import commands
-import asyncio
 import requests
+
+from utils.async_utils import run_blocking
 
 from models import database as db
 from models.audit_service import log_auth_fail
@@ -90,8 +91,7 @@ class GmCog(commands.Cog):
 
         try:
             # Run the blocking request in a thread so the bot stays responsive.
-            loop = asyncio.get_running_loop()
-            text = await loop.run_in_executor(None, agent.query, constrained_prompt)
+            text = await run_blocking(agent.query, constrained_prompt)
         except requests.exceptions.ConnectionError:
             print("LOG: Failed to connect to the Mixtral/LLM server.")
             text = (

--- a/ironaccord-bot/cogs/start.py
+++ b/ironaccord-bot/cogs/start.py
@@ -1,9 +1,9 @@
-import asyncio
 import discord
 from discord import app_commands
 from discord.ext import commands
 
 from ai.mixtral_agent import MixtralAgent
+from utils.async_utils import run_blocking
 from utils.embed import simple
 from models import database as db
 from models import player_service
@@ -17,7 +17,6 @@ class StartCog(commands.Cog):
     async def start(self, interaction: discord.Interaction):
         # Generate a rich intro using the Mixtral agent
         agent = MixtralAgent()
-        loop = asyncio.get_running_loop()
         prompt = (
             "You are the Game Master for a gritty, steampunk survival game called "
             "Iron Accord. A new player has just joined. Write a single, compelling "
@@ -26,7 +25,7 @@ class StartCog(commands.Cog):
             "weight of this world and the constant struggle for survival. End with "
             "a question that prompts them to begin their journey."
         )
-        intro = await loop.run_in_executor(None, agent.query, prompt)
+        intro = await run_blocking(agent.query, prompt)
         embed = simple("The World You've Entered...", description=intro)
         view = IntroView(interaction.user)
         await interaction.response.send_message(embed=embed, view=view, ephemeral=True)

--- a/ironaccord-bot/utils/async_utils.py
+++ b/ironaccord-bot/utils/async_utils.py
@@ -1,0 +1,9 @@
+import asyncio
+from functools import partial
+from typing import Any, Callable
+
+async def run_blocking(func: Callable[..., Any], *args: Any, **kwargs: Any) -> Any:
+    """Run a blocking function in a separate executor thread."""
+    loop = asyncio.get_running_loop()
+    return await loop.run_in_executor(None, partial(func, *args, **kwargs))
+


### PR DESCRIPTION
## Summary
- add `run_blocking` coroutine to run blocking calls in an executor
- use `run_blocking` instead of direct `agent.query` or `run_in_executor`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686d6d3d7eb083279e9a72b7478abb98