### PR TITLE
Add AI agent abstraction with Ollama service

### DIFF
--- a/ironaccord-bot/ai/ai_agent.py
+++ b/ironaccord-bot/ai/ai_agent.py
@@ -1,0 +1,32 @@
+from services.ollama_service import OllamaService
+
+class AIAgent:
+    """Main AI agent bridging cogs with the Ollama service."""
+
+    def __init__(self, world_bible_path: str = "docs/iron_accord_lore_gdd.md"):
+        """Initialize the agent and load world context."""
+        self.ollama_service = OllamaService()
+        self.world_bible = self._load_world_bible(world_bible_path)
+
+    def _load_world_bible(self, path: str) -> str:
+        """Return the contents of the world bible file."""
+        try:
+            with open(path, "r", encoding="utf-8") as f:
+                return f.read()
+        except FileNotFoundError:
+            return (
+                "The world is a grim, dark, post-apocalyptic wasteland. Resources are scarce. "
+                "Survival is paramount."
+            )
+        except Exception as e:  # pragma: no cover - unexpected errors
+            print(f"Error loading world bible: {e}")
+            return "Error: Could not load world bible."
+
+    async def get_narrative(self, prompt: str) -> str:
+        """Generate a narrative response using the world context."""
+        full_prompt = f"WORLD CONTEXT:\n{self.world_bible}\n\nSTORY PROMPT:\n{prompt}"
+        return await self.ollama_service.get_narrative(full_prompt)
+
+    async def get_gm_response(self, prompt: str) -> str:
+        """Generate a GM-style response without extra context."""
+        return await self.ollama_service.get_gm_response(prompt)

--- a/ironaccord-bot/services/ollama_service.py
+++ b/ironaccord-bot/services/ollama_service.py
@@ -1,0 +1,40 @@
+import os
+import logging
+import asyncio
+import requests
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s - %(levelname)s - [LLM_TRACE] - %(message)s",
+)
+
+class OllamaService:
+    """Client for interacting with local Ollama models."""
+
+    def __init__(self, base_url: str | None = None, narrator_model: str = "narrator", gm_model: str = "gm") -> None:
+        self.base_url = base_url or os.getenv("OLLAMA_API_URL", "http://localhost:11434/v1")
+        self.narrator_model = narrator_model
+        self.gm_model = gm_model
+
+    async def _post(self, model: str, prompt: str) -> str:
+        url = self.base_url.rstrip("/") + "/chat/completions"
+        payload = {
+            "model": model,
+            "messages": [{"role": "user", "content": prompt}],
+            "stream": False,
+        }
+        logging.info("Sending prompt to %s model: \"%s...\"", model, prompt[:80])
+        response = await asyncio.to_thread(requests.post, url, json=payload, timeout=30)
+        response.raise_for_status()
+        data = response.json()
+        text = data.get("choices", [{}])[0].get("message", {}).get("content", "").strip()
+        logging.info("Response from %s model: \"%s...\"", model, text[:80])
+        return text
+
+    async def get_narrative(self, prompt: str) -> str:
+        """Generate narrative text."""
+        return await self._post(self.narrator_model, prompt)
+
+    async def get_gm_response(self, prompt: str) -> str:
+        """Generate GM-style text."""
+        return await self._post(self.gm_model, prompt)

--- a/ironaccord-bot/tests/test_ai_agent.py
+++ b/ironaccord-bot/tests/test_ai_agent.py
@@ -1,0 +1,43 @@
+import pytest
+
+from ironaccord_bot.ai.ai_agent import AIAgent
+
+
+class DummyService:
+    def __init__(self):
+        self.calls = []
+
+    async def get_narrative(self, prompt: str) -> str:
+        self.calls.append(("narrative", prompt))
+        return "story"
+
+    async def get_gm_response(self, prompt: str) -> str:
+        self.calls.append(("gm", prompt))
+        return "gm_reply"
+
+
+@pytest.mark.asyncio
+async def test_get_narrative_prepends_world(tmp_path):
+    world_file = tmp_path / "world.md"
+    world_file.write_text("lore")
+    agent = AIAgent(world_bible_path=str(world_file))
+    dummy = DummyService()
+    agent.ollama_service = dummy
+
+    result = await agent.get_narrative("Prompt")
+
+    assert result == "story"
+    assert dummy.calls[0][0] == "narrative"
+    assert dummy.calls[0][1].startswith("WORLD CONTEXT:\nlore\n\nSTORY PROMPT:\nPrompt")
+
+
+@pytest.mark.asyncio
+async def test_get_gm_response_passes_through(monkeypatch):
+    agent = AIAgent(world_bible_path="missing_file")
+    dummy = DummyService()
+    agent.ollama_service = dummy
+
+    result = await agent.get_gm_response("hello")
+
+    assert result == "gm_reply"
+    assert dummy.calls == [("gm", "hello")]


### PR DESCRIPTION
## Summary
- add `OllamaService` for async interaction with Ollama models
- create `AIAgent` that loads world bible context and delegates to `OllamaService`
- add tests for `AIAgent`

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686ed17239348327b5fb504303b20c55