### PR TITLE
Ensure commands sync on bot startup

### DIFF
--- a/ironaccord-bot/bot.py
+++ b/ironaccord-bot/bot.py
@@ -1,68 +1,72 @@
 import os
-import logging
-import asyncio
 import discord
 from discord.ext import commands
 from dotenv import load_dotenv
+import logging
+import asyncio
 
-from services.ollama_service import OllamaService
-from services.rag_service import RAGService
+# --- Local Imports ---
 from ai.ai_agent import AIAgent
+from services.rag_service import RAGService
 
-# --- Basic Logging Setup ---
-logging.basicConfig(
-    level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s"
-)
-logger = logging.getLogger(__name__)
-
-# --- Load Environment Variables ---
+# --- Environment and Logging ---
 load_dotenv()
-DISCORD_TOKEN = os.getenv("DISCORD_TOKEN")
+TOKEN = os.getenv("DISCORD_TOKEN")
+logger = logging.getLogger("discord")
 
-# --- Bot Initialization ---
+# --- Bot Intents ---
 intents = discord.Intents.default()
 intents.message_content = True
-bot = commands.Bot(command_prefix="!", intents=intents)
+intents.members = True
 
+# --- Bot Definition ---
+class IronAccordBot(commands.Bot):
+    def __init__(self):
+        super().__init__(command_prefix="!", intents=intents)
+        # --- Service Initialization ---
+        self.rag_service = RAGService()
+        self.ai_agent = AIAgent()
 
-async def load_cogs(bot: commands.Bot) -> None:
-    for filename in os.listdir("./cogs"):
-        if filename.endswith(".py") and filename != "__init__.py":
-            cog_name = f"cogs.{filename[:-3]}"
-            try:
-                await bot.load_extension(cog_name)
-                logger.info(f"Loaded cog: {cog_name}")
-            except Exception as e:
-                logger.error(f"Failed to load cog {cog_name}: {e}")
+bot = IronAccordBot()
 
-
-async def main() -> None:
-    """Main function to run the bot."""
-    logger.info("Initializing services...")
-    bot.ollama_service = OllamaService()
-    bot.rag_service = RAGService()
-    bot.agent = AIAgent()
-    logger.info("Services initialized.")
-
-    logger.info("Loading cogs...")
-    await load_cogs(bot)
-
-    if DISCORD_TOKEN:
-        await bot.start(DISCORD_TOKEN)
-    else:
-        logger.error("FATAL: DISCORD_TOKEN not found in .env file. Bot cannot start.")
-
-
-# --- Bot Events ---
+# --- THE CRUCIAL PART: on_ready Event ---
 @bot.event
 async def on_ready():
-    """Called when the bot is fully logged in and ready."""
-    print("────────────────────")
-    print(f"Logged in as {bot.user.name} (ID: {bot.user.id})")
-    print("────────────────────")
-    await bot.change_presence(activity=discord.Game(name="Iron Accord | /start"))
+    """Called when the bot is ready and connected to Discord."""
+    logger.info(f'Logged in as {bot.user.name} (ID: {bot.user.id})')
+    logger.info('────────────────────')
+
+    try:
+        synced = await bot.tree.sync()
+        logger.info(f"Synced {len(synced)} slash command(s).")
+    except Exception as e:
+        logger.error(f"Failed to sync command tree: {e}")
+
+
+async def load_cogs():
+    """Loads all cogs from the cogs directory."""
+    for filename in os.listdir("./cogs"):
+        if filename.endswith(".py") and not filename.startswith("__"):
+            try:
+                await bot.load_extension(f"cogs.{filename[:-3]}")
+                logger.info(f"Loaded cog: cogs.{filename[:-3]}")
+            except Exception as e:
+                logger.error(f"Failed to load cog {filename}: {e}")
+
+
+async def main():
+    """Main function to setup and run the bot."""
+    logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - %(message)s')
+    logger.info("Loading cogs...")
+    await load_cogs()
+
+    logger.info("Bot is starting...")
+    await bot.start(TOKEN)
 
 
 # --- Run the Bot ---
 if __name__ == "__main__":
-    asyncio.run(main())
+    try:
+        asyncio.run(main())
+    except KeyboardInterrupt:
+        logger.info("Bot shutting down.")


### PR DESCRIPTION
## Summary
- sync slash commands in `on_ready`
- streamline bot initialization without unused services
- update main entrypoint and logging

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686fe79196cc8327ac57be6237e4b19a