### PR TITLE
Implement dynamic background quiz

### DIFF
--- a/ironaccord-bot/cogs/start.py
+++ b/ironaccord-bot/cogs/start.py
@@ -2,112 +2,42 @@ import discord
 from discord.ext import commands
 from discord import app_commands
 
-from ai.ai_agent import AIAgent
-from services.opening_scene_service import OpeningSceneService
-from views.opening_scene_view import OpeningSceneView
-from views.background_quiz_view import BackgroundQuizView
-from services.background_quiz_service import BackgroundQuizService
-from models import character_service
-import logging
-
-
-EDRAZ_GREETING = (
-    "Signal acquired. I am Edraz, the Chronicler. I read the static between the worlds, "
-    "and today it led me to you. Your story is unwritten, a blank slate in the great archive. "
-    "Before we begin, I need to tune into your signal."
-)
-
-EDRAZ_IMAGE_URL = "https://example.com/edraz-sanctum.png"
+from ironaccord_bot.services.background_quiz_service import BackgroundQuizService
+from ironaccord_bot.views.background_quiz_view import BackgroundQuizView
 
 
 class StartCog(commands.Cog):
     def __init__(self, bot: commands.Bot):
         self.bot = bot
-        self.agent = AIAgent()
-        self.rag_service = getattr(bot, "rag_service", None)
-        self.quiz_service = BackgroundQuizService(self.agent)
+        self.quiz_service = BackgroundQuizService()
 
     @app_commands.command(
-        name="start", description="Begin your journey in the world of Iron Accord."
+        name="start",
+        description="Begin your journey and discover your place in the Iron Accord.",
     )
     async def start(self, interaction: discord.Interaction):
-        """Begin the Edraz interview question flow."""
+        """Kick off the interactive background quiz."""
         await interaction.response.defer(ephemeral=True)
 
         try:
-            questions = await self.quiz_service.generate_questions()
-        except Exception as exc:  # pragma: no cover - unexpected failure
-            logging.error("Failed generating quiz questions: %s", exc, exc_info=True)
+            user_id = interaction.user.id
+            session = await self.quiz_service.start_quiz(user_id)
+            if not session:
+                await interaction.followup.send(
+                    "There was an error generating the quiz. Please try again later.",
+                    ephemeral=True,
+                )
+                return
+
+            view = BackgroundQuizView(self.quiz_service, user_id)
+            first_question = session.get_current_question_text()
+            await interaction.followup.send(first_question, view=view, ephemeral=True)
+        except Exception as exc:  # pragma: no cover - safety net
+            print(f"Error starting quiz: {exc}")
             await interaction.followup.send(
-                "An error occurred while generating the quiz.", ephemeral=True
+                "A critical error occurred while starting your journey. The archivists have been notified.",
+                ephemeral=True,
             )
-            return
-
-        if not questions:
-            await interaction.followup.send(
-                "An error occurred while generating the quiz.", ephemeral=True
-            )
-            return
-
-        view = BackgroundQuizView(self, questions)
-        embed = discord.Embed(
-            title="Edraz, Chronicler of the Accord",
-            description=f"{EDRAZ_GREETING}\n\n**{view._current_question()}**",
-            color=discord.Color.dark_gold(),
-        )
-        embed.set_image(url=EDRAZ_IMAGE_URL)
-
-        await interaction.followup.send(embed=embed, view=view, ephemeral=True)
-
-    async def handle_background_result(
-        self, interaction: discord.Interaction, background: str, explanation: str
-    ) -> None:
-        """Narrate the chosen background then continue to the opening scene."""
-        try:
-            await character_service.set_player_background(
-                str(interaction.user.id), background
-            )
-        except Exception as exc:  # pragma: no cover - db failure
-            logging.error("Failed to store background: %s", exc, exc_info=True)
-        try:
-            narration = await self.agent.get_narrative(explanation)
-        except Exception:  # pragma: no cover - network failure
-            narration = explanation
-
-        embed = discord.Embed(
-            title=f"Background Chosen: {background}",
-            description=narration,
-            color=discord.Color.dark_gold(),
-        )
-        await interaction.followup.send(embed=embed, ephemeral=True)
-
-        await self.handle_character_description(interaction, explanation)
-
-    async def handle_character_description(
-        self, interaction: discord.Interaction, text: str
-    ) -> None:
-        """Generate the opening scene from the player's answers."""
-        service = OpeningSceneService(self.agent, self.rag_service)
-        result = await service.generate_opening(text)
-
-        if not result:
-            await interaction.followup.send(
-                "An error occurred while generating the scene.", ephemeral=True
-            )
-            return
-
-        scene = result.get("scene", "")
-        question = result.get("question", "")
-        choices = result.get("choices", [])
-
-        embed = discord.Embed(
-            title="A Fateful Encounter",
-            description=f"{scene}\n\n**{question}**",
-            color=discord.Color.dark_gold(),
-        )
-
-        view = OpeningSceneView(self.agent, scene, question, choices)
-        await interaction.followup.send(embed=embed, view=view, ephemeral=True)
 
 
 async def setup(bot: commands.Bot):

