### PR TITLE
Refactor opening scene

### DIFF
--- a/ironaccord-bot/data/locations/brasshaven.yaml
+++ b/ironaccord-bot/data/locations/brasshaven.yaml
@@ -1,22 +1,13 @@
-name: Brasshaven
-type: city
-description: >-
-  Brasshaven is a layered megacity of soot-stained pipes, rotating pressure lifts, and
-  massive forge towers that pierce the smog-filled sky.
-key_districts:
-  - name: Forge Choir
-    description: >-
-      The central industrial and crafting hub, where the city's heart beats in the rhythm of a thousand hammers.
-  - name: Steamward Chapel
-    description: >-
-      A cathedral-like temple to the Flame, where Forgeseers preach the Credo Ferrum.
-  - name: The Grateworks
-    description: >-
-      The sprawling slums and service tunnels, home to scavengers, outcasts, and those who live in the city's shadows.
-  - name: The Bastion Blades
-    description: >-
-      The heavily fortified defensive perimeter and garrison, constantly vigilant against rogue machines and Neon Dharma incursions.
-  - name: The Archivalt
-    description: >-
-      A sealed memory vault containing pre-War technologies and forbidden texts, guarded by the most devout members of the Order of the Flame.
-faction: Iron Accord
+name: "Brasshaven"
+type: "Location"
+description: "The resilient heart of the Iron Accord, a city built in the husk of a colossal, dormant war machine. Its streets are a maze of salvaged metal and repurposed technology."
+atmosphere:
+  - "The constant, low hum of dormant machinery."
+  - "Air smells of hot metal, ozone, and clean water from the purification systems."
+  - "Gleaming brass and polished steel reflect the glow of steam-lamps."
+factions:
+  - name: "The Steamwrights Guild"
+    presence: "High"
+    disposition: "Neutral"
+key_npcs:
+  - "Edraz"

--- a/ironaccord-bot/data/npcs/edraz.yaml
+++ b/ironaccord-bot/data/npcs/edraz.yaml
@@ -1,16 +1,14 @@
-name: Edraz
-role: Iron Seeker
-type: npc
-description: >-
-  Edraz is the grizzled and pragmatic leader of the Iron Accord, known for his unwavering resolve and deep knowledge of pre-Cataclysm technology. Stern and distant, he fiercely protects those under his command.
-physical_description: >-
-  A powerfully built man in his late 50s with a thick, iron-grey beard and numerous scars. He carries a custom-forged power wrench and wears reinforced Accord gear.
-personality_traits:
-  - Pragmatic and cautious
-  - Protective of his crew
-  - Strokes his beard when contemplating difficult decisions
-background: >-
-  Formerly an engineer, Edraz witnessed the Cataclysm firsthand. He founded the Iron Accord to safeguard surviving technology and maintain order.
-plot_hooks:
-  goal: Seeks a lost pre-Cataclysm artifact known as the "Heart of the Cog" to restore power to Brasshaven.
-  conflict: Deeply suspicious of the Steamwrights Guild and their reckless experiments.
+name: "Edraz"
+type: "NPC"
+title: "Chronicler of the Accord"
+location: "Brasshaven"
+description: "An ancient, patient automaton. Edraz's chassis is a mix of polished brass and dark iron, with optical sensors that glow with a soft, golden light. He is the living library of the Iron Accord."
+personality:
+  - "Patient"
+  - "Inquisitive"
+  - "Methodical"
+  - "A passive observer, rarely showing emotion."
+knowledge:
+  - "The complete history of the Iron Accord."
+  - "The operational status of Brasshaven's systems."
+initial_greeting: "Signal integrity confirmed. Welcome, traveler. I am Edraz. Your arrival has been noted in the chronicle. State your purpose."

--- a/ironaccord-bot/tests/test_opening_scene_service.py
+++ b/ironaccord-bot/tests/test_opening_scene_service.py
@@ -7,22 +7,22 @@ from services.opening_scene_service import OpeningSceneService
 async def test_generate_opening(monkeypatch):
     calls = {}
 
-    def fake_query(self, q, k=3):
-        calls['query'] = q
-        return 'lore bit'
+    def fake_get(self, name, typ):
+        calls.setdefault('get', []).append((name, typ))
+        return {'name': name}
 
     async def fake_get_completion(self, prompt):
         calls['prompt'] = prompt
         return '{"scene": "start", "question": "do?", "choices": ["a", "b"]}'
 
-    def fake_prompt(self, desc, ctx):
-        calls['prompt_args'] = (desc, ctx)
+    def fake_prompt(self, location, npc):
+        calls['prompt_args'] = (location, npc)
         return 'PROMPT'
 
-    rag = type('R', (), {'query': fake_query})()
+    rag = type('R', (), {'get_entity_by_name': fake_get})()
     agent = type('A', (), {
         'get_completion': fake_get_completion,
-        'get_opening_scene_prompt': fake_prompt,
+        'get_structured_scene_prompt': fake_prompt,
     })()
 
     service = OpeningSceneService(agent, rag)
@@ -34,9 +34,10 @@ async def test_generate_opening(monkeypatch):
         'choices': ['a', 'b']
     }
     assert calls['prompt'] == 'PROMPT'
-    assert calls['prompt_args'][0] == 'brave hero'
-    assert 'lore bit' in calls['prompt_args'][1]
-    assert calls['query'] == 'brave hero'
+    assert calls['prompt_args'][0]['name'] == 'Brasshaven'
+    assert calls['prompt_args'][1]['name'] == 'Edraz'
+    assert ('Brasshaven', 'Location') in calls['get']
+    assert ('Edraz', 'NPC') in calls['get']
 
 
 @pytest.mark.asyncio
@@ -44,12 +45,12 @@ async def test_generate_opening_failure(monkeypatch):
     async def fake_get_completion(self, prompt):
         raise RuntimeError('fail')
 
-    rag = type('R', (), {'query': lambda q, k=3: ''})()
-    def fake_prompt(self, desc, ctx):
+    rag = type('R', (), {'get_entity_by_name': lambda *a, **k: {}})()
+    def fake_prompt(self, location, npc):
         return 'PROMPT'
     agent = type('A', (), {
         'get_completion': fake_get_completion,
-        'get_opening_scene_prompt': fake_prompt,
+        'get_structured_scene_prompt': fake_prompt,
     })()
 
     service = OpeningSceneService(agent, rag)
@@ -62,10 +63,10 @@ async def test_generate_opening_parses_malformed_json(monkeypatch):
     async def fake_get_completion(self, prompt):
         return 'text before {"scene": "start", "question": "do?", "choices": []} text after'
 
-    rag = type('R', (), {'query': lambda q, k=3: ''})()
+    rag = type('R', (), {'get_entity_by_name': lambda *a, **k: {}})()
     agent = type('A', (), {
         'get_completion': fake_get_completion,
-        'get_opening_scene_prompt': lambda self, d, c: 'PROMPT',
+        'get_structured_scene_prompt': lambda self, d, c: 'PROMPT',
     })()
 
     service = OpeningSceneService(agent, rag)


### PR DESCRIPTION
## Summary
- update Brasshaven and Edraz lore yaml
- allow `OpeningSceneService` to pull structured lore via `RAGService`
- adjust tests for new structured scene workflow

## Testing
- `PYTHONPATH=ironaccord-bot pytest ironaccord-bot/tests/test_opening_scene_service.py -q`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'ironaccord_bot')*

------
https://chatgpt.com/codex/tasks/task_e_6872e532dbe883278ca827a467e12520