### PR TITLE
Add debug mission generation command

### DIFF
--- a/ironaccord_bot/cogs/debug.py
+++ b/ironaccord_bot/cogs/debug.py
@@ -1,0 +1,30 @@
+import json
+import discord
+from discord import app_commands
+from discord.ext import commands
+
+from services.mission_engine_service import MissionEngineService
+
+
+class DebugCog(commands.Cog):
+    """Developer slash commands."""
+
+    def __init__(self, bot: commands.Bot):
+        self.bot = bot
+        self.service = MissionEngineService(bot.ai_agent, bot.rag_service)
+
+    @app_commands.command(name="generate_mission", description="Generate a mission for testing")
+    async def generate_mission(self, interaction: discord.Interaction, background: str):
+        await interaction.response.defer(ephemeral=True)
+        mission = await self.service.generate_mission(background)
+        if not mission:
+            await interaction.followup.send("Mission generation failed.", ephemeral=True)
+            return
+        data = json.dumps(mission, indent=2)
+        if len(data) > 1900:
+            data = data[:1900] + "..."
+        await interaction.followup.send(f"```json\n{data}\n```", ephemeral=True)
+
+
+async def setup(bot: commands.Bot):
+    await bot.add_cog(DebugCog(bot))

--- a/ironaccord_bot/services/__init__.py
+++ b/ironaccord_bot/services/__init__.py
@@ -2,10 +2,12 @@ from .ollama_service import OllamaService
 from .rag_service import RAGService
 from .player_context_service import gather_player_context
 from .background_quiz_service import BackgroundQuizService
+from .mission_engine_service import MissionEngineService
 
 __all__ = [
     "OllamaService",
     "RAGService",
     "gather_player_context",
     "BackgroundQuizService",
+    "MissionEngineService",
 ]

--- a/ironaccord_bot/services/mission_engine_service.py
+++ b/ironaccord_bot/services/mission_engine_service.py
@@ -1,0 +1,28 @@
+import logging
+from typing import Optional
+
+from ai.ai_agent import AIAgent
+from .mission_generator import MissionGenerator
+from .rag_service import RAGService
+
+logger = logging.getLogger(__name__)
+
+
+class MissionEngineService:
+    """Simple service for generating test missions."""
+
+    def __init__(self, agent: AIAgent | None = None, rag_service: RAGService | None = None) -> None:
+        self.agent = agent or AIAgent()
+        self.generator = MissionGenerator(self.agent, rag_service)
+
+    async def generate_mission(self, background: str) -> Optional[dict]:
+        """Generate a basic mission definition using ``background``."""
+        intro = await self.generator.generate_intro(background)
+        if not intro:
+            return None
+        return {
+            "id": 0,
+            "name": f"Generated-{background}",
+            "intro": intro,
+            "rounds": [],
+        }

--- a/ironaccord_bot/services/mission_generator.py
+++ b/ironaccord_bot/services/mission_generator.py
@@ -4,7 +4,7 @@ import logging
 from typing import Optional
 
 from ai.ai_agent import AIAgent
-from services.rag_service import RAGService
+from .rag_service import RAGService
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
## Summary
- add `MissionEngineService` for mission generation
- export new service in `services/__init__.py`
- update `MissionGenerator` imports
- add `DebugCog` with `/generate_mission` slash command for developer testing

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68766aaae324832793dec191429c6e1a