### PR TITLE
Add PlayerService and new game commands

### DIFF
--- a/ironaccord-bot/bot.py
+++ b/ironaccord-bot/bot.py
@@ -1,123 +1,45 @@
-import sys
 import os
-import pprint
-
-# Add the parent directory of 'ironaccord-bot' to the Python path
-project_root = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
-if project_root not in sys.path:
-    sys.path.insert(0, project_root)
-
-
-import argparse
+import sys
+import asyncio
 import discord
 from discord.ext import commands
 from dotenv import load_dotenv
-import logging
-import asyncio
 
-# --- Local Imports ---
-from ai.ai_agent import AIAgent
+# Add the project root to the path to allow for absolute imports
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+# Import our custom services
 from services.rag_service import RAGService
-try:
-    from services.mission_generator import MissionGenerator
-except Exception:  # pragma: no cover - optional dependency
-    MissionGenerator = None
+from services.player_service import PlayerService
 
-# --- Environment and Logging ---
+# --- Bot Setup ---
 load_dotenv()
-TOKEN = os.getenv("DISCORD_TOKEN")
-logger = logging.getLogger("discord")
-logger.debug("--- PYTHON PATH ---")
-logger.debug(pprint.pformat(sys.path))
-logger.debug("-------------------")
+DISCORD_TOKEN = os.getenv("DISCORD_TOKEN")
 
-
-def parse_args() -> argparse.Namespace:
-    """Parse command line arguments for the bot."""
-    parser = argparse.ArgumentParser(description="Iron Accord Bot")
-    parser.add_argument(
-        "--redeploy",
-        action="store_true",
-        help="Clear and redeploy all slash commands on startup",
-    )
-    return parser.parse_args()
-
-# --- Bot Intents ---
 intents = discord.Intents.default()
 intents.message_content = True
-intents.members = True
 
-# --- Bot Definition ---
 class IronAccordBot(commands.Bot):
     def __init__(self):
         super().__init__(command_prefix="!", intents=intents)
-        # --- Service Initialization ---
+        # Create instances of our services
         self.rag_service = RAGService()
-        self.ai_agent = AIAgent()
-        self.mission_generator = (
-            MissionGenerator(self.ai_agent, self.rag_service) if MissionGenerator else None
-        )
-        # Expose the Ollama service directly for cogs expecting it
-        self.ollama_service = self.ai_agent.ollama_service
-        # Flag controlling whether to redeploy slash commands on startup
-        self.redeploy: bool = False
+        self.player_service = PlayerService()
+
+    async def on_ready(self):
+        print(f'Logged in as {self.user} (ID: {self.user.id})')
+        print('------')
+
+    async def setup_hook(self):
+        # This is the new way to load cogs in discord.py 2.0
+        # It runs after the bot logs in but before it connects to the gateway.
+        await self.load_extension("cogs.game_commands_cog")
+        print("Cogs loaded.")
 
 bot = IronAccordBot()
 
-# --- THE CRUCIAL PART: on_ready Event ---
-@bot.event
-async def on_ready():
-    """Called when the bot is ready and connected to Discord."""
-    logger.info(f'Logged in as {bot.user.name} (ID: {bot.user.id})')
-    logger.info('────────────────────')
-
-    try:
-        if bot.redeploy:
-            logger.info("Clearing all global commands...")
-            try:
-                cleared = await bot.tree.clear_commands(guild=None)
-                logger.info(f"Successfully cleared {len(cleared)} global commands.")
-            except Exception as e:
-                logger.error(f"Failed to clear commands: {e}")
-
-        synced = await bot.tree.sync()
-        logger.info(f"Synced {len(synced)} slash command(s).")
-    except Exception as e:
-        logger.error(f"Failed to sync command tree: {e}")
-
-
-async def load_cogs():
-    """Loads all cogs from the cogs directory."""
-    for filename in os.listdir("./cogs"):
-        if filename.endswith(".py") and not filename.startswith("__"):
-            try:
-                await bot.load_extension(f"cogs.{filename[:-3]}")
-                logger.info(f"Loaded cog: cogs.{filename[:-3]}")
-            except Exception as e:
-                logger.error(f"Failed to load cog {filename}: {e}")
-
-
-async def main():
-    """Main function to setup and run the bot."""
-    args = parse_args()
-
-    logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - %(message)s')
-    bot.redeploy = args.redeploy
-
-    logger.info("Loading cogs...")
-    await load_cogs()
-
-    if bot.redeploy:
-        logger.info("Bot is starting in redeploy mode...")
-    else:
-        logger.info("Bot is starting...")
-
-    await bot.start(TOKEN)
-
-
-# --- Run the Bot ---
 if __name__ == "__main__":
