### PR TITLE
Switch bot startup prints to debug logging

### DIFF
--- a/ironaccord-bot/bot.py
+++ b/ironaccord-bot/bot.py
@@ -7,9 +7,6 @@ project_root = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
 if project_root not in sys.path:
     sys.path.insert(0, project_root)
 
-print("--- PYTHON PATH ---")
-pprint.pprint(sys.path)
-print("-------------------")
 
 import argparse
 import discord
@@ -30,6 +27,9 @@ except Exception:  # pragma: no cover - optional dependency
 load_dotenv()
 TOKEN = os.getenv("DISCORD_TOKEN")
 logger = logging.getLogger("discord")
+logger.debug("--- PYTHON PATH ---")
+logger.debug(pprint.pformat(sys.path))
+logger.debug("-------------------")
 
 
 def parse_args() -> argparse.Namespace:


### PR DESCRIPTION
## Summary
- use `logging.debug` for Python path output during bot startup

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6874162728d4832790a0987dfcf7ddc2