### PR TITLE
Enable automatic command sync

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,6 +12,7 @@ APP_ID=YOUR_APP_ID
 
 # Discord guild/server ID where commands are deployed
 GUILD_ID=YOUR_GUILD_ID
+DISCORD_GUILD_ID=YOUR_GUILD_ID
 
 # MySQL database connection settings
 DB_HOST=localhost

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ This repository houses the Discord bot used for the auto battler experiments alo
 ## Setup
 
 1. Install **Python 3.11+**.
-2. Copy `.env.example` to `.env` and provide your Discord token, application ID, guild ID and MySQL credentials. You can also override the default Ollama models by setting `OLLAMA_NARRATOR_MODEL` and `OLLAMA_GM_MODEL`.
+2. Copy `.env.example` to `.env` and provide your Discord token, application ID, and `DISCORD_GUILD_ID` for your development server along with MySQL credentials. You can also override the default Ollama models by setting `OLLAMA_NARRATOR_MODEL` and `OLLAMA_GM_MODEL`.
 3. Install dependencies from the consolidated list:
    ```bash
    pip install -r requirements.txt

--- a/ironaccord_bot/bot.py
+++ b/ironaccord_bot/bot.py
@@ -30,6 +30,16 @@ class IronAccordBot(commands.Bot):
     async def setup_hook(self):
         """A hook that is called when the bot is setting up."""
         print("[Bot] Running setup hook...")
+        guild_id = os.getenv("DISCORD_GUILD_ID")
+        if not guild_id:
+            print("[Bot] WARNING: DISCORD_GUILD_ID is not set. Commands will be synced globally, which can be slow.")
+            await self.tree.sync()
+        else:
+            guild = discord.Object(id=int(guild_id))
+            self.tree.copy_global_to(guild=guild)
+            await self.tree.sync(guild=guild)
+            print(f"[Bot] Commands synced to development guild (ID: {guild_id})")
+
         await self.add_cog(GameCommandsCog(self, self.rag_service, self.player_service))
         print("[Bot] Cogs loaded.")
 


### PR DESCRIPTION
## Summary
- automatically sync slash commands on startup to development guild
- document `DISCORD_GUILD_ID` env var in setup instructions
- add `DISCORD_GUILD_ID` to env example

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687681112e7483279ce7fca99098934c