### PR TITLE
Update tests and OllamaService error handling

### DIFF
--- a/ironaccord-bot/services/ollama_service.py
+++ b/ironaccord-bot/services/ollama_service.py
@@ -18,7 +18,12 @@ class OllamaService:
         try:
             logging.info(f"Sending request to Ollama model: {model_name}")
             response = await self.client.post(OLLAMA_API_URL, json=payload)
-            response.raise_for_status()
+            if response.status_code >= 400:
+                logging.error(
+                    "Ollama API returned status %s for model %s", response.status_code, model_name
+                )
+                return f"Error: Ollama API responded with status code {response.status_code}."
+
             data = response.json()
             return data.get("response", "Error: 'response' key not found in Ollama output.")
         except httpx.RequestError as e:

--- a/ironaccord-bot/tests/test_ollama_service.py
+++ b/ironaccord-bot/tests/test_ollama_service.py
@@ -1,41 +1,69 @@
 import pytest
 import httpx
+from unittest.mock import AsyncMock, patch
 
-from ironaccord_bot.services.ollama_service import OllamaService
+from services.ollama_service import OllamaService
 
+# Mark all tests in this file as asyncio
+pytestmark = pytest.mark.asyncio
 
-class DummyResponse:
-    def __init__(self, data):
-        self._data = data
+@pytest.fixture
+def ollama_service():
+    """Pytest fixture to create an instance of OllamaService for each test."""
+    return OllamaService()
 
-    def raise_for_status(self):
-        pass
+async def test_get_narrative_success(ollama_service: OllamaService):
+    """
+    Tests a successful call to the get_narrative method, ensuring it
+    correctly processes a valid API response.
+    """
+    mock_prompt = "Tell me a story."
+    mock_response_text = "Once upon a time..."
+    
+    # Mock the JSON response from the Ollama API
+    mock_api_response = {"response": mock_response_text}
 
-    def json(self):
-        return self._data
+    # Patch the post method of the httpx.AsyncClient
+    with patch.object(ollama_service.client, 'post', new_callable=AsyncMock) as mock_post:
+        # Configure the mock to return a successful response object
+        mock_response = httpx.Response(200, json=mock_api_response)
+        mock_post.return_value = mock_response
 
+        # Call the method we are testing
+        result = await ollama_service.get_narrative(mock_prompt)
 
-@pytest.mark.asyncio
-async def test_get_narrative_success(monkeypatch):
-    service = OllamaService()
+        # Assertions
+        mock_post.assert_called_once()  # Ensure the post method was called
+        assert result == mock_response_text # Ensure we got the correct text back
 
-    async def fake_post(url, json):
-        return DummyResponse({"response": "hello"})
+async def test_get_gm_response_success(ollama_service: OllamaService):
+    """
+    Tests a successful call to the get_gm_response method.
+    """
+    mock_prompt = "Confirm choice."
+    mock_response_text = "Choice confirmed."
+    mock_api_response = {"response": mock_response_text}
 
-    monkeypatch.setattr(service.client, "post", fake_post)
+    with patch.object(ollama_service.client, 'post', new_callable=AsyncMock) as mock_post:
+        mock_response = httpx.Response(200, json=mock_api_response)
+        mock_post.return_value = mock_response
 
-    result = await service.get_narrative("prompt")
-    assert result == "hello"
+        result = await ollama_service.get_gm_response(mock_prompt)
 
+        mock_post.assert_called_once()
+        assert result == mock_response_text
 
-@pytest.mark.asyncio
-async def test_get_narrative_request_error(monkeypatch):
-    service = OllamaService()
+async def test_api_connection_error(ollama_service: OllamaService):
+    """
+    Tests how the service handles a connection error when trying to reach Ollama.
+    """
+    mock_prompt = "This will fail."
 
-    async def fake_post(url, json):
-        raise httpx.RequestError("boom")
+    with patch.object(ollama_service.client, 'post', new_callable=AsyncMock) as mock_post:
+        # Configure the mock to raise a connection error
+        mock_post.side_effect = httpx.ConnectError("Connection refused")
 
-    monkeypatch.setattr(service.client, "post", fake_post)
+        result = await ollama_service.get_narrative(mock_prompt)
 
-    result = await service.get_narrative("prompt")
-    assert result.startswith("Error")
+        # Assert that the method returns a user-friendly error message
+        assert "Error: Could not connect to the Ollama API" in result

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 pytest>=7.0
 pytest-asyncio>=1.0
 requests
+httpx


### PR DESCRIPTION
## Summary
- install httpx dependency for tests
- rewrite test_ollama_service.py to use AsyncMock and fixture
- adjust OllamaService to avoid calling `raise_for_status`

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686ed7118608832799a6fa90b947f932