### PR TITLE
Enable dynamic mission start from JSON

### DIFF
--- a/ironaccord-bot/tests/test_mission_cog.py
+++ b/ironaccord-bot/tests/test_mission_cog.py
@@ -4,6 +4,7 @@ pytest.importorskip("aiomysql")
 discord = pytest.importorskip("discord")
 from discord.ext import commands
 from ironaccord_bot.cogs import mission
+from models import mission_service as mission_service
 
 class DummyResponse:
     def __init__(self):
@@ -44,8 +45,105 @@ async def test_mission_create(monkeypatch):
     cog = mission.MissionCog(bot)
     interaction = DummyInteraction()
 
-    await cog.create.callback(cog, interaction)
+    called = {}
+
+    async def fake_start(self, inter, mission_json, *, followup=False):
+        called["mission"] = mission_json
+        called["followup"] = followup
+
+    monkeypatch.setattr(mission.MissionCog, "start_mission_from_json", fake_start)
+
+    await cog.create(interaction)
 
     assert interaction.response.deferred
-    assert interaction.followup.called
+    assert called.get("mission") == {"id": 1}
+    assert called.get("followup") is True
     assert bot.mission_generator.called
+
+
+class DummySend:
+    def __init__(self):
+        self.called = False
+        self.kwargs = None
+
+    async def send_message(self, **kwargs):
+        self.called = True
+        self.kwargs = kwargs
+
+
+class DummyThread:
+    def __init__(self):
+        self.messages = []
+
+    async def send(self, msg, view=None):
+        self.messages.append(msg)
+
+
+class DummyChannel:
+    def __init__(self):
+        self.thread = DummyThread()
+
+    async def create_thread(self, name, auto_archive_duration=60):
+        return self.thread
+
+
+class DummyInteraction2:
+    def __init__(self):
+        self.user = type("User", (), {"id": 2})()
+        self.response = DummySend()
+        self.followup = DummySend()
+        self.channel = DummyChannel()
+
+
+@pytest.mark.asyncio
+async def test_start_mission_progress(monkeypatch):
+    bot = commands.Bot(command_prefix="!", intents=discord.Intents.none())
+    cog = mission.MissionCog(bot)
+
+    mission_json = {
+        "id": 1,
+        "name": "dyn",
+        "intro": "hi",
+        "rounds": [
+            {"text": "r1", "options": [{"text": "a"}]},
+            {"text": "r2", "options": [{"text": "b"}]},
+        ],
+    }
+
+    async def fake_get_player_id(did):
+        return 5
+
+    async def fake_start_mission(pid, mid):
+        return 11
+
+    records = []
+
+    def fake_record_choice(log_id, round_idx, choice_idx, durability_delta=0):
+        records.append((round_idx, choice_idx))
+
+    async def fake_complete(log_id, outcome, rewards, codex, player_id):
+        records.append(("done", outcome))
+
+    async def fake_resolve(pid, option):
+        return {"tier": "success"}
+
+    class DummyView:
+        def __init__(self, user, options):
+            self.choice = 0
+
+        async def wait(self):
+            pass
+
+    monkeypatch.setattr(mission_service, "get_player_id", fake_get_player_id)
+    monkeypatch.setattr(mission_service, "start_mission", fake_start_mission)
+    monkeypatch.setattr(mission_service, "record_choice", fake_record_choice)
+    monkeypatch.setattr(mission_service, "complete_mission", fake_complete)
+    monkeypatch.setattr(mission, "resolve_choice", fake_resolve)
+    monkeypatch.setattr(mission, "OptionView", DummyView)
+
+    interaction = DummyInteraction2()
+
+    await cog.start_mission_from_json(interaction, mission_json)
+
+    assert records == [(0, 0), (1, 0), ("done", "success")]
+    assert interaction.response.called


### PR DESCRIPTION
## Summary
- refactor `MissionCog.start` to delegate to new `start_mission_from_json`
- start missions generated by `/mission create` immediately
- add tests covering the new mission flow and round progression

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687045186e708327b7678caa051e21f7