### PR TITLE
Add Iron Accord background documentation

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -17,6 +17,7 @@ Background lore for the Iron Accord has been split into several focused files:
 - [lore/mythology_of_metal.md](lore/mythology_of_metal.md)
 - [lore/story_design_principles.md](lore/story_design_principles.md)
 - [lore/narrative_hooks.md](lore/narrative_hooks.md)
+- [backgrounds/iron_accord/README.md](backgrounds/iron_accord/README.md)
 
 The original combined document lives in
 [archive/iron_accord_lore_gdd.md](archive/iron_accord_lore_gdd.md). The

--- a/docs/backgrounds/iron_accord/README.md
+++ b/docs/backgrounds/iron_accord/README.md
@@ -1,0 +1,14 @@
+# Iron Accord Backgrounds
+
+This directory holds sample backgrounds for Iron Accord characters. Each file outlines flavor, skills, gear, hooks, mechanics, and advancement notes.
+
+- [guild_apprentice.md](guild_apprentice.md): A young worker bound to a guild who learned craft and record keeping.
+- [steamwright.md](steamwright.md): A tinkerer who keeps steam gear running with clever repairs.
+- [marshal.md](marshal.md): An enforcer of council law trained to maintain public order.
+- [cipher.md](cipher.md): A secretive agent who handles codes and couriers across the land.
+- [salvage_scout.md](salvage_scout.md): A wanderer who scours ruins for scrap and hidden caches.
+- [field_healer.md](field_healer.md): A medic skilled in tending wounds with limited tools.
+- [clockwork_guard.md](clockwork_guard.md): A sentinel who pilots and repairs steam-driven defenders.
+- [communal_farmer.md](communal_farmer.md): A crop tender from the communal plots outside the city.
+- [lore_keeper.md](lore_keeper.md): A recorder of history charged with keeping the Accord's stories alive.
+- [street_urchin.md](street_urchin.md): A survivor of the alleys who trades in secrets and swift escapes.

--- a/docs/backgrounds/iron_accord/cipher.md
+++ b/docs/backgrounds/iron_accord/cipher.md
@@ -1,0 +1,31 @@
+# Cipher
+
+**Flavor Description**
+Trained to protect and decode the Accord's secret communications.
+
+### Typical Skills/Knowledge
+- message encryption
+- forgery detection
+- covert travel methods
+- spycraft tradition
+
+### Starting Gear or Contacts
+- cipher wheel or codebook
+- courier network contact
+
+### Roleplay Hooks/Flaws
+- suspicious of strangers
+- enjoys puzzles
+- keeps secrets
+- reluctant to share personal history
+
+### Example Story Hooks
+- intercept a dangerous message
+- smuggle a sealed packet across enemy lines
+
+### Mechanics
+- easier to create or break codes
+- can request courier assistance
+
+### Advancement Notes
+May join the council as an intelligence advisor.

--- a/docs/backgrounds/iron_accord/clockwork_guard.md
+++ b/docs/backgrounds/iron_accord/clockwork_guard.md
@@ -1,0 +1,33 @@
+# Clockwork Guard
+
+**Flavor Description**
+You maintain and pilot steam-driven constructs that protect settlements.
+
+### Typical Skills/Knowledge
+- machine operation
+- heavy armor use
+- tactics for defense
+- basic maintenance
+
+### Starting Gear or Contacts
+- repair hammer
+- basic exosuit or automaton
+- official guard contact
+- access to guard barracks
+
+### Roleplay Hooks/Flaws
+- sworn to duty
+- distrusts wild tech
+- slow to trust outsiders
+- sees the world in black and white
+
+### Example Story Hooks
+- escort a caravan
+- defend a forge from raiders
+
+### Mechanics
+- proficient with heavy gear
+- command automaton guardians
+
+### Advancement Notes
+Could craft custom machines or lead recruits.

