### PR TITLE
Implement OllamaService with tests

### DIFF
--- a/ironaccord-bot/tests/test_ollama_service.py
+++ b/ironaccord-bot/tests/test_ollama_service.py
@@ -1,0 +1,51 @@
+import pytest
+import httpx
+from unittest.mock import AsyncMock, patch
+
+from services.ollama_service import OllamaService
+
+pytestmark = pytest.mark.asyncio
+
+
+@pytest.fixture
+def ollama_service():
+    return OllamaService()
+
+
+async def test_get_narrative_success(ollama_service: OllamaService):
+    mock_prompt = "Tell me a story."
+    mock_response_text = "Once upon a time..."
+    mock_api_response = {"response": mock_response_text}
+
+    with patch.object(ollama_service.client, "post", new_callable=AsyncMock) as mock_post:
+        mock_post.return_value = httpx.Response(200, json=mock_api_response)
+
+        result = await ollama_service.get_narrative(mock_prompt)
+
+        mock_post.assert_called_once()
+        assert result == mock_response_text
+
+
+async def test_get_gm_response_success(ollama_service: OllamaService):
+    mock_prompt = "Confirm choice."
+    mock_response_text = "Choice confirmed."
+    mock_api_response = {"response": mock_response_text}
+
+    with patch.object(ollama_service.client, "post", new_callable=AsyncMock) as mock_post:
+        mock_post.return_value = httpx.Response(200, json=mock_api_response)
+
+        result = await ollama_service.get_gm_response(mock_prompt)
+
+        mock_post.assert_called_once()
+        assert result == mock_response_text
+
+
+async def test_api_connection_error(ollama_service: OllamaService):
+    mock_prompt = "This will fail."
+
+    with patch.object(ollama_service.client, "post", new_callable=AsyncMock) as mock_post:
+        mock_post.side_effect = httpx.ConnectError("Connection refused")
+
+        result = await ollama_service.get_narrative(mock_prompt)
+
+        assert "Error: Could not connect to the Ollama API" in result

--- a/services/ollama_service.py
+++ b/services/ollama_service.py
@@ -1,0 +1,34 @@
+import os
+import httpx
+
+
+class OllamaService:
+    """Asynchronous client for interacting with an Ollama API."""
+
+    def __init__(self, base_url: str | None = None) -> None:
+        self.base_url = base_url or os.getenv("OLLAMA_API_URL", "http://localhost:11434")
+        self.client = httpx.AsyncClient()
+
+    async def _request(self, endpoint: str, prompt: str) -> str:
+        url = self.base_url.rstrip('/') + endpoint
+        try:
+            response = await self.client.post(url, json={"prompt": prompt})
+            if response.status_code == 200:
+                data = response.json()
+                return data.get("response", "")
+            return f"Error: API responded with status {response.status_code}"
+        except httpx.ConnectError:
+            return "Error: Could not connect to the Ollama API"
+        except Exception as exc:
+            return f"Error: {exc}"
+
+    async def get_narrative(self, prompt: str) -> str:
+        """Retrieve narrative text from the Ollama API."""
+        return await self._request("/api/generate", prompt)
+
+    async def get_gm_response(self, prompt: str) -> str:
+        """Retrieve a GM confirmation/response from the Ollama API."""
+        return await self._request("/api/gm", prompt)
+
+    async def close(self) -> None:
+        await self.client.aclose()


### PR DESCRIPTION
## Summary
- add asynchronous `OllamaService` for talking to an Ollama API
- include unit tests validating the service

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686ed1a2822083278ceaf07f841c7e5c