### PR TITLE
Use new AI agent service

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -19,8 +19,8 @@ DB_USER=root
 DB_PASSWORD=password
 DB_DATABASE=auto_battler
 
-# Base URL for the Mixtral LLM agent
-MIXTRAL_API_URL=http://localhost:1234/v1
+# Base URL for the Ollama server
+OLLAMA_API_URL=http://localhost:11434/api/generate
 
 # ---------------------------------------------------------------------
 # Node.js specific settings (ignored by the Python bot)

--- a/ironaccord-bot/.env.example
+++ b/ironaccord-bot/.env.example
@@ -5,5 +5,5 @@ DB_USER=root
 DB_PASSWORD=password
 DB_DATABASE=auto_battler
 
-# Base URL for the Mixtral LLM agent
-MIXTRAL_API_URL=http://localhost:1234/v1
+# Base URL for the Ollama server
+OLLAMA_API_URL=http://localhost:11434/api/generate

--- a/ironaccord-bot/ai/__init__.py
+++ b/ironaccord-bot/ai/__init__.py
@@ -1,4 +1,3 @@
 from .ai_agent import AIAgent
-from .mixtral_agent import MixtralAgent
 
-__all__ = ["AIAgent", "MixtralAgent"]
+__all__ = ["AIAgent"]

--- a/ironaccord-bot/services/ollama_service.py
+++ b/ironaccord-bot/services/ollama_service.py
@@ -1,9 +1,10 @@
+import os
 import httpx
 import logging
 import json
 
 # --- Constants ---
-OLLAMA_API_URL = "http://localhost:11434/api/generate"
+OLLAMA_API_URL = os.getenv("OLLAMA_API_URL", "http://localhost:11434/api/generate")
 NARRATOR_MODEL = "mixtral:8x7b-instruct-v0.1-q4_0"  # The creative storyteller
 GM_MODEL = "phi3:mini"  # The fast, logical game master
 


### PR DESCRIPTION
## Summary
- swap MixtralAgent for AIAgent in GM and Codex cogs
- export only AIAgent from ai package
- configure OllamaService base URL with environment variable
- document `OLLAMA_API_URL` in `.env.example` files

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686eeebafb788327958d9071c75da618