### PR TITLE
Fix bot async startup and add markdown dependency

### DIFF
--- a/ironaccord-bot/requirements.txt
+++ b/ironaccord-bot/requirements.txt
@@ -14,6 +14,7 @@ langchain==0.1.16
 langchain-community==0.0.32
 faiss-cpu==1.7.4 # For local vector storage
 tqdm==4.66.4
+markdown
 
 # Testing Framework
 pytest==8.2.2


### PR DESCRIPTION
## Summary
- make bot startup async so cogs load before commands sync
- await cog loading and run bot via `asyncio.run()`
- add missing `markdown` loader dependency

## Testing
- `pip install -r ironaccord-bot/requirements.txt` *(fails: Failed to build faiss-cpu)*
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement unstructured==0.12.6)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_e_686f22d2e2c88327ac4e6adc3693654e