### PR TITLE
Fix import path for interview config

### DIFF
--- a/ironaccord-bot/cogs/start.py
+++ b/ironaccord-bot/cogs/start.py
@@ -6,7 +6,7 @@ from ai.ai_agent import AIAgent
 from services.opening_scene_service import OpeningSceneService
 from views.opening_scene_view import OpeningSceneView
 from views.interview_view import InterviewView
-from ironaccord_bot.interview_config import EDRAZ_GREETING, EDRAZ_IMAGE_URL
+from ..interview_config import EDRAZ_GREETING, EDRAZ_IMAGE_URL
 
 
 class StartCog(commands.Cog):


### PR DESCRIPTION
## Summary
- fix module import in the Start cog

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6871925327a08327958488a82668cebb