### PR TITLE
Add unstructured requirement and fix cog path

### DIFF
--- a/ironaccord-bot/bot.py
+++ b/ironaccord-bot/bot.py
@@ -31,7 +31,8 @@ logging.info("Services initialized.")
 
 # --- Cog Loading ---
 logging.info("Loading cogs...")
-for filename in os.listdir("./ironaccord-bot/cogs"):
+cogs_path = "./cogs"
+for filename in os.listdir(cogs_path):
     if filename.endswith(".py") and not filename.startswith("__"):
         try:
             cog_name = f"cogs.{filename[:-3]}"

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,5 @@ httpx
 langchain-community
 langchain-text-splitters
 faiss-cpu
+unstructured==0.12.6
+pypdf==4.2.0


### PR DESCRIPTION
## Summary
- install `unstructured` and `pypdf`
- add these packages to `requirements.txt`
- load cogs from `./cogs` instead of `./ironaccord-bot/cogs`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686f129b3a008327a8f904cfe3480a97