### PR TITLE
Add entity retrieval via name/type in RAGService

### DIFF
--- a/ironaccord-bot/tests/test_rag_service.py
+++ b/ironaccord-bot/tests/test_rag_service.py
@@ -1,4 +1,5 @@
 import pytest
+import sys
 
 from services import rag_service
 
@@ -49,3 +50,62 @@ def test_query_without_vector_store(monkeypatch):
     service = rag_service.RAGService()
     assert service.vector_store is None
     assert service.query("anything") == []
+
+
+class DummyCollection:
+    def __init__(self, document):
+        self.document = document
+        self.last_where = None
+        self.last_include = None
+        self.last_limit = None
+
+    def get(self, *, where=None, include=None, limit=None):
+        self.last_where = where
+        self.last_include = include
+        self.last_limit = limit
+        return {"documents": [self.document]}
+
+
+def _init_service(monkeypatch):
+    monkeypatch.setattr(rag_service.chromadb, "PersistentClient", lambda *a, **kw: DummyClient())
+    monkeypatch.setattr(rag_service, "HuggingFaceEmbeddings", lambda *a, **kw: DummyEmbeddings())
+    monkeypatch.setattr(rag_service, "Chroma", lambda *a, **kw: DummyChroma(*a, **kw))
+    return rag_service.RAGService()
+
+
+def test_get_entity_by_name_parses_yaml(monkeypatch):
+    service = _init_service(monkeypatch)
+    coll = DummyCollection("foo: bar")
+    service.vector_store._collection = coll
+
+    parsed = {"foo": "bar"}
+
+    import types
+
+    fake_yaml = types.SimpleNamespace(safe_load=lambda x: parsed)
+    monkeypatch.setitem(sys.modules, "yaml", fake_yaml)
+
+    result = service.get_entity_by_name("foo", "npc")
+
+    assert coll.last_where == {"name": "foo", "type": "npc"}
+    assert result == parsed
+
+
+def test_get_entity_by_name_without_yaml(monkeypatch):
+    service = _init_service(monkeypatch)
+    coll = DummyCollection("foo: bar")
+    service.vector_store._collection = coll
+
+    import builtins
+    orig_import = builtins.__import__
+
+    def fake_import(name, globals=None, locals=None, fromlist=(), level=0):
+        if name == "yaml":
+            raise ModuleNotFoundError
+        return orig_import(name, globals, locals, fromlist, level)
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+
+    result = service.get_entity_by_name("foo", "npc")
+
+    assert result == "foo: bar"


### PR DESCRIPTION
## Summary
- implement `get_entity_by_name` in `RAGService`
- extend rag service tests for YAML retrieval

## Testing
- `PYTHONPATH=./ironaccord-bot pytest ironaccord-bot/tests/test_rag_service.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6872e0fb2b148327afe334d8d75c1ff6