### PR TITLE
Refactor mission generator interface

### DIFF
--- a/ironaccord-bot/cogs/mission.py
+++ b/ironaccord-bot/cogs/mission.py
@@ -89,7 +89,11 @@ class MissionCog(commands.Cog):
         if not generator:
             await interaction.followup.send('Mission generator unavailable.', ephemeral=True)
             return
-        mission = await generator.generate(str(interaction.user.id))
+        context = await generator._collect_player_context(str(interaction.user.id))
+        if context is None:
+            await interaction.followup.send('Failed to load player context.', ephemeral=True)
+            return
+        mission = await generator.generate('default', '', context)
         if not mission:
             await interaction.followup.send('Failed to generate mission.', ephemeral=True)
             return


### PR DESCRIPTION
## Summary
- update MissionGenerator.generate signature to take request info and player context
- query RAGService for details and validate the mission JSON
- adapt MissionCog to gather context and call the new generator
- update tests for the new API

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687045170fa88327951873733cb9a27b