### PR TITLE
Gracefully skip missing optional dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,3 +59,7 @@ pip install -r requirements.txt
 pip install -r ironaccord-bot/requirements.txt
 pytest
 ```
+
+The optional dependencies `discord.py` and `aiomysql` are needed for some tests
+under `ironaccord-bot`. Tests that rely on these packages will be skipped if
+they are not installed.

--- a/ironaccord-bot/tests/test_database.py
+++ b/ironaccord-bot/tests/test_database.py
@@ -1,6 +1,7 @@
 import types
 import pytest
 
+pytest.importorskip("aiomysql")
 from ironaccord_bot.models import database
 
 class DummyCursor:

--- a/ironaccord-bot/tests/test_ping_cog.py
+++ b/ironaccord-bot/tests/test_ping_cog.py
@@ -1,5 +1,5 @@
 import pytest
-import discord
+discord = pytest.importorskip("discord")
 from discord.ext import commands
 
 from ironaccord_bot.cogs import ping

--- a/ironaccord-bot/tests/test_player_service.py
+++ b/ironaccord-bot/tests/test_player_service.py
@@ -1,4 +1,5 @@
 import pytest
+pytest.importorskip("aiomysql")
 
 from ironaccord_bot.models import player_service
 


### PR DESCRIPTION
## Summary
- skip `discord.py` and `aiomysql` tests when modules aren't installed
- clarify optional dependencies in README

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686d6d3ee5d88327920efb58ee2db097