### PR TITLE
Add character persistence and tutorial integration

### DIFF
--- a/ironaccord-bot/models/character_service.py
+++ b/ironaccord-bot/models/character_service.py
@@ -73,3 +73,12 @@ async def get_character_sheet(discord_id: str) -> Dict[str, Any] | None:
 
     return { 'level': player['level'], 'stats': stats, 'gear': gear, 'flags': flags, 'codex': codex }
 
+
+async def insert_character(name: str, origin: str, skill: str) -> int:
+    """Insert a new character into the database and return its id."""
+    res = await db.query(
+        'INSERT INTO characters (name, origin, skill) VALUES (%s, %s, %s)',
+        [name, origin, skill]
+    )
+    return res['insertId']
+

--- a/ironaccord-bot/tests/test_character_service.py
+++ b/ironaccord-bot/tests/test_character_service.py
@@ -1,0 +1,24 @@
+import pytest
+pytest.importorskip("aiomysql")
+
+from ironaccord_bot.models import character_service
+
+class DummyDB:
+    def __init__(self):
+        self.calls = []
+    async def query(self, sql, params=None):
+        self.calls.append((sql, params))
+        return {'rows': [], 'insertId': 7}
+
+db = DummyDB()
+
+@pytest.mark.asyncio
+async def test_insert_character(monkeypatch):
+    monkeypatch.setattr(character_service, 'db', db)
+    db.calls.clear()
+    insert_id = await character_service.insert_character('Alice', 'Brasshaven', 'tinker')
+    assert insert_id == 7
+    assert db.calls[0] == (
+        'INSERT INTO characters (name, origin, skill) VALUES (%s, %s, %s)',
+        ['Alice', 'Brasshaven', 'tinker']
+    )

--- a/ironaccord-bot/tests/test_tutorial_view.py
+++ b/ironaccord-bot/tests/test_tutorial_view.py
@@ -1,0 +1,18 @@
+import pytest
+pytest.importorskip("aiomysql")
+
+from ironaccord_bot import tutorial
+
+class DummyService:
+    def __init__(self):
+        self.calls = []
+    async def insert_character(self, name, origin, skill):
+        self.calls.append((name, origin, skill))
+
+@pytest.mark.asyncio
+async def test_run_phase_8_calls_insert(monkeypatch):
+    svc = DummyService()
+    monkeypatch.setattr(tutorial, 'character_service', svc)
+    view = tutorial.TutorialView()
+    await view.run_phase_8('Bob', 'Wasteland', 'survival')
+    assert svc.calls == [('Bob', 'Wasteland', 'survival')]

--- a/ironaccord-bot/tutorial.py
+++ b/ironaccord-bot/tutorial.py
@@ -1,0 +1,6 @@
+from models import character_service
+
+class TutorialView:
+    async def run_phase_8(self, name: str, origin: str, skill: str) -> None:
+        """Finalize the tutorial by persisting the player's character."""
+        await character_service.insert_character(name, origin, skill)


### PR DESCRIPTION
## Summary
- store new character records via `insert_character`
- call this storage function from `TutorialView.run_phase_8`
- cover character persistence and tutorial hook in tests

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686d76b1270483278bf91df5a3ab7a93