### PR TITLE
Add set_player_background function

### DIFF
--- a/ironaccord-bot/models/character_service.py
+++ b/ironaccord-bot/models/character_service.py
@@ -64,3 +64,11 @@ async def insert_character(name: str, origin: str, skill: str) -> int:
     )
     return res['insertId']
 
+
+async def set_player_background(discord_id: str, background: str) -> None:
+    """Persist the player's chosen background."""
+    await db.query(
+        'UPDATE players SET background=%s WHERE discord_id=%s',
+        [background, discord_id],
+    )
+

--- a/ironaccord-bot/tests/test_character_service.py
+++ b/ironaccord-bot/tests/test_character_service.py
@@ -22,3 +22,14 @@ async def test_insert_character(monkeypatch):
         'INSERT INTO characters (name, origin, skill) VALUES (%s, %s, %s)',
         ['Alice', 'Brasshaven', 'tinker']
     )
+
+
+@pytest.mark.asyncio
+async def test_set_player_background(monkeypatch):
+    monkeypatch.setattr(character_service, 'db', db)
+    db.calls.clear()
+    await character_service.set_player_background('42', 'steamwright')
+    assert db.calls[0] == (
+        'UPDATE players SET background=%s WHERE discord_id=%s',
+        ['steamwright', '42']
+    )


### PR DESCRIPTION
## Summary
- add a service helper to update a player's background
- unit test for background persistence

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6873fa1a1ea08327aafcbc4e9a3db2cc