### PR TITLE
Update opening scene service

### DIFF
--- a/ironaccord-bot/services/opening_scene_service.py
+++ b/ironaccord-bot/services/opening_scene_service.py
@@ -40,9 +40,11 @@ class OpeningSceneService:
         Generates the opening scene using the AI agent and RAG service.
         This method is now robust against malformed JSON from the LLM.
         """
-        logging.info(f"Performing RAG query for: '{text}'")
-        rag_context = self.rag_service.query(text)
-        prompt = self.agent.get_opening_scene_prompt(text, rag_context)
+        logging.info("Fetching location and NPC data from RAG service")
+        location = self.rag_service.get_entity_by_name("Brasshaven") if self.rag_service else {}
+        npc = self.rag_service.get_entity_by_name("Edraz") if self.rag_service else {}
+
+        prompt = self.agent.get_structured_scene_prompt(location, npc)
 
         raw_response = await self.agent.get_completion(prompt)
 

--- a/ironaccord-bot/services/rag_service.py
+++ b/ironaccord-bot/services/rag_service.py
@@ -53,6 +53,25 @@ class RAGService:
             logger.error(f"An error occurred during the RAG query: {e}")
             return []
 
+    def get_entity_by_name(self, name: str) -> dict:
+        """Return YAML data for an entity by ``name`` if available."""
+        import yaml  # Local import avoids dependency when unused
+        from pathlib import Path
+
+        key = name.lower()
+        search_paths = [
+            Path("ironaccord-bot/data/locations") / f"{key}.yaml",
+            Path("ironaccord-bot/data/npcs") / f"{key}.yaml",
+        ]
+        for path in search_paths:
+            try:
+                if path.exists():
+                    with path.open("r", encoding="utf-8") as f:
+                        return yaml.safe_load(f) or {}
+            except Exception as exc:  # pragma: no cover - unexpected file errors
+                logger.error("Failed to read %s: %s", path, exc)
+        return {}
+
     def get_character_section(self, character_name: str, section_name: str) -> str:
         """Retrieve a specific section of lore for a character."""
         if not self.vector_store:

--- a/ironaccord-bot/tests/test_opening_scene_service.py
+++ b/ironaccord-bot/tests/test_opening_scene_service.py
@@ -7,22 +7,22 @@ from services.opening_scene_service import OpeningSceneService
 async def test_generate_opening(monkeypatch):
     calls = {}
 
-    def fake_query(self, q, k=3):
-        calls['query'] = q
-        return 'lore bit'
+    def fake_get_entity(self, name):
+        calls.setdefault('entities', []).append(name)
+        return {'name': name}
 
     async def fake_get_completion(self, prompt):
         calls['prompt'] = prompt
         return '{"scene": "start", "question": "do?", "choices": ["a", "b"]}'
 
-    def fake_prompt(self, desc, ctx):
-        calls['prompt_args'] = (desc, ctx)
+    def fake_prompt(self, loc, npc):
+        calls['prompt_args'] = (loc, npc)
         return 'PROMPT'
 
-    rag = type('R', (), {'query': fake_query})()
+    rag = type('R', (), {'get_entity_by_name': fake_get_entity})()
     agent = type('A', (), {
         'get_completion': fake_get_completion,
-        'get_opening_scene_prompt': fake_prompt,
+        'get_structured_scene_prompt': fake_prompt,
     })()
 
     service = OpeningSceneService(agent, rag)
@@ -34,9 +34,9 @@ async def test_generate_opening(monkeypatch):
         'choices': ['a', 'b']
     }
     assert calls['prompt'] == 'PROMPT'
-    assert calls['prompt_args'][0] == 'brave hero'
-    assert 'lore bit' in calls['prompt_args'][1]
-    assert calls['query'] == 'brave hero'
+    assert calls['prompt_args'][0]['name'] == 'Brasshaven'
+    assert calls['prompt_args'][1]['name'] == 'Edraz'
+    assert calls['entities'] == ['Brasshaven', 'Edraz']
 
 
 @pytest.mark.asyncio
@@ -44,12 +44,12 @@ async def test_generate_opening_failure(monkeypatch):
     async def fake_get_completion(self, prompt):
         raise RuntimeError('fail')
 
-    rag = type('R', (), {'query': lambda q, k=3: ''})()
-    def fake_prompt(self, desc, ctx):
+    rag = type('R', (), {'get_entity_by_name': lambda self, n: {}})()
+    def fake_prompt(self, loc, npc):
         return 'PROMPT'
     agent = type('A', (), {
         'get_completion': fake_get_completion,
-        'get_opening_scene_prompt': fake_prompt,
+        'get_structured_scene_prompt': fake_prompt,
     })()
 
     service = OpeningSceneService(agent, rag)
@@ -62,10 +62,10 @@ async def test_generate_opening_parses_malformed_json(monkeypatch):
     async def fake_get_completion(self, prompt):
         return 'text before {"scene": "start", "question": "do?", "choices": []} text after'
 
-    rag = type('R', (), {'query': lambda q, k=3: ''})()
+    rag = type('R', (), {'get_entity_by_name': lambda self, n: {}})()
     agent = type('A', (), {
         'get_completion': fake_get_completion,
-        'get_opening_scene_prompt': lambda self, d, c: 'PROMPT',
+        'get_structured_scene_prompt': lambda self, d, c: 'PROMPT',
     })()
 
     service = OpeningSceneService(agent, rag)


### PR DESCRIPTION
## Summary
- update OpeningSceneService to gather location and NPC info
- add a helper to RAGService for loading entity YAML
- adjust tests for new structured scene prompt

## Testing
- `PYTHONPATH=ironaccord-bot pytest ironaccord-bot/tests/test_opening_scene_service.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6872e4acb4b483279c2d9cb3e833a5dd