### PR TITLE
Refactor start cog to use SimpleTutorialView

### DIFF
--- a/ironaccord-bot/cogs/start.py
+++ b/ironaccord-bot/cogs/start.py
@@ -1,121 +1,57 @@
 import discord
-from discord import app_commands
 from discord.ext import commands
+from discord import app_commands
 
+from views.simple_tutorial_view import SimpleTutorialView
 from ai.mixtral_agent import MixtralAgent
 from utils.async_utils import run_blocking
-from utils.decorators import defer_command
-from utils.embed import simple
 import requests
-from models import database as db
-from models import player_service
-from views.simple_tutorial_view import SimpleTutorialView
-
 
 class StartCog(commands.Cog):
-    def __init__(self, bot: commands.Bot) -> None:
+    def __init__(self, bot: commands.Bot):
         self.bot = bot
         self.agent = MixtralAgent()
 
-    @app_commands.command(name="start", description="Begin your adventure")
-    @defer_command
+    @app_commands.command(name="start", description="Begin your journey in the world of Iron Accord.")
     async def start(self, interaction: discord.Interaction):
-        # Generate a rich intro using the Mixtral agent
+        await interaction.response.defer(ephemeral=True)
+
+        # --- Phase 1: The Spark of Memory ---
         prompt = (
-            "You are the Game Master for a gritty, steampunk survival game called "
-            "Iron Accord. A new player has just joined. Write a single, compelling "
-            "paragraph that sets the scene. The player is in the city of Brasshaven, "
-            "a place of soot-stained pipes and roaring forges. They should feel the "
-            "weight of this world and the constant struggle for survival. End with "
-            "a question that prompts them to begin their journey."
+            "You are the Game Master for 'Iron Accord'. Write a short, evocative opening "
+            "that uses the phrase 'The world burned under the march of metal' to introduce "
+            "a new player to the world's harsh reality."
         )
+
         try:
