### PR TITLE
Fix bot initialization typo

### DIFF
--- a/ironaccord_bot/cogs/start.py
+++ b/ironaccord_bot/cogs/start.py
@@ -24,18 +24,18 @@ class StartCog(commands.Cog):
             session = await self.quiz_service.start_quiz(user_id)
             if not session:
                 await interaction.followup.send(
-                    "There was an error generating the quiz. Please try again later.",
+                    content="There was an error generating the quiz. Please try again later.",
                     ephemeral=True,
                 )
                 return
 
             view = BackgroundQuizView(self.quiz_service, user_id)
             first_question = session.get_current_question_text()
-            await interaction.followup.send(first_question, view=view, ephemeral=True)
+            await interaction.followup.send(content=first_question, view=view, ephemeral=True)
         except Exception as exc:  # pragma: no cover - safety net
             print(f"Error starting quiz: {exc}")
             await interaction.followup.send(
-                "A critical error occurred while starting your journey. The archivists have been notified.",
+                content="A critical error occurred while starting your journey. The archivists have been notified.",
                 ephemeral=True,
             )
 


### PR DESCRIPTION
## Summary
- adjust RAGService instantiation
- expose `AIAgent` and `ollama_service` on the bot
- implement module-level `on_ready` and global `bot`
- send background quiz text using named kwargs

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687663a89b2c8327995e85afe017982f