### PR TITLE
Switch RAG service to local Ollama model

### DIFF
--- a/ironaccord-bot/services/rag_service.py
+++ b/ironaccord-bot/services/rag_service.py
@@ -1,17 +1,16 @@
 import os
 from langchain_community.vectorstores import Chroma
 from langchain_community.embeddings import SentenceTransformerEmbeddings
+from langchain_community.llms import Ollama
 from langchain.prompts import PromptTemplate
 from langchain.chains import RetrievalQA
-from langchain_openai import OpenAI
 
 # Define paths and constants
 ABS_PATH = os.path.dirname(os.path.abspath(__file__))
 DB_DIR = os.path.join(ABS_PATH, "../../", "chromadb")
-DEFAULT_COLLECTION = "ironaccord"
 
 class RAGService:
-    """Handles the Retrieval-Augmented Generation logic."""
+    """Handles the Retrieval-Augmented Generation logic using a local LLM via Ollama."""
 
     def __init__(self):
         # Initialize embeddings and vector store
@@ -21,9 +20,8 @@ class RAGService:
             embedding_function=self.embedding_function
         )
 
-        # Initialize the Language Model (LLM)
-        # Note: You would typically use an API key from .env here
-        self.llm = OpenAI(temperature=0.7)
+        # Initialize the local Language Model (LLM) via Ollama
+        self.llm = Ollama(model="mixtral")
 
         # Define the prompt template
         prompt_template = """
@@ -43,11 +41,15 @@ class RAGService:
             return_source_documents=True,
             chain_type_kwargs={"prompt": qa_prompt},
         )
-        print("RAGService initialized.")
+        print("RAGService initialized with local Ollama model.")
 
     def query(self, query_text: str) -> dict:
         """Queries the QA chain and returns a standardized dictionary."""
         raw_result = self.qa_chain({"query": query_text})
         answer = raw_result.get("result", "No answer could be generated.")
         source_docs = raw_result.get("source_documents", [])
-        return {"answer": answer, "source_documents": source_docs}
+
+        return {
+            "answer": answer,
+            "source_documents": source_docs
+        }

--- a/ironaccord-bot/tests/test_rag_service.py
+++ b/ironaccord-bot/tests/test_rag_service.py
@@ -16,7 +16,7 @@ def _init_service(monkeypatch):
         def as_retriever(self):
             return None
     monkeypatch.setattr(rag_service, "Chroma", DummyChroma)
-    monkeypatch.setattr(rag_service, "OpenAI", lambda *a, **kw: object())
+    monkeypatch.setattr(rag_service, "Ollama", lambda *a, **kw: object())
     dummy = DummyQA()
     monkeypatch.setattr(rag_service.RetrievalQA, "from_chain_type", classmethod(lambda cls, **kw: dummy))
     service = rag_service.RAGService()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+# Main App Dependencies (from discord.py, langchain, etc.)
 discord.py
 python-dotenv
 langchain
@@ -8,5 +9,7 @@ sentence-transformers
 faiss-cpu
 numpy
 PyYAML
+
+# Development & Testing Dependencies
 pytest
 pytest-asyncio


### PR DESCRIPTION
## Summary
- use `Ollama` from langchain-community to run the RAG service
- clean up requirements list
- adjust RAG service unit test for new LLM class

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'ironaccord_bot')*

------
https://chatgpt.com/codex/tasks/task_e_68747889c0f8832794df3480d2ea09f4