### PR TITLE
Add simple RAG test setup

### DIFF
--- a/data/edraz_test.md
+++ b/data/edraz_test.md
@@ -1,0 +1,3 @@
+# Character Profile: Edraz
+
+Edraz is a stoic and battle-hardened warrior, known for his unwavering loyalty and a grim past that haunts his every step. He is the last surviving member of the Iron Accord.

--- a/test_query.py
+++ b/test_query.py
@@ -1,0 +1,25 @@
+import pathlib, sys
+sys.path.append(str(pathlib.Path(__file__).resolve().parent / "ironaccord-bot"))
+import ironaccord_bot
+import asyncio
+from ironaccord_bot.services.rag_service import RAGService
+
+async def main():
+    """Initializes the RAGService and performs a test query."""
+    print("Initializing RAG service...")
+    rag_service = RAGService()
+    await asyncio.sleep(1)
+    query = "Who is Edraz?"
+    print(f"\nPerforming query: '{query}'")
+    result = await rag_service.query(query)
+    print("\n--- Query Result ---")
+    if result and result.get("answer"):
+        print(f"Answer: {result['answer']}")
+        print("\n--- Source Documents ---")
+        for doc in result.get("source_documents", []):
+            print(f"- {doc.page_content}")
+    else:
+        print("No answer found.")
+
+if __name__ == "__main__":
+    asyncio.run(main())


### PR DESCRIPTION
## Summary
- add minimal Edraz test data
- provide test_query script for quick RAG check

## Testing
- `python ironaccord-bot/ingest.py` *(fails: connection refused)*
- `pytest -q` *(fails: ModuleNotFoundError for `ironaccord_bot`)*
- `python test_query.py` *(fails: `RAGService` has no attribute `query`)*

------
https://chatgpt.com/codex/tasks/task_e_6874268a7c6c8327ae3e537cdd78fc24