### PR TITLE
Add launcher and refactor bot imports

### DIFF
--- a/ironaccord-bot/__init__.py
+++ b/ironaccord-bot/__init__.py
@@ -1,3 +1,0 @@
-import sys
-sys.modules.setdefault('ironaccord_bot', sys.modules[__name__])
-

--- a/ironaccord-bot/bot.py
+++ b/ironaccord-bot/bot.py
@@ -5,25 +5,16 @@ import discord
 from discord.ext import commands
 from dotenv import load_dotenv
 
-# -- Start of Path Fix --
-# This block of code ensures that the script can find its modules,
-# no matter how it's run.
-SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
-PROJECT_ROOT = os.path.dirname(SCRIPT_DIR)
-if PROJECT_ROOT not in sys.path:
-    sys.path.append(PROJECT_ROOT)
-# -- End of Path Fix --
+from ironaccord_bot.services.rag_service import RAGService
+from ironaccord_bot.services.player_service import PlayerService
+from ironaccord_bot.cogs.game_commands_cog import GameCommandsCog
 
-from services.rag_service import RAGService
-from services.player_service import PlayerService
-from cogs.game_commands_cog import GameCommandsCog
+dotenv_path = os.path.join(sys.path[0], '.env')
+load_dotenv(dotenv_path=dotenv_path)
 
-# Load environment variables from .env file
-load_dotenv()
 DISCORD_TOKEN = os.getenv("DISCORD_TOKEN")
 OLLAMA_ENDPOINT = os.getenv("OLLAMA_ENDPOINT")
 
-# Define the intents for the bot
 intents = discord.Intents.default()
 intents.message_content = True
 
@@ -35,31 +26,30 @@ class IronAccordBot(commands.Bot):
 
     async def setup_hook(self):
         """A hook that is called when the bot is setting up."""
-        print("Running setup hook...")
-        # Pass the services to the cog when initializing it
+        print("[Bot] Running setup hook...")
         await self.add_cog(GameCommandsCog(self, self.rag_service, self.player_service))
-        print("Cogs loaded.")
+        print("[Bot] Cogs loaded.")
 
     async def on_ready(self):
         """Event that is called when the bot is ready and connected to Discord."""
-        print(f'Logged in as {self.user} (ID: {self.user.id})')
-        print('------')
+        print(f'[Bot] Logged in as {self.user} (ID: {self.user.id})')
+        print('[Bot] ------')
 
-async def main():
+async def start_bot():
     """The main function to run the bot."""
     if not DISCORD_TOKEN:
-        print("Error: DISCORD_TOKEN is not set in the .env file.")
+        print("[Bot] Error: DISCORD_TOKEN is not set in the .env file.")
         return
 
     if not OLLAMA_ENDPOINT:
-        print("Error: OLLAMA_ENDPOINT is not set in the .env file.")
+        print("[Bot] Error: OLLAMA_ENDPOINT is not set in the .env file.")
         return
-        
+
     bot = IronAccordBot()
     await bot.start(DISCORD_TOKEN)
 
 if __name__ == "__main__":
     try:
-        asyncio.run(main())
+        asyncio.run(start_bot())
     except KeyboardInterrupt:
-        print("Bot shutdown gracefully.")
+        print("[Bot] Shutdown signal received.")

--- a/ironaccord-bot/services/background_quiz_service.py
+++ b/ironaccord-bot/services/background_quiz_service.py
@@ -5,8 +5,8 @@ from pathlib import Path
 from collections import Counter
 from typing import Dict, List, Tuple
 
-from .ollama_service import OllamaService
-from ..views.background_quiz_view import QuizSession
+from ironaccord_bot.services.ollama_service import OllamaService
+from ironaccord_bot.views.background_quiz_view import QuizSession
 
 logger = logging.getLogger(__name__)
 

--- a/run.py
+++ b/run.py
@@ -1,0 +1,28 @@
+import sys
+import os
+import asyncio
+import runpy
+
+
+def main():
+    """Sets up the system path to include the project root and runs the bot module."""
+    try:
+        project_root = os.path.dirname(os.path.abspath(__file__))
+        if project_root not in sys.path:
+            sys.path.insert(0, project_root)
+            print(f"[Launcher] Added project root to path: {project_root}")
+
+        print("[Launcher] Starting the Iron Accord bot...")
+        runpy.run_module("ironaccord_bot.bot", run_name="__main__")
+
+    except KeyboardInterrupt:
+        print("\n[Launcher] Bot shutdown gracefully.")
+    except ModuleNotFoundError as e:
+        print(f"\n[Launcher] A module could not be found: {e}")
+        print("[Launcher] Please ensure all dependencies from requirements.txt are installed.")
+    except Exception as e:
+        print(f"\n[Launcher] An unexpected error occurred: {e}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- create root `run.py` launcher that imports the bot module
- refactor `bot.py` to rely on the launcher for path setup
- use absolute imports in `background_quiz_service`
- clear out `ironaccord-bot/__init__.py`

## Testing
- `pip install discord.py python-dotenv httpx`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'ironaccord_bot')*

------
https://chatgpt.com/codex/tasks/task_e_68758ef99740832786c8517a3a087367