### PR TITLE
Add mission generator service and command

### DIFF
--- a/ironaccord-bot/bot.py
+++ b/ironaccord-bot/bot.py
@@ -9,6 +9,10 @@ import asyncio
 # --- Local Imports ---
 from ai.ai_agent import AIAgent
 from services.rag_service import RAGService
+try:
+    from services.mission_generator import MissionGenerator
+except Exception:  # pragma: no cover - optional dependency
+    MissionGenerator = None
 
 # --- Environment and Logging ---
 load_dotenv()
@@ -38,6 +42,9 @@ class IronAccordBot(commands.Bot):
         # --- Service Initialization ---
         self.rag_service = RAGService()
         self.ai_agent = AIAgent()
+        self.mission_generator = (
+            MissionGenerator(self.ai_agent, self.rag_service) if MissionGenerator else None
+        )
         # Expose the Ollama service directly for cogs expecting it
         self.ollama_service = self.ai_agent.ollama_service
         # Flag controlling whether to redeploy slash commands on startup

--- a/ironaccord-bot/services/__init__.py
+++ b/ironaccord-bot/services/__init__.py
@@ -1,0 +1,4 @@
+from .ollama_service import OllamaService
+from .rag_service import RAGService
+
+__all__ = ["OllamaService", "RAGService"]

--- a/ironaccord-bot/services/mission_generator.py
+++ b/ironaccord-bot/services/mission_generator.py
@@ -1,0 +1,77 @@
+import json
+import logging
+from typing import Any, Dict, Optional
+
+from models import mission_service, database
+from ai.ai_agent import AIAgent
+from services.rag_service import RAGService
+
+logger = logging.getLogger(__name__)
+
+
+class MissionGenerator:
+    """Generate missions using player context and lore."""
+
+    def __init__(self, agent: AIAgent, rag_service: RAGService | None = None) -> None:
+        self.agent = agent
+        self.rag_service = rag_service
+
+    async def _collect_player_context(self, discord_id: str) -> Dict[str, Any] | None:
+        player_id = await mission_service.get_player_id(discord_id)
+        if not player_id:
+            return None
+
+        res = await database.query(
+            "SELECT level FROM players WHERE id = %s", [player_id]
+        )
+        level = res["rows"][0]["level"] if res["rows"] else 1
+
+        stats_res = await database.query(
+            "SELECT stat, value FROM user_stats WHERE player_id = %s", [player_id]
+        )
+        stats = {row["stat"]: row["value"] for row in stats_res["rows"]}
+
+        codex_res = await database.query(
+            "SELECT entry_key FROM codex_entries WHERE player_id = %s", [player_id]
+        )
+        codex = [r["entry_key"] for r in codex_res["rows"]]
+
+        return {"level": level, "stats": stats, "codex": codex}
+
+    def _get_lore_snippets(self) -> str:
+        if not self.rag_service:
+            return ""
+        try:
+            results = self.rag_service.query("important lore", k=3)
+            snippets = []
+            for doc in results:
+                if hasattr(doc, "page_content"):
+                    snippets.append(doc.page_content)
+                else:
+                    snippets.append(str(doc))
+            return "\n".join(snippets)
+        except Exception as exc:  # pragma: no cover - RAG may fail
+            logger.warning("RAG query failed: %s", exc)
+            return ""
+
+    async def generate(self, discord_id: str, objective: str = "") -> Optional[Dict[str, Any]]:
+        """Generate a mission for the given player."""
+        context = await self._collect_player_context(discord_id)
+        if context is None:
+            return None
+
+        lore = self._get_lore_snippets()
+        prompt = (
+            "You are a mission design AI. Use the player info and lore below to "
+            "create a short mission in JSON format.\n\n"
+            f"PLAYER: {context}\n\nLORE:\n{lore}\n\nOBJECTIVE: {objective}\n"
+            "Return only valid JSON describing the mission with keys 'id', "
+            "'name', 'intro', 'rounds', 'rewards', and 'codexFragment'."
+        )
+
+        response = await self.agent.get_narrative(prompt)
+        try:
+            return json.loads(response)
+        except json.JSONDecodeError:
+            logger.error("Failed to parse mission JSON: %s", response)
+            return None

