### PR TITLE
Fix Iron Accord background link in docs

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -17,7 +17,7 @@ Background lore for the Iron Accord has been split into several focused files:
 - [lore/mythology_of_metal.md](lore/mythology_of_metal.md)
 - [lore/story_design_principles.md](lore/story_design_principles.md)
 - [lore/narrative_hooks.md](lore/narrative_hooks.md)
-- [backgrounds/iron_accord/README.md](backgrounds/iron_accord/README.md)
+- [../data/backgrounds/iron_accord/README.md](../data/backgrounds/iron_accord/README.md)
 
 The original combined document lives in
 [archive/iron_accord_lore_gdd.md](archive/iron_accord_lore_gdd.md). The


### PR DESCRIPTION
## Summary
- link to Iron Accord backgrounds from the data folder

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'aiomysql')*

------
https://chatgpt.com/codex/tasks/task_e_687564efd68c8327bf82ad23abda9147