### PR TITLE
Add reusable MissionView component

### DIFF
--- a/ironaccord_bot/tests/test_mission_view.py
+++ b/ironaccord_bot/tests/test_mission_view.py
@@ -1,0 +1,39 @@
+import pytest
+
+discord = pytest.importorskip("discord")
+
+from ironaccord_bot.views.mission_view import MissionView
+
+
+class DummyResponse:
+    def __init__(self):
+        self.kwargs = None
+
+    async def edit_message(self, **kwargs):
+        self.kwargs = kwargs
+
+
+class DummyInteraction:
+    def __init__(self):
+        self.response = DummyResponse()
+
+
+@pytest.mark.asyncio
+async def test_choice_disables_buttons_and_records_selection():
+    view = MissionView("scene", ["A", "B"])
+    interaction = DummyInteraction()
+    button = view.children[0]
+    await button.callback(interaction)
+
+    assert view.selected_choice == "A"
+    assert all(child.disabled for child in view.children)
+    assert interaction.response.kwargs["content"] == "You chose: A"
+
+
+@pytest.mark.asyncio
+async def test_update_scene_repopulates_buttons():
+    view = MissionView("one", ["A", "B"])
+    view.update_scene("two", ["X"])
+    assert view.narrative_text == "two"
+    assert view.choices == ["X"]
+    assert len(view.children) == 1

--- a/ironaccord_bot/views/__init__.py
+++ b/ironaccord_bot/views/__init__.py
@@ -1,1 +1,7 @@
 from .background_quiz_view import BackgroundQuizView
+from .mission_view import MissionView
+
+__all__ = [
+    "BackgroundQuizView",
+    "MissionView",
+]

--- a/ironaccord_bot/views/mission_view.py
+++ b/ironaccord_bot/views/mission_view.py
@@ -1,0 +1,39 @@
+import discord
+
+class MissionView(discord.ui.View):
+    """Simple view for presenting a mission scene with multiple choices."""
+
+    def __init__(self, narrative_text: str, choices: list[str]):
+        super().__init__(timeout=300)
+        self.narrative_text = narrative_text
+        self.choices = choices
+        self.selected_choice: str | None = None
+        self._populate_buttons()
+
+    def _populate_buttons(self) -> None:
+        self.clear_items()
+        for idx, choice in enumerate(self.choices):
+            self.add_item(self.ChoiceButton(choice, idx))
+
+    def update_scene(self, narrative_text: str, choices: list[str]) -> None:
+        """Reuse the view for a new scene by updating text and buttons."""
+        self.narrative_text = narrative_text
+        self.choices = choices
+        self.selected_choice = None
+        self._populate_buttons()
+
+    class ChoiceButton(discord.ui.Button):
+        def __init__(self, label: str, idx: int):
+            super().__init__(label=label, style=discord.ButtonStyle.primary)
+            self.label_text = label
+            self.idx = idx
+
+        async def callback(self, interaction: discord.Interaction) -> None:
+            view: "MissionView" = self.view  # type: ignore[assignment]
+            view.selected_choice = self.label_text
+            for item in view.children:
+                item.disabled = True
+            await interaction.response.edit_message(
+                content=f"You chose: {self.label_text}", view=view
+            )
+            view.stop()


### PR DESCRIPTION
## Summary
- implement `MissionView` for mission scene choices
- expose view in `views.__init__`
- test MissionView behaviour

## Testing
- `pytest ironaccord_bot/tests/test_mission_view.py -q`
- `pytest -q` *(fails: `sentence_transformers` missing)*

------
https://chatgpt.com/codex/tasks/task_e_68766aa7f49c83279d4cdb61d3797792