### PR TITLE
Update Iron Accord roadmap for dual LLM architecture

### DIFF
--- a/docs/iron_accord_mvp_rollout.md
+++ b/docs/iron_accord_mvp_rollout.md
@@ -2,6 +2,8 @@
 
 This document summarizes the staged rollout plan for the Iron Accord Discord bot. Each phase adds new features and AI integration to gradually build the game loop.
 
+This roadmap now embraces a **Dual-LLM Architecture**. A creative "Lore Weaver" model (e.g., GPT-4o, Mixtral) generates story content while a lightweight "DM LLM" (e.g., Phi-3, Gemma) handles real-time rules resolution and state changes. Separating narration from mechanics enables a dynamic, responsive world.
+
 ## Phase 1: Core System (✅ Complete)
 - **Objective:** Prove that the basic mission loop works and establish Codex and survival mechanics.
 - **Resources:**
@@ -43,17 +45,18 @@ This document summarizes the staged rollout plan for the Iron Accord Discord bot
   - NPC dialogue via lightweight local models
   - Visual outputs from mission logs (image generation)
 - **Tech Focus:**
+  - Implement a Dual-LLM Architecture, separating the creative "Lore Weaver" (e.g., GPT-4o, Mixtral) from a lightweight, high-speed "DM LLM" (e.g., Phi-3, Gemma). The DM LLM handles real-time rules resolution and state changes, while the Lore Weaver generates immersive narrative based on the DM's outputs.
   - Codex agents suggest story expansions
   - GPT‑4o or local agents create item variants
   - Player choices influence generated missions
   - Begin an exportable React/WebGL frontend
 
 ## Codex Agent Integration Concepts
-| GPT Agent Use Case      | MVP Phase | Tooling Suggestion                     |
-|-------------------------|-----------|---------------------------------------|
-| Codex entry creation    | ✅ Phase 1   | GPT‑4o or prompt‑style lore builder    |
-| Lore-aware narration    | ✅ Phase 1.5 | World Bible system prompt             |
-| Item generator          | 🚀 Phase 2   | Codex prompts for weapons/armor/tools |
-| Dynamic lore retrieval  | 🚀 Phase 2   | RAG system with vector database       |
-| Dialogue/NPC assistant  | 🚀 Phase 3   | GPT‑4o or local wrapper               |
-| Auto‑mission designer   | 🚀 Phase 3   | Task GPT agent to build mission threads|
+| GPT Agent Use Case      | MVP Phase | Tooling Suggestion                     | Engine |
+|-------------------------|-----------|---------------------------------------|--------|
+| Lore-aware narration    | ✅ Phase 1.5 | World Bible system prompt            | Lore Weaver |
+| Dynamic lore retrieval  | 🚀 Phase 2   | RAG system with vector DB            | Lore Weaver |
+| Item generation         | ✅ Phase 2   | Codex prompts for weapons/armor      | Lore Weaver |
+| Rules & Mechanics engine| 🚀 Phase 3   | TTRPG ruleset processing             | DM LLM |
+| NPC dialogue/assistant  | 🚀 Phase 3   | Character-specific prompts           | Lore Weaver |
+| Auto-mission designer   | 🚀 Phase 3   | Task agent to build threads          | Lore Weaver |


### PR DESCRIPTION
## Summary
- document the new dual-LLM plan in *iron_accord_mvp_rollout.md*
- outline the Lore Weaver vs DM LLM roles in the integration table
- add note about the separation of storytelling from mechanics

## Testing
- `npm test --silent` in `discord-bot`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686d9e6765ec83278abc51823a5ac969