### PR TITLE
Improve start command UX

### DIFF
--- a/ironaccord-bot/cogs/start.py
+++ b/ironaccord-bot/cogs/start.py
@@ -7,21 +7,31 @@ from services.opening_scene_service import OpeningSceneService
 from views.opening_scene_view import OpeningSceneView
 
 
+class StartView(discord.ui.View):
+    """View that launches the character creation modal."""
+
+    def __init__(self, cog: "StartCog") -> None:
+        super().__init__(timeout=None)
+        self.cog = cog
+
+    @discord.ui.button(label="Create My Character", style=discord.ButtonStyle.success)
+    async def create_character(
+        self, interaction: discord.Interaction, button: discord.ui.Button
+    ) -> None:
+        await interaction.response.send_modal(CharacterPromptModal(self.cog))
+
+
 
 
 class CharacterPromptModal(discord.ui.Modal):
     """Prompt the player to describe their character."""
 
     def __init__(self, cog: "StartCog") -> None:
-        super().__init__(title="Welcome to Iron Accord")
+        super().__init__(title="Create Your Character")
         self.cog = cog
         self.description = discord.ui.TextInput(
-            label="Character Description",
-            placeholder=(
-                "Tell me about the person you want to be. "
-                "What is their name? What do they look like? "
-                "What drives them?"
-            ),
+            label="Describe Your Character",
+            placeholder="Tell your story here...",
             style=discord.TextStyle.paragraph,
             max_length=500,
             required=True,
@@ -43,8 +53,13 @@ class StartCog(commands.Cog):
     @app_commands.command(name="start", description="Begin your journey in the world of Iron Accord.")
     async def start(self, interaction: discord.Interaction):
         """Begin the character creation flow."""
-        modal = CharacterPromptModal(self)
-        await interaction.response.send_modal(modal)
+        prompt_text = (
+            "Welcome to the world of Iron Accord. Before your story can begin, "
+            "tell me about the person you want to be. What is their name? "
+            "What do they look like? What drives them? What secrets do they keep?"
+        )
+        view = StartView(self)
+        await interaction.response.send_message(prompt_text, view=view, ephemeral=True)
 
     async def handle_character_description(
         self, interaction: discord.Interaction, text: str

--- a/ironaccord-bot/tests/test_start_cog.py
+++ b/ironaccord-bot/tests/test_start_cog.py
@@ -7,10 +7,14 @@ from ironaccord_bot.cogs import start
 
 class DummyResponse:
     def __init__(self):
+        self.kwargs = None
         self.modal = None
 
     async def send_modal(self, modal):
         self.modal = modal
+
+    async def send_message(self, *args, **kwargs):
+        self.kwargs = kwargs
 
 class DummyInteraction:
     def __init__(self):
@@ -28,7 +32,8 @@ async def test_start_cog_returns_view(monkeypatch):
 
     await cog.start.callback(cog, interaction)
 
-    assert isinstance(interaction.response.modal, start.CharacterPromptModal)
+    assert isinstance(interaction.response.kwargs["view"], start.StartView)
+    assert interaction.response.kwargs["ephemeral"] is True
 
 
 class DummyFollowup:


### PR DESCRIPTION
## Summary
- rework `/start` command to send a prompt then launch a modal
- shorten modal placeholder text
- update tests for new start flow

## Testing
- `pip install -q python-dotenv==1.0.1 langchain==0.1.16 langchain-community==0.0.32`
- `pip install -q -r dev-requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687184bd3284832793121f7e813293e6