### PR TITLE
Improve JSON handling and view callbacks

### DIFF
--- a/ironaccord_bot/services/background_quiz_service.py
+++ b/ironaccord_bot/services/background_quiz_service.py
@@ -86,14 +86,14 @@ class BackgroundQuizService:
             logger.info(f"Attempting to generate quiz (Attempt {attempt + 1}/{max_attempts})")
             try:
                 raw_response = await self.ollama_service.get_gm_response(prompt)
-                json_string = extract_json_from_string(raw_response)
+                quiz_data = extract_json_from_string(raw_response)
 
-                if not json_string:
-                    logger.warning(f"Attempt {attempt + 1}: Could not extract JSON from LLM response.")
+                if not quiz_data:
+                    logger.warning(
+                        f"Attempt {attempt + 1}: Could not extract JSON from LLM response."
+                    )
                     await asyncio.sleep(1)
                     continue
-
-                quiz_data = json.loads(json_string)
 
                 background_text_map = {
                     "A": backgrounds.get(quiz_data["background_map"]["A"], ""),
@@ -155,3 +155,13 @@ class BackgroundQuizService:
 
         del self.active_quizzes[user_id]
         return result, background_name
+
+    def create_welcome_message(self, session: "QuizSession", background_name: str) -> str:
+        """Return a short welcome message for the completed quiz."""
+
+        description = session.background_text.get(background_name, "")
+        return (
+            f"**Welcome, {background_name}!**\n\n"
+            f"*{description}*\n\n"
+            "You are now ready to begin your first mission. Use the `/mission` command to see what's available."
+        )

--- a/ironaccord_bot/tests/test_mission_view.py
+++ b/ironaccord_bot/tests/test_mission_view.py
@@ -9,7 +9,7 @@ class DummyService:
     def __init__(self):
         self.choice = None
 
-    async def make_choice(self, uid, choice):
+    async def make_mission_choice(self, uid, choice):
         self.choice = choice
         return "done"
 

--- a/ironaccord_bot/views/background_quiz_view.py
+++ b/ironaccord_bot/views/background_quiz_view.py
@@ -102,8 +102,8 @@ class BackgroundQuizView(discord.ui.View):
             await interaction.edit_original_response(content="Edraz is considering your answers...", view=None)
             final_text, background = await self.quiz_service.evaluate_result(self.user_id)
 
-            # MODIFICATION: Tag the user in the final welcome message
-            welcome_message = f"{final_text}\n\nWelcome to your new life, <@{self.user_id}>."
+            # Build a concise welcome message that fits within Discord limits
+            welcome_message = self.quiz_service.create_welcome_message(session, background)
             await interaction.followup.send(welcome_message, ephemeral=True)
 
             # Start the first mission

--- a/ironaccord_bot/views/mission_view.py
+++ b/ironaccord_bot/views/mission_view.py
@@ -34,7 +34,7 @@ class MissionView(discord.ui.View):
                 item.disabled = True
             await interaction.response.edit_message(view=view)
 
-            result_text = await view.mission_service.make_choice(view.user_id, self.choice_data)
+            result_text = await view.mission_service.make_mission_choice(view.user_id, self.choice_data)
             await interaction.followup.send(result_text, ephemeral=True)
             view.stop()
 


### PR DESCRIPTION
## Summary
- make JSON parsing resilient to trailing commas and fenced blocks
- rename mission button callback to call `make_mission_choice`
- shorten welcome text generation and expose helper
- update mission view test for new method name

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6877054100388327ba09478a0c326efd