### PR TITLE
Add ChromaDB ingestion and refactor RAG service

### DIFF
--- a/ironaccord-bot/cogs/codex.py
+++ b/ironaccord-bot/cogs/codex.py
@@ -20,9 +20,9 @@ class CodexCog(commands.Cog):
         """Handle the `/codex` slash command."""
         await interaction.response.defer()
 
-        retrieved_context = self.rag_service.query_lore(query)
+        results = self.rag_service.query(query)
 
-        if not retrieved_context or "offline" in retrieved_context:
+        if not results:
             embed = discord.Embed(
                 title=f"Codex Entry: {query}",
                 description="I could not find any information on that topic in my archives.",
@@ -30,6 +30,8 @@ class CodexCog(commands.Cog):
             )
             await interaction.followup.send(embed=embed)
             return
+
+        retrieved_context = "\n\n---\n\n".join([doc.page_content for doc in results])
 
         prompt = f"""
         You are a helpful assistant. Based ONLY on the following context, provide a concise answer to the user's query.

--- a/ironaccord-bot/ingest.py
+++ b/ironaccord-bot/ingest.py
@@ -1,0 +1,96 @@
+import os
+import glob
+import logging
+import chromadb
+from langchain.document_loaders import UnstructuredMarkdownLoader
+from langchain.text_splitter import RecursiveCharacterTextSplitter
+from langchain.embeddings import HuggingFaceEmbeddings
+
+# --- Configuration ---
+# Point to the local ChromaDB server
+CHROMA_HOST = "localhost"
+CHROMA_PORT = "8000"
+# This is the name of the collection inside ChromaDB
+# Think of it like a table name in a traditional database
+COLLECTION_NAME = "iron_accord_lore"
+# Path to your lore documents
+DOCS_PATH = "../docs"
+# Model used to create embeddings. "all-MiniLM-L6-v2" is a great starting point.
+EMBEDDING_MODEL = "sentence-transformers/all-MiniLM-L6-v2"
+
+# --- Logging Setup ---
+logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - %(message)s')
+
+def ingest_data():
+    """
+    Connects to ChromaDB, processes markdown files, and ingests them into a collection.
+    """
+    logging.info("--- Starting Data Ingestion Process ---")
+
+    # --- 1. Connect to ChromaDB ---
+    try:
+        logging.info(f"Connecting to ChromaDB at {CHROMA_HOST}:{CHROMA_PORT}...")
+        client = chromadb.HttpClient(host=CHROMA_HOST, port=CHROMA_PORT)
+        logging.info("Successfully connected to ChromaDB.")
+    except Exception as e:
+        logging.critical(f"Failed to connect to ChromaDB. Is it running? Error: {e}")
+        return
+
+    # --- 2. Get or Create the Collection ---
+    logging.info(f"Accessing collection: '{COLLECTION_NAME}'")
+    collection = client.get_or_create_collection(name=COLLECTION_NAME)
+    logging.info("Collection is ready.")
+
+    # --- 3. Load and Process Documents ---
+    logging.info(f"Scanning for documents in: {DOCS_PATH}")
+    try:
+        md_files = glob.glob(os.path.join(DOCS_PATH, "**/*.md"), recursive=True)
+        total_files = len(md_files)
+        if total_files == 0:
+            logging.error("No markdown documents found. Aborting.")
+            return
+        logging.info(f"Found {total_files} documents to process.")
+    except Exception as e:
+        logging.critical(f"Failed to scan for documents. Error: {e}")
+        return
+
+    all_docs = []
+    for i, doc_path in enumerate(md_files):
+        logging.info(f"Loading document [{i+1}/{total_files}]: {os.path.basename(doc_path)}")
+        try:
+            loader = UnstructuredMarkdownLoader(doc_path, mode="elements")
+            docs = loader.load()
+            all_docs.extend(docs)
+        except Exception as e:
+            logging.error(f"Failed to load or process document {doc_path}: {e}")
+            continue
+
+    if not all_docs:
+        logging.error("No documents were successfully loaded. Aborting ingestion.")
+        return
+
+    # --- 4. Split Documents into Chunks ---
+    logging.info("Splitting documents into manageable chunks...")
+    text_splitter = RecursiveCharacterTextSplitter(chunk_size=1024, chunk_overlap=128)
+    chunks = text_splitter.split_documents(all_docs)
+    logging.info(f"Split documents into {len(chunks)} chunks.")
+
+    # --- 5. Add Chunks to ChromaDB ---
+    logging.info("Starting ingestion of chunks into ChromaDB. This may take a while...")
+
+    chunk_texts = [chunk.page_content for chunk in chunks]
+    chunk_metadatas = [chunk.metadata for chunk in chunks]
+    chunk_ids = [f"chunk_{i}" for i in range(len(chunks))]
+
+    try:
+        collection.add(
+            documents=chunk_texts,
+            metadatas=chunk_metadatas,
+            ids=chunk_ids
+        )
+        logging.info(f"--- Successfully ingested {len(chunks)} chunks into ChromaDB! ---")
+    except Exception as e:
+        logging.critical(f"Failed during batch ingestion. Error: {e}")
+
+if __name__ == "__main__":
+    ingest_data()

--- a/ironaccord-bot/requirements.txt
+++ b/ironaccord-bot/requirements.txt
@@ -18,3 +18,6 @@ markdown
 
 # Testing Framework
 pytest==8.2.2
+
+# Vector store
+chromadb

--- a/ironaccord-bot/tests/test_rag_service.py
+++ b/ironaccord-bot/tests/test_rag_service.py
@@ -1,59 +1,51 @@
-import os
-import logging
 import pytest
 
 from services import rag_service
 
 
-def dummy_build(self, embeddings):
-    self.vector_store = True
+class DummyClient:
+    pass
 
 
-def dummy_embeddings(*args, **kwargs):
-    return None
+class DummyChroma:
+    def __init__(self, *args, **kwargs):
+        self.args = args
+        self.kwargs = kwargs
+
+    def similarity_search(self, query_text, k=5):
+        return [f"result-{i}" for i in range(k)]
 
 
-class DummyFAISS:
-    @staticmethod
-    def load_local(*args, **kwargs):
-        return True
+class DummyEmbeddings:
+    pass
 
 
-@pytest.mark.asyncio
-async def test_cache_dir_created_and_writable(tmp_path, monkeypatch, caplog):
-    cache_dir = tmp_path / "cache"
-    index_path = cache_dir / "faiss_index"
-    monkeypatch.setattr(rag_service, "FAISS_INDEX_PATH", str(index_path))
-    monkeypatch.setattr(rag_service, "CACHE_DIRECTORY", str(cache_dir))
-    monkeypatch.setattr(rag_service.RAGService, "_build_and_cache_index", dummy_build)
-    monkeypatch.setattr(rag_service, "OllamaEmbeddings", dummy_embeddings)
-    monkeypatch.setattr(rag_service, "FAISS", DummyFAISS)
+def test_initialize_and_query(monkeypatch):
+    created = {}
 
-    caplog.set_level(logging.INFO)
-    rag_service.RAGService()
+    def dummy_http_client(*args, **kwargs):
+        created["client"] = True
+        return DummyClient()
 
-    assert cache_dir.exists()
-    assert any("Cache directory not found" in m for m in caplog.messages)
-    assert any("is writable" in m for m in caplog.messages)
+    monkeypatch.setattr(rag_service.chromadb, "HttpClient", dummy_http_client)
+    monkeypatch.setattr(rag_service, "HuggingFaceEmbeddings", lambda *a, **kw: DummyEmbeddings())
+    monkeypatch.setattr(rag_service, "Chroma", lambda *a, **kw: DummyChroma(*a, **kw))
+
+    service = rag_service.RAGService()
+
+    assert isinstance(service.vector_store, DummyChroma)
+    assert created.get("client")
+
+    results = service.query("test", k=2)
+    assert results == ["result-0", "result-1"]
 
 
-@pytest.mark.asyncio
-async def test_cache_dir_not_writable(tmp_path, monkeypatch):
-    cache_dir = tmp_path / "cache"
-    index_path = cache_dir / "faiss_index"
-    cache_dir.mkdir()
-    monkeypatch.setattr(rag_service, "FAISS_INDEX_PATH", str(index_path))
-    monkeypatch.setattr(rag_service, "CACHE_DIRECTORY", str(cache_dir))
-    monkeypatch.setattr(rag_service.RAGService, "_build_and_cache_index", dummy_build)
-    monkeypatch.setattr(rag_service, "OllamaEmbeddings", dummy_embeddings)
-    monkeypatch.setattr(rag_service, "FAISS", DummyFAISS)
+def test_query_without_vector_store(monkeypatch):
+    def fail_client(*args, **kwargs):
+        raise RuntimeError("no connection")
 
-    def fake_access(path, mode):
-        if path == str(cache_dir):
-            return False
-        return os.access(path, mode)
+    monkeypatch.setattr(rag_service.chromadb, "HttpClient", fail_client)
 
-    monkeypatch.setattr(os, "access", fake_access)
-
-    with pytest.raises(PermissionError):
-        rag_service.RAGService()
+    service = rag_service.RAGService()
+    assert service.vector_store is None
+    assert service.query("anything") == []


### PR DESCRIPTION
## Summary
- add `chromadb` dependency
- create `ingest.py` for loading markdown docs into ChromaDB
- refactor `RAGService` to connect to a running ChromaDB instance
- update Codex cog to use new RAG service API
- update unit tests for the new service

## Testing
- `pip install -r requirements.txt`
- `pip install -r ironaccord-bot/requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686f2b7a4a2c8327990c1b23f4230216