--- a/docs/backgrounds/iron_accord/communal_farmer.md
+++ b/docs/backgrounds/iron_accord/communal_farmer.md
@@ -1,0 +1,33 @@
+# Communal Farmer
+
+**Flavor Description**
+Raised on shared plots outside the city, you know how to coax crops from dusty soil.
+
+### Typical Skills/Knowledge
+- agriculture
+- animal care
+- simple carpentry
+- crop rotation knowledge
+
+### Starting Gear or Contacts
+- sturdy hoe
+- seed pouch
+- family network
+- farmhand contact
+
+### Roleplay Hooks/Flaws
+- values cooperation
+- distrusts hoarders
+- cares for distant family
+- frets over poor harvests
+
+### Example Story Hooks
+- trade produce with merchants
+- handle pests threatening crops
+
+### Mechanics
+- bonus on foraging
+- improved trade with rural folk
+
+### Advancement Notes
+May oversee a commune or handle supply lines.

--- a/docs/backgrounds/iron_accord/field_healer.md
+++ b/docs/backgrounds/iron_accord/field_healer.md
@@ -1,0 +1,33 @@
+# Field Healer
+
+**Flavor Description**
+A medic trained to treat wounds with minimal equipment.
+
+### Typical Skills/Knowledge
+- first aid
+- herbal remedies
+- simple surgery
+- crisis triage
+
+### Starting Gear or Contacts
+- medical pouch
+- herbal kit
+- access to an infirmary
+- trusted nurse contact
+
+### Roleplay Hooks/Flaws
+- compassionate to a fault
+- haunted by past failures
+- expects respect
+- quick to help the wounded
+
+### Example Story Hooks
+- save a wounded scout
+- gather rare herbs for a plague
+
+### Mechanics
+- restores extra hit points
+- reduces downtime after injuries
+
+### Advancement Notes
+Might oversee a clinic or train new medics.

--- a/docs/backgrounds/iron_accord/guild_apprentice.md
+++ b/docs/backgrounds/iron_accord/guild_apprentice.md
@@ -1,0 +1,31 @@
+# Guild Apprentice
+
+**Flavor Description**
+A junior member of a trade guild who follows strict codes and hones a chosen craft.
+
+### Typical Skills/Knowledge
+- forgecraft basics
+- inventory tracking
+- metal shaping
+- meeting quotas
+
+### Starting Gear or Contacts
+- guild token
+- simple tool set
+
+### Roleplay Hooks/Flaws
+- loyal to guild traditions
+- protective of secrets
+- naive about politics
+- tends to lecture novices
+
+### Example Story Hooks
+- finish a masterwork for a mentor
+- deliver a message across enemy lines
+
+### Mechanics
+- gain advantage on checks to craft simple items
+- repairs cost fewer resources
+
+### Advancement Notes
+Over time you may open a workshop or lead apprentices.

--- a/docs/backgrounds/iron_accord/lore_keeper.md
+++ b/docs/backgrounds/iron_accord/lore_keeper.md
@@ -1,0 +1,33 @@
+# Lore Keeper
+
+**Flavor Description**
+You study oral histories and maintain the Accord's written records.
+
+### Typical Skills/Knowledge
+- research
+- storytelling
+- ancient languages
+- record keeping
+
+### Starting Gear or Contacts
+- library case
+- scrolls
+- mentor in archives
+- connections to traveling scribes
+
+### Roleplay Hooks/Flaws
+- curious by nature
+- long-winded
+- protective of records
+- clashes with revisionists
+
+### Example Story Hooks
+- recover lost texts
+- chronicle a hero's deeds
+
+### Mechanics
+- advantage on knowledge checks about the Accord
+- cite laws or traditions for persuasion
+
+### Advancement Notes
+Experienced keepers may teach apprentices or join the council.

