### PR TITLE
Enable dynamic mission creation

### DIFF
--- a/docs/iron_accord_roadmap.md
+++ b/docs/iron_accord_roadmap.md
@@ -48,7 +48,7 @@ This roadmap outlines the high-level and detailed phases of development for **Ir
 - Scavenging loot tables & mission zones
 - Item crafting system
 - Field repair logic with failure states
-- `/mission` creation tool
+- `/mission create` tool for generating dynamic missions
 - Faction-themed NPC generation
 - Codex discovery hooks & narrative ties
 

--- a/ironaccord-bot/tests/test_mission_cog.py
+++ b/ironaccord-bot/tests/test_mission_cog.py
@@ -37,8 +37,8 @@ async def test_mission_create(monkeypatch):
     class DummyGen:
         def __init__(self):
             self.called = False
-        async def generate(self, did):
-            self.called = True
+        async def generate(self, did, typ, details):
+            self.called = (did, typ, details)
             return {"id": 1}
 
     bot.mission_generator = DummyGen()
@@ -53,12 +53,12 @@ async def test_mission_create(monkeypatch):
 
     monkeypatch.setattr(mission.MissionCog, "start_mission_from_json", fake_start)
 
-    await cog.create(interaction)
+    await cog.create.callback(cog, interaction, "item_retrieval", "part")
 
     assert interaction.response.deferred
     assert called.get("mission") == {"id": 1}
     assert called.get("followup") is True
-    assert bot.mission_generator.called
+    assert bot.mission_generator.called == ("1", "item_retrieval", "part")
 
 
 class DummySend:

--- a/ironaccord-bot/tests/test_mission_generator.py
+++ b/ironaccord-bot/tests/test_mission_generator.py
@@ -32,7 +32,7 @@ async def test_generate_returns_json(monkeypatch):
     agent = type('A', (), {'get_narrative': fake_get_narrative})()
 
     gen = MissionGenerator(agent, rag)
-    mission = await gen.generate('123')
+    mission = await gen.generate('123', 'item_retrieval', 'find a part')
 
     assert mission == {"id": 1, "name": "test"}
     assert calls['pid'] == '123'
@@ -53,4 +53,4 @@ async def test_invalid_json(monkeypatch):
     monkeypatch.setattr(database, 'query', fake_query)
     agent = type('A', (), {'get_narrative': fake_get_narrative})()
     gen = MissionGenerator(agent, None)
-    assert await gen.generate('x') is None
+    assert await gen.generate('x', 't', 'd') is None


### PR DESCRIPTION
## Summary
- update roadmap docs with `/mission create` reference
- allow missions to start from JSON objects
- add `type` and `details` options to `/mission create`
- fetch lore based on request details
- adjust tests for new generator API

## Testing
- `pytest ironaccord-bot/tests/test_mission_cog.py::test_mission_create -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68714c70bf7083278d3df99fc332cf84