### PR TITLE
Refactor: Remove unused ironaccord_bot directory

### DIFF
--- a/ironaccord_bot/__init__.py
+++ b/ironaccord_bot/__init__.py
@@ -1,9 +1,0 @@
-import importlib.util, sys, pathlib
-pkg_path = pathlib.Path(__file__).resolve().parent.parent / 'ironaccord-bot'
-spec = importlib.util.spec_from_file_location('ironaccord-bot', pkg_path / '__init__.py')
-pkg = importlib.util.module_from_spec(spec)
-sys.modules['ironaccord-bot'] = pkg
-spec.loader.exec_module(pkg)
-for k, v in pkg.__dict__.items():
-    globals()[k] = v
-sys.modules.setdefault('ironaccord_bot', pkg)


### PR DESCRIPTION
## Summary
- remove the redundant `ironaccord_bot` directory

## Testing
- `python3 ironaccord-bot/bot.py` *(fails: ModuleNotFoundError: no module named 'discord')*
- `python3 -m pytest -q` *(fails: 4 failed, 40 passed)*

------
https://chatgpt.com/codex/tasks/task_e_6874258dab7883278a4d912bcf7c98e8