### PR TITLE
Remove ironaccord_bot package and update imports

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ This repository houses the Discord bot used for the auto battler experiments alo
    ```
 5. Start the bot:
    ```bash
-   python -m ironaccord_bot.bot
+   python -m ironaccord-bot.bot
    ```
    Using `python -m` runs the package as a module so relative imports work.
 6. Once the bot is online, use `/start` in your Discord server to play through a one-shot adventure generated from the structured lore data.

--- a/ironaccord-bot/tests/conftest.py
+++ b/ironaccord-bot/tests/conftest.py
@@ -6,7 +6,7 @@ from pathlib import Path
 # Ensure the project root is on the Python path and advertise it via the
 # PYTHONPATH environment variable so that ``ironaccord_bot`` can be imported
 # when tests run from any directory.
-project_root = Path(__file__).resolve().parents[1]
+project_root = Path(__file__).resolve().parents[2]
 if str(project_root) not in sys.path:
     sys.path.insert(0, str(project_root))
 os.environ.setdefault("PYTHONPATH", str(project_root))
@@ -14,37 +14,50 @@ os.environ.setdefault("PYTHONPATH", str(project_root))
 # Alias the hyphenated package name so `import ironaccord_bot` works
 try:
     pkg = importlib.import_module("ironaccord-bot")
+except ModuleNotFoundError:
+    pkg_path = project_root / "ironaccord-bot"
+    spec = importlib.util.spec_from_file_location(
+        "ironaccord-bot",
+        pkg_path / "__init__.py",
+        submodule_search_locations=[str(pkg_path)],
+    )
+    pkg = importlib.util.module_from_spec(spec)
+    sys.modules["ironaccord-bot"] = pkg
+    spec.loader.exec_module(pkg)
+except Exception:
+    pkg = None
+
+if pkg:
     sys.modules["ironaccord_bot"] = pkg
 
-    # Expose subpackages like ``services`` and ``models`` at the top level so
-    # tests can simply ``import services`` without the dashed package name.
-    # Import ``models`` first so that ``services`` modules depending on it load
-    # correctly during this setup.
-    for name in ("models", "services"):
-        try:
-            sys.modules.setdefault(name, importlib.import_module(f"ironaccord-bot.{name}"))
-        except Exception:
-            pass
 
-    # Ensure ``services`` and other subpackages can be imported by adding the
-    # package path directly to ``sys.path``.
-    pkg_path = Path(__file__).resolve().parent.parent / "ironaccord-bot"
-    sys.path.insert(0, str(pkg_path))
+# Expose subpackages like ``services`` and ``models`` at the top level so
+# tests can simply ``import services`` without the dashed package name.
+# Import ``models`` first so that ``services`` modules depending on it load
+# correctly during this setup.
+for name in ("models", "services", "ai", "views", "utils", "data"):
+    try:
+        sys.modules.setdefault(name, importlib.import_module(f"ironaccord-bot.{name}"))
+    except Exception:
+        pass
 
-    # Provide lightweight stand-ins for optional heavy dependencies used by the
-    # RAG service so the module can be imported during testing.
-    import types
-    sys.modules.setdefault("chromadb", types.SimpleNamespace(PersistentClient=None))
-    sys.modules.setdefault(
-        "langchain_community.vectorstores",
-        types.SimpleNamespace(Chroma=None),
-    )
-    sys.modules.setdefault(
-        "langchain_community.embeddings",
-        types.SimpleNamespace(
-            HuggingFaceEmbeddings=None,
-            OllamaEmbeddings=None,
-        ),
-    )
-except Exception:
-    pass
+# Ensure ``services`` and other subpackages can be imported by adding the
+# package path directly to ``sys.path``.
+pkg_path = project_root / "ironaccord-bot"
+sys.path.insert(0, str(pkg_path))
+
+# Provide lightweight stand-ins for optional heavy dependencies used by the
+# RAG service so the module can be imported during testing.
+import types
+sys.modules.setdefault("chromadb", types.SimpleNamespace(PersistentClient=None))
+sys.modules.setdefault(
+    "langchain_community.vectorstores",
+    types.SimpleNamespace(Chroma=None),
+)
+sys.modules.setdefault(
+    "langchain_community.embeddings",
+    types.SimpleNamespace(
+        HuggingFaceEmbeddings=None,
+        OllamaEmbeddings=None,
+    ),
+)

--- a/ironaccord-bot/tests/test_ai_agent.py
+++ b/ironaccord-bot/tests/test_ai_agent.py
@@ -1,7 +1,8 @@
 import pytest
+from importlib import import_module
 
-from ironaccord_bot.ai.ai_agent import AIAgent
-from ironaccord_bot.services.ollama_service import OllamaService
+AIAgent = import_module('ironaccord-bot.ai.ai_agent').AIAgent
+OllamaService = import_module('ironaccord-bot.services.ollama_service').OllamaService
 
 
 @pytest.mark.asyncio

--- a/ironaccord-bot/tests/test_background_quiz_service.py
+++ b/ironaccord-bot/tests/test_background_quiz_service.py
@@ -1,6 +1,7 @@
 import pytest
 
-from services.background_quiz_service import BackgroundQuizService
+from importlib import import_module
+BackgroundQuizService = import_module('ironaccord-bot.services.background_quiz_service').BackgroundQuizService
 
 
 @pytest.mark.asyncio

--- a/ironaccord-bot/tests/test_bot.py
+++ b/ironaccord-bot/tests/test_bot.py
@@ -1,6 +1,7 @@
 import pytest
+from importlib import import_module
 
-from ironaccord_bot.bot import IronAccordBot
+IronAccordBot = import_module('ironaccord-bot.bot').IronAccordBot
 
 class DummyService:
     pass
@@ -14,7 +15,7 @@ class DummyRAG:
 
 
 def test_bot_exposes_ollama_service(monkeypatch):
-    monkeypatch.setattr('ironaccord_bot.bot.RAGService', lambda: DummyRAG())
-    monkeypatch.setattr('ironaccord_bot.bot.AIAgent', DummyAgent)
+    monkeypatch.setattr('ironaccord-bot.bot.RAGService', lambda: DummyRAG())
+    monkeypatch.setattr('ironaccord-bot.bot.AIAgent', DummyAgent)
     bot = IronAccordBot()
     assert bot.ollama_service is bot.ai_agent.ollama_service

--- a/ironaccord-bot/tests/test_character_service.py
+++ b/ironaccord-bot/tests/test_character_service.py
@@ -1,7 +1,7 @@
 import pytest
 pytest.importorskip("aiomysql")
-
-from ironaccord_bot.models import character_service
+from importlib import import_module
+character_service = import_module('ironaccord-bot.models.character_service')
 
 class DummyDB:
     def __init__(self):

--- a/ironaccord-bot/tests/test_database.py
+++ b/ironaccord-bot/tests/test_database.py
@@ -2,7 +2,8 @@ import types
 import pytest
 
 pytest.importorskip("aiomysql")
-from ironaccord_bot.models import database
+from importlib import import_module
+database = import_module('ironaccord-bot.models.database')
 
 class DummyCursor:
     def __init__(self, rows=None, description=True, lastrowid=1):

--- a/ironaccord-bot/tests/test_ingest.py
+++ b/ironaccord-bot/tests/test_ingest.py
@@ -2,7 +2,8 @@ import os
 from pathlib import Path
 from types import SimpleNamespace
 from langchain.schema import Document
-from ironaccord_bot import ingest
+from importlib import import_module
+ingest = import_module('ironaccord-bot.ingest')
 
 class DummyLoader:
     def __init__(self, *a, **kw):

--- a/ironaccord-bot/tests/test_mission_cog.py
+++ b/ironaccord-bot/tests/test_mission_cog.py
@@ -3,8 +3,9 @@ pytest.importorskip("aiomysql")
 
 discord = pytest.importorskip("discord")
 from discord.ext import commands
-from ironaccord_bot.cogs import mission
-from models import mission_service as mission_service
+from importlib import import_module
+mission = import_module('ironaccord-bot.cogs.mission')
+mission_service = import_module('ironaccord-bot.models.mission_service')
 
 class DummyResponse:
     def __init__(self):

--- a/ironaccord-bot/tests/test_mission_engine.py
+++ b/ironaccord-bot/tests/test_mission_engine.py
@@ -1,6 +1,7 @@
 import pytest
 
-from ironaccord_bot.utils import mission_engine
+from importlib import import_module
+mission_engine = import_module('ironaccord-bot.utils.mission_engine')
 
 class DummyDB:
     def __init__(self, stats_rows=None, eq_row=None, items=None):

--- a/ironaccord-bot/tests/test_mission_generator.py
+++ b/ironaccord-bot/tests/test_mission_generator.py
@@ -1,5 +1,6 @@
 import pytest
-from services.mission_generator import MissionGenerator
+from importlib import import_module
+MissionGenerator = import_module('ironaccord-bot.services.mission_generator').MissionGenerator
 
 @pytest.mark.asyncio
 async def test_generate_intro(monkeypatch):

--- a/ironaccord-bot/tests/test_ollama_service.py
+++ b/ironaccord-bot/tests/test_ollama_service.py
@@ -7,7 +7,8 @@ from typing import TYPE_CHECKING
 
 # Import OllamaService only for type checking to allow environment overrides
 if TYPE_CHECKING:  # pragma: no cover - type checking
-    from services.ollama_service import OllamaService
+    from importlib import import_module
+    OllamaService = import_module('ironaccord-bot.services.ollama_service').OllamaService
 
 # Mark all tests in this file as asyncio
 pytestmark = pytest.mark.asyncio
@@ -15,7 +16,8 @@ pytestmark = pytest.mark.asyncio
 @pytest.fixture
 def ollama_service():
     """Pytest fixture to create an instance of OllamaService for each test."""
-    from services.ollama_service import OllamaService
+    from importlib import import_module
+    OllamaService = import_module('ironaccord-bot.services.ollama_service').OllamaService
     return OllamaService()
 
 async def test_get_narrative_success(ollama_service: OllamaService):
@@ -77,8 +79,8 @@ async def test_api_connection_error(ollama_service: OllamaService):
 async def test_env_override_narrator_model(monkeypatch):
     """Ensure environment variable overrides the narrator model."""
     monkeypatch.setenv("OLLAMA_NARRATOR_MODEL", "test-narrator")
-    from importlib import reload
-    import services.ollama_service as module
+    from importlib import reload, import_module
+    module = import_module('ironaccord-bot.services.ollama_service')
     reload(module)
     service = module.OllamaService()
     with patch.object(service.client, "post", new_callable=AsyncMock) as mock_post:
@@ -89,8 +91,8 @@ async def test_env_override_narrator_model(monkeypatch):
 async def test_env_override_gm_model(monkeypatch):
     """Ensure environment variable overrides the GM model."""
     monkeypatch.setenv("OLLAMA_GM_MODEL", "test-gm")
-    from importlib import reload
-    import services.ollama_service as module
+    from importlib import reload, import_module
+    module = import_module('ironaccord-bot.services.ollama_service')
     reload(module)
     service = module.OllamaService()
     with patch.object(service.client, "post", new_callable=AsyncMock) as mock_post:

--- a/ironaccord-bot/tests/test_opening_scene_service.py
+++ b/ironaccord-bot/tests/test_opening_scene_service.py
@@ -1,6 +1,7 @@
 import pytest
 
-from services.opening_scene_service import OpeningSceneService
+from importlib import import_module
+OpeningSceneService = import_module('ironaccord-bot.services.opening_scene_service').OpeningSceneService
 
 
 @pytest.mark.asyncio

--- a/ironaccord-bot/tests/test_opening_scene_view.py
+++ b/ironaccord-bot/tests/test_opening_scene_view.py
@@ -2,7 +2,8 @@ import pytest
 
 discord = pytest.importorskip("discord")
 
-from ironaccord_bot.views.opening_scene_view import OpeningSceneView
+from importlib import import_module
+OpeningSceneView = import_module('ironaccord-bot.views.opening_scene_view').OpeningSceneView
 
 
 class DummyResponse:

--- a/ironaccord-bot/tests/test_ping_cog.py
+++ b/ironaccord-bot/tests/test_ping_cog.py
@@ -2,7 +2,8 @@ import pytest
 discord = pytest.importorskip("discord")
 from discord.ext import commands
 
-from ironaccord_bot.cogs import ping
+from importlib import import_module
+ping = import_module('ironaccord-bot.cogs.ping')
 
 class DummySend:
     def __init__(self):

--- a/ironaccord-bot/tests/test_player_context_service.py
+++ b/ironaccord-bot/tests/test_player_context_service.py
@@ -1,6 +1,8 @@
 import pytest
-from services import player_context_service
-from models import mission_service, database
+from importlib import import_module
+player_context_service = import_module('ironaccord-bot.services.player_context_service')
+mission_service = import_module('ironaccord-bot.models.mission_service')
+database = import_module('ironaccord-bot.models.database')
 
 pytest.importorskip("aiomysql")
 

--- a/ironaccord-bot/tests/test_player_service.py
+++ b/ironaccord-bot/tests/test_player_service.py
@@ -1,5 +1,6 @@
 import pytest
-from ironaccord_bot.models import player_service
+from importlib import import_module
+player_service = import_module('ironaccord-bot.models.player_service')
 
 
 @pytest.mark.asyncio

--- a/ironaccord-bot/tests/test_rag_service.py
+++ b/ironaccord-bot/tests/test_rag_service.py
@@ -1,7 +1,8 @@
 import pytest
 import sys
+from importlib import import_module
 
-from services import rag_service
+rag_service = import_module('ironaccord-bot.services.rag_service')
 
 
 class DummyClient:

--- a/ironaccord-bot/tests/test_redeploy.py
+++ b/ironaccord-bot/tests/test_redeploy.py
@@ -2,7 +2,8 @@ import pytest
 
 discord = pytest.importorskip("discord")
 
-from ironaccord_bot import bot as bot_module
+from importlib import import_module
+bot_module = import_module('ironaccord-bot.bot')
 
 
 class DummyTree:

--- a/ironaccord-bot/tests/test_start_cog.py
+++ b/ironaccord-bot/tests/test_start_cog.py
@@ -2,7 +2,8 @@ import pytest
 
 discord = pytest.importorskip("discord")
 from discord.ext import commands
-from ironaccord_bot.cogs import start
+from importlib import import_module
+start = import_module('ironaccord-bot.cogs.start')
 
 
 class DummyResponse:

--- a/ironaccord-bot/views/tutorial_view.py
+++ b/ironaccord-bot/views/tutorial_view.py
@@ -56,6 +56,7 @@ class TutorialView(discord.ui.View):
             text = "An unexpected error occurred during narration."
 
         embed = simple(f"Welcome, {name}", description=text)
-        from ironaccord_bot.cogs.start import FactionView  # local import to avoid circular
+        from importlib import import_module
+        FactionView = import_module('ironaccord-bot.cogs.start').FactionView  # local import to avoid circular
         view = FactionView(self.user)
         await interaction.followup.send(embed=embed, view=view, ephemeral=True)

--- a/ironaccord_bot/__init__.py
+++ b/ironaccord_bot/__init__.py
@@ -1,9 +1,0 @@
-import importlib.util, sys, pathlib
-pkg_path = pathlib.Path(__file__).resolve().parent.parent / 'ironaccord-bot'
-spec = importlib.util.spec_from_file_location('ironaccord-bot', pkg_path / '__init__.py')
-pkg = importlib.util.module_from_spec(spec)
-sys.modules['ironaccord-bot'] = pkg
-spec.loader.exec_module(pkg)
-for k, v in pkg.__dict__.items():
-    globals()[k] = v
-sys.modules.setdefault('ironaccord_bot', pkg)


### PR DESCRIPTION
## Summary
- delete the old `ironaccord_bot` compatibility package
- update README instructions to use the dashed package name
- switch all tests and runtime code to import from `ironaccord-bot`
- load the dashed package explicitly in tests before aliasing

## Testing
- `pip install httpx langchain langchain-community faiss-cpu pyyaml discord.py aiomysql pytest tqdm markdown`
- `pytest -q` *(fails: 39 failed, 5 passed, 32 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_6874621b7d288327a33b6c75dcfb6f73