### PR TITLE
Ensure bot module loads from any directory

### DIFF
--- a/ironaccord-bot/bot.py
+++ b/ironaccord-bot/bot.py
@@ -1,4 +1,12 @@
+import sys
 import os
+
+# Add the parent directory of 'ironaccord-bot' to the Python path
+# This allows for absolute imports from the project root.
+project_root = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
+if project_root not in sys.path:
+    sys.path.insert(0, project_root)
+
 import argparse
 import discord
 from discord.ext import commands

--- a/ironaccord-bot/tests/conftest.py
+++ b/ironaccord-bot/tests/conftest.py
@@ -1,14 +1,5 @@
 import sys
 import importlib
-from pathlib import Path
-
-# Ensure project root is on sys.path
-ROOT = Path(__file__).resolve().parents[2]
-if str(ROOT) not in sys.path:
-    sys.path.insert(0, str(ROOT))
-PKG_DIR = ROOT / "ironaccord-bot"
-if str(PKG_DIR) not in sys.path:
-    sys.path.insert(0, str(PKG_DIR))
 
 # Alias the hyphenated package name so `import ironaccord_bot` works
 try:


### PR DESCRIPTION
## Summary
- adjust `sys.path` at runtime so the bot can run from any directory
- remove custom path setup from `conftest.py`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'ironaccord_bot')*

------
https://chatgpt.com/codex/tasks/task_e_68719f3531b08327a6fcd3da0993e325