### PR TITLE
Improve logging across bot

### DIFF
--- a/ironaccord_bot/bot.py
+++ b/ironaccord_bot/bot.py
@@ -1,6 +1,7 @@
 import os
 import sys
 import asyncio
+import logging
 import discord
 from discord.ext import commands
 from dotenv import load_dotenv
@@ -9,13 +10,16 @@ from ironaccord_bot.services.rag_service import RAGService
 from ironaccord_bot.services.player_service import PlayerService
 from ironaccord_bot.ai.ai_agent import AIAgent
 
-dotenv_path = os.path.join(sys.path[0], '.env')
+logger = logging.getLogger(__name__)
+
+dotenv_path = os.path.join(sys.path[0], ".env")
 load_dotenv(dotenv_path=dotenv_path)
 
 DISCORD_TOKEN = os.getenv("DISCORD_TOKEN")
 
 intents = discord.Intents.default()
 intents.message_content = True
+
 
 class IronAccordBot(commands.Bot):
     def __init__(self):
@@ -25,10 +29,10 @@ class IronAccordBot(commands.Bot):
         self.rag_service = RAGService()
         self.player_service = PlayerService()
         self.redeploy = False
-        
+
     async def setup_hook(self):
         """This is called when the bot is setting up."""
-        print("[Bot] Running setup hook...")
+        logger.info("[Bot] Running setup hook...")
 
         # --- FIX STARTS HERE ---
 
@@ -37,53 +41,66 @@ class IronAccordBot(commands.Bot):
             if filename.endswith(".py") and not filename.startswith("_"):
                 try:
                     await self.load_extension(f"cogs.{filename[:-3]}")
-                    print(f"{filename[:-3].capitalize()}Cog loaded.")
+                    logger.info(f"{filename[:-3].capitalize()}Cog loaded.")
                 except Exception as e:
-                    print(f"Failed to load extension {filename[:-3]}: {e}")
-        print("[Bot] Cogs loaded.")
+                    logger.error(f"Failed to load extension {filename[:-3]}: {e}")
+        logger.info("[Bot] Cogs loaded.")
 
         # STEP 2: Sync the commands after the tree is populated.
         guild_id = os.getenv("DISCORD_GUILD_ID")
         if not guild_id:
-            print("[Bot] WARNING: DISCORD_GUILD_ID is not set. Commands will be synced globally, which can be slow.")
-            print("[Bot] For fast development, please set DISCORD_GUILD_ID in your .env file.")
+            logger.warning(
+                "[Bot] DISCORD_GUILD_ID is not set. Commands will be synced globally, which can be slow."
+            )
+            logger.warning(
+                "[Bot] For fast development, please set DISCORD_GUILD_ID in your .env file."
+            )
             await self.tree.sync()
         else:
             guild = discord.Object(id=int(guild_id))
             self.tree.copy_global_to(guild=guild)
             await self.tree.sync(guild=guild)
-            print(f"[Bot] Commands synced to development guild (ID: {guild_id})")
+            logger.info(f"[Bot] Commands synced to development guild (ID: {guild_id})")
 
         # --- FIX ENDS HERE ---
 
     async def on_ready(self):
         """Event that is called when the bot is ready and connected to Discord."""
-        print(f'[Bot] Logged in as {self.user} (ID: {self.user.id})')
-        print('[Bot] ------')
+        logger.info(f"[Bot] Logged in as {self.user} (ID: {self.user.id})")
+        logger.info("[Bot] ------")
+
 
 bot: IronAccordBot | None = None
+
 
 async def on_ready():
     """Event handler dispatched when the bot becomes ready."""
     if bot is None:
         return
-    print(f'[Bot] Logged in as {bot.user} (ID: {bot.user.id})')
+    logger.info(f"[Bot] Logged in as {bot.user} (ID: {bot.user.id})")
     if getattr(bot, "redeploy", False):
         await bot.tree.clear_commands()
     await bot.tree.sync()
 
+
 async def start_bot():
     """The main function to run the bot."""
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s - %(levelname)s - [%(name)s] - %(message)s",
+        stream=sys.stdout,
+    )
     if not DISCORD_TOKEN:
-        print("[Bot] Error: DISCORD_TOKEN is not set in the .env file.")
+        logging.error("[Bot] DISCORD_TOKEN is not set in the .env file.")
         return
 
     global bot
     bot = IronAccordBot()
     await bot.start(DISCORD_TOKEN)
 
