### PR TITLE
Ensure ironaccord_bot imports during tests

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,3 +1,7 @@
 discord.py==2.3.2
 aiomysql==0.2.0
 httpx==0.27.0
+langchain==0.1.16
+pytest>=7.0
+pytest-asyncio>=1.0
+python-dotenv

--- a/ironaccord-bot/tests/conftest.py
+++ b/ironaccord-bot/tests/conftest.py
@@ -1,6 +1,15 @@
+import os
 import sys
 import importlib
 from pathlib import Path
+
+# Ensure the project root is on the Python path and advertise it via the
+# PYTHONPATH environment variable so that ``ironaccord_bot`` can be imported
+# when tests run from any directory.
+project_root = Path(__file__).resolve().parents[1]
+if str(project_root) not in sys.path:
+    sys.path.insert(0, str(project_root))
+os.environ.setdefault("PYTHONPATH", str(project_root))
 
 # Alias the hyphenated package name so `import ironaccord_bot` works
 try:
@@ -32,7 +41,10 @@ try:
     )
     sys.modules.setdefault(
         "langchain_community.embeddings",
-        types.SimpleNamespace(HuggingFaceEmbeddings=None),
+        types.SimpleNamespace(
+            HuggingFaceEmbeddings=None,
+            OllamaEmbeddings=None,
+        ),
     )
 except Exception:
     pass


### PR DESCRIPTION
## Summary
- insert the project root in `PYTHONPATH` during tests so that `ironaccord_bot` is importable
- document required packages for tests in `dev-requirements.txt`

## Testing
- `pip install -r dev-requirements.txt`
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6873fa1bca208327b765212def0852f6