### PR TITLE
Fix bot service init and mission view

### DIFF
--- a/ironaccord_bot/tests/test_mission_view.py
+++ b/ironaccord_bot/tests/test_mission_view.py
@@ -3,7 +3,15 @@ import pytest
 discord = pytest.importorskip("discord")
 
 from ironaccord_bot.views.mission_view import MissionView
-from ironaccord_bot.services.mission_engine_service import MissionEngineService
+
+
+class DummyService:
+    def __init__(self):
+        self.choice = None
+
+    async def make_choice(self, uid, choice):
+        self.choice = choice
+        return "done"
 
 
 class DummyResponse:
@@ -13,40 +21,26 @@ class DummyResponse:
     async def edit_message(self, **kwargs):
         self.kwargs = kwargs
 
+    async def send(self, *args, **kwargs):
+        self.kwargs = kwargs
+
 
 class DummyInteraction:
     def __init__(self):
+        self.user = type("U", (), {"id": 1})()
         self.response = DummyResponse()
         self.followup = DummyResponse()
-        self.edit_kwargs = None
-
-    async def edit_original_response(self, **kwargs):
-        self.edit_kwargs = kwargs
 
 
 @pytest.mark.asyncio
-async def test_choice_advances_scene(monkeypatch):
-    class DummyService(MissionEngineService):
-        def __init__(self):
-            pass
-        async def advance_mission(self, uid, choice):
-            return {"text": "next", "status": "complete"}
-
+async def test_button_sends_choice():
     service = DummyService()
-    view = MissionView(service, 1, "scene", ["A", "B"])
+    choices = [{"text": "A"}, {"text": "B"}]
+    view = MissionView(service, 1, "scene", choices)
     interaction = DummyInteraction()
     button = view.children[0]
+
     await button.callback(interaction)
 
-    assert interaction.response.kwargs["view"] is view
-    assert interaction.edit_kwargs["content"] == "next"
-
-
-@pytest.mark.asyncio
-async def test_update_scene_repopulates_buttons():
-    service = type("S", (), {"advance_mission": lambda *a, **k: None})()
-    view = MissionView(service, 1, "one", ["A", "B"])
-    view.update_scene("two", ["X"])
-    assert view.narrative_text == "two"
-    assert view.choices == ["X"]
-    assert len(view.children) == 1
+    assert service.choice == choices[0]
+    assert interaction.followup.kwargs is not None

--- a/ironaccord_bot/views/mission_view.py
+++ b/ironaccord_bot/views/mission_view.py
@@ -1,51 +1,40 @@
 import discord
-from ..services.mission_engine_service import MissionEngineService
+import logging
+from typing import List, Dict
+
+logger = logging.getLogger(__name__)
 
 class MissionView(discord.ui.View):
-    """Simple view for presenting a mission scene with multiple choices."""
+    """A view to display mission choices to the player."""
 
-    def __init__(self, service: MissionEngineService, user_id: int, narrative_text: str, choices: list[str]):
-        super().__init__(timeout=300)
-        self.service = service
+    def __init__(self, mission_service, user_id: int, text: str, choices: List[Dict]):
+        super().__init__(timeout=600)
+        self.mission_service = mission_service
         self.user_id = user_id
-        self.narrative_text = narrative_text
-        self.choices = choices
-        self.selected_choice: str | None = None
-        self._populate_buttons()
+        self.message_text = text
 
-    def _populate_buttons(self) -> None:
-        self.clear_items()
-        for idx, choice in enumerate(self.choices):
-            self.add_item(self.ChoiceButton(choice, idx))
+        # Create a button for each choice using its text
+        for choice_data in choices:
+            label = choice_data.get("text", "Invalid Choice")
+            self.add_item(self.MissionButton(label=label, choice_data=choice_data))
 
-    def update_scene(self, narrative_text: str, choices: list[str]) -> None:
-        """Reuse the view for a new scene by updating text and buttons."""
-        self.narrative_text = narrative_text
-        self.choices = choices
-        self.selected_choice = None
-        self._populate_buttons()
+    class MissionButton(discord.ui.Button):
+        def __init__(self, label: str, choice_data: Dict):
+            super().__init__(label=label[:80], style=discord.ButtonStyle.secondary)
+            self.choice_data = choice_data
 
-    class ChoiceButton(discord.ui.Button):
-        def __init__(self, label: str, idx: int):
-            super().__init__(label=label, style=discord.ButtonStyle.primary)
-            self.label_text = label
-            self.idx = idx
+        async def callback(self, interaction: discord.Interaction):
+            view: "MissionView" = self.view
+            if interaction.user.id != view.user_id:
+                await interaction.response.send_message("This is not your mission.", ephemeral=True)
+                return
 
-        async def callback(self, interaction: discord.Interaction) -> None:
-            view: "MissionView" = self.view  # type: ignore[assignment]
+            # Disable all buttons to prevent multiple selections
             for item in view.children:
                 item.disabled = True
             await interaction.response.edit_message(view=view)
 
-            result = await view.service.advance_mission(view.user_id, self.label_text)
-            if not result:
-                await interaction.followup.send("An error occurred.", ephemeral=True)
-                view.stop()
-                return
+            result_text = await view.mission_service.make_choice(view.user_id, self.choice_data)
+            await interaction.followup.send(result_text, ephemeral=True)
+            view.stop()
 
-            if result.get("status"):
-                await interaction.edit_original_response(content=result.get("text", ""), view=None)
-                view.stop()
-            else:
-                view.update_scene(result.get("text", ""), result.get("choices", []))
-                await interaction.edit_original_response(content=result.get("text", ""), view=view)


### PR DESCRIPTION
## Summary
- initialize services early in `IronAccordBot`
- expose `ollama_service` on bot and use same instance for `AIAgent`
- fix timestamp setting and add redeploy `on_ready` helper
- update `MissionView` to label buttons correctly
- adjust mission view tests for new interface

## Testing
- `pytest ironaccord_bot/tests/test_mission_view.py ironaccord_bot/tests/test_bot.py -q` *(fails: Missing pytest-asyncio plugin)*

------
https://chatgpt.com/codex/tasks/task_e_6876bfb167408327ac1c95513fb89acb