--- a/docs/backgrounds/iron_accord/marshal.md
+++ b/docs/backgrounds/iron_accord/marshal.md
@@ -1,0 +1,33 @@
+# Marshal
+
+**Flavor Description**
+A sworn keeper of order who upholds the Council's law across Accord territory.
+
+### Typical Skills/Knowledge
+- investigation methods
+- crowd control
+- close-quarters training
+- command presence
+
+### Starting Gear or Contacts
+- badge of authority
+- baton or sidearm
+- network of deputies
+- access to jail resources
+
+### Roleplay Hooks/Flaws
+- bound by duty
+- skeptical of rebels
+- may overstep authority
+- values public order
+
+### Example Story Hooks
+- track a fugitive
+- mediate a dispute
+
+### Mechanics
+- intimidation checks easier in Accord settlements
+- may requisition common supplies
+
+### Advancement Notes
+Senior marshals command squads or travel as judges.

--- a/docs/backgrounds/iron_accord/salvage_scout.md
+++ b/docs/backgrounds/iron_accord/salvage_scout.md
@@ -1,0 +1,33 @@
+# Salvage Scout
+
+**Flavor Description**
+You range into the wasteland seeking usable scraps and hidden caches.
+
+### Typical Skills/Knowledge
+- scavenging
+- stealth in ruins
+- mapping hazardous areas
+- trap disarming
+
+### Starting Gear or Contacts
+- rugged backpack
+- pry bar
+- tattered maps
+- local salvage merchant contact
+
+### Roleplay Hooks/Flaws
+- thrill-seeker
+- mistrusts easy deals
+- hoards scrap
+- refuses to waste anything
+
+### Example Story Hooks
+- rumor of a new crash site
+- companions lost during a risky haul
+
+### Mechanics
+- find salvage more easily
+- navigate ruins safely
+
+### Advancement Notes
+May lead salvage teams or start a black market.

--- a/docs/backgrounds/iron_accord/steamwright.md
+++ b/docs/backgrounds/iron_accord/steamwright.md
@@ -1,0 +1,31 @@
+# Steamwright
+
+**Flavor Description**
+A tinker devoted to keeping steam-powered gear running through skill and improvisation.
+
+### Typical Skills/Knowledge
+- mechanical repair
+- steam engine theory
+- creative tinkering
+- safe pressure management
+
+### Starting Gear or Contacts
+- well-worn tool satchel
+- jar of spare valves
+
+### Roleplay Hooks/Flaws
+- obsessed with efficiency
+- suspicious of untested ideas
+- proud of workmanship
+- open to barter
+
+### Example Story Hooks
+- fix a derelict exosuit
+- deliver custom engine parts
+
+### Mechanics
+- repair steam gear with fewer parts
+- advantage when diagnosing mechanical faults
+
+### Advancement Notes
+May branch into building prototypes for the Accord.

--- a/docs/backgrounds/iron_accord/street_urchin.md
+++ b/docs/backgrounds/iron_accord/street_urchin.md
@@ -1,0 +1,33 @@
+# Street Urchin
+
+**Flavor Description**
+You survived by wits in the crowded alleys of Brasshaven.
+
+### Typical Skills/Knowledge
+- pickpocketing
+- street navigation
+- quick escapes
+- gossip trading
+
+### Starting Gear or Contacts
+- dagger or sling
+- bundle of stolen keys
+- network of vagrants
+- safe hideout known only to you
+
+### Roleplay Hooks/Flaws
+- suspicious of authority
+- protective of fellow outcasts
+- quick to run from danger
+- occasionally acts impulsively
+
+### Example Story Hooks
+- stumble upon a secret meeting
+- hired for petty thefts
+
+### Mechanics
+- advantage on stealth in cities
+- call in favors from urchins
+
+### Advancement Notes
+Could become a spy or smuggler.


### PR DESCRIPTION
## Summary
- add Iron Accord background docs with individual markdown files and index
- link the backgrounds index from main README

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_68701abf1c84832795e1d8776ac07d7c