### PR TITLE
Handle missing docs directory

### DIFF
--- a/ironaccord-bot/ingest.py
+++ b/ironaccord-bot/ingest.py
@@ -34,12 +34,17 @@ def ingest_data():
                 else:
                     print(f"  - WARNING: Skipping {filename}, missing required fields.")
 
-    print("Processing unstructured markdown data...")
-    markdown_loader = DirectoryLoader(
-        "docs", glob="**/*.md", loader_cls=UnstructuredMarkdownLoader, show_progress=True
-    )
-    markdown_docs = markdown_loader.load()
-    all_documents.extend(markdown_docs)
+    print("Checking for unstructured markdown data...")
+    docs_path = "docs"
+    if os.path.exists(docs_path) and os.path.isdir(docs_path):
+        print("Processing unstructured markdown data...")
+        markdown_loader = DirectoryLoader(
+            docs_path, glob="**/*.md", loader_cls=UnstructuredMarkdownLoader, show_progress=True
+        )
+        markdown_docs = markdown_loader.load()
+        all_documents.extend(markdown_docs)
+    else:
+        print("  - 'docs' directory not found, skipping markdown ingestion.")
 
     print("Splitting documents and creating vector store...")
     text_splitter = RecursiveCharacterTextSplitter(chunk_size=750, chunk_overlap=50)


### PR DESCRIPTION
## Summary
- avoid crash when `docs/` directory is absent
- only load markdown files if the folder exists

## Testing
- `PYTHONPATH=$(pwd):$(pwd)/ironaccord-bot pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6873ef152aa88327b88df8e847084c3e