--- a/ironaccord-bot/tests/test_mission_cog.py
+++ b/ironaccord-bot/tests/test_mission_cog.py
@@ -1,0 +1,51 @@
+import pytest
+pytest.importorskip("aiomysql")
+
+discord = pytest.importorskip("discord")
+from discord.ext import commands
+from ironaccord_bot.cogs import mission
+
+class DummyResponse:
+    def __init__(self):
+        self.deferred = False
+        self.kwargs = None
+
+    async def defer(self, *args, **kwargs):
+        self.deferred = True
+        self.kwargs = kwargs
+
+class DummyFollowup:
+    def __init__(self):
+        self.called = False
+        self.kwargs = None
+
+    async def send(self, *args, **kwargs):
+        self.called = True
+        self.kwargs = kwargs
+
+class DummyInteraction:
+    def __init__(self):
+        self.user = type("User", (), {"id": 1})()
+        self.response = DummyResponse()
+        self.followup = DummyFollowup()
+
+@pytest.mark.asyncio
+async def test_mission_create(monkeypatch):
+    bot = commands.Bot(command_prefix="!", intents=discord.Intents.none())
+
+    class DummyGen:
+        def __init__(self):
+            self.called = False
+        async def generate(self, did):
+            self.called = True
+            return {"id": 1}
+
+    bot.mission_generator = DummyGen()
+    cog = mission.MissionCog(bot)
+    interaction = DummyInteraction()
+
+    await cog.create.callback(cog, interaction)
+
+    assert interaction.response.deferred
+    assert interaction.followup.called
+    assert bot.mission_generator.called

--- a/ironaccord-bot/tests/test_mission_generator.py
+++ b/ironaccord-bot/tests/test_mission_generator.py
@@ -1,0 +1,56 @@
+import pytest
+pytest.importorskip("aiomysql")
+
+from services.mission_generator import MissionGenerator
+from models import mission_service, database
+
+@pytest.mark.asyncio
+async def test_generate_returns_json(monkeypatch):
+    calls = {}
+
+    async def fake_get_player_id(did):
+        calls['pid'] = did
+        return 1
+
+    async def fake_query(sql, params=None):
+        calls.setdefault('queries', []).append(sql)
+        if 'FROM players' in sql:
+            return {'rows': [{'level': 2}]}
+        return {'rows': []}
+
+    def fake_rag_query(q, k=5):
+        calls['rag'] = True
+        return ['lore']
+
+    async def fake_get_narrative(self, prompt):
+        calls['prompt'] = prompt
+        return '{"id":1,"name":"test"}'
+
+    monkeypatch.setattr(mission_service, 'get_player_id', fake_get_player_id)
+    monkeypatch.setattr(database, 'query', fake_query)
+    rag = type('R', (), {'query': fake_rag_query})()
+    agent = type('A', (), {'get_narrative': fake_get_narrative})()
+
+    gen = MissionGenerator(agent, rag)
+    mission = await gen.generate('123')
+
+    assert mission == {"id": 1, "name": "test"}
+    assert calls['pid'] == '123'
+    assert 'prompt' in calls
+
+@pytest.mark.asyncio
+async def test_invalid_json(monkeypatch):
+    async def fake_get_player_id(did):
+        return 1
+
+    async def fake_query(sql, params=None):
+        return {'rows': []}
+
+    async def fake_get_narrative(self, prompt):
+        return 'not json'
+
+    monkeypatch.setattr(mission_service, 'get_player_id', fake_get_player_id)
+    monkeypatch.setattr(database, 'query', fake_query)
+    agent = type('A', (), {'get_narrative': fake_get_narrative})()
+    gen = MissionGenerator(agent, None)
+    assert await gen.generate('x') is None


### PR DESCRIPTION
## Summary
- generate missions with a new MissionGenerator service
- wire MissionGenerator into bot initialization
- expose `/mission create` command
- test mission generation logic and command behaviour

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68703996189c8327aa2d7b69c1cf67cd