### PR TITLE
Move chromadb test stub

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ __pycache__/
 *.pyc
 chroma_db/
 chromadb/
+!ironaccord-bot/tests/stubs/chromadb/
 langchain_community/
 dotenv.py
 db/

--- a/README.md
+++ b/README.md
@@ -9,6 +9,9 @@ This repository houses the Discord bot used for the auto battler experiments alo
 - `docs/yaml/` – structured YAML lore used for retrieval.
 - `index.html`, `poc2/` – early browser prototypes kept for reference.
 - `ironaccord-bot/data/items.py` – base item definitions consumed by missions and rewards.
+- `ironaccord-bot/tests/stubs/chromadb/` – lightweight stand‑in for the
+  [Chromadb](https://github.com/chroma-core/chroma) client so the test suite can
+  run without the heavy dependency installed.
 
 ## Setup
 

--- a/chromadb/__init__.py
+++ b/chromadb/__init__.py
@@ -1,3 +1,0 @@
-class PersistentClient:
-    def __init__(self, *a, **kw):
-        pass

--- a/ironaccord-bot/tests/stubs/chromadb/__init__.py
+++ b/ironaccord-bot/tests/stubs/chromadb/__init__.py
@@ -1,0 +1,11 @@
+"""Minimal stand-in for the ``chromadb`` package used in tests.
+
+Only the ``PersistentClient`` class is defined because the real library is
+heavy and rarely needed during unit testing.  Services import this module so the
+test suite can run without pulling in the actual dependency.
+"""
+
+
+class PersistentClient:
+    def __init__(self, *a, **kw):
+        pass

--- a/ironaccord-bot/tests/test_rag_service.py
+++ b/ironaccord-bot/tests/test_rag_service.py
@@ -28,7 +28,8 @@ def test_initialize_and_query(monkeypatch):
         created["client"] = True
         return DummyClient()
 
-    monkeypatch.setattr(rag_service.chromadb, "PersistentClient", dummy_http_client)
+    import chromadb
+    monkeypatch.setattr(chromadb, "PersistentClient", dummy_http_client)
     monkeypatch.setattr(rag_service, "HuggingFaceEmbeddings", lambda *a, **kw: DummyEmbeddings())
     monkeypatch.setattr(rag_service, "Chroma", lambda *a, **kw: DummyChroma(*a, **kw))
 
@@ -45,7 +46,8 @@ def test_query_without_vector_store(monkeypatch):
     def fail_client(*args, **kwargs):
         raise RuntimeError("no connection")
 
-    monkeypatch.setattr(rag_service.chromadb, "PersistentClient", fail_client)
+    import chromadb
+    monkeypatch.setattr(chromadb, "PersistentClient", fail_client)
 
     service = rag_service.RAGService()
     assert service.vector_store is None
@@ -69,7 +71,8 @@ class DummyCollection:
 
 
 def _init_service(monkeypatch):
-    monkeypatch.setattr(rag_service.chromadb, "PersistentClient", lambda *a, **kw: DummyClient())
+    import chromadb
+    monkeypatch.setattr(chromadb, "PersistentClient", lambda *a, **kw: DummyClient())
     monkeypatch.setattr(rag_service, "HuggingFaceEmbeddings", lambda *a, **kw: DummyEmbeddings())
     monkeypatch.setattr(rag_service, "Chroma", lambda *a, **kw: DummyChroma(*a, **kw))
     return rag_service.RAGService()


### PR DESCRIPTION
## Summary
- document the chromadb stub in the README
- relocate chromadb stub into `ironaccord-bot/tests/stubs`
- load the stub from `conftest.py` and update tests
- allow the stub directory despite the existing gitignore rule

## Testing
- `pytest -q ironaccord-bot/tests/test_rag_service.py -vv` *(fails: RAGService has no attribute 'query')*

------
https://chatgpt.com/codex/tasks/task_e_68746217162c8327914cb72d9ea17e98