### PR TITLE
Remove duplicate prompts in ContinueButton

### DIFF
--- a/ironaccord-bot/views/adventure_view.py
+++ b/ironaccord-bot/views/adventure_view.py
@@ -72,11 +72,10 @@ class AdventureView(discord.ui.View):
 
             user_name = view.user.display_name
             prompts = {
-                2: f"As Edraz, tell {user_name} about the Machine War. Keep it dramatic but sprinkle in meta-commentary about it being 'classic video game backstory stuff'. Keep it brief.",
-                3: f"As Edraz, explain the two factions, Iron Accord and Neon Dharma, to {user_name}. Tell them about only the Iron Accord's values and views. To them the Neon Dharma is the enemy. Tell them to 'pick a class' by clicking a button below, hinting that their choice has 'like, actual consequences... probably'.",
-                5: f"As Edraz, narrate the beginning of the fight in Griz's workshop for {user_name}. Describe two clunky, sparking automatons turning towards them. The player easily dodges the first clumsy attack. End by prompting them to fight back by clicking the button.",
-                6: f"The player, {user_name}, attacks! As a {view.player_class}, narrate them landing a powerful, cinematic blow that staggers one of the automatons. Describe the sparks and crunching metal.",
-                7: f"As Edraz, narrate {user_name} finishing off both automatons in a cool final move. They are victorious! Griz is impressed. The narration should feel like a triumphant, over-the-top end to their first tutorial fight. Tell them their real journey is about to begin."
+                phase: PROMPTS[phase].format(
+                    user_name=user_name, player_class=view.player_class
+                )
+                for phase in (2, 3, 5, 6, 7)
             }
             
             narrative_text = await view.prefetch_task


### PR DESCRIPTION
## Summary
- deduplicate prompts used in `ContinueButton`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687039c16e4883279e03bc96f38d037d