### PR TITLE
Add effect ordering utility

### DIFF
--- a/ironaccord_bot/tests/test_effect_ordering.py
+++ b/ironaccord_bot/tests/test_effect_ordering.py
@@ -1,0 +1,27 @@
+from ironaccord_bot.utils.effect_ordering import order_effects
+
+
+def test_order_effects_respects_dependencies():
+    effects = [
+        {"id": 1, "type": "damage"},
+        {"id": 2, "type": "heal"},
+        {"id": 3, "type": "buff"},
+        {"id": 4, "type": "damage"},
+        {"id": 5, "type": "heal"},
+    ]
+    deps = {"heal": ["damage"], "damage": ["buff"]}
+    ordered = order_effects(effects, deps)
+    assert [e["id"] for e in ordered] == [3, 1, 4, 2, 5]
+
+
+def test_order_effects_leaves_unknown_intact():
+    effects = [
+        {"id": 1, "type": "special"},
+        {"id": 2, "type": "damage"},
+        {"id": 3, "type": "heal"},
+        {"id": 4, "type": "special"},
+    ]
+    deps = {"heal": ["damage"]}
+    ordered = order_effects(effects, deps)
+    # Unknown "special" type should keep input order
+    assert [e["id"] for e in ordered] == [2, 3, 1, 4]

--- a/ironaccord_bot/utils/effect_ordering.py
+++ b/ironaccord_bot/utils/effect_ordering.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+from graphlib import TopologicalSorter, CycleError
+from typing import Any, Dict, Iterable, List
+
+# Default partial ordering between effect types. Each key lists the effect
+# types that must resolve *before* it.
+DEFAULT_DEPENDENCIES: Dict[str, List[str]] = {
+    "heal": ["damage"],
+    "damage": ["buff", "debuff"],
+}
+
+
+def order_effects(
+    effects: Iterable[Dict[str, Any]],
+    dependencies: Dict[str, List[str]] | None = None,
+) -> List[Dict[str, Any]]:
+    """Order effects using a partial type hierarchy.
+
+    Parameters
+    ----------
+    effects:
+        Iterable of effect dictionaries containing at least a ``"type"`` key.
+    dependencies:
+        Mapping of effect type to a list of types that should resolve first.
+        If ``None``, :data:`DEFAULT_DEPENDENCIES` is used.
+
+    Returns
+    -------
+    List[Dict[str, Any]]
+        Effects ordered according to the partial ordering. Types not present
+        in the dependency mapping keep their original order relative to each
+        other and appear after the ordered groups.
+    """
+
+    deps = dependencies or DEFAULT_DEPENDENCIES
+    # Determine the effect types that are part of the ordering graph
+    ordered_types = set(deps)
+    effect_types = [e.get("type") for e in effects]
+    ordered_effects: List[Dict[str, Any]] = []
+
+    graph = {t: deps.get(t, []) for t in ordered_types}
+
+    try:
+        ts = TopologicalSorter(graph)
+        type_order = list(ts.static_order())
+    except CycleError as exc:  # pragma: no cover - safety net
+        raise ValueError("Cyclic dependency detected in effect hierarchy") from exc
+
+    buckets = {t: [] for t in type_order}
+    others: List[Dict[str, Any]] = []
+
+    for eff in effects:
+        t = eff.get("type")
+        if t in buckets:
+            buckets[t].append(eff)
+        else:
+            others.append(eff)
+
+    for t in type_order:
+        ordered_effects.extend(buckets[t])
+    ordered_effects.extend(others)
+
+    return ordered_effects


### PR DESCRIPTION
## Summary
- implement `order_effects` in `effect_ordering.py`
- test effect ordering using a simple dependency graph

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_e_68766aa9ca688327a5a3484cfb427cd2