### PR TITLE
Add httpx and aiomysql dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,16 +39,13 @@ Base item properties live in `ironaccord-bot/data/items.py`. The mission engine 
 ## Running Python Tests
 
 The repository includes pytest suites for both the legacy prototype and the new
-Iron Accord bot. After installing the requirements from `requirements.txt` and
-the additional packages listed in `dev-requirements.txt`, execute the tests
-from the project root:
+Iron Accord bot. After installing the requirements from `requirements.txt`,
+execute the tests from the project root:
 
 ```bash
 pip install -r requirements.txt
-pip install -r dev-requirements.txt
 pytest
 ```
 
-The tests under `ironaccord-bot` rely on `discord.py`, `aiomysql` and `httpx`.
-Installing `dev-requirements.txt` ensures these packages are available;
-otherwise the affected tests will be skipped.
+The tests under `ironaccord-bot` rely on `discord.py`, `aiomysql` and `httpx`,
+all of which are included in the consolidated `requirements.txt` file.

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,6 +9,8 @@ sentence-transformers
 faiss-cpu
 numpy
 PyYAML
+httpx
+aiomysql
 
 # Development & Testing Dependencies
 pytest


### PR DESCRIPTION
## Summary
- include `httpx` and `aiomysql` in consolidated `requirements.txt`
- update README to remove the old `dev-requirements.txt` instructions

## Testing
- `pip install --dry-run -r requirements.txt`

------
https://chatgpt.com/codex/tasks/task_e_687564f2a2b08327b9f07fc2bc2e7c18