### PR TITLE
Improve LLM output limits and tutorial message flow

### DIFF
--- a/ironaccord-bot/ai/mixtral_agent.py
+++ b/ironaccord-bot/ai/mixtral_agent.py
@@ -29,13 +29,18 @@ class MixtralAgent:
     def query(self, prompt: str, context: str = "general_query") -> str:
         """Send a prompt to the Mixtral API and return the generated text."""
         request_id = uuid.uuid4()
-        full_prompt = f"{self.world_bible}\n\nCONTEXT: {context}\nTASK: {prompt}"
+        constrained_prompt = (
+            f"{prompt}\n\n"
+            f"(IMPORTANT: Your entire response MUST be concise and less than 1000 characters.)"
+        )
+
+        full_prompt = f"{self.world_bible}\n\nCONTEXT: {context}\nTASK: {constrained_prompt}"
 
         url = self.base_url.rstrip("/") + "/chat/completions"
         payload = {
             "model": "mixtral",
             "messages": [{"role": "user", "content": full_prompt}],
-            "max_tokens": 500,
+            "max_tokens": 250,
         }
 
         logging.info(

--- a/ironaccord-bot/views/simple_tutorial_view.py
+++ b/ironaccord-bot/views/simple_tutorial_view.py
@@ -26,8 +26,12 @@ class SimpleTutorialView(discord.ui.View):
         if self.phase > 4:
             # End of the simple tutorial
             button.disabled = True
-            await interaction.followup.send("The story will continue...", ephemeral=True)
-            await interaction.edit_original_response(view=self)
+            button.label = "To be continued..."
+            await interaction.edit_original_response(
+                content="The story will continue...",
+                embed=None,
+                view=self
+            )
             return
 
         # Get the new prompt and update the button label
@@ -48,6 +52,5 @@ class SimpleTutorialView(discord.ui.View):
             color=discord.Color.orange()
         )
 
-        # Send the new embed as a followup and update the original message with the button
-        await interaction.followup.send(embed=embed, ephemeral=True)
-        await interaction.edit_original_response(view=self)
+        # Update the original message with the new embed and button
+        await interaction.edit_original_response(embed=embed, view=self)


### PR DESCRIPTION
## Summary
- update tutorial view to edit the original message rather than sending followups
- shorten MixtralAgent responses and instruct the LLM to stay under 1000 characters

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686db7048b7083279f45cba0476861e1