### PR TITLE
Add ironaccord_bot alias

### DIFF
--- a/ironaccord-bot/__init__.py
+++ b/ironaccord-bot/__init__.py
@@ -1,1 +1,3 @@
+import sys
+sys.modules.setdefault('ironaccord_bot', sys.modules[__name__])
 


### PR DESCRIPTION
## Summary
- alias the hyphenated package as `ironaccord_bot`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_e_68718f761e7883279477c9a6663ec819