### PR TITLE
Improve JSON parsing for opening scenes

### DIFF
--- a/ironaccord-bot/ai/ai_agent.py
+++ b/ironaccord-bot/ai/ai_agent.py
@@ -90,3 +90,36 @@ class AIAgent:
             A direct response string from the GM model.
         """
         return await self.ollama_service.get_gm_response(prompt)
+
+    async def get_completion(self, prompt: str) -> str:
+        """Return a creative completion from the Lore Weaver model."""
+        return await self.get_narrative(prompt)
+
+    def get_opening_scene_prompt(self, character_description: str, rag_context: str) -> str:
+        """Return the prompt used to generate the opening scene."""
+        return f"""
+        You are Lore Weaver, a master storyteller and game master for a tabletop role-playing game.
+        Your task is to generate the opening scene for a new player based on their character description and relevant lore.
+
+        **Character Description:**
+        {character_description}
+
+        **Relevant Lore from the World Codex:**
+        {rag_context}
+
+        **Your Instructions:**
+        Generate a JSON object with three keys: "scene", "question", and "choices".
+        - "scene": A compelling opening scene that introduces the character to the world. **The scene description must be concise and limited to a maximum of two to three paragraphs.**
+        - "question": A thought-provoking question for the player to answer, based on the scene.
+        - "choices": An array of two distinct choices the player can make in response to the question. Each choice should be an object with a "Choice" and a "Result" key, describing the immediate consequence of that choice.
+
+        **Output Format (Strictly JSON):**
+        {{
+            "scene": "...",
+            "question": "...",
+            "choices": [
+                {{"Choice": "...", "Result": "..."}},
+                {{"Choice": "...", "Result": "..."}}
+            ]
+        }}
+        """

--- a/ironaccord-bot/tests/test_opening_scene_service.py
+++ b/ironaccord-bot/tests/test_opening_scene_service.py
@@ -9,14 +9,21 @@ async def test_generate_opening(monkeypatch):
 
     def fake_query(self, q, k=3):
         calls['query'] = q
-        return [type('D', (), {'page_content': 'lore bit'})()]
+        return 'lore bit'
 
-    async def fake_get_narrative(self, prompt):
+    async def fake_get_completion(self, prompt):
         calls['prompt'] = prompt
         return '{"scene": "start", "question": "do?", "choices": ["a", "b"]}'
 
+    def fake_prompt(self, desc, ctx):
+        calls['prompt_args'] = (desc, ctx)
+        return 'PROMPT'
+
     rag = type('R', (), {'query': fake_query})()
-    agent = type('A', (), {'get_narrative': fake_get_narrative})()
+    agent = type('A', (), {
+        'get_completion': fake_get_completion,
+        'get_opening_scene_prompt': fake_prompt,
+    })()
 
     service = OpeningSceneService(agent, rag)
     result = await service.generate_opening('brave hero')
@@ -26,19 +33,45 @@ async def test_generate_opening(monkeypatch):
         'question': 'do?',
         'choices': ['a', 'b']
     }
-    assert 'brave hero' in calls['prompt']
-    assert 'lore bit' in calls['prompt']
-    assert 'Adopt the persona of Edraz' in calls['prompt']
+    assert calls['prompt'] == 'PROMPT'
+    assert calls['prompt_args'][0] == 'brave hero'
+    assert 'lore bit' in calls['prompt_args'][1]
     assert calls['query'] == 'brave hero'
 
 
 @pytest.mark.asyncio
 async def test_generate_opening_failure(monkeypatch):
-    async def fake_get_narrative(self, prompt):
+    async def fake_get_completion(self, prompt):
         raise RuntimeError('fail')
 
-    rag = type('R', (), {'query': lambda q, k=3: []})()
-    agent = type('A', (), {'get_narrative': fake_get_narrative})()
+    rag = type('R', (), {'query': lambda q, k=3: ''})()
+    def fake_prompt(self, desc, ctx):
+        return 'PROMPT'
+    agent = type('A', (), {
+        'get_completion': fake_get_completion,
+        'get_opening_scene_prompt': fake_prompt,
+    })()
 
     service = OpeningSceneService(agent, rag)
-    assert await service.generate_opening('hero') is None
+    with pytest.raises(RuntimeError):
+        await service.generate_opening('hero')
+
+
+@pytest.mark.asyncio
+async def test_generate_opening_parses_malformed_json(monkeypatch):
+    async def fake_get_completion(self, prompt):
+        return 'text before {"scene": "start", "question": "do?", "choices": []} text after'
+
+    rag = type('R', (), {'query': lambda q, k=3: ''})()
+    agent = type('A', (), {
+        'get_completion': fake_get_completion,
+        'get_opening_scene_prompt': lambda self, d, c: 'PROMPT',
+    })()
+
+    service = OpeningSceneService(agent, rag)
+    result = await service.generate_opening('hero')
+    assert result == {
+        'scene': 'start',
+        'question': 'do?',
+        'choices': []
+    }


### PR DESCRIPTION
## Summary
- add `get_completion` and `get_opening_scene_prompt` helpers in `AIAgent`
- parse malformed JSON in `OpeningSceneService.generate_opening`
- update tests for new interface and add regression for malformed JSON

## Testing
- `PYTHONPATH=ironaccord-bot pytest ironaccord-bot/tests/test_opening_scene_service.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6872dcadd7748327b83f3aaeee91f500