### PR TITLE
Add dev requirements list

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,8 +39,9 @@ Base item properties live in `ironaccord-bot/data/items.py`. The mission engine 
 ## Running Python Tests
 
 The repository includes pytest suites for both the legacy prototype and the new
-Iron Accord bot. After installing the requirements from `requirements.txt` and
-the additional packages listed in `dev-requirements.txt`, execute the tests
+Iron Accord bot. After installing the runtime requirements in
+`requirements.txt` and the development dependencies from
+`dev-requirements.txt` (both located in the repository root), execute the tests
 from the project root:
 
 ```bash

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,0 +1,5 @@
+# Packages used only for development and testing
+pytest
+pytest-asyncio
+httpx
+aiomysql


### PR DESCRIPTION
## Summary
- add `dev-requirements.txt` with testing libraries
- document installing dev requirements for running tests

## Testing
- `pip install -r dev-requirements.txt`
- `pip install -r requirements.txt`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'ironaccord_bot')*

------
https://chatgpt.com/codex/tasks/task_e_687564ef3dbc8327bcbc5585f573a469