### PR TITLE
Update outdated discord-bot references

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -16,10 +16,10 @@ jobs:
           node-version: '20'
       - name: Install dependencies
         run: npm install
-        working-directory: discord-bot
+        working-directory: ironaccord-bot
       - name: Run ESLint
         run: npx --yes eslint .
-        working-directory: discord-bot
+        working-directory: ironaccord-bot
       - name: Run Tests
         run: npm test
-        working-directory: discord-bot
+        working-directory: ironaccord-bot

--- a/README.md
+++ b/README.md
@@ -4,10 +4,10 @@ This repository houses the Discord bot used for the auto battler experiments alo
 
 ## Repository Layout
 
-- `discord-bot/` – Node.js bot and MySQL schema (legacy implementation).
+- `ironaccord-bot/` – Python Discord bot and data files.
 - `docs/` – design notes and lore.
 - `index.html`, `poc2/` – early browser prototypes kept for reference.
-- `discord-bot/src/data/items.js` – base item definitions consumed by missions and rewards.
+- `ironaccord-bot/data/items.py` – base item definitions consumed by missions and rewards.
 
 ## Setup
 
@@ -15,13 +15,13 @@ This repository houses the Discord bot used for the auto battler experiments alo
 2. Copy `.env.example` to `.env` and provide your Discord token, application ID, guild ID and MySQL credentials. These values are required for the Python bot as well. The Node.js utilities additionally use `PVP_CHANNEL_ID` and `WEB_APP_URL`.
 3. Install dependencies and start the bot:
    ```bash
-   cd discord-bot
+   cd ironaccord-bot
    npm install
    node deploy-commands.js
    node index.js
    ```
 
-See [discord-bot/README.md](discord-bot/README.md) for additional details on running tests and migrating the database schema.
+See [ironaccord-bot/README.md](ironaccord-bot/README.md) for additional details on running tests and migrating the database schema.
 
 ## Python Bot
 
@@ -46,7 +46,7 @@ A small Python prototype is also provided. Environment variables match the Node.
 
 ## Item Data
 