--- a/ironaccord-bot/tests/test_background_quiz_service.py
+++ b/ironaccord-bot/tests/test_background_quiz_service.py
@@ -1,25 +1,53 @@
+import json
 import pytest
+from pathlib import Path
 
-from services.background_quiz_service import BackgroundQuizService
-
-
-@pytest.mark.asyncio
-async def test_generate_questions_parses_extra_text():
-    async def fake_get(self, prompt):
-        return "Some intro {\"questions\": [{\"text\": \"q\", \"choices\": [\"a\", \"b\"]}]} more"
-
-    agent = type('A', (), {'get_completion': fake_get})()
-    service = BackgroundQuizService(agent)
-    result = await service.generate_questions()
-    assert result == [{"text": "q", "choices": ["a", "b"]}]
+from ironaccord_bot.services import background_quiz_service as bqs
 
 
 @pytest.mark.asyncio
-async def test_evaluate_answers_parses_extra_text():
-    async def fake_get(self, prompt):
-        return "preface {\"background\": \"soldier\", \"explanation\": \"because\"} end"
+async def test_start_quiz_parses_json(monkeypatch, tmp_path):
+    # create three dummy background files
+    for i in range(3):
+        (tmp_path / f"bg{i}.md").write_text(f"lore {i}")
 
-    agent = type('A', (), {'get_completion': fake_get})()
-    service = BackgroundQuizService(agent)
-    result = await service.evaluate_answers([], [])
-    assert result == {"background": "soldier", "explanation": "because"}
+    monkeypatch.setattr(bqs, "BACKGROUNDS_PATH", Path(tmp_path))
+
+    async def fake_gm(self, prompt):
+        return json.dumps(
+            {
+                "background_map": {"A": "One", "B": "Two", "C": "Three"},
+                "questions": [{"question": "Q1", "answers": ["A. a", "B. b", "C. c"]}],
+            }
+        )
+
+    monkeypatch.setattr(bqs.OllamaService, "get_gm_response", fake_gm)
+
+    service = bqs.BackgroundQuizService()
+    session = await service.start_quiz(1)
+
+    assert session is not None
+    assert session.get_current_question_text().startswith("Q1")
+
+
+@pytest.mark.asyncio
+async def test_evaluate_result(monkeypatch):
+    service = bqs.BackgroundQuizService()
+    session = bqs.QuizSession(
+        questions=[{"question": "Q1", "answers": ["A", "B", "C"]}],
+        background_map={"A": "Alpha", "B": "Beta", "C": "Gamma"},
+        background_text={"A": "a", "B": "b", "C": "c"},
+    )
+    session.answers = ["B", "B", "A"]
+    service.active_quizzes[1] = session
+
+    async def fake_narrative(self, prompt):
+        return "final"
+
+    monkeypatch.setattr(bqs.OllamaService, "get_narrative", fake_narrative)
+
+    result = await service.evaluate_result(1)
+
+    assert result == "final"
+    assert 1 not in service.active_quizzes
+

--- a/ironaccord-bot/tests/test_start_cog.py
+++ b/ironaccord-bot/tests/test_start_cog.py
@@ -1,7 +1,7 @@
 import pytest
-
-discord = pytest.importorskip("discord")
+import discord
 from discord.ext import commands
+
 from ironaccord_bot.cogs import start
 
 
@@ -9,9 +9,6 @@ class DummyResponse:
     def __init__(self):
         self.kwargs = None
         self.deferred = False
-
-    async def send_message(self, *args, **kwargs):
-        self.kwargs = kwargs
 
     async def defer(self, *args, **kwargs):
         self.deferred = True
@@ -28,146 +25,31 @@ class DummyFollowup:
 
 class DummyInteraction:
     def __init__(self):
-        self.user = type(
-            "User", (), {"id": 1, "name": "Test", "display_name": "Test"}
-        )()
+        self.user = type("User", (), {"id": 1})()
         self.response = DummyResponse()
         self.followup = DummyFollowup()
 
 
 @pytest.mark.asyncio
-async def test_start_cog_returns_view(monkeypatch):
+async def test_start_cog_sends_first_question(monkeypatch):
     bot = commands.Bot(command_prefix="!", intents=discord.Intents.none())
-    bot.rag_service = None
     cog = start.StartCog(bot)
 
     interaction = DummyInteraction()
 
-    async def fake_gen(self):
-        return [{"text": "q1", "choices": ["a", "b"]}]
+    class DummySession:
+        def get_current_question_text(self):
+            return "Q1"
 
