### PR TITLE
Improve /start workflow

### DIFF
--- a/ironaccord-bot/tests/conftest.py
+++ b/ironaccord-bot/tests/conftest.py
@@ -1,9 +1,21 @@
 import sys
+from pathlib import Path
 import importlib
+import types
 
-# Alias the hyphenated package name so `import ironaccord_bot` works
+# Add repository root and package directory to sys.path
+ROOT = Path(__file__).resolve().parents[2]
+PKG_PATH = ROOT / 'ironaccord-bot'
+for p in (str(PKG_PATH), str(ROOT)):
+    if p not in sys.path:
+        sys.path.insert(0, p)
+
+# Provide dummy modules for optional heavy dependencies
+sys.modules.setdefault('chromadb', types.SimpleNamespace(PersistentClient=object))
+
+# Alias hyphenated package name
 try:
     pkg = importlib.import_module('ironaccord-bot')
-    sys.modules['ironaccord_bot'] = pkg
+    sys.modules.setdefault('ironaccord_bot', pkg)
 except Exception:
     pass

--- a/ironaccord-bot/tests/test_start_cog.py
+++ b/ironaccord-bot/tests/test_start_cog.py
@@ -25,12 +25,22 @@ async def test_start_cog_returns_view(monkeypatch):
     bot.rag_service = None
     cog = start.StartCog(bot)
 
+    created = {}
+
+    class DummyService:
+        def __init__(self, agent, rag):
+            created["rag"] = rag
+
+    monkeypatch.setattr(start, "OpeningSceneService", DummyService)
+
     interaction = DummyInteraction()
 
     await cog.start.callback(cog, interaction)
 
     assert isinstance(interaction.response.kwargs["view"], start.InterviewView)
     assert interaction.response.kwargs["ephemeral"] is True
+    assert isinstance(cog.opening_scene_service, DummyService)
+    assert created["rag"] is bot.rag_service
 
 
 class DummyFollowup:
@@ -86,8 +96,8 @@ async def test_handle_character_description(monkeypatch):
             self.question = question
             self.choices = choices
 
-    monkeypatch.setattr(start, "OpeningSceneService", DummyService)
     monkeypatch.setattr(start, "OpeningSceneView", DummyView)
+    cog.opening_scene_service = DummyService(None, None)
 
     interaction = DummyInteraction2()
 


### PR DESCRIPTION
## Summary
- initialize OpeningSceneService during `/start`
- fall back to new service if missing
- simplify test setup with path adjustments
- update StartCog tests for structured openening scene

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6872e0fd57d08327a0f1beed6a88114d