+
 if __name__ == "__main__":
     try:
         asyncio.run(start_bot())
     except KeyboardInterrupt:
-        print("[Bot] Shutdown signal received.")
+        logging.info("Shutdown signal received.")

--- a/ironaccord_bot/cogs/codex.py
+++ b/ironaccord_bot/cogs/codex.py
@@ -1,9 +1,12 @@
 import discord
 from discord import app_commands
 from discord.ext import commands
+import logging
 
 from ironaccord_bot.services.rag_service import RAGService
 from ironaccord_bot.services.ollama_service import OllamaService
+
+logger = logging.getLogger(__name__)
 
 
 class CodexCog(commands.Cog):
@@ -14,60 +17,79 @@ class CodexCog(commands.Cog):
         self.rag_service: RAGService = bot.rag_service
         self.ollama_service: OllamaService = bot.ollama_service
 
-        self.group = app_commands.Group(
-            name="codex", description="Codex commands"
-        )
-        self.group.command(name="query", description="Search the Iron Accord knowledge base.")(self.query)
+        self.group = app_commands.Group(name="codex", description="Codex commands")
+        self.group.command(
+            name="query", description="Search the Iron Accord knowledge base."
+        )(self.query)
         bot.tree.add_command(self.group)
 
     @app_commands.describe(query="What lore are you looking for?")
     async def query(self, interaction: discord.Interaction, query: str):
         """Handle the `/codex query` slash command."""
+        logger.info(f"Received /codex query from '{interaction.user.name}': '{query}'")
         await interaction.response.defer()
 
-        # Provide the RAG service with additional context so searches prefer
-        # Iron Accord lore over generic definitions.
-        prompt_template = (
-            "Within the context of the steampunk fantasy game world known as 'Iron Accord', "
-            "please answer the following question: \"{user_query}\""
-        )
-        enhanced_query = prompt_template.format(user_query=query)
-        print(f"Original codex query: '{query}'")
-        print(f"Enhanced query for RAG: '{enhanced_query}'")
+        try:
+            prompt_template = (
+                "Within the context of the steampunk fantasy game world known as 'Iron Accord', "
+                'please answer the following question: "{user_query}"'
+            )
+            enhanced_query = prompt_template.format(user_query=query)
+            logger.info(f"Enhanced query for RAG: '{enhanced_query}'")
 
-        results = self.rag_service.query(enhanced_query)
+            results = self.rag_service.query(enhanced_query)
 
-        if not results:
+            if not results or not results.get("source_documents"):
+                logger.warning(
+                    f"RAG service returned no results for query: '{enhanced_query}'"
+                )
+                embed = discord.Embed(
+                    title=f"Codex Entry: {query}",
+                    description="I could not find any information on that topic in my archives.",
+                    color=discord.Color.orange(),
+                )
+                await interaction.followup.send(embed=embed)
+                return
+
+            retrieved_context = "\n\n---\n\n".join(
+                [doc.page_content for doc in results["source_documents"]]
+            )
+            logger.debug(
+                f"Retrieved context for prompt:\n---\n{retrieved_context}\n---"
+            )
+
+            prompt = f"""
+            You are a helpful assistant. Based ONLY on the following context, provide a concise answer to the user's query.
+            Structure your answer clearly. Do not add any information that is not in the context.
+            If the context does not seem relevant to the query, state that you have no information on the topic.
+
+            CONTEXT:
+            {retrieved_context}
+
+            QUERY:
+            {query}
+            """
+
+            logger.info("Sending final prompt to GM model for summary.")
+            summary = await self.ollama_service.get_gm_response(prompt)
+            logger.info("Received summary from GM model.")
+
             embed = discord.Embed(
                 title=f"Codex Entry: {query}",
-                description="I could not find any information on that topic in my archives.",
-                color=discord.Color.orange(),
+                description=summary,
+                color=discord.Color.blue(),
             )
             await interaction.followup.send(embed=embed)
-            return
+            logger.info(f"Successfully sent codex response for query: '{query}'")
 
