### PR TITLE
Replace MixtralAgent with AIAgent

### DIFF
--- a/ironaccord-bot/.env.example
+++ b/ironaccord-bot/.env.example
@@ -5,5 +5,6 @@ DB_USER=root
 DB_PASSWORD=password
 DB_DATABASE=auto_battler
 
-# Base URL for the Mixtral LLM agent
-MIXTRAL_API_URL=http://localhost:1234/v1
+# Base URLs for the dual LLM agents
+NARRATOR_API_URL=http://localhost:1234/v1
+GM_API_URL=http://localhost:1235/v1

--- a/ironaccord-bot/ai/__init__.py
+++ b/ironaccord-bot/ai/__init__.py
@@ -1,0 +1,3 @@
+from .ai_agent import AIAgent
+
+__all__ = ["AIAgent"]

--- a/ironaccord-bot/ai/ai_agent.py
+++ b/ironaccord-bot/ai/ai_agent.py
@@ -3,6 +3,7 @@ import logging
 import time
 import uuid
 import requests
+import asyncio
 
 logging.basicConfig(
     level=logging.INFO,
@@ -10,11 +11,12 @@ logging.basicConfig(
 )
 
 
-class MixtralAgent:
-    """Simple client for querying a local Mixtral LLM endpoint."""
+class AIAgent:
+    """Client for interacting with the narrator and GM LLM endpoints."""
 
-    def __init__(self, base_url: str | None = None) -> None:
-        self.base_url = base_url or os.getenv("MIXTRAL_API_URL", "http://localhost:1234/v1")
+    def __init__(self, narrator_url: str | None = None, gm_url: str | None = None) -> None:
+        self.narrator_url = narrator_url or os.getenv("NARRATOR_API_URL", "http://localhost:1234/v1")
+        self.gm_url = gm_url or os.getenv("GM_API_URL", "http://localhost:1235/v1")
         self.world_bible = (
             "You are the Game Master for 'Iron Accord'. Your name is Edraz. Your persona is a unique blend, but you must ALWAYS adhere to the following core world truths.\n\n"
             "== YOUR PERSONA ==\n"
@@ -31,23 +33,19 @@ class MixtralAgent:
             "- **World Tone:** The world itself is gritty, reverent, and somber. Survival is a constant struggle. Your witty persona is a layer on top of this harsh reality, not a replacement for it."
         )
 
-    def query(self, prompt: str, context: str = "general_query") -> str:
-        """Send a prompt to the Mixtral API and return the generated text."""
+    def _post(self, base_url: str, prompt: str, context: str) -> str:
         request_id = uuid.uuid4()
         constrained_prompt = (
             f"{prompt}\n\n"
             f"(IMPORTANT: Your entire response MUST be concise and less than 1000 characters.)"
         )
-
         full_prompt = f"{self.world_bible}\n\nCONTEXT: {context}\nTASK: {constrained_prompt}"
-
-        url = self.base_url.rstrip("/") + "/chat/completions"
+        url = base_url.rstrip("/") + "/chat/completions"
         payload = {
             "model": "mixtral",
             "messages": [{"role": "user", "content": full_prompt}],
             "max_tokens": 250,
         }
-
         logging.info(
             "ID: %s | Context: %s | Sending prompt: \"%s...\"",
             request_id,
@@ -55,17 +53,14 @@ class MixtralAgent:
             prompt[:80],
         )
         start_time = time.time()
-
         try:
             response = requests.post(url, json=payload, timeout=30)
             response.raise_for_status()
-
             duration = time.time() - start_time
             data = response.json()
             response_text = (
                 data.get("choices", [{}])[0].get("message", {}).get("content", "").strip()
             )
-
             logging.info(
                 "ID: %s | SUCCESS | Duration: %.2fs | Response: \"%s...\"",
                 request_id,
@@ -73,7 +68,6 @@ class MixtralAgent:
                 response_text[:80],
             )
             return response_text
-
         except requests.exceptions.RequestException as e:
             duration = time.time() - start_time
             logging.error(
@@ -84,3 +78,14 @@ class MixtralAgent:
             )
             raise
 
+    def query(self, prompt: str, context: str = "general_query") -> str:
+        """Backward compatible query using the narrator model."""
+        return self._post(self.narrator_url, prompt, context)
+
+    async def get_narrative(self, prompt: str, context: str = "narrative") -> str:
+        """Asynchronously request narrative text from the narrator model."""
+        return await asyncio.to_thread(self._post, self.narrator_url, prompt, context)
+
+    async def get_gm_response(self, prompt: str, context: str = "gm") -> str:
+        """Asynchronously request a response from the GM model."""
+        return await asyncio.to_thread(self._post, self.gm_url, prompt, context)

--- a/ironaccord-bot/cogs/codex.py
+++ b/ironaccord-bot/cogs/codex.py
@@ -6,7 +6,7 @@ from models import database as db
 from utils.embed import simple
 from utils.decorators import long_running_command
 from utils.async_utils import run_blocking
-from ai.mixtral_agent import MixtralAgent
+from ai.ai_agent import AIAgent
 import requests
 
 class CodexCog(commands.Cog):
@@ -47,7 +47,7 @@ class CodexCog(commands.Cog):
         narrative = codex_data.get('narrative', 'No lore available.')
         embed = simple(codex_data['name'], [{"name": "Lore", "value": narrative}])
 
-        agent = MixtralAgent()
+        agent = AIAgent()
         prompt = (
             f"As a weary member of the Iron Accord, I'm reading the Codex entry for '{codex_data['name']}'. "
             f"The entry says: '{narrative}'. Generate a single, short paragraph of my character's personal, gritty thoughts or memories about this."

--- a/ironaccord-bot/cogs/gm.py
+++ b/ironaccord-bot/cogs/gm.py
@@ -8,7 +8,7 @@ from utils.async_utils import run_blocking
 from models import database as db
 from models.audit_service import log_auth_fail
 from utils.embed import simple
-from ai.mixtral_agent import MixtralAgent
+from ai.ai_agent import AIAgent
 
 class GmCog(commands.Cog):
     def __init__(self, bot: commands.Bot):
@@ -80,7 +80,7 @@ class GmCog(commands.Cog):
         # Immediately defer to avoid the 3-second interaction timeout.
         await interaction.response.defer(ephemeral=True, thinking=True)
 
-        agent = MixtralAgent()
+        agent = AIAgent()
 
         # Append a strict instruction so the LLM replies with only one concise paragraph.
         constrained_prompt = (

--- a/ironaccord-bot/cogs/start.py
+++ b/ironaccord-bot/cogs/start.py
@@ -1,46 +1,41 @@
 import discord
 from discord.ext import commands
 from discord import app_commands
-
 from views.adventure_view import AdventureView
-from ai.mixtral_agent import MixtralAgent
-from utils.async_utils import run_blocking
-import asyncio
+from utils.embed import create_embed
+
+from ai.ai_agent import AIAgent
 
 
 class StartCog(commands.Cog):
+    """Handle the '/start' command and onboarding flow."""
+
     def __init__(self, bot: commands.Bot):
         self.bot = bot
-        self.agent = MixtralAgent()
+        self.bot.agent = AIAgent()
 
-    @app_commands.command(name="start", description="Begin your journey in the world of Iron Accord.")
+    @app_commands.command(name="start", description="Begin your adventure in the Iron Accord.")
     async def start(self, interaction: discord.Interaction):
-        # Give the LLM time to respond
-        await interaction.response.defer(ephemeral=True)
+        await interaction.response.defer()
 
-        user_name = interaction.user.display_name
         prompt = (
-            f"Your name is Edraz. Start the story for a new player named {user_name}. "
-            "Begin with 'The world burned under the march of metal', but then immediately "
-            "break the fourth wall to introduce yourself as their witty guide through this whole... game thing."
+            "You are the narrator for a grim-dark, post-apocalyptic TTRPG called Iron Accord. "
+            "Write a compelling, short (2-3 paragraphs) opening scene for a new player. "
+            "They have just woken up in a desolate, rusty metal landscape with no memory of how they got there. "
+            "Set a tone of mystery, danger, and survival."
+        )
+        story_text = await self.bot.agent.get_narrative(prompt)
+
+        embed = create_embed(
+            title="A Memory, Lost to Rust...",
+            description=story_text,
+            color=discord.Color.dark_red(),
         )
 
-        narrative_text = await run_blocking(
-            self.agent.query,
-            prompt,
-            context=f"adventure_phase_1_user_{user_name}"
-        )
+        view = AdventureView(agent=self.bot.agent, user=interaction.user)
 
-        embed = discord.Embed(
-            title=f"The Adventure of {user_name}",
-            description=narrative_text,
-            color=discord.Color.dark_gold()
-        )
+        await interaction.followup.send(embed=embed, view=view)
 
-        view = AdventureView(agent=self.agent, user=interaction.user)
-        # Start prefetching the next phase in the background
-        asyncio.create_task(view._prefetch_for_phase(2))
-        await interaction.followup.send(embed=embed, view=view, ephemeral=True)
 
-async def setup(bot: commands.Bot):
-    await bot.add_cog(StartCog(bot))
+def setup(bot: commands.Bot):
+    bot.add_cog(StartCog(bot))

--- a/ironaccord-bot/tests/test_ai_agent.py
+++ b/ironaccord-bot/tests/test_ai_agent.py
@@ -2,7 +2,7 @@ import logging
 import pytest
 import requests
 
-from ironaccord_bot.ai.mixtral_agent import MixtralAgent
+from ironaccord_bot.ai.ai_agent import AIAgent
 
 
 class DummyResponse:
@@ -17,7 +17,7 @@ class DummyResponse:
 
 
 def test_query_logs_success(monkeypatch, caplog):
-    agent = MixtralAgent(base_url="http://test")
+    agent = AIAgent(narrator_url="http://test")
 
     def fake_post(url, json, timeout):
         return DummyResponse("hello world")
@@ -33,7 +33,7 @@ def test_query_logs_success(monkeypatch, caplog):
 
 
 def test_query_logs_failure(monkeypatch, caplog):
-    agent = MixtralAgent(base_url="http://test")
+    agent = AIAgent(narrator_url="http://test")
 
     def fake_post(url, json, timeout):
         raise requests.exceptions.Timeout("boom")

--- a/ironaccord-bot/tests/test_start_cog.py
+++ b/ironaccord-bot/tests/test_start_cog.py
@@ -5,29 +5,32 @@ from discord.ext import commands
 from ironaccord_bot.cogs import start
 
 
-class DummyResponse:
-    def __init__(self):
-        self.deferred = False
-        self.kwargs = None
-
-    async def defer(self, *args, **kwargs):
-        self.deferred = True
-        self.kwargs = kwargs
-
-class DummyFollowup:
-    def __init__(self):
-        self.called = False
-        self.kwargs = None
-
-    async def send(self, *args, **kwargs):
-        self.called = True
-        self.kwargs = kwargs
-
 class DummyInteraction:
     def __init__(self):
         self.user = type("User", (), {"id": 1, "name": "Test", "display_name": "Test"})()
-        self.response = DummyResponse()
-        self.followup = DummyFollowup()
+
+        class Resp:
+            def __init__(self, outer):
+                self.outer = outer
+                self.deferred = False
+                self.kwargs = None
+
+            async def defer(self, *args, **kwargs):
+                self.deferred = True
+                self.kwargs = kwargs
+
+        class Followup:
+            def __init__(self, outer):
+                self.outer = outer
+                self.sent = False
+                self.kwargs = None
+
+            async def send(self, *args, **kwargs):
+                self.sent = True
+                self.kwargs = kwargs
+
+        self.response = Resp(self)
+        self.followup = Followup(self)
 
 @pytest.mark.asyncio
 async def test_start_cog_returns_view(monkeypatch):
@@ -43,19 +46,17 @@ async def test_start_cog_returns_view(monkeypatch):
 
     monkeypatch.setattr(start, "AdventureView", DummyView)
 
-    async def fake_run_blocking(func, *a, **kw):
+    async def fake_get_narrative(prompt):
         called["func"] = True
         return "story"
 
-    monkeypatch.setattr(start, "run_blocking", fake_run_blocking)
+    monkeypatch.setattr(bot.agent, "get_narrative", fake_get_narrative)
     interaction = DummyInteraction()
 
     await cog.start.callback(cog, interaction)
 
     assert interaction.response.deferred
-    assert interaction.response.kwargs.get("ephemeral") is True
-    assert interaction.followup.called
-    assert interaction.followup.kwargs.get("ephemeral") is True
+    assert interaction.followup.sent
     assert isinstance(interaction.followup.kwargs.get("view"), DummyView)
     assert called.get("created")
     assert called.get("func")

--- a/ironaccord-bot/utils/embed.py
+++ b/ironaccord-bot/utils/embed.py
@@ -13,3 +13,10 @@ def simple(title: str, fields: Optional[List[Dict[str, str]]] = None,
     if thumbnail_url:
         embed.set_thumbnail(url=thumbnail_url)
     return embed
+
+
+def create_embed(title: str, description: str, color: discord.Color | int = discord.Color.blurple()) -> discord.Embed:
+    """Lightweight helper used by the new onboarding flow."""
+    embed = discord.Embed(title=title, description=description, color=color)
+    embed.set_footer(text="Iron Accord")
+    return embed

--- a/ironaccord-bot/views/adventure_view.py
+++ b/ironaccord-bot/views/adventure_view.py
@@ -1,7 +1,7 @@
 import asyncio
 import os
 import discord
-from ai.mixtral_agent import MixtralAgent
+from ai.ai_agent import AIAgent
 from utils.async_utils import run_blocking
 
 # Prompts used for each narrative phase
@@ -16,7 +16,7 @@ PROMPTS = {
 
 
 class AdventureView(discord.ui.View):
-    def __init__(self, agent: MixtralAgent, user: discord.User):
+    def __init__(self, agent: AIAgent, user: discord.User):
         super().__init__(timeout=300)
         self.agent = agent
         self.user = user

--- a/ironaccord-bot/views/simple_tutorial_view.py
+++ b/ironaccord-bot/views/simple_tutorial_view.py
@@ -1,10 +1,10 @@
 import discord
-from ai.mixtral_agent import MixtralAgent
+from ai.ai_agent import AIAgent
 from utils.async_utils import run_blocking
 
 
 class SimpleTutorialView(discord.ui.View):
-    def __init__(self, agent: MixtralAgent, user: discord.User):
+    def __init__(self, agent: AIAgent, user: discord.User):
         super().__init__(timeout=300)
         self.agent = agent
         self.user = user

--- a/ironaccord-bot/views/tutorial_view.py
+++ b/ironaccord-bot/views/tutorial_view.py
@@ -1,7 +1,7 @@
 import discord
 import requests
 
-from ai.mixtral_agent import MixtralAgent
+from ai.ai_agent import AIAgent
 from utils.async_utils import run_blocking
 from utils.embed import simple
 from models import database as db
@@ -27,7 +27,7 @@ class TutorialView(discord.ui.View):
     def __init__(self, user: discord.User) -> None:
         super().__init__()
         self.user = user
-        self.agent = MixtralAgent()
+        self.agent = AIAgent()
 
     @discord.ui.button(label="Begin", style=discord.ButtonStyle.primary)
     async def begin(self, interaction: discord.Interaction, button: discord.ui.Button) -> None:


### PR DESCRIPTION
## Summary
- add `AIAgent` to drive narrator/GM requests
- update `/start` command to use AIAgent
- remove old MixtralAgent and rename its tests
- refactor tests for new interfaces
- update embed helpers and environment variables

## Testing
- `pip install -r requirements.txt`
- `pip install -r ironaccord-bot/requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686ed19656088327897c44158b206925