### PR TITLE
Add Mission Engine Service

### DIFF
--- a/data/missions/missing_person.json
+++ b/data/missions/missing_person.json
@@ -1,0 +1,5 @@
+{
+  "title": "Missing Person",
+  "premise": "A local mechanic has vanished under mysterious circumstances.",
+  "objective": "Track down the missing mechanic and uncover what happened"
+}

--- a/data/missions/salvage_run.json
+++ b/data/missions/salvage_run.json
@@ -1,0 +1,5 @@
+{
+  "title": "Salvage Run",
+  "premise": "Scavenge parts from a crashed airship on the outskirts of Brasshaven.",
+  "objective": "Recover valuable components before rival scavengers arrive"
+}

--- a/ironaccord_bot/services/__init__.py
+++ b/ironaccord_bot/services/__init__.py
@@ -2,10 +2,12 @@ from .ollama_service import OllamaService
 from .rag_service import RAGService
 from .player_context_service import gather_player_context
 from .background_quiz_service import BackgroundQuizService
+from .mission_engine_service import MissionEngineService
 
 __all__ = [
     "OllamaService",
     "RAGService",
     "gather_player_context",
     "BackgroundQuizService",
+    "MissionEngineService",
 ]

--- a/ironaccord_bot/services/mission_engine_service.py
+++ b/ironaccord_bot/services/mission_engine_service.py
@@ -1,0 +1,66 @@
+"""Generate mission openings using player backgrounds and mission templates."""
+
+import json
+import logging
+from pathlib import Path
+from typing import Optional, Dict, Any, TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from ai.ai_agent import AIAgent
+
+logger = logging.getLogger(__name__)
+
+MISSIONS_PATH = Path("data/missions")
+
+
+def _extract_json(text: str) -> Dict[str, Any]:
+    """Best-effort parse of JSON text returned from the LLM."""
+    start = text.find("{")
+    end = text.rfind("}") + 1
+    if start == -1 or end == 0:
+        raise ValueError("No JSON object found")
+    return json.loads(text[start:end])
+
+
+class MissionEngineService:
+    """Combine mission templates with player backgrounds using an LLM."""
+
+    def __init__(self, agent: "AIAgent") -> None:
+        self.agent = agent
+
+    def load_template(self, name: str) -> Optional[Dict[str, Any]]:
+        """Load the mission template with the given ``name``."""
+        file = MISSIONS_PATH / f"{name}.json"
+        if not file.exists():
+            return None
+        try:
+            return json.loads(file.read_text(encoding="utf-8"))
+        except Exception as exc:  # pragma: no cover - unexpected I/O errors
+            logger.error("Failed to load template %s: %s", name, exc, exc_info=True)
+            return None
+
+    async def generate_opening(self, background: str, template_name: str) -> Optional[Dict[str, Any]]:
+        """Return a mission opening using ``background`` and ``template_name``."""
+        template = self.load_template(template_name)
+        if template is None:
+            return None
+
+        prompt = (
+            "You are Lore Weaver, a master TTRPG storyteller. "
+            "Using the player's background and the mission template, "
+            "craft a short opening scene followed by two or three numbered choices.\n\n"
+            f"PLAYER BACKGROUND:\n{background}\n\n"
+            f"MISSION TEMPLATE:\n{json.dumps(template)}\n\n"
+            "Respond ONLY with a JSON object containing 'text' and 'choices'."
+        )
+        try:
+            raw = await self.agent.get_completion(prompt)
+        except Exception as exc:
+            logger.error("LLM call failed: %s", exc, exc_info=True)
+            return None
+
+        try:
+            return _extract_json(raw)
+        except Exception as exc:  # pragma: no cover - malformed JSON
+            logger.error("Failed to parse LLM output: %s", exc, exc_info=True)
+            return None

--- a/ironaccord_bot/tests/test_mission_engine_service.py
+++ b/ironaccord_bot/tests/test_mission_engine_service.py
@@ -1,0 +1,38 @@
+import pytest
+from services import mission_engine_service as mes
+
+
+@pytest.mark.asyncio
+async def test_generate_opening(monkeypatch, tmp_path):
+    (tmp_path / "demo.json").write_text('{"title": "Demo"}')
+    monkeypatch.setattr(mes, "MISSIONS_PATH", tmp_path)
+
+    async def fake_completion(self, prompt):
+        return '{"text": "intro", "choices": ["a", "b"]}'
+
+    agent = type('A', (), {'get_completion': fake_completion})()
+    svc = mes.MissionEngineService(agent)
+    result = await svc.generate_opening("Scout", "demo")
+
+    assert result == {"text": "intro", "choices": ["a", "b"]}
+
+
+@pytest.mark.asyncio
+async def test_generate_opening_llm_error(monkeypatch, tmp_path):
+    (tmp_path / "demo.json").write_text('{"title": "Demo"}')
+    monkeypatch.setattr(mes, "MISSIONS_PATH", tmp_path)
+
+    async def fake_completion(self, prompt):
+        raise RuntimeError('fail')
+
+    agent = type('A', (), {'get_completion': fake_completion})()
+    svc = mes.MissionEngineService(agent)
+    result = await svc.generate_opening("Scout", "demo")
+
+    assert result is None
+
+
+def test_load_template_missing(monkeypatch, tmp_path):
+    monkeypatch.setattr(mes, "MISSIONS_PATH", tmp_path)
+    svc = mes.MissionEngineService(agent=None)  # type: ignore[arg-type]
+    assert svc.load_template("nope") is None


### PR DESCRIPTION
## Summary
- create `MissionEngineService` to blend player backgrounds with mission templates
- export the new service from the services package
- add example mission templates
- include tests for the service

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68766aa71c408327b535685c5f8b9e21