### PR TITLE
Add options to mission create command

### DIFF
--- a/ironaccord-bot/cogs/mission.py
+++ b/ironaccord-bot/cogs/mission.py
@@ -44,7 +44,10 @@ class MissionCog(commands.Cog):
         self.bot = bot
         self.group = app_commands.Group(name='mission', description='Mission commands')
         self.group.command(name='start', description='Start a mission')(self.start)
-        self.group.command(name='create', description='Generate a mission')(self.create)
+        self.group.command(
+            name='create',
+            description='Generate a mission with the given type and details'
+        )(self.create)
         bot.tree.add_command(self.group)
 
     def load_mission(self, name: str):
@@ -83,13 +86,14 @@ class MissionCog(commands.Cog):
         await thread.send(f"Mission complete with outcome: {outcome}")
         await interaction.response.send_message(embed=simple('Mission started! Check the thread.'), ephemeral=True)
 
-    async def create(self, interaction: discord.Interaction):
+    async def create(self, interaction: discord.Interaction, type: str, details: str):
         await interaction.response.defer(ephemeral=True)
         generator = getattr(self.bot, 'mission_generator', None)
         if not generator:
             await interaction.followup.send('Mission generator unavailable.', ephemeral=True)
             return
-        mission = await generator.generate(str(interaction.user.id))
+        objective = f"{type}: {details}"
+        mission = await generator.generate(str(interaction.user.id), objective)
         if not mission:
             await interaction.followup.send('Failed to generate mission.', ephemeral=True)
             return

--- a/ironaccord-bot/tests/test_mission_cog.py
+++ b/ironaccord-bot/tests/test_mission_cog.py
@@ -36,16 +36,20 @@ async def test_mission_create(monkeypatch):
     class DummyGen:
         def __init__(self):
             self.called = False
-        async def generate(self, did):
+            self.args = None
+
+        async def generate(self, did, objective=""):
             self.called = True
+            self.args = (did, objective)
             return {"id": 1}
 
     bot.mission_generator = DummyGen()
     cog = mission.MissionCog(bot)
     interaction = DummyInteraction()
 
-    await cog.create.callback(cog, interaction)
+    await cog.create(interaction, "rescue", "save the hostages")
 
     assert interaction.response.deferred
     assert interaction.followup.called
     assert bot.mission_generator.called
+    assert bot.mission_generator.args == ("1", "rescue: save the hostages")


### PR DESCRIPTION
## Summary
- accept `type` and `details` options for `/mission create`
- send these options to the mission generator
- update tests for the new parameters

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6870451535488327b057fd5207c93f0a