### PR TITLE
Add structured scene prompt

### DIFF
--- a/ironaccord-bot/tests/conftest.py
+++ b/ironaccord-bot/tests/conftest.py
@@ -1,9 +1,36 @@
 import sys
 import importlib
+from pathlib import Path
 
 # Alias the hyphenated package name so `import ironaccord_bot` works
 try:
-    pkg = importlib.import_module('ironaccord-bot')
-    sys.modules['ironaccord_bot'] = pkg
+    pkg = importlib.import_module("ironaccord-bot")
+    sys.modules["ironaccord_bot"] = pkg
+
+    # Expose subpackages like ``services`` and ``models`` at the top level
+    # so tests can simply ``import services`` without the dashed package name.
+    for name in ("services", "models"):
+        try:
+            sys.modules.setdefault(name, importlib.import_module(f"ironaccord-bot.{name}"))
+        except Exception:
+            pass
+
+    # Ensure ``services`` and other subpackages can be imported by adding the
+    # package path directly to ``sys.path``.
+    pkg_path = Path(__file__).resolve().parent.parent / "ironaccord-bot"
+    sys.path.insert(0, str(pkg_path))
+
+    # Provide lightweight stand-ins for optional heavy dependencies used by the
+    # RAG service so the module can be imported during testing.
+    import types
+    sys.modules.setdefault("chromadb", types.SimpleNamespace(PersistentClient=None))
+    sys.modules.setdefault(
+        "langchain_community.vectorstores",
+        types.SimpleNamespace(Chroma=None),
+    )
+    sys.modules.setdefault(
+        "langchain_community.embeddings",
+        types.SimpleNamespace(HuggingFaceEmbeddings=None),
+    )
 except Exception:
     pass

--- a/ironaccord-bot/tests/test_ai_agent.py
+++ b/ironaccord-bot/tests/test_ai_agent.py
@@ -13,3 +13,13 @@ async def test_agent_delegates_to_service(monkeypatch):
     monkeypatch.setattr(agent.ollama_service, "get_narrative", fake_get)
     result = await agent.get_narrative("hi")
     assert result == "result"
+
+
+def test_structured_scene_prompt_includes_context():
+    agent = AIAgent()
+    location = {"name": "Rust Market"}
+    npc = {"name": "Edraz"}
+    prompt = agent.get_structured_scene_prompt(location, npc)
+    assert isinstance(prompt, str)
+    assert location["name"] in prompt
+    assert npc["name"] in prompt


### PR DESCRIPTION
## Summary
- add helper to load OllamaService without heavy service imports
- generate structured scene prompt referencing location and NPC
- expand tests to cover new helper
- load dashed `ironaccord-bot` package in tests

## Testing
- `PYTHONPATH=$PWD pytest ironaccord-bot/tests/test_ai_agent.py -q`
- `PYTHONPATH=$PWD pytest -q` *(fails: ModuleNotFoundError: No module named 'ai')*

------
https://chatgpt.com/codex/tasks/task_e_6872e0fbf7648327a4c4a509108d59e1