### PR TITLE
Fix start cog import

### DIFF
--- a/ironaccord-bot/cogs/start.py
+++ b/ironaccord-bot/cogs/start.py
@@ -6,7 +6,7 @@ from ai.ai_agent import AIAgent
 from services.opening_scene_service import OpeningSceneService
 from views.opening_scene_view import OpeningSceneView
 from views.interview_view import InterviewView
-from ..interview_config import EDRAZ_GREETING, EDRAZ_IMAGE_URL
+from interview_config import EDRAZ_GREETING, EDRAZ_IMAGE_URL
 
 
 class StartCog(commands.Cog):

--- a/ironaccord-bot/views/interview_view.py
+++ b/ironaccord-bot/views/interview_view.py
@@ -1,5 +1,5 @@
 import discord
-from ironaccord_bot.interview_config import QUESTIONS
+from interview_config import QUESTIONS
 
 class InterviewView(discord.ui.View):
     """Interactive interview conducted by Edraz."""


### PR DESCRIPTION
## Summary
- use absolute imports in start cog and interview view

## Testing
- `python bot.py` *(fails to start bot but loads all cogs)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'ironaccord_bot')*

------
https://chatgpt.com/codex/tasks/task_e_6872d7ff306883278427fda3836cc0f0