### PR TITLE
Refactor start to stateless intro and improve logging

### DIFF
--- a/ironaccord-bot/models/player_service.py
+++ b/ironaccord-bot/models/player_service.py
@@ -1,14 +1,23 @@
-from . import database as db
+"""Utility functions for player data."""
+
+import logging
+
+logger = logging.getLogger(__name__)
+
+# Database functionality has been removed as part of the stateless refactor.
+# These functions now simply log their usage.
 
 async def set_player_state(player_id: int, state: str) -> None:
-    await db.query('UPDATE players SET state = %s WHERE id = %s', [state, player_id])
+    """Previously persisted the player's state. Now logs the request."""
+    logger.info("set_player_state called for id=%s state=%s", player_id, state)
 
 async def get_player_state(player_id: int) -> str | None:
-    res = await db.query('SELECT state FROM players WHERE id = %s', [player_id])
-    return res['rows'][0]['state'] if res['rows'] else None
+    """Return None as no state is stored."""
+    logger.info("get_player_state called for id=%s", player_id)
+    return None
 
 
 async def store_faction(discord_id: str, faction: str) -> None:
-    """Persist the player's chosen faction."""
-    await db.query('UPDATE players SET faction = %s WHERE discord_id = %s', [faction, discord_id])
+    """Previously stored the player's faction. Now logs the request."""
+    logger.info("store_faction called for discord_id=%s faction=%s", discord_id, faction)
 

--- a/ironaccord-bot/tests/test_player_service.py
+++ b/ironaccord-bot/tests/test_player_service.py
@@ -1,29 +1,19 @@
 import pytest
-pytest.importorskip("aiomysql")
-
 from ironaccord_bot.models import player_service
 
-class DummyDB:
-    def __init__(self):
-        self.calls = []
-    async def query(self, sql, params=None):
-        self.calls.append((sql, params))
-        if sql.startswith('SELECT'):
-            return {'rows': [{'state': 'idle'}]}
-        return {'rows': [], 'insertId': 1}
-
-db = DummyDB()
 
 @pytest.mark.asyncio
-async def test_set_player_state(monkeypatch):
-    monkeypatch.setattr(player_service, 'db', db)
-    db.calls.clear()
-    await player_service.set_player_state(5, 'busy')
-    assert db.calls[0] == ('UPDATE players SET state = %s WHERE id = %s', ['busy', 5])
+async def test_set_player_state_logs(monkeypatch):
+    messages = []
+    monkeypatch.setattr(player_service.logger, "info", lambda msg, *a: messages.append(msg % a))
+    await player_service.set_player_state(5, "busy")
+    assert any("set_player_state" in m for m in messages)
+
 
 @pytest.mark.asyncio
-async def test_get_player_state(monkeypatch):
-    monkeypatch.setattr(player_service, 'db', db)
+async def test_get_player_state_returns_none(monkeypatch):
+    messages = []
+    monkeypatch.setattr(player_service.logger, "info", lambda msg, *a: messages.append(msg % a))
     state = await player_service.get_player_state(1)
-    assert state == 'idle'
+    assert state is None
 


### PR DESCRIPTION
## Summary
- decouple player data persistence by stubbing out `player_service`
- overhaul `MissionGenerator` to produce intro scenes and log errors
- redesign `/start` command to show two random backgrounds and generate a scene
- adjust unit tests for the new behaviour

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687158c021ac832798585784742e0f4a