### PR TITLE
Add SimpleTutorialView for Mixtral prompts

### DIFF
--- a/ironaccord-bot/cogs/start.py
+++ b/ironaccord-bot/cogs/start.py
@@ -9,7 +9,7 @@ from utils.embed import simple
 import requests
 from models import database as db
 from models import player_service
-from views.tutorial_view import TutorialView
+from views.simple_tutorial_view import SimpleTutorialView
 
 
 class StartCog(commands.Cog):
@@ -41,7 +41,7 @@ class StartCog(commands.Cog):
             return "An unexpected error occurred during intro generation."
 
         embed = simple("The World You've Entered...", description=intro)
-        view = TutorialView(interaction.user)
+        view = SimpleTutorialView(interaction.user)
         return (embed, view)
 
 

--- a/ironaccord-bot/tests/test_start_cog.py
+++ b/ironaccord-bot/tests/test_start_cog.py
@@ -38,3 +38,20 @@ async def test_start_cog_connection_error(monkeypatch):
 
     content = interaction.followup.args[0] if interaction.followup.args else ""
     assert "Could not connect" in content
+
+
+@pytest.mark.asyncio
+async def test_start_cog_returns_view(monkeypatch):
+    bot = commands.Bot(command_prefix="!", intents=discord.Intents.none())
+    cog = start.StartCog(bot)
+
+    def fake_query(self, prompt, max_tokens=200):
+        return "intro"
+
+    monkeypatch.setattr(start.MixtralAgent, "query", fake_query, raising=False)
+    interaction = DummyInteraction()
+
+    await cog.start.callback(cog, interaction)
+
+    view = interaction.followup.kwargs.get("view")
+    assert isinstance(view, start.SimpleTutorialView)

--- a/ironaccord-bot/views/simple_tutorial_view.py
+++ b/ironaccord-bot/views/simple_tutorial_view.py
@@ -1,0 +1,51 @@
+import discord
+import requests
+
+from ai.mixtral_agent import MixtralAgent
+from utils.async_utils import run_blocking
+from utils.embed import simple
+
+
+class SimpleTutorialView(discord.ui.View):
+    """Lightweight multi-phase tutorial view."""
+
+    PROMPTS = [
+        (
+            "You are the Game Master for a gritty, steampunk survival game called Iron Accord. "
+            "Welcome a new player to the city of Brasshaven in a single dramatic paragraph."
+        ),
+        "Briefly describe the two major factions and prompt the player to continue.",
+    ]
+
+    def __init__(self, user: discord.User) -> None:
+        super().__init__()
+        self.user = user
+        self.agent = MixtralAgent()
+        self.phase = 0
+
+    async def get_current_embed(self) -> discord.Embed:
+        """Generate narration for the current phase."""
+        prompt = self.PROMPTS[self.phase]
+        try:
+            text = await run_blocking(self.agent.query, prompt)
+        except requests.exceptions.ConnectionError:
+            print("LOG: Failed to connect to the Mixtral/LLM server.")
+            text = (
+                "Error: Could not connect to the narration service. Is the LLM server running?"
+            )
+        except Exception as exc:
+            print(f"Error generating tutorial text: {exc}")
+            text = "An unexpected error occurred during narration."
+        return simple("The World You've Entered...", description=text)
+
+    @discord.ui.button(label="Continue", style=discord.ButtonStyle.primary)
+    async def continue_button(self, interaction: discord.Interaction, button: discord.ui.Button) -> None:
+        if interaction.user.id != self.user.id:
+            await interaction.response.send_message("This is not your prompt.", ephemeral=True)
+            return
+        if self.phase + 1 >= len(self.PROMPTS):
+            await interaction.response.edit_message(view=None)
+            return
+        self.phase += 1
+        embed = await self.get_current_embed()
+        await interaction.response.edit_message(embed=embed, view=self)


### PR DESCRIPTION
## Summary
- implement `SimpleTutorialView` to drive a basic tutorial flow
- instantiate `SimpleTutorialView` in `/start`
- test `/start` uses the new view and still handles connection errors

## Testing
- `pip install -r requirements.txt`
- `pip install -r ironaccord-bot/requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686d9a6d7bc48327bc86df767936b869