### PR TITLE
Fix README to remove old Node.js instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Auto Battler
 
-This repository houses the Discord bot used for the auto battler experiments along with various design documents and legacy HTML prototypes. The previous React client and Express server have been removed. A Python rewrite of the bot is underway but the existing Node.js implementation remains for now.
+This repository houses the Discord bot used for the auto battler experiments along with various design documents and legacy HTML prototypes. The earlier Node.js implementation and React client have been removed; the bot is now written entirely in Python.
 
 ## Repository Layout
 
@@ -11,37 +11,17 @@ This repository houses the Discord bot used for the auto battler experiments alo
 
 ## Setup
 
-1. Install [Node.js](https://nodejs.org/) version 20 or newer. Tests require Node 20+.
-2. Copy `.env.example` to `.env` and provide your Discord token, application ID, guild ID and MySQL credentials. These values are required for the Python bot as well. The Node.js utilities additionally use `PVP_CHANNEL_ID` and `WEB_APP_URL`.
-3. Install dependencies and start the bot:
+1. Install **Python 3.11+**.
+2. Copy `.env.example` to `.env` and provide your Discord token, application ID, guild ID and MySQL credentials.
+3. Install dependencies:
    ```bash
-   cd ironaccord-bot
-   npm install
-   node deploy-commands.js
-   node index.js
-   ```
-
-See [ironaccord-bot/README.md](ironaccord-bot/README.md) for additional details on running tests and migrating the database schema.
-
-## Python Bot
-
-A small Python prototype is also provided. Environment variables match the Node.js version and should be defined in `.env`:
-
-1. Copy `.env.example` to `.env` and supply values for `DISCORD_TOKEN`, `APP_ID`, and `GUILD_ID`.
-2. Install dependencies and start the bot:
-   ```bash
-   cd ironaccord-bot
    pip install -r requirements.txt
-   ```
-3. Install dependencies for the Iron Accord bot:
-   ```bash
    pip install -r ironaccord-bot/requirements.txt
    ```
-4. Deploy commands and start the bot:
+4. Start the bot:
    ```bash
-  python deploy_commands.py
-  python bot.py
-  ```
+   python ironaccord-bot/bot.py
+   ```
 5. Once the bot is online, use `/start` in your Discord server to begin character creation.
 
 ## Item Data


### PR DESCRIPTION
## Summary
- clarify that only the Python bot remains
- simplify setup steps to cover Python only

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_e_686fe7ac8dc88327b965fee72262cd27