### PR TITLE
Implement character intro prompt via RAG

### DIFF
--- a/ironaccord-bot/tests/test_start_cog.py
+++ b/ironaccord-bot/tests/test_start_cog.py
@@ -32,6 +32,13 @@ class DummyInteraction:
 @pytest.mark.asyncio
 async def test_start_cog_returns_view(monkeypatch):
     bot = commands.Bot(command_prefix="!", intents=discord.Intents.none())
+    rag_called = {"count": 0}
+
+    def fake_get_section(*args, **kwargs):
+        rag_called["count"] += 1
+        return "info"
+
+    bot.rag_service = type("RAG", (), {"get_character_section": fake_get_section})()
     cog = start.StartCog(bot)
 
     called = {}
@@ -59,3 +66,4 @@ async def test_start_cog_returns_view(monkeypatch):
     assert isinstance(interaction.followup.kwargs.get("view"), DummyView)
     assert called.get("created")
     assert called.get("func")
+    assert rag_called["count"] == 3


### PR DESCRIPTION
## Summary
- access rag_service in StartCog
- assemble character brief from RAG sections
- craft structured introduction prompt for Edraz
- update tests to handle RAG lookups

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687034d91bc48327b73e5dd602e71dd0