-            intro = await run_blocking(self.agent.query, prompt)
-        except requests.exceptions.ConnectionError:
-            print("LOG: Failed to connect to the Mixtral/LLM server.")
-            return (
-                "Error: Could not connect to the narration service. Is the LLM server running?"
+            narrative_text = await run_blocking(
+                self.agent.query,
+                prompt,
+                context=f"start_tutorial_phase_1_user_{interaction.user.id}"
             )
+        except requests.exceptions.ConnectionError:
+            await interaction.followup.send(
+                "Error: Could not connect to the narration service. Is the LLM server running?",
+                ephemeral=True,
+            )
+            return
         except Exception as exc:
             print(f"Error generating intro: {exc}")
-            return "An unexpected error occurred during intro generation."
-
-        embed = simple("The World You've Entered...", description=intro)
-        view = SimpleTutorialView(interaction.user)
-        return (embed, view)
-
-
-class IntroView(discord.ui.View):
-    def __init__(self, user: discord.User) -> None:
-        super().__init__()
-        self.user = user
-
-    @discord.ui.button(label="Begin", style=discord.ButtonStyle.primary)
-    async def begin(self, interaction: discord.Interaction, button: discord.ui.Button):
-        if interaction.user.id != self.user.id:
-            await interaction.response.send_message("This is not your prompt.", ephemeral=True)
-            return
-        embed = simple("Choose your faction")
-        view = FactionView(self.user)
-        await interaction.response.edit_message(embed=embed, view=view)
-
-
-class FactionView(discord.ui.View):
-    def __init__(self, user: discord.User) -> None:
-        super().__init__()
-        self.user = user
-
-    async def _set_faction(self, interaction: discord.Interaction, faction: str):
-        discord_id = str(self.user.id)
-        name = self.user.name
-        res = await db.query('SELECT id FROM players WHERE discord_id = %s', [discord_id])
-        if res['rows']:
-            await player_service.store_faction(discord_id, faction)
-        else:
-            await db.query(
-                'INSERT INTO players (discord_id, name, faction) VALUES (%s, %s, %s)',
-                [discord_id, name, faction]
+            await interaction.followup.send(
+                "An unexpected error occurred during intro generation.",
+                ephemeral=True,
             )
-        embed = simple(f"Welcome to the {faction}!", [{"name": "Next Step", "value": "Select one stat to increase."}])
-        view = StatSelectView(self.user)
-        await interaction.response.edit_message(embed=embed, view=view)
-
-    @discord.ui.button(label="Iron Accord", style=discord.ButtonStyle.primary)
-    async def iron(self, interaction: discord.Interaction, button: discord.ui.Button):
-        await self._set_faction(interaction, "Iron Accord")
-
-    @discord.ui.button(label="Neon Dharma", style=discord.ButtonStyle.secondary)
-    async def neon(self, interaction: discord.Interaction, button: discord.ui.Button):
-        await self._set_faction(interaction, "Neon Dharma")
-
-
-class StatSelect(discord.ui.Select):
-    def __init__(self, user: discord.User) -> None:
-        options = [
-            discord.SelectOption(label='Might', value='MGT'),
-            discord.SelectOption(label='Agility', value='AGI'),
-            discord.SelectOption(label='Fortitude', value='FOR'),
-            discord.SelectOption(label='Intuition', value='INTU'),
-            discord.SelectOption(label='Resolve', value='RES'),
-            discord.SelectOption(label='Ingenuity', value='ING'),
-        ]
-        super().__init__(custom_id='stat_select', placeholder='Choose a stat', min_values=1, max_values=1, options=options)
-        self.user = user
-
-    async def callback(self, interaction: discord.Interaction):
-        if interaction.user.id != self.user.id:
-            await interaction.response.send_message("This menu isn't for you.", ephemeral=True)
             return
-        await player_service.store_stat_selection(str(self.user.id), list(self.values))
-        embed = simple('Character creation complete!', [{"name": "Commands", "value": "Use /help to view commands."}])
-        await interaction.response.edit_message(embed=embed, view=None)
 
+        embed = discord.Embed(
+            title="The World You've Entered...",
+            description=narrative_text,
+            color=discord.Color.dark_red()
+        )
 
-class StatSelectView(discord.ui.View):
-    def __init__(self, user: discord.User) -> None:
-        super().__init__()
-        self.add_item(StatSelect(user))
-
+        # Create the view and send it with the first message
+        view = SimpleTutorialView(self.agent)
+        await interaction.followup.send(embed=embed, view=view, ephemeral=True)
 
 async def setup(bot: commands.Bot):
     await bot.add_cog(StartCog(bot))

--- a/ironaccord-bot/views/simple_tutorial_view.py
+++ b/ironaccord-bot/views/simple_tutorial_view.py
@@ -17,10 +17,9 @@ class SimpleTutorialView(discord.ui.View):
         "Briefly describe the two major factions and prompt the player to continue.",
     ]
 
-    def __init__(self, user: discord.User) -> None:
+    def __init__(self, agent: MixtralAgent) -> None:
         super().__init__()
-        self.user = user
-        self.agent = MixtralAgent()
+        self.agent = agent
         self.phase = 0
 
     async def get_current_embed(self) -> discord.Embed:
@@ -40,9 +39,6 @@ class SimpleTutorialView(discord.ui.View):
 
     @discord.ui.button(label="Continue", style=discord.ButtonStyle.primary)
     async def continue_button(self, interaction: discord.Interaction, button: discord.ui.Button) -> None:
-        if interaction.user.id != self.user.id:
-            await interaction.response.send_message("This is not your prompt.", ephemeral=True)
-            return
         if self.phase + 1 >= len(self.PROMPTS):
             await interaction.response.edit_message(view=None)
             return

--- a/ironaccord-bot/views/tutorial_view.py
+++ b/ironaccord-bot/views/tutorial_view.py
@@ -62,6 +62,4 @@ class TutorialView(discord.ui.View):
             text = "An unexpected error occurred during narration."
 
         embed = simple(f"Welcome, {name}", description=text)
-        from ironaccord_bot.cogs.start import FactionView  # local import to avoid circular
-        view = FactionView(self.user)
-        await interaction.followup.send(embed=embed, view=view, ephemeral=True)
+        await interaction.followup.send(embed=embed, ephemeral=True)


### PR DESCRIPTION
## Summary
- simplify `/start` command logic
- adjust SimpleTutorialView to take a MixtralAgent instead of a user
- remove unused faction selection flow from tutorial view

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686db0cddb4c83278fef307cef3a120d