-    monkeypatch.setattr(start.BackgroundQuizService, "generate_questions", fake_gen)
+    async def fake_start(self, user_id):
+        return DummySession()
+
+    monkeypatch.setattr(start.BackgroundQuizService, "start_quiz", fake_start)
 
     await cog.start.callback(cog, interaction)
 
     assert interaction.response.deferred is True
+    assert interaction.followup.kwargs["content"] == "Q1"
     assert isinstance(interaction.followup.kwargs["view"], start.BackgroundQuizView)
     assert interaction.followup.kwargs["ephemeral"] is True
 
-
-class DummyInteraction2:
-    def __init__(self):
-        self.user = type("User", (), {"id": 2, "display_name": "Hero"})()
-        self.followup = DummyFollowup()
-
-
-class DummyInteraction3:
-    def __init__(self):
-        async def edit_message(*args, **kwargs):
-            pass
-
-        self.response = type("Resp", (), {"edit_message": edit_message})()
-        self.followup = DummyFollowup()
-        self.kwargs = None
-
-    async def edit_original_response(self, **kwargs):
-        self.kwargs = kwargs
-
-
-@pytest.mark.asyncio
-async def test_handle_character_description(monkeypatch):
-    bot = commands.Bot(command_prefix="!", intents=discord.Intents.none())
-    bot.rag_service = None
-    cog = start.StartCog(bot)
-
-    class DummyService:
-        called = None
-
-        def __init__(self, agent, rag):
-            pass
-
-        async def generate_opening(self, desc):
-            DummyService.called = desc
-            return {"scene": "begin", "question": "what do?", "choices": ["a", "b"]}
-
-    class DummyView:
-        def __init__(self, agent, scene, question, choices):
-            self.agent = agent
-            self.scene = scene
-            self.question = question
-            self.choices = choices
-
-    monkeypatch.setattr(start, "OpeningSceneService", DummyService)
-    monkeypatch.setattr(start, "OpeningSceneView", DummyView)
-
-    interaction = DummyInteraction2()
-
-    await cog.handle_character_description(interaction, "desc")
-
-    assert DummyService.called == "desc"
-    assert interaction.followup.kwargs["ephemeral"] is True
-    assert isinstance(interaction.followup.kwargs["view"], DummyView)
-    assert interaction.followup.kwargs["view"].choices == ["a", "b"]
-
-
-@pytest.mark.asyncio
-async def test_background_view_compiles_answers(monkeypatch):
-    bot = commands.Bot(command_prefix="!", intents=discord.Intents.none())
-    cog = start.StartCog(bot)
-
-    called = {}
-
-    async def fake_eval(self, q, a):
-        return {"background": "scout", "explanation": "because"}
-
-    monkeypatch.setattr(start.BackgroundQuizService, "evaluate_answers", fake_eval)
-
-    async def fake_result(self, inter, bg, exp):
-        called.update({"bg": bg, "exp": exp})
-
-    monkeypatch.setattr(start.StartCog, "handle_background_result", fake_result)
-
-    questions = [
-        {"text": "q1", "choices": ["a", "b"]},
-        {"text": "q2", "choices": ["a", "b"]},
-    ]
-    view = start.BackgroundQuizView(cog, questions)
-    inter = DummyInteraction3()
-
-    for _ in range(len(questions)):
-        button = view.children[0]
-        await button.callback(inter)
-
-    assert called["bg"] == "scout"
-
-
-@pytest.mark.asyncio
-async def test_handle_background_result_saves_and_narrates(monkeypatch):
-    bot = commands.Bot(command_prefix="!", intents=discord.Intents.none())
-    cog = start.StartCog(bot)
-
-    interaction = DummyInteraction2()
-
-    stored = {}
-
-    async def fake_store(discord_id, background):
-        stored["id"] = discord_id
-        stored["bg"] = background
-
-    async def fake_narrative(prompt):
-        return "story"
-
-    async def fake_desc(self, inter, text):
-        stored["desc"] = text
-
-    monkeypatch.setattr(start.character_service, "set_player_background", fake_store)
-    monkeypatch.setattr(cog.agent, "get_narrative", fake_narrative)
-    monkeypatch.setattr(start.StartCog, "handle_character_description", fake_desc)
-
-    await cog.handle_background_result(interaction, "lore keeper", "because")
-
-    assert stored["id"] == str(interaction.user.id)
-    assert stored["bg"] == "lore keeper"
-    assert stored["desc"] == "because"
-    assert interaction.followup.kwargs["embed"].description == "story"
-    assert interaction.followup.kwargs["ephemeral"] is True

--- a/ironaccord-bot/views/background_quiz_view.py
+++ b/ironaccord-bot/views/background_quiz_view.py
@@ -1,55 +1,62 @@
 import discord
