### PR TITLE
Update background docs path

### DIFF
--- a/ironaccord-bot/services/background_quiz_service.py
+++ b/ironaccord-bot/services/background_quiz_service.py
@@ -46,7 +46,7 @@ class BackgroundQuizService:
         self.agent = agent
 
     def _read_background_docs(self) -> str:
-        base = Path("docs/backgrounds/iron_accord")
+        base = Path("data/backgrounds/iron_accord")
         parts: list[str] = []
         for md in sorted(base.glob("*.md")):
             try:


### PR DESCRIPTION
## Summary
- read background docs from `data/backgrounds/iron_accord` instead of `docs`

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687564f131ac83278b70cdbb4d887e4d