### PR TITLE
Add Brasshaven lore to data

### DIFF
--- a/data/brasshaven.md
+++ b/data/brasshaven.md
@@ -1,0 +1,10 @@
+# Brasshaven – The Last Stronghold
+
+Brasshaven is a layered megacity of soot-stained pipes, rotating pressure lifts, and massive forge towers that pierce the smog-filled sky.
+
+### Key Districts
+- **The Forge Choir:** The central industrial and crafting hub, where the city's heart beats in the rhythm of a thousand hammers.
+- **Steamward Chapel:** A cathedral-like temple to the Flame, where Forgeseers preach the Credo Ferrum.
+- **The Grateworks:** The sprawling slums and service tunnels, home to scavengers, outcasts, and those who live in the city's shadows.
+- **The Bastion Blades:** The heavily fortified defensive perimeter and garrison, constantly vigilant against rogue machines and Neon Dharma incursions.
+- **The Archivalt:** A sealed memory vault containing pre-War technologies and forbidden texts, guarded by the most devout members of the Order of the Flame.

--- a/ironaccord-bot/services/rag_service.py
+++ b/ironaccord-bot/services/rag_service.py
@@ -8,6 +8,7 @@ from langchain.chains import RetrievalQA
 # Define paths and constants
 ABS_PATH = os.path.dirname(os.path.abspath(__file__))
 DB_DIR = os.path.join(ABS_PATH, "../../", "chromadb")
+DEFAULT_COLLECTION = "lore"
 
 class RAGService:
     """Handles the Retrieval-Augmented Generation logic using a local LLM via Ollama."""


### PR DESCRIPTION
## Summary
- copy the brasshaven lore into the ingestion directory
- define `DEFAULT_COLLECTION` constant for the RAG service

## Testing
- `pip install -r requirements.txt`
- `pip install aiomysql unstructured markdown`
- `python ironaccord-bot/ingest.py` *(fails: Error raised by inference endpoint)*
- `pytest -q` *(fails to collect tests)*

------
https://chatgpt.com/codex/tasks/task_e_68752d1c3e74832794a3448336a09225