### PR TITLE
Refactor defer decorator

### DIFF
--- a/ironaccord-bot/cogs/codex.py
+++ b/ironaccord-bot/cogs/codex.py
@@ -4,7 +4,7 @@ from discord.ext import commands
 
 from models import database as db
 from utils.embed import simple
-from utils.decorators import long_running_command
+from utils.decorators import defer_command
 from ai.mixtral_agent import MixtralAgent
 
 class CodexCog(commands.Cog):
@@ -26,7 +26,7 @@ class CodexCog(commands.Cog):
         value = ', '.join(entries) if entries else 'None'
         await interaction.response.send_message(embed=simple('Codex', [{"name": 'Entries', "value": value}]), ephemeral=True)
 
-    @long_running_command
+    @defer_command
     async def view(self, interaction: discord.Interaction, entry: str):
         player_res = await db.query('SELECT id FROM players WHERE discord_id = %s', [str(interaction.user.id)])
         if not player_res['rows']:

--- a/ironaccord-bot/utils/decorators.py
+++ b/ironaccord-bot/utils/decorators.py
@@ -2,8 +2,8 @@ import functools
 import discord
 
 
-def long_running_command(func):
-    """Decorator to handle defer/followup for slow commands."""
+def defer_command(func):
+    """Defer the interaction then send a follow-up with the returned value."""
 
     @functools.wraps(func)
     async def wrapper(cog_instance, interaction: discord.Interaction, *args, **kwargs):
@@ -14,8 +14,12 @@ def long_running_command(func):
                 await interaction.followup.send(embed=result, ephemeral=True)
             elif isinstance(result, str):
                 await interaction.followup.send(result, ephemeral=True)
+            elif result is None:
+                return
+            else:
+                await interaction.followup.send("An unexpected response type was returned.", ephemeral=True)
         except Exception as exc:
-            print(f"Error in long_running_command wrapper: {exc}")
+            print(f"Error in defer_command wrapper: {exc}")
             await interaction.followup.send("An unexpected error occurred.", ephemeral=True)
 
     return wrapper


### PR DESCRIPTION
## Summary
- rename `long_running_command` to `defer_command`
- handle embed/string/None responses in decorator
- update `CodexCog` to use new decorator

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686d6d3e80d08327b103d3eb12c411c9