### PR TITLE
Handle missing backgrounds for /start

### DIFF
--- a/ironaccord-bot/cogs/start.py
+++ b/ironaccord-bot/cogs/start.py
@@ -69,7 +69,26 @@ class StartCog(commands.Cog):
         await interaction.response.defer(ephemeral=True, thinking=True)
 
         intro_text = self._intro_text()
-        backgrounds = random.sample(self._background_names(), k=2)
+        background_names = self._background_names()
+
+        # Randomly sample backgrounds only if at least two are available. This
+        # avoids ValueError when the list is too small and lets us gracefully
+        # fall back to whatever options exist.
+        if len(background_names) >= 2:
+            backgrounds = random.sample(background_names, k=2)
+        elif len(background_names) == 1:
+            backgrounds = background_names
+        else:
+            backgrounds = []
+
+        # If no backgrounds exist, inform the user and exit early. The
+        # followup message is ephemeral so only they see the warning.
+        if not backgrounds:
+            await interaction.followup.send(
+                "No backgrounds are available. Please contact an administrator.",
+                ephemeral=True,
+            )
+            return
 
         embed = discord.Embed(
             title="Welcome to Iron Accord",


### PR DESCRIPTION
## Summary
- let `/start` run even when there are fewer than two backgrounds
- inform the user if no backgrounds exist

## Testing
- `pytest` *(fails: missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6871641e434c83278418ee0e27b424fe