### PR TITLE
Fix mission view button calling wrong method

### DIFF
--- a/ironaccord_bot/tests/test_mission_view.py
+++ b/ironaccord_bot/tests/test_mission_view.py
@@ -9,7 +9,7 @@ class DummyService:
     def __init__(self):
         self.choice = None
 
-    async def make_choice(self, uid, choice):
+    async def make_mission_choice(self, uid, choice):
         self.choice = choice
         return "done"
 

--- a/ironaccord_bot/views/mission_view.py
+++ b/ironaccord_bot/views/mission_view.py
@@ -34,7 +34,7 @@ class MissionView(discord.ui.View):
                 item.disabled = True
             await interaction.response.edit_message(view=view)
 
-            result_text = await view.mission_service.make_choice(view.user_id, self.choice_data)
+            result_text = await view.mission_service.make_mission_choice(view.user_id, self.choice_data)
             await interaction.followup.send(result_text, ephemeral=True)
             view.stop()
 


### PR DESCRIPTION
## Summary
- call `make_mission_choice` in `MissionView` button callback
- update mission view test to use `make_mission_choice`

## Testing
- `pytest -q ironaccord_bot/tests/test_mission_view.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687706f564a88327940809aff30c6e56