-    try:
-        asyncio.run(main())
-    except KeyboardInterrupt:
-        logger.info("Bot shutting down.")
+    if DISCORD_TOKEN is None:
+        print("FATAL: DISCORD_TOKEN not found in .env file.")
+    else:
+        bot.run(DISCORD_TOKEN)

--- a/ironaccord-bot/cogs/game_commands_cog.py
+++ b/ironaccord-bot/cogs/game_commands_cog.py
@@ -1,0 +1,52 @@
+import discord
+from discord.ext import commands
+
+# We will pass our services to this cog when we load it
+from services.rag_service import RAGService
+from services.player_service import PlayerService
+
+class GameCommandsCog(commands.Cog):
+    def __init__(self, bot: commands.Bot, rag_service: RAGService, player_service: PlayerService):
+        self.bot = bot
+        self.rag_service = rag_service
+        self.player_service = player_service
+        print("GameCommandsCog loaded.")
+
+    @commands.command(name="lore")
+    async def lore(self, ctx: commands.Context, *, query: str):
+        """Asks a question to the Lore Weaver AI."""
+        async with ctx.typing():
+            print(f"Received lore query: '{query}'")
+            result = await self.rag_service.query(query)
+            answer = result.get("answer", "I do not have an answer for that.")
+            await ctx.send(f"**Query:** {query}\n**Answer:** {answer}")
+
+    @commands.command(name="status")
+    async def status(self, ctx: commands.Context):
+        """Checks your current status."""
+        user_id = ctx.author.id
+        current_status = self.player_service.get_player_status(user_id)
+        await ctx.send(f"Your current status is: **{current_status}**")
+
+    @commands.command(name="mission")
+    async def mission(self, ctx: commands.Context):
+        """Requests a new mission from the Iron Accord."""
+        async with ctx.typing():
+            user_id = ctx.author.id
+            mission_prompt = "Generate a simple, one-sentence mission objective for a new warrior of the Iron Accord."
+            
+            # Get the mission from our AI
+            result = await self.rag_service.query(mission_prompt)
+            mission_objective = result.get("answer", "Patrol the walls of Brasshaven.") # Fallback mission
+
+            # Update the player's status
+            self.player_service.set_player_status(user_id, mission_objective)
+
+            await ctx.send(f"A new directive comes in from the Accord...\n**Your new mission is:** {mission_objective}")
+
+async def setup(bot: commands.Bot):
+    # This setup function is called when the cog is loaded
+    # We will need to get our services from the bot instance
+    rag_service = bot.rag_service
+    player_service = bot.player_service
+    await bot.add_cog(GameCommandsCog(bot, rag_service, player_service))

--- a/ironaccord-bot/services/player_service.py
+++ b/ironaccord-bot/services/player_service.py
@@ -1,0 +1,26 @@
+class PlayerService:
+    """
+    Manages the state and data for all players in the game.
+    For now, it uses a simple in-memory dictionary.
+    """
+    def __init__(self):
+        # A dictionary to store player data, keyed by Discord user ID.
+        # Example: { 123456789: {"status": "Idle"} }
+        self._players = {}
+
+    def _get_or_create_player(self, user_id: int):
+        """Ensures a player entry exists, creating one if not."""
+        if user_id not in self._players:
+            self._players[user_id] = {"status": "Idle"}
+        return self._players[user_id]
+
+    def get_player_status(self, user_id: int) -> str:
+        """Gets the current status for a given player."""
+        player = self._get_or_create_player(user_id)
+        return player.get("status", "Idle")
+
+    def set_player_status(self, user_id: int, status: str):
+        """Sets the status for a given player."""
+        player = self._get_or_create_player(user_id)
+        player["status"] = status
+        print(f"Updated status for player {user_id} to '{status}'")


### PR DESCRIPTION
## Summary
- add `PlayerService` for storing in-memory player status
- implement `GameCommandsCog` with `!lore`, `!status` and `!mission`
- simplify bot startup to create services and load `game_commands_cog`

## Testing
- `pip install -r requirements.txt -r dev-requirements.txt`
- `PYTHONPATH=$PWD pytest -q` *(fails: ImportError in rag_service and missing attributes in updated bot)*

------
https://chatgpt.com/codex/tasks/task_e_687469248b5c8327a179441b08dfb15e