### PR TITLE
Fix quiz JSON extraction import

### DIFF
--- a/ironaccord_bot/services/background_quiz_service.py
+++ b/ironaccord_bot/services/background_quiz_service.py
@@ -7,6 +7,7 @@ from collections import Counter
 
 from ironaccord_bot.services.ollama_service import OllamaService
 from ironaccord_bot.views.background_quiz_view import QuizSession
+from ironaccord_bot.utils.json_utils import extract_json_from_string
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
## Summary
- import `extract_json_from_string` in background quiz service

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6876ecbb2cf48327a78f7ceb51b500b5