### PR TITLE
Implement command redeployment mode

### DIFF
--- a/ironaccord-bot/tests/test_redeploy.py
+++ b/ironaccord-bot/tests/test_redeploy.py
@@ -1,0 +1,60 @@
+import pytest
+
+discord = pytest.importorskip("discord")
+
+from ironaccord_bot import bot as bot_module
+
+
+class DummyTree:
+    def __init__(self):
+        self.cleared = False
+        self.synced = False
+
+    async def clear_commands(self, guild=None):
+        self.cleared = True
+        return []
+
+    async def sync(self):
+        self.synced = True
+        return []
+
+
+class DummyUser:
+    name = "Test"
+    id = 1
+
+
+@pytest.mark.asyncio
+async def test_on_ready_clears_when_redeploy(monkeypatch):
+    dummy_bot = type("Bot", (), {})()
+    dummy_bot.user = DummyUser()
+    dummy_bot.tree = DummyTree()
+    dummy_bot.redeploy = True
+
+    monkeypatch.setattr(bot_module, "bot", dummy_bot)
+
+    await bot_module.on_ready()
+
+    assert dummy_bot.tree.cleared
+    assert dummy_bot.tree.synced
+
+
+@pytest.mark.asyncio
+async def test_on_ready_no_clear_without_flag(monkeypatch):
+    dummy_bot = type("Bot", (), {})()
+    dummy_bot.user = DummyUser()
+    dummy_bot.tree = DummyTree()
+    dummy_bot.redeploy = False
+
+    monkeypatch.setattr(bot_module, "bot", dummy_bot)
+
+    await bot_module.on_ready()
+
+    assert not dummy_bot.tree.cleared
+    assert dummy_bot.tree.synced
+
+
+def test_redeploy_default_false():
+    bot = bot_module.IronAccordBot()
+    assert bot.redeploy is False
+


### PR DESCRIPTION
## Summary
- add optional `--redeploy` startup flag
- clear and resync slash commands when in redeploy mode
- expose redeploy attribute on bot
- test clearing behaviour and default flag

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686ffe42002c8327900bd7a2eb17106d