### PR TITLE
Fix CodexCog initialization

### DIFF
--- a/ironaccord-bot/bot.py
+++ b/ironaccord-bot/bot.py
@@ -26,6 +26,8 @@ class IronAccordBot(commands.Bot):
         # --- Service Initialization ---
         self.rag_service = RAGService()
         self.ai_agent = AIAgent()
+        # Expose the Ollama service directly for cogs expecting it
+        self.ollama_service = self.ai_agent.ollama_service
 
 bot = IronAccordBot()
 

--- a/ironaccord-bot/tests/test_bot.py
+++ b/ironaccord-bot/tests/test_bot.py
@@ -1,0 +1,20 @@
+import pytest
+
+from ironaccord_bot.bot import IronAccordBot
+
+class DummyService:
+    pass
+
+class DummyAgent:
+    def __init__(self):
+        self.ollama_service = DummyService()
+
+class DummyRAG:
+    pass
+
+
+def test_bot_exposes_ollama_service(monkeypatch):
+    monkeypatch.setattr('ironaccord_bot.bot.RAGService', lambda: DummyRAG())
+    monkeypatch.setattr('ironaccord_bot.bot.AIAgent', DummyAgent)
+    bot = IronAccordBot()
+    assert bot.ollama_service is bot.ai_agent.ollama_service


### PR DESCRIPTION
## Summary
- expose the Ollama service on `IronAccordBot`
- add regression test for the new attribute

## Testing
- `pip install discord.py chromadb`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686fecbdad0c8327b186c95c6ef5ad51