### PR TITLE
Add prelude summary flow

### DIFF
--- a/ironaccord-bot/tests/test_opening_scene_view.py
+++ b/ironaccord-bot/tests/test_opening_scene_view.py
@@ -1,0 +1,49 @@
+import pytest
+
+discord = pytest.importorskip("discord")
+
+from ironaccord_bot.views.opening_scene_view import OpeningSceneView
+
+
+class DummyResponse:
+    def __init__(self):
+        self.kwargs = None
+
+    async def edit_message(self, **kwargs):
+        self.kwargs = kwargs
+
+
+class DummyMessage:
+    def __init__(self):
+        self.kwargs = None
+
+    async def edit(self, **kwargs):
+        self.kwargs = kwargs
+
+
+class DummyInteraction:
+    def __init__(self):
+        self.response = DummyResponse()
+        self.message = DummyMessage()
+        self.followup = DummyResponse()
+
+
+@pytest.mark.asyncio
+async def test_view_calls_summary_after_final_turn():
+    calls = []
+
+    async def fake_get_narrative(self, prompt):
+        calls.append(prompt)
+        if "Summarize" in prompt:
+            return "the summary"
+        return '{"scene": "s", "question": "q", "choices": ["a"]}'
+
+    agent = type("Agent", (), {"get_narrative": fake_get_narrative})()
+    view = OpeningSceneView(agent, "intro", "q", ["a"], turns=1)
+    interaction = DummyInteraction()
+
+    button = view.children[0]
+    await button.callback(interaction)
+
+    assert any("Summarize the events" in c for c in calls)
+    assert "Your story has just begun." in interaction.message.kwargs["embed"].description


### PR DESCRIPTION
## Summary
- craft a final summary when the opening scene ends
- flesh out `OpeningSceneView` to ask the Lore Weaver for a synopsis
- test that the view requests a summary after the last turn

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687177b8c1c48327a87bc0bf9c9f1a98