### PR TITLE
Add RAG service and new Codex command

### DIFF
--- a/ironaccord-bot/bot.py
+++ b/ironaccord-bot/bot.py
@@ -5,6 +5,10 @@ import discord
 from discord.ext import commands
 from dotenv import load_dotenv
 
+from services.ollama_service import OllamaService
+from services.rag_service import RAGService
+from ai.ai_agent import AIAgent
+
 # --- Path and Environment Setup ---
 
 project_root = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
@@ -23,19 +27,23 @@ intents.members = True
 
 bot = commands.Bot(command_prefix="!", intents=intents)
 
+# Cogs to load
+cogs_list = [
+    'start',
+    'codex',
+]
+
 
 async def load_cogs():
-    """Dynamically loads all command cogs from the /cogs directory."""
+    """Load all cogs listed in ``cogs_list``."""
     print("─" * 20)
     print("Loading cogs...")
-    cogs_dir = os.path.join(os.path.dirname(__file__), "cogs")
-    for filename in os.listdir(cogs_dir):
-        if filename.endswith(".py") and not filename.startswith("__"):
-            try:
-                await bot.load_extension(f"cogs.{filename[:-3]}")
-                print(f"  ✅ Loaded cog: {filename}")
-            except Exception as e:
-                print(f"  ❌ Failed to load cog {filename}: {e}")
+    for cog in cogs_list:
+        try:
+            await bot.load_extension(f"cogs.{cog}")
+            print(f"  ✅ Loaded cog: {cog}")
+        except Exception as e:
+            print(f"  ❌ Failed to load cog {cog}: {e}")
     print("─" * 20)
 
 
@@ -44,6 +52,13 @@ async def on_ready():
     """Event handler for when the bot logs in and is ready."""
     print(f"\nLogged in as {bot.user} (ID: {bot.user.id})")
     print("─" * 20)
+
+    # Initialize services and attach them to the bot instance
+    print("Initializing services...")
+    bot.ollama_service = OllamaService()
+    bot.rag_service = RAGService()
+    bot.agent = AIAgent()
+    print("Services initialized.")
 
     print("Attempting to clear all old commands...")
     try:
@@ -79,3 +94,4 @@ if __name__ == "__main__":
         asyncio.run(main())
     except KeyboardInterrupt:
         print("\n🤖 Bot shutting down.")
+

--- a/ironaccord-bot/cogs/codex_legacy.py
+++ b/ironaccord-bot/cogs/codex_legacy.py
@@ -1,0 +1,60 @@
+import discord
+from discord import app_commands
+from discord.ext import commands
+
+from models import database as db
+from utils.embed import simple
+from utils.decorators import long_running_command
+from ai.ai_agent import AIAgent
+
+class CodexCog(commands.Cog):
+    def __init__(self, bot: commands.Bot):
+        self.bot = bot
+        self.agent = AIAgent()
+        self.group = app_commands.Group(name='codex', description='Codex commands')
+        self.group.command(name='list', description='Display your unlocked codex entries')(self.list)
+        self.group.command(name='view', description='View a codex entry')(self.view)
+        bot.tree.add_command(self.group)
+
+    async def list(self, interaction: discord.Interaction):
+        player_res = await db.query('SELECT id FROM players WHERE discord_id = %s', [str(interaction.user.id)])
+        if not player_res['rows']:
+            await interaction.response.send_message(embed=simple('You have no character.'), ephemeral=True)
+            return
+        player_id = player_res['rows'][0]['id']
+        entries_res = await db.query('SELECT entry_key FROM codex_entries WHERE player_id = %s', [player_id])
+        entries = [r['entry_key'] for r in entries_res['rows']]
+        value = ', '.join(entries) if entries else 'None'
+        await interaction.response.send_message(embed=simple('Codex', [{"name": 'Entries', "value": value}]), ephemeral=True)
+
+    @long_running_command
+    async def view(self, interaction: discord.Interaction, entry: str):
+        player_res = await db.query('SELECT id FROM players WHERE discord_id = %s', [str(interaction.user.id)])
+        if not player_res['rows']:
+            return simple('You have no character.')
+
+        player_id = player_res['rows'][0]['id']
+        check = await db.query('SELECT 1 FROM codex_entries WHERE player_id = %s AND entry_key = %s', [player_id, entry])
+        if not check['rows']:
+            return simple('Entry not unlocked.')
+
+        from data.codex import CODEX
+        codex_data = CODEX.get(entry)
+        if not codex_data:
+            return simple('Entry not found.')
+
+        narrative = codex_data.get('narrative', 'No lore available.')
+        embed = simple(codex_data['name'], [{"name": "Lore", "value": narrative}])
+
+        prompt = (
+            f"As a weary member of the Iron Accord, I'm reading the Codex entry for '{codex_data['name']}'. "
+            f"The entry says: '{narrative}'. Generate a single, short paragraph of my character's personal, gritty thoughts or memories about this."
+        )
+        reflection = await self.agent.get_narrative(prompt)
+        embed.add_field(name="Personal Reflection", value=f"_{reflection}_", inline=False)
+
+        return embed
+
+async def setup(bot: commands.Bot):
+    await bot.add_cog(CodexCog(bot))
+

