### PR TITLE
Add SimpleTutorialView with phased flow

### DIFF
--- a/ironaccord-bot/cogs/start.py
+++ b/ironaccord-bot/cogs/start.py
@@ -41,7 +41,7 @@ class StartCog(commands.Cog):
             return "An unexpected error occurred during intro generation."
 
         embed = simple("The World You've Entered...", description=intro)
-        view = SimpleTutorialView(interaction.user)
+        view = SimpleTutorialView(self.agent)
         return (embed, view)
 
 


### PR DESCRIPTION
## Summary
- implement a four-phase `SimpleTutorialView` that defers interactions and generates narration with Mixtral
- adjust `StartCog` to pass its agent into the new view

## Testing
- `pip install -r ironaccord-bot/requirements.txt`
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686db0bfffc0832787c87376d877989f