-from typing import List, Dict, Any
+from dataclasses import dataclass, field
+from typing import List, Dict
+
+
+@dataclass
+class QuizSession:
+    """Represents an active background quiz for a player."""
+
+    questions: List[Dict]
+    background_map: Dict[str, str]
+    background_text: Dict[str, str]
+    answers: List[str] = field(default_factory=list)
+    current_question_index: int = 0
+
+    def get_current_question_text(self) -> str:
+        q = self.questions[self.current_question_index]
+        question = q.get("question", "")
+        answers = q.get("answers", [])
+        answer_lines = "\n".join(answers)
+        return f"{question}\n{answer_lines}"
+
+    def record_answer(self, label: str) -> None:
+        self.answers.append(label)
+        self.current_question_index += 1
+
+    def is_finished(self) -> bool:
+        return self.current_question_index >= len(self.questions)
+
 
 class BackgroundQuizView(discord.ui.View):
-    """Interactive view that walks the player through a background quiz."""
+    """Discord UI for progressing through the background quiz."""
 
-    def __init__(self, cog: "StartCog", questions: List[Dict[str, Any]]) -> None:
+    def __init__(self, quiz_service, user_id: int):
         super().__init__(timeout=300)
-        self.cog = cog
-        self.questions = questions
-        self.index = 0
-        self.answers: List[str] = []
-        self._populate_buttons()
+        self.quiz_service = quiz_service
+        self.user_id = user_id
 
-    def _populate_buttons(self) -> None:
-        self.clear_items()
-        for idx, choice in enumerate(self.questions[self.index]["choices"]):
-            self.add_item(self.ChoiceButton(choice, idx))
+    async def handle_answer(self, interaction: discord.Interaction, answer_label: str):
+        session, next_question = await self.quiz_service.record_answer_and_get_next(
+            self.user_id, answer_label
+        )
 
-    def _current_question(self) -> str:
-        return self.questions[self.index]["text"]
+        if not session.is_finished():
+            await interaction.response.edit_message(content=next_question, view=self)
+        else:
+            await interaction.response.edit_message(content="Edraz is considering your answers...", view=None)
+            final_result = await self.quiz_service.evaluate_result(self.user_id)
+            await interaction.followup.send(final_result, ephemeral=True)
+            self.stop()
 
-    class ChoiceButton(discord.ui.Button):
-        def __init__(self, text: str, idx: int) -> None:
-            super().__init__(label=text, style=discord.ButtonStyle.primary, custom_id=f"bg_choice_{idx}")
-            self.choice_text = text
+    @discord.ui.button(label="A", style=discord.ButtonStyle.secondary, custom_id="answer_a")
+    async def answer_a(self, interaction: discord.Interaction, button: discord.ui.Button):
+        await self.handle_answer(interaction, "A")
 
-        async def callback(self, interaction: discord.Interaction) -> None:
-            view: "BackgroundQuizView" = self.view  # type: ignore[assignment]
-            for item in view.children:
-                item.disabled = True
-            await interaction.response.edit_message(view=view)
-            view.answers.append(self.choice_text)
-            view.index += 1
-            if view.index >= len(view.questions):
-                result = await view.cog.quiz_service.evaluate_answers(view.questions, view.answers)
-                if not result:
-                    await interaction.followup.send(
-                        "An error occurred while evaluating your answers.", ephemeral=True
-                    )
-                    view.stop()
-                    return
-                background = result.get("background", "Unknown")
-                explanation = result.get("explanation", "")
-                await view.cog.handle_background_result(interaction, background, explanation)
-                view.stop()
-                return
+    @discord.ui.button(label="B", style=discord.ButtonStyle.secondary, custom_id="answer_b")
+    async def answer_b(self, interaction: discord.Interaction, button: discord.ui.Button):
+        await self.handle_answer(interaction, "B")
 
-            view._populate_buttons()
-            embed = discord.Embed(
-                title="Edraz, Chronicler of the Accord",
-                description=f"**{view._current_question()}**",
-                color=discord.Color.dark_gold(),
-            )
-            await interaction.edit_original_response(embed=embed, view=view)
+    @discord.ui.button(label="C", style=discord.ButtonStyle.secondary, custom_id="answer_c")
+    async def answer_c(self, interaction: discord.Interaction, button: discord.ui.Button):
+        await self.handle_answer(interaction, "C")


### PR DESCRIPTION
## Summary
- implement new interactive background quiz with `BackgroundQuizService`
- overhaul `/start` command to run quiz
- create `QuizSession` and `BackgroundQuizView` for button-based flow
- update tests for new quiz logic

## Testing
- `pytest -q` *(fails: ModuleNotFoundError due to environment)*

------
https://chatgpt.com/codex/tasks/task_e_68756c21f9c88327819c86b62212edba