--- a/ironaccord-bot/requirements.txt
+++ b/ironaccord-bot/requirements.txt
@@ -4,3 +4,6 @@ mysql-connector-python
 aiomysql
 requests
 httpx
+langchain-community
+langchain-text-splitters
+faiss-cpu

--- a/ironaccord-bot/services/rag_service.py
+++ b/ironaccord-bot/services/rag_service.py
@@ -1,0 +1,55 @@
+import logging
+from langchain_community.document_loaders import DirectoryLoader
+from langchain_community.vectorstores import FAISS
+from langchain_community.embeddings import OllamaEmbeddings
+from langchain_text_splitters import RecursiveCharacterTextSplitter
+
+# --- Constants ---
+LORE_DIRECTORY = 'docs'
+EMBEDDING_MODEL = 'nomic-embed-text'
+
+class RAGService:
+    """Service for Retrieval-Augmented Generation (RAG)."""
+
+    def __init__(self) -> None:
+        """Load documents and build the vector store."""
+        self.vector_store = None
+        try:
+            logging.info("Initializing RAG Service...")
+            loader = DirectoryLoader(LORE_DIRECTORY, glob="**/*.md", show_progress=True)
+            docs = loader.load()
+
+            if not docs:
+                logging.warning(
+                    "No documents found in '%s'. RAG service will be inactive.",
+                    LORE_DIRECTORY,
+                )
+                return
+
+            text_splitter = RecursiveCharacterTextSplitter(
+                chunk_size=1000, chunk_overlap=200
+            )
+            splits = text_splitter.split_documents(docs)
+
+            embeddings = OllamaEmbeddings(model=EMBEDDING_MODEL)
+            self.vector_store = FAISS.from_documents(splits, embeddings)
+            logging.info(
+                "RAG Service initialized successfully. Indexed %s document chunks.",
+                len(splits),
+            )
+        except Exception as e:  # pragma: no cover - initialization safety net
+            logging.error("Failed to initialize RAG Service: %s", e, exc_info=True)
+
+    def query_lore(self, question: str) -> str:
+        """Retrieve relevant lore text for the given question."""
+        if not self.vector_store:
+            return "The Codex is currently offline or has no knowledge loaded."
+
+        logging.info("Performing similarity search for query: '%s'", question)
+        results = self.vector_store.similarity_search(question, k=3)
+
+        if not results:
+            return ""
+
+        context = "\n\n---\n\n".join(doc.page_content for doc in results)
+        return context

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,6 @@ pytest>=7.0
 pytest-asyncio>=1.0
 requests
 httpx
+langchain-community
+langchain-text-splitters
+faiss-cpu


### PR DESCRIPTION
## Summary
- implement `RAGService` using LangChain and FAISS
- add `/codex` cog that queries lore with RAG and summarizes with the GM model
- attach `OllamaService`, `RAGService`, and `AIAgent` during bot startup
- specify which cogs to load and load them explicitly
- update requirements
- keep legacy codex implementation as `codex_legacy.py`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686f017489c08327bb825a1a4c51db17