### PR TITLE
Add LangChain libraries

### DIFF
--- a/ironaccord-bot/requirements.txt
+++ b/ironaccord-bot/requirements.txt
@@ -1,6 +1,17 @@
-discord.py
-python-dotenv
-mysql-connector-python
-aiomysql
-requests
-httpx
+# Core Discord Bot Libraries
+discord.py==2.3.2
+python-dotenv==1.0.1
+
+# Asynchronous Database Connector
+aiomysql==0.2.0
+
+# Asynchronous HTTP Requests for Ollama API
+httpx==0.27.0
+
+# --- NEW: RAG and Vector Store Libraries ---
+langchain==0.1.16
+langchain-community==0.0.32
+faiss-cpu==1.7.4 # For local vector storage
+
+# Testing Framework
+pytest==8.2.2


### PR DESCRIPTION
## Summary
- pin Python package versions in `ironaccord-bot/requirements.txt`
- include LangChain and FAISS dependencies for RAG functionality

## Testing
- `pip install -r requirements.txt` *(fails: Could not build `faiss-cpu`)*
- `ollama pull nomic-embed-text` *(fails: command not found)*
- `pytest -q` *(fails: ModuleNotFoundError for `httpx`)*

------
https://chatgpt.com/codex/tasks/task_e_686f0153a8e08327996c53eb0d7b48bf