### PR TITLE
Fix startup race in bot and add tqdm dependency

### DIFF
--- a/ironaccord-bot/requirements.txt
+++ b/ironaccord-bot/requirements.txt
@@ -13,6 +13,7 @@ httpx==0.27.0
 langchain==0.1.16
 langchain-community==0.0.32
 faiss-cpu==1.7.4 # For local vector storage
+tqdm==4.66.4
 
 # Testing Framework
 pytest==8.2.2


### PR DESCRIPTION
## Summary
- load dependencies before loading cogs by restructuring `bot.py`
- add `tqdm` to requirements for the Discord bot

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686f11015f6c8327826d015b95779c08