-Base item properties live in `discord-bot/src/data/items.js`. The mission engine and other services import this file to look up item bonuses when applying rewards or combat modifiers.
+Base item properties live in `ironaccord-bot/data/items.py`. The mission engine and other services import this file to look up item bonuses when applying rewards or combat modifiers.
 
 ## Running Python Tests
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -21,7 +21,7 @@ The snarky shopkeeper NPC is detailed in [edraz_character_bible.md](edraz_charac
 
 ## Mission Data Fields
 
-Mission JSON files are stored in `discord-bot/src/data/missions`. Each mission defines several rounds of player choices. Choice objects support additional fields used during combat:
+Mission JSON files are stored in `ironaccord-bot/data/missions`. Each mission defines several rounds of player choices. Choice objects support additional fields used during combat:
 
 - `combat` – boolean indicating that selecting the choice triggers a combat roll.
 - `dc` – numeric difficulty class for that roll.

--- a/docs/archive/ImageGen.md
+++ b/docs/archive/ImageGen.md
@@ -1,6 +1,6 @@
 # Image Generation Utility
 
-This bot composes team images using the `makeTeamImage` helper. Icons are loaded from `discord-bot/assets/heroes`.
+This bot composes team images using the `makeTeamImage` helper. Icons are loaded from `ironaccord-bot/assets/heroes`.
 
 ## Usage
 
@@ -14,7 +14,7 @@ The function returns a PNG `Buffer` that can be attached to a Discord message.
 ## Folder Structure
 
 ```
-discord-bot/
+ironaccord-bot/
   assets/
     heroes/
       hero-1.png

--- a/docs/archive/poc_html_GDD.md
+++ b/docs/archive/poc_html_GDD.md
@@ -61,7 +61,7 @@
 *   **Tailwind CSS for Rapid UI Prototyping:** Demonstrates the utility of a utility-first CSS framework for quickly building UI mockups.
 
 ## 8. Connections to Other Projects
-*   **Visual Basis:** Provides a potential visual direction for the cards used in the `auto-battler-react/` client and the `discord-bot/` (especially for `cardRenderer.js`).
+*   **Visual Basis:** Provides a potential visual direction for the cards used in the `auto-battler-react/` client and the `ironaccord-bot/` (especially for `cardRenderer.js`).
 *   **Data Structure Ideas:** The hardcoded data (hero stats, abilities) reflects the kind of information that is structured in `data.js` files in other projects.
 *   The "Ultra Rare" rarity used here likely corresponds to the "Epic" rarity defined in the main game data.
 

--- a/docs/archive/roadmap.md
+++ b/docs/archive/roadmap.md
@@ -22,14 +22,14 @@ A robust progression system beyond simple hero acquisition to keep players engag
 
 ### Leveling and Experience (XP)
 **Implementation Plan:**
--   **Database:** Propose adding `xp` and `level` columns to a new `user_heroes` table in `discord-bot/db-schema.sql`. This table would link users (`discord_id`) to `allPossibleHeroes` (`id`) and store instance-specific data.
+-   **Database:** Propose adding `xp` and `level` columns to a new `user_heroes` table in `ironaccord-bot/db-schema.sql`. This table would link users (`discord_id`) to `allPossibleHeroes` (`id`) and store instance-specific data.
 -   **Game Engine:** Modify `backend/game/engine.js` to calculate and return the XP awarded at the end of a battle based on the outcome.
--   **Discord Bot:** Update the `InteractionCreate` handler in `discord-bot/index.js`. After a battle completes, update the user's XP in the database and notify them if they've leveled up.
+-   **Discord Bot:** Update the `InteractionCreate` handler in `ironaccord-bot/index.js`. After a battle completes, update the user's XP in the database and notify them if they've leveled up.
 
 ### Skill Trees
 **Implementation Plan:**
 -   **Data Structure:** Propose a new object, `allHeroSkillTrees`, in `backend/game/data.js` to define unique skills for each hero class.
--   **Discord Command:** Suggest a new command, `/skills [hero]`, in the `discord-bot/commands/` directory that allows a player to view their hero's skill tree and spend skill points.
+-   **Discord Command:** Suggest a new command, `/skills [hero]`, in the `ironaccord-bot/commands/` directory that allows a player to view their hero's skill tree and spend skill points.
 
 ### Prestige/Evolution
 **Implementation Plan:**
@@ -46,13 +46,13 @@ The core combat is already implemented but can be expanded for a Discord environ
 
 ### Party System
 **Implementation Plan:**
--   **Session Management:** Suggest expanding `discord-bot/sessionManager.js` to handle multiple users in a single draft/battle session.
+-   **Session Management:** Suggest expanding `ironaccord-bot/sessionManager.js` to handle multiple users in a single draft/battle session.
 -   **Database:** Modify the `games` table in `db-schema.sql` to allow for multiple player IDs (e.g., `player1_id`, `player2_id`, etc.).
 
 ### Detailed Combat Logs
 **Implementation Plan:**
     -   **Existing Feature:** Note that `BattleScene.jsx` in `auto-battler-react/src/scenes` and the `GameEngine` in the backend already produce detailed battle logs.
--   **Discord Display:** The task is to format this log output within a Discord embed, potentially using pagination for long fights. Reference the simple embed builder in `discord-bot/src/utils/embedBuilder.js`.
+-   **Discord Display:** The task is to format this log output within a Discord embed, potentially using pagination for long fights. Reference the simple embed builder in `ironaccord-bot/src/utils/embedBuilder.js`.
 
 ## 3. In-Game Economy and Currency
 A currency system will motivate players. Reference `docs/progression_economy_gdd.md`.
@@ -82,7 +82,7 @@ A currency system will motivate players. Reference `docs/progression_economy_gdd
 **Sub-Features & Implementation Plan:**
 -   **Daily/Weekly Quests:**
     -   **Data Structure:** Define quest types (e.g., 'win_x_battles', 'collect_y_heroes') in `backend/game/data.js`.
-    -   **Discord Bot:** A system in `discord-bot/index.js` to assign daily/weekly quests and track progress, storing status in a new `user_quests` table.
+    -   **Discord Bot:** A system in `ironaccord-bot/index.js` to assign daily/weekly quests and track progress, storing status in a new `user_quests` table.
 -   **Achievement Tiers:**
     -   **Database:** A new `achievements` table (id, name, description, criteria) and `user_achievements` (user_id, achievement_id, progress).
     -   **Discord Command:** `/achievements` to view completed and in-progress achievements.
@@ -91,7 +91,7 @@ A currency system will motivate players. Reference `docs/progression_economy_gdd
 **Summary:** Host time-limited events and tournaments with unique rules and rewards.
 **Sub-Features & Implementation Plan:**
 -   **Event System:**
-    -   **Session Management:** Extend `discord-bot/sessionManager.js` to manage event-specific states (e.g., tournament brackets, special event currency).
+    -   **Session Management:** Extend `ironaccord-bot/sessionManager.js` to manage event-specific states (e.g., tournament brackets, special event currency).
     -   **Discord Commands:** `/event join [event_name]`, `/tournament register`.
 -   **Special Game Modes:**
     -   **Game Engine:** Allow `backend/game/engine.js` to accept modifiers or rule variations for event battles. Reference `docs/game_modes_gdd.md`.
@@ -100,7 +100,7 @@ A currency system will motivate players. Reference `docs/progression_economy_gdd
 **Summary:** Allow players to personalize their heroes with cosmetic items.
 **Sub-Features & Implementation Plan:**
 -   **Skins/Variant Art:**
-    -   **Asset Storage:** Store alternative hero art in `discord-bot/assets/heroes/[hero_name]/skins/`.
+    -   **Asset Storage:** Store alternative hero art in `ironaccord-bot/assets/heroes/[hero_name]/skins/`.
     -   **Database:** A `user_hero_cosmetics` table to track unlocked skins for each hero instance.
     -   **Discord Command:** `/equip_skin [hero] [skin_name]`.
 -   **Titles and Badges:**
@@ -122,10 +122,10 @@ A currency system will motivate players. Reference `docs/progression_economy_gdd
 **Summary:** Introduce engaging minigames for players to earn rewards or pass the time.
 **Sub-Features & Implementation Plan:**
 -   **Example Minigame (e.g., Gacha/Card Pack Opening):**
-    -   **Existing Logic:** Reference `discord-bot/commands/openpack.js` for the gacha mechanism.
+    -   **Existing Logic:** Reference `ironaccord-bot/commands/openpack.js` for the gacha mechanism.
     -   **Expansion:** Could be expanded with different pack types or probabilities defined in `backend/game/data.js`.
 -   **Other Minigames:**
-    -   **System Design:** Propose simple text-based or RNG games initially, managed within new commands in `discord-bot/commands/`.
+    -   **System Design:** Propose simple text-based or RNG games initially, managed within new commands in `ironaccord-bot/commands/`.
 
 ## 10. Story Mode and Lore Integration
 **Summary:** Develop a narrative campaign or integrate lore elements to enrich the game world.


### PR DESCRIPTION
## Summary
- fix mission data path in docs
- update README to reference `ironaccord-bot`
- update archived docs and CI workflow with new path

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686f0452d8d483278cb50f3506592da2