### PR TITLE
Improve context for /lore queries

### DIFF
--- a/ironaccord_bot/cogs/codex.py
+++ b/ironaccord_bot/cogs/codex.py
@@ -25,7 +25,17 @@ class CodexCog(commands.Cog):
         """Handle the `/codex query` slash command."""
         await interaction.response.defer()
 
-        results = self.rag_service.query(query)
+        # Provide the RAG service with additional context so searches prefer
+        # Iron Accord lore over generic definitions.
+        prompt_template = (
+            "Within the context of the steampunk fantasy game world known as 'Iron Accord', "
+            "please answer the following question: \"{user_query}\""
+        )
+        enhanced_query = prompt_template.format(user_query=query)
+        print(f"Original codex query: '{query}'")
+        print(f"Enhanced query for RAG: '{enhanced_query}'")
+
+        results = self.rag_service.query(enhanced_query)
 
         if not results:
             embed = discord.Embed(

--- a/ironaccord_bot/cogs/game_commands_cog.py
+++ b/ironaccord_bot/cogs/game_commands_cog.py
@@ -24,8 +24,18 @@ class GameCommandsCog(commands.Cog):
         """Asks a question to the Lore Weaver AI."""
         await interaction.response.defer(ephemeral=True)
         print(f"Received lore query: '{query}'")
+
+        # Build a more descriptive query so the RAG system understands this is
+        # about the Iron Accord setting rather than a generic term.
+        prompt_template = (
+            "Within the context of the steampunk fantasy game world known as 'Iron Accord', "
+            "please answer the following question: \"{user_query}\""
+        )
+        enhanced_query = prompt_template.format(user_query=query)
+        print(f"Enhanced query for RAG: '{enhanced_query}'")
+
         # CORRECTED: The RAG service query is now run in a non-blocking way.
-        result = await self.run_sync_query(self.rag_service.query, query)
+        result = await self.run_sync_query(self.rag_service.query, enhanced_query)
         answer = result.get("answer", "I do not have an answer for that.")
         await interaction.followup.send(f"**Query:** {query}\n**Answer:** {answer}", ephemeral=True)
 


### PR DESCRIPTION
## Summary
- enhance the /lore command so queries are wrapped with Iron Accord context
- apply the same prompt engineering to the codex query command

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68766bd526f4832790ed880a679e7031