-        retrieved_context = "\n\n---\n\n".join([doc.page_content for doc in results])
-
-        prompt = f"""
-        You are a helpful assistant. Based ONLY on the following context, provide a concise answer to the user's query.
-        Structure your answer clearly. Do not add any information that is not in the context.
-        If the context does not seem relevant to the query, state that you have no information on the topic.
-
-        CONTEXT:
-        {retrieved_context}
-
-        QUERY:
-        {query}
-        """
-
-        summary = await self.ollama_service.get_gm_response(prompt)
-
-        embed = discord.Embed(
-            title=f"Codex Entry: {query}",
-            description=summary,
-            color=discord.Color.blue(),
-        )
-        await interaction.followup.send(embed=embed)
+        except Exception as e:
+            logger.error(f"An error occurred during /codex query: {e}", exc_info=True)
+            error_embed = discord.Embed(
+                title="Error",
+                description="A critical error occurred while consulting the archives. The developers have been notified.",
+                color=discord.Color.red(),
+            )
+            await interaction.followup.send(embed=error_embed)
 
 
 async def setup(bot: commands.Bot):

--- a/ironaccord_bot/services/ollama_service.py
+++ b/ironaccord_bot/services/ollama_service.py
@@ -11,6 +11,9 @@ NARRATOR_MODEL = os.getenv(
 )  # The creative storyteller
 GM_MODEL = os.getenv("OLLAMA_GM_MODEL", "phi3:mini")  # The fast, logical game master
 
+logger = logging.getLogger(__name__)
+
+
 class OllamaService:
     """Handle interactions with the local Ollama API."""
 
@@ -20,24 +23,53 @@ class OllamaService:
     async def _generate_response(self, model_name: str, prompt: str) -> str:
         payload = {"model": model_name, "prompt": prompt, "stream": False}
         try:
-            logging.info(f"Sending request to Ollama model: {model_name}")
+            logger.debug("OLLAMA_PAYLOAD: %s", json.dumps(payload))
+            logger.info(f"Sending request to Ollama model: {model_name}")
+
             response = await self.client.post(OLLAMA_API_URL, json=payload)
-            if response.status_code >= 400:
-                logging.error(
-                    "Ollama API returned status %s for model %s", response.status_code, model_name
-                )
-                return f"Error: Ollama API responded with status code {response.status_code}."
+            try:
+                response.raise_for_status()
+            except RuntimeError:
+                # Raised when the response lacks a request (e.g. in tests)
+                if response.status_code >= 400:
+                    raise httpx.HTTPStatusError(
+                        "Invalid status", request=None, response=response
+                    )
 
             data = response.json()
-            return data.get("response", "Error: 'response' key not found in Ollama output.")
+            response_text = data.get(
+                "response", "Error: 'response' key not found in Ollama output."
+            )
+            logger.info(f"Received response from {model_name}.")
+            logger.debug("OLLAMA_RESPONSE: %s", response_text)
+            return response_text
+
+        except httpx.HTTPStatusError as e:
+            logger.error(
+                "Ollama API returned status %s for model %s. Response: %s",
+                e.response.status_code,
+                model_name,
+                e.response.text,
+                exc_info=True,
+            )
+            return f"Error: The language model service returned an error (HTTP {e.response.status_code})."
         except httpx.RequestError as e:
-            logging.error(f"Ollama API request error for model {model_name}: {e}")
-            return f"Error: Could not connect to the Ollama API at {OLLAMA_API_URL}. Is Ollama running?"
+            logger.error(
+                f"Ollama API request error for model {model_name}: {e}",
+                exc_info=True,
+            )
+            return f"Error: Could not connect to the Ollama API at {OLLAMA_API_URL}. Is it running?"
         except json.JSONDecodeError:
-            logging.error(f"Failed to decode JSON response from Ollama for model {model_name}.")
-            return "Error: Received an invalid response from the Ollama server."
+            logger.error(
+                f"Failed to decode JSON response from Ollama for model {model_name}.",
+                exc_info=True,
+            )
+            return "Error: Received an invalid response from the language model server."
         except Exception as e:  # pragma: no cover - safety net
-            logging.error(f"An unexpected error occurred while contacting Ollama for model {model_name}: {e}")
+            logger.error(
+                f"An unexpected error occurred while contacting Ollama: {e}",
+                exc_info=True,
+            )
             return "An unexpected error occurred. Please check the bot logs."
 
     async def get_narrative(self, prompt: str) -> str:


### PR DESCRIPTION
## Summary
- configure python logger at startup
- add structured logging to codex queries
- expand Ollama service logging and error handling

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687695b1df588327a00710c9bd18e7d2