### PR TITLE
Fix ingest doc processing and test

### DIFF
--- a/ironaccord-bot/ingest.py
+++ b/ironaccord-bot/ingest.py
@@ -1,5 +1,6 @@
 import os
 import yaml
+from langchain.schema import Document
 from langchain_community.vectorstores import Chroma
 from langchain_community.embeddings import OllamaEmbeddings
 from langchain.text_splitter import RecursiveCharacterTextSplitter
@@ -28,7 +29,9 @@ def ingest_data():
                     and "type" in data
                     and "description" in data
                 ):
-                    doc = {"page_content": data["description"], "metadata": data}
+                    doc = Document(
+                        page_content=data.get("description", ""), metadata=data
+                    )
                     all_documents.append(doc)
                     print(f"  - Loaded entity: {data['name']}")
                 else:

--- a/ironaccord-bot/tests/test_ingest.py
+++ b/ironaccord-bot/tests/test_ingest.py
@@ -1,0 +1,54 @@
+import os
+from pathlib import Path
+from types import SimpleNamespace
+from langchain.schema import Document
+from ironaccord_bot import ingest
+
+class DummyLoader:
+    def __init__(self, *a, **kw):
+        self.docs = [Document(page_content="md", metadata={"src": "m"})]
+    def load(self):
+        return self.docs
+
+class DummySplitter:
+    def __init__(self, *a, **kw):
+        pass
+    def split_documents(self, docs):
+        DummySplitter.docs = docs
+        return docs
+
+class DummyChroma:
+    def __init__(self, *a, **kw):
+        pass
+    @classmethod
+    def from_documents(cls, documents, embedding, collection_name, persist_directory):
+        DummyChroma.docs = documents
+        DummyChroma.persist_dir = persist_directory
+        return cls()
+    def persist(self):
+        DummyChroma.persisted = True
+
+class DummyEmb:
+    pass
+
+
+def test_ingest_mixed_sources(tmp_path, monkeypatch):
+    data_dir = tmp_path / "data"
+    data_dir.mkdir()
+    yaml_file = data_dir / "npc.yaml"
+    yaml_file.write_text("""\nname: Test\ntype: npc\ndescription: hi\n""")
+    docs_dir = tmp_path / "docs"
+    docs_dir.mkdir()
+
+    monkeypatch.setattr(ingest, "DATA_PATH", str(data_dir))
+    monkeypatch.setattr(ingest, "DB_PATH", str(tmp_path / "db"))
+    monkeypatch.setattr(ingest, "DirectoryLoader", DummyLoader)
+    monkeypatch.setattr(ingest, "RecursiveCharacterTextSplitter", DummySplitter)
+    monkeypatch.setattr(ingest, "Chroma", DummyChroma)
+    monkeypatch.setattr(ingest, "OllamaEmbeddings", lambda *a, **kw: DummyEmb())
+
+    ingest.ingest_data()
+
+    assert all(isinstance(d, Document) for d in DummySplitter.docs)
+    assert len(DummyChroma.docs) == len(DummySplitter.docs)
+    assert DummyChroma.persisted

--- a/ironaccord_bot/__init__.py
+++ b/ironaccord_bot/__init__.py
@@ -1,0 +1,9 @@
+import importlib.util, sys, pathlib
+pkg_path = pathlib.Path(__file__).resolve().parent.parent / 'ironaccord-bot'
+spec = importlib.util.spec_from_file_location('ironaccord-bot', pkg_path / '__init__.py')
+pkg = importlib.util.module_from_spec(spec)
+sys.modules['ironaccord-bot'] = pkg
+spec.loader.exec_module(pkg)
+for k, v in pkg.__dict__.items():
+    globals()[k] = v
+sys.modules.setdefault('ironaccord_bot', pkg)

--- a/sitecustomize.py
+++ b/sitecustomize.py
@@ -1,0 +1,17 @@
+import importlib, importlib.util, sys, pathlib
+pkg_path = pathlib.Path(__file__).resolve().parent / 'ironaccord-bot'
+if pkg_path.exists():
+    spec = importlib.util.spec_from_file_location(
+        'ironaccord-bot', pkg_path / '__init__.py', submodule_search_locations=[str(pkg_path)]
+    )
+    pkg = importlib.util.module_from_spec(spec)
+    sys.modules['ironaccord-bot'] = pkg
+    spec.loader.exec_module(pkg)
+    sys.modules.setdefault('ironaccord_bot', pkg)
+    # expose subpackages like ai, services, models, views, utils
+    # ensure interview_config is loaded first since other modules may depend on it
+    for name in ("interview_config", "models", "services", "ai", "views", "utils", "data"):
+        try:
+            sys.modules.setdefault(name, importlib.import_module(f"ironaccord-bot.{name}"))
+        except Exception:
+            pass


### PR DESCRIPTION
## Summary
- fix ingest script to wrap YAML data as `Document`
- add alias loader via `sitecustomize.py` so tests can import hyphenated package
- create basic test to cover ingestion of mixed YAML and markdown sources

## Testing
- `PYTHONPATH=. pytest ironaccord-bot/tests/test_ingest.py::test_ingest_mixed_sources -q`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6873f2b06a008327a697a98742d43511