### PR TITLE
Implement Edraz interview flow

### DIFF
--- a/ironaccord-bot/cogs/start.py
+++ b/ironaccord-bot/cogs/start.py
@@ -5,7 +5,8 @@ from discord import app_commands
 from ai.ai_agent import AIAgent
 from services.opening_scene_service import OpeningSceneService
 from views.opening_scene_view import OpeningSceneView
-from views.oracle_view import OracleView
+from views.interview_view import InterviewView
+from ironaccord_bot.interview_config import EDRAZ_GREETING, EDRAZ_IMAGE_URL
 
 
 class StartCog(commands.Cog):
@@ -16,17 +17,14 @@ class StartCog(commands.Cog):
 
     @app_commands.command(name="start", description="Begin your journey in the world of Iron Accord.")
     async def start(self, interaction: discord.Interaction):
-        """Begin the Wasteland Oracle question flow."""
-        view = OracleView(self)
+        """Begin the Edraz interview question flow."""
+        view = InterviewView(self)
         embed = discord.Embed(
-            title="The Wasteland Oracle",
-            description=(
-                "A crackle of static breaks the silence. A voice, smooth and calm, "
-                "echoes from a forgotten frequency... it's the Oracle. He has a question for you.\n\n"
-                f"**{view._current_question()}**"
-            ),
+            title="Edraz, Chronicler of the Accord",
+            description=f"{EDRAZ_GREETING}\n\n**{view._current_question()}**",
             color=discord.Color.dark_gold(),
         )
+        embed.set_image(url=EDRAZ_IMAGE_URL)
         await interaction.response.send_message(embed=embed, view=view, ephemeral=True)
 
     async def handle_character_description(

--- a/ironaccord-bot/interview_config.py
+++ b/ironaccord-bot/interview_config.py
@@ -1,0 +1,49 @@
+EDRAZ_GREETING = (
+    "Signal acquired. I am Edraz, the Chronicler. I read the static between the worlds, and today it led me to you."
+    " Your story is unwritten, a blank slate in the great archive. Before we begin, I need to tune into your signal."
+)
+
+EDRAZ_IMAGE_URL = "https://example.com/edraz-sanctum.png"
+
+QUESTIONS = [
+    {
+        "text": "When you look upon the ruins, what stirs within you?",
+        "options": [
+            ("A sense of loss", "you mourn what was lost"),
+            ("A chance for rebirth", "you see opportunity among the wreckage"),
+            ("Only hardened resolve", "you feel nothing but determination"),
+            ("Curiosity", "you thirst to uncover forgotten secrets"),
+        ],
+        "transition": "Hm. {choice}... The static sharpens. Now, tell me this",
+    },
+    {
+        "text": "A starving family pleads for your last rations. How do you respond?",
+        "options": [
+            ("Share freely", "you share without hesitation"),
+            ("Offer aid for a price", "you demand a trade"),
+            ("Turn them away", "you ignore their plight"),
+            ("Take what little they have", "you seize what is theirs"),
+        ],
+        "transition": "Your signal grows clearer. {choice} It reveals much. Another question",
+    },
+    {
+        "text": "Rumors whisper that the Accord is built on lies. What do you do with such talk?",
+        "options": [
+            ("Seek the truth", "you dig deeper"),
+            ("Silence the rumor", "you destroy evidence"),
+            ("Use it for leverage", "you keep the secret close"),
+            ("Ignore it", "you dismiss such chatter"),
+        ],
+        "transition": "Interesting. {choice} The pattern emerges. Finally",
+    },
+    {
+        "text": "What quality do you prize most in those who walk beside you?",
+        "options": [
+            ("Loyalty", "you value steadfast allies"),
+            ("Honesty", "you demand the truth"),
+            ("Ingenuity", "you admire clever minds"),
+            ("Survival skill", "you rely on the capable"),
+        ],
+        "transition": "Noted. {choice} The signal resolves at last.",
+    },
+]

--- a/ironaccord-bot/services/opening_scene_service.py
+++ b/ironaccord-bot/services/opening_scene_service.py
@@ -41,13 +41,13 @@ class OpeningSceneService:
         """
         context = self._gather_context(description)
         prompt = (
-            "You are the Lore Weaver, a master storyteller. A new hero has entered the world. "
-            f"Their description is: {description}\n"
+            "Adopt the persona of Edraz, the Chronicler of the Iron Accord. "
+            "You are wise, patient, and speak in metaphors of data, static, and signals. "
+            f"You are reading the 'signal' of a new traveler based on this profile: {description}\n"
             f"Relevant lore:\n{context}\n\n"
-            "Using this information, craft a thrilling opening scene. "
-            "Place them in immediate peril or before a critical decision. "
-            "Conclude your response with a question and provide three distinct choices as a list. "
-            "Return the result as JSON with the keys 'scene', 'question', and 'choices'."
+            "Speaking directly to the traveler, interpret their signal and narrate the opening scene of their story "
+            "as a vision you see in the static. Seamlessly weave their traits into the scene and conclude with their first critical choice. "
+            "Return JSON with the keys 'scene', 'question', and 'choices'."
         )
         try:
             text = await self.agent.get_narrative(prompt)

--- a/ironaccord-bot/tests/test_opening_scene_service.py
+++ b/ironaccord-bot/tests/test_opening_scene_service.py
@@ -28,6 +28,7 @@ async def test_generate_opening(monkeypatch):
     }
     assert 'brave hero' in calls['prompt']
     assert 'lore bit' in calls['prompt']
+    assert 'Adopt the persona of Edraz' in calls['prompt']
     assert calls['query'] == 'brave hero'
 
 

--- a/ironaccord-bot/tests/test_start_cog.py
+++ b/ironaccord-bot/tests/test_start_cog.py
@@ -3,6 +3,7 @@ import pytest
 discord = pytest.importorskip("discord")
 from discord.ext import commands
 from ironaccord_bot.cogs import start
+from ironaccord_bot.interview_config import QUESTIONS
 
 
 class DummyResponse:
@@ -28,7 +29,7 @@ async def test_start_cog_returns_view(monkeypatch):
 
     await cog.start.callback(cog, interaction)
 
-    assert isinstance(interaction.response.kwargs["view"], start.OracleView)
+    assert isinstance(interaction.response.kwargs["view"], start.InterviewView)
     assert interaction.response.kwargs["ephemeral"] is True
 
 
@@ -110,18 +111,18 @@ async def test_oracle_view_compiles_answers(monkeypatch):
 
     monkeypatch.setattr(start.StartCog, "handle_character_description", fake_handle)
 
-    view = start.OracleView(cog)
+    view = start.InterviewView(cog)
     inter = DummyInteraction3()
 
     # simulate clicking first option for each question
-    for _ in range(len(view.QUESTIONS)):
+    for _ in range(len(QUESTIONS)):
         button = view.children[0]
         await button.callback(inter)
 
     expected = (
-        "This person sees the old world as a tragic loss. "
-        "They share what little you have with those in need. "
-        "They seek the truth behind conspiracies. "
-        "They value unwavering loyalty in a companion."
+        "Signal Profile: you mourn what was lost, "
+        "you share without hesitation, "
+        "you dig deeper, "
+        "you value steadfast allies"
     )
     assert called["summary"] == expected

--- a/ironaccord-bot/views/__init__.py
+++ b/ironaccord-bot/views/__init__.py
@@ -1,0 +1,1 @@
+from .interview_view import InterviewView

--- a/ironaccord-bot/views/interview_view.py
+++ b/ironaccord-bot/views/interview_view.py
@@ -1,0 +1,55 @@
+import discord
+from ironaccord_bot.interview_config import QUESTIONS
+
+class InterviewView(discord.ui.View):
+    """Interactive interview conducted by Edraz."""
+
+    def __init__(self, cog: "StartCog") -> None:
+        super().__init__(timeout=300)
+        self.cog = cog
+        self.index = 0
+        self.answers: list[str] = []
+        self._populate_buttons()
+
+    def _populate_buttons(self) -> None:
+        self.clear_items()
+        for idx, (label, _) in enumerate(QUESTIONS[self.index]["options"]):
+            self.add_item(self.ChoiceButton(label, idx))
+
+    def _current_question(self) -> str:
+        return QUESTIONS[self.index]["text"]
+
+    def _compile_summary(self) -> str:
+        return f"Signal Profile: {', '.join(self.answers)}"
+
+    class ChoiceButton(discord.ui.Button):
+        def __init__(self, label: str, idx: int):
+            super().__init__(label=label, style=discord.ButtonStyle.primary)
+            self.idx = idx
+
+        async def callback(self, interaction: discord.Interaction) -> None:
+            view: "InterviewView" = self.view  # type: ignore[assignment]
+            q = QUESTIONS[view.index]
+            _, phrase = q["options"][self.idx]
+            transition = q.get("transition", "")
+            transition = transition.format(choice=phrase)
+            view.answers.append(phrase)
+            for child in view.children:
+                child.disabled = True
+            await interaction.response.edit_message(view=view)
+
+            view.index += 1
+            if view.index >= len(QUESTIONS):
+                await view.cog.handle_character_description(
+                    interaction, view._compile_summary()
+                )
+                view.stop()
+                return
+
+            view._populate_buttons()
+            embed = discord.Embed(
+                title="Edraz, Chronicler of the Accord",
+                description=f"{transition}\n\n**{view._current_question()}**",
+                color=discord.Color.dark_gold(),
+            )
+            await interaction.edit_original_response(embed=embed, view=view)


### PR DESCRIPTION
## Summary
- replace Oracle-based `/start` with Edraz interview
- move interview questions to `interview_config.py`
- add `InterviewView` for interactive question flow
- update opening scene prompt to speak as Edraz
- adjust tests for new view and config

## Testing
- `python3 -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68718a9835e483278cb0a63ecd18b871