### PR TITLE
Sync default collection for ingest and RAG

### DIFF
--- a/ironaccord-bot/ingest.py
+++ b/ironaccord-bot/ingest.py
@@ -2,6 +2,7 @@ import os
 import yaml
 from langchain.schema import Document
 from langchain_community.vectorstores import Chroma
+from services.rag_service import DEFAULT_COLLECTION
 try:  # OllamaEmbeddings may not be available during testing
     from langchain_community.embeddings import OllamaEmbeddings
 except Exception:  # pragma: no cover - provide lightweight fallback
@@ -78,7 +79,7 @@ def ingest_data():
     vector_store = Chroma.from_documents(
         documents=splits,
         embedding=OllamaEmbeddings(model="nomic-embed-text", show_progress=True),
-        collection_name="ironaccord-lore",
+        collection_name=DEFAULT_COLLECTION,
         persist_directory=DB_PATH,
     )
 

--- a/ironaccord-bot/services/rag_service.py
+++ b/ironaccord-bot/services/rag_service.py
@@ -3,12 +3,15 @@ import chromadb
 from langchain_community.vectorstores import Chroma
 from langchain_community.embeddings import HuggingFaceEmbeddings
 
+# Default collection name shared with the ingest script
+DEFAULT_COLLECTION = "ironaccord-lore"
+
 logger = logging.getLogger(__name__)
 
 class RAGService:
     """Service to connect to a persistent ChromaDB vector store and perform queries."""
 
-    def __init__(self, db_path="./db", collection_name="iron_accord_lore"):
+    def __init__(self, db_path="./db", collection_name: str = DEFAULT_COLLECTION):
         self.db_path = db_path
         self.collection_name = collection_name
         self.client = None


### PR DESCRIPTION
## Summary
- centralize the ChromaDB collection name
- update ingestion script and RAG service to reference the same constant

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68741626322c832784d494f00aa13da4