### PR TITLE
Improve JSON parsing and Discord interaction

### DIFF
--- a/ironaccord-bot/cogs/start.py
+++ b/ironaccord-bot/cogs/start.py
@@ -32,9 +32,19 @@ class StartCog(commands.Cog):
     )
     async def start(self, interaction: discord.Interaction):
         """Begin the Edraz interview question flow."""
-        questions = await self.quiz_service.generate_questions()
+        await interaction.response.defer(ephemeral=True)
+
+        try:
+            questions = await self.quiz_service.generate_questions()
+        except Exception as exc:  # pragma: no cover - unexpected failure
+            logging.error("Failed generating quiz questions: %s", exc, exc_info=True)
+            await interaction.followup.send(
+                "An error occurred while generating the quiz.", ephemeral=True
+            )
+            return
+
         if not questions:
-            await interaction.response.send_message(
+            await interaction.followup.send(
                 "An error occurred while generating the quiz.", ephemeral=True
             )
             return
@@ -46,7 +56,8 @@ class StartCog(commands.Cog):
             color=discord.Color.dark_gold(),
         )
         embed.set_image(url=EDRAZ_IMAGE_URL)
-        await interaction.response.send_message(embed=embed, view=view, ephemeral=True)
+
+        await interaction.followup.send(embed=embed, view=view, ephemeral=True)
 
     async def handle_background_result(
         self, interaction: discord.Interaction, background: str, explanation: str

--- a/ironaccord-bot/services/background_quiz_service.py
+++ b/ironaccord-bot/services/background_quiz_service.py
@@ -5,6 +5,16 @@ from typing import List, Dict, Any
 
 from ai.ai_agent import AIAgent
 
+
+def extract_json_from_llm(response_text: str) -> dict:
+    """Find and parse a JSON object embedded in ``response_text``."""
+    start_index = response_text.find("{")
+    end_index = response_text.rfind("}") + 1
+    if start_index == -1 or end_index == 0:
+        raise ValueError("No JSON object found in the LLM response.")
+    json_str = response_text[start_index:end_index]
+    return json.loads(json_str)
+
 logger = logging.getLogger(__name__)
 
 
@@ -42,9 +52,9 @@ class BackgroundQuizService:
             return []
 
         try:
-            data = json.loads(text)
+            data = extract_json_from_llm(text)
             return data.get("questions", [])
-        except json.JSONDecodeError:
+        except Exception:
             logger.error("Invalid JSON from LLM: %s", text)
             return []
 
@@ -69,7 +79,7 @@ class BackgroundQuizService:
             return None
 
         try:
-            return json.loads(text)
-        except json.JSONDecodeError:
+            return extract_json_from_llm(text)
+        except Exception:
             logger.error("Invalid JSON from LLM: %s", text)
             return None

--- a/ironaccord-bot/tests/test_background_quiz_service.py
+++ b/ironaccord-bot/tests/test_background_quiz_service.py
@@ -1,0 +1,25 @@
+import pytest
+
+from services.background_quiz_service import BackgroundQuizService
+
+
+@pytest.mark.asyncio
+async def test_generate_questions_parses_extra_text():
+    async def fake_get(self, prompt):
+        return "Some intro {\"questions\": [{\"text\": \"q\", \"choices\": [\"a\", \"b\"]}]} more"
+
+    agent = type('A', (), {'get_completion': fake_get})()
+    service = BackgroundQuizService(agent)
+    result = await service.generate_questions()
+    assert result == [{"text": "q", "choices": ["a", "b"]}]
+
+
+@pytest.mark.asyncio
+async def test_evaluate_answers_parses_extra_text():
+    async def fake_get(self, prompt):
+        return "preface {\"background\": \"soldier\", \"explanation\": \"because\"} end"
+
+    agent = type('A', (), {'get_completion': fake_get})()
+    service = BackgroundQuizService(agent)
+    result = await service.evaluate_answers([], [])
+    assert result == {"background": "soldier", "explanation": "because"}

--- a/ironaccord-bot/tests/test_start_cog.py
+++ b/ironaccord-bot/tests/test_start_cog.py
@@ -8,8 +8,21 @@ from ironaccord_bot.cogs import start
 class DummyResponse:
     def __init__(self):
         self.kwargs = None
+        self.deferred = False
 
     async def send_message(self, *args, **kwargs):
+        self.kwargs = kwargs
+
+    async def defer(self, *args, **kwargs):
+        self.deferred = True
+        self.kwargs = kwargs
+
+
+class DummyFollowup:
+    def __init__(self):
+        self.kwargs = None
+
+    async def send(self, *args, **kwargs):
         self.kwargs = kwargs
 
 
@@ -19,7 +32,7 @@ class DummyInteraction:
             "User", (), {"id": 1, "name": "Test", "display_name": "Test"}
         )()
         self.response = DummyResponse()
-        self.followup = None
+        self.followup = DummyFollowup()
 
 
 @pytest.mark.asyncio
@@ -37,16 +50,9 @@ async def test_start_cog_returns_view(monkeypatch):
 
     await cog.start.callback(cog, interaction)
 
-    assert isinstance(interaction.response.kwargs["view"], start.BackgroundQuizView)
-    assert interaction.response.kwargs["ephemeral"] is True
-
-
-class DummyFollowup:
-    def __init__(self):
-        self.kwargs = None
-
-    async def send(self, *args, **kwargs):
-        self.kwargs = kwargs
+    assert interaction.response.deferred is True
+    assert isinstance(interaction.followup.kwargs["view"], start.BackgroundQuizView)
+    assert interaction.followup.kwargs["ephemeral"] is True
 
 
 class DummyInteraction2:


### PR DESCRIPTION
## Summary
- robustly extract JSON portions from LLM output
- defer the `/start` command before generating the quiz
- add regression tests for background quiz service
- update start cog tests for the new interaction flow

## Testing
- `PYTHONPATH=$(pwd) pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68740583253083279d693dad54c5bd0c