### PR TITLE
Improve opening scene generation

### DIFF
--- a/ironaccord-bot/ai/ai_agent.py
+++ b/ironaccord-bot/ai/ai_agent.py
@@ -123,3 +123,36 @@ class AIAgent:
             ]
         }}
         """
+
+    def get_structured_scene_prompt(
+        self, character_description: str, location: str, npc: str
+    ) -> str:
+        """Return the prompt for a structured opening scene."""
+        return f"""
+        You are Lore Weaver, a master storyteller and game master for a tabletop role-playing game.
+        Your task is to generate the opening scene for a new player based on their character description
+        and the following world information.
+
+        **Character Description:**
+        {character_description}
+
+        **Location Lore:**
+        {location}
+
+        **NPC Lore:**
+        {npc}
+
+        **Instructions:** Generate a JSON object with "scene", "question", and "choices" keys.
+        The scene must be concise (no more than two short paragraphs).
+        Each choice should have a "Choice" and a "Result" describing the immediate consequence.
+
+        **Output Format (Strictly JSON):**
+        {{
+            "scene": "...",
+            "question": "...",
+            "choices": [
+                {{"Choice": "...", "Result": "..."}},
+                {{"Choice": "...", "Result": "..."}}
+            ]
+        }}
+        """

--- a/ironaccord-bot/services/opening_scene_service.py
+++ b/ironaccord-bot/services/opening_scene_service.py
@@ -40,9 +40,20 @@ class OpeningSceneService:
         Generates the opening scene using the AI agent and RAG service.
         This method is now robust against malformed JSON from the LLM.
         """
-        logging.info(f"Performing RAG query for: '{text}'")
-        rag_context = self.rag_service.query(text)
-        prompt = self.agent.get_opening_scene_prompt(text, rag_context)
+        logging.info("Fetching opening scene context from RAG")
+        location_info = ""
+        npc_info = ""
+        if self.rag_service:
+            try:
+                location_info = self.rag_service.get_entity_by_name("Brasshaven")
+            except Exception as exc:  # pragma: no cover - rag failure
+                logger.error("Failed retrieving Brasshaven info: %s", exc, exc_info=True)
+            try:
+                npc_info = self.rag_service.get_entity_by_name("Edraz")
+            except Exception as exc:  # pragma: no cover - rag failure
+                logger.error("Failed retrieving Edraz info: %s", exc, exc_info=True)
+
+        prompt = self.agent.get_structured_scene_prompt(text, location_info, npc_info)
 
         raw_response = await self.agent.get_completion(prompt)
 

--- a/ironaccord-bot/services/rag_service.py
+++ b/ironaccord-bot/services/rag_service.py
@@ -75,3 +75,24 @@ class RAGService:
                 f"Error retrieving section '{section_name}' for character '{character_name}': {e}"
             )
             return ""
+
+    def get_entity_by_name(self, name: str) -> str:
+        """Retrieve lore for an entity identified by ``name``."""
+        if not self.vector_store:
+            logger.error("Vector store not available. Cannot perform query.")
+            return ""
+
+        try:
+            results = self.vector_store._collection.query(
+                query_texts=[f"Retrieve lore for {name}"],
+                where={"name": name},
+                n_results=1,
+            )
+
+            if results and results.get("documents") and results["documents"][0]:
+                return results["documents"][0][0]
+
+            return ""
+        except Exception as e:
+            logger.error("Error retrieving entity '%s': %s", name, e)
+            return ""

--- a/ironaccord-bot/tests/test_opening_scene_service.py
+++ b/ironaccord-bot/tests/test_opening_scene_service.py
@@ -7,22 +7,22 @@ from services.opening_scene_service import OpeningSceneService
 async def test_generate_opening(monkeypatch):
     calls = {}
 
-    def fake_query(self, q, k=3):
-        calls['query'] = q
-        return 'lore bit'
+    def fake_get_entity(self, name):
+        calls.setdefault('entity_calls', []).append(name)
+        return f'lore {name}'
 
     async def fake_get_completion(self, prompt):
         calls['prompt'] = prompt
         return '{"scene": "start", "question": "do?", "choices": ["a", "b"]}'
 
-    def fake_prompt(self, desc, ctx):
-        calls['prompt_args'] = (desc, ctx)
+    def fake_prompt(self, desc, loc, npc):
+        calls['prompt_args'] = (desc, loc, npc)
         return 'PROMPT'
 
-    rag = type('R', (), {'query': fake_query})()
+    rag = type('R', (), {'get_entity_by_name': fake_get_entity})()
     agent = type('A', (), {
         'get_completion': fake_get_completion,
-        'get_opening_scene_prompt': fake_prompt,
+        'get_structured_scene_prompt': fake_prompt,
     })()
 
     service = OpeningSceneService(agent, rag)
@@ -35,8 +35,9 @@ async def test_generate_opening(monkeypatch):
     }
     assert calls['prompt'] == 'PROMPT'
     assert calls['prompt_args'][0] == 'brave hero'
-    assert 'lore bit' in calls['prompt_args'][1]
-    assert calls['query'] == 'brave hero'
+    assert calls['prompt_args'][1] == 'lore Brasshaven'
+    assert calls['prompt_args'][2] == 'lore Edraz'
+    assert calls['entity_calls'] == ['Brasshaven', 'Edraz']
 
 
 @pytest.mark.asyncio
@@ -44,12 +45,12 @@ async def test_generate_opening_failure(monkeypatch):
     async def fake_get_completion(self, prompt):
         raise RuntimeError('fail')
 
-    rag = type('R', (), {'query': lambda q, k=3: ''})()
-    def fake_prompt(self, desc, ctx):
+    rag = type('R', (), {'get_entity_by_name': lambda n: ''})()
+    def fake_prompt(self, desc, loc, npc):
         return 'PROMPT'
     agent = type('A', (), {
         'get_completion': fake_get_completion,
-        'get_opening_scene_prompt': fake_prompt,
+        'get_structured_scene_prompt': fake_prompt,
     })()
 
     service = OpeningSceneService(agent, rag)
@@ -62,10 +63,10 @@ async def test_generate_opening_parses_malformed_json(monkeypatch):
     async def fake_get_completion(self, prompt):
         return 'text before {"scene": "start", "question": "do?", "choices": []} text after'
 
-    rag = type('R', (), {'query': lambda q, k=3: ''})()
+    rag = type('R', (), {'get_entity_by_name': lambda n: ''})()
     agent = type('A', (), {
         'get_completion': fake_get_completion,
-        'get_opening_scene_prompt': lambda self, d, c: 'PROMPT',
+        'get_structured_scene_prompt': lambda self, d, l, n: 'PROMPT',
     })()
 
     service = OpeningSceneService(agent, rag)


### PR DESCRIPTION
## Summary
- add structured scene prompt helper to `AIAgent`
- support entity lookup in `RAGService`
- update `OpeningSceneService.generate_opening` to use entity lore
- adjust tests for new behavior

## Testing
- `PYTHONPATH=.:ironaccord-bot pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6872e0fce2bc83278fbeb840e966a695