### PR TITLE
Fix archetype result handling

### DIFF
--- a/ironaccord_bot/services/background_quiz_service.py
+++ b/ironaccord_bot/services/background_quiz_service.py
@@ -127,11 +127,11 @@ class BackgroundQuizService:
         next_question = session.get_current_question()
         return session, next_question
 
-    def evaluate_result(self, user_id: int) -> Tuple[str, QuizSession | None]:
-        """Evaluate the quiz locally and return the background name and session."""
+    def evaluate_result(self, user_id: int) -> Tuple[str, str, QuizSession | None]:
+        """Return the chosen archetype key, its name, and the quiz session."""
         session = self.active_quizzes.get(user_id)
         if not session:
-            return "Unknown", None
+            return "Unknown", "Unknown", None
 
         counts = Counter(session.answers)
         if not counts:
@@ -139,8 +139,8 @@ class BackgroundQuizService:
         else:
             most_common_label = counts.most_common(1)[0][0]
 
-        background_name = session.background_map.get(most_common_label, "Unknown")
-        return background_name, session
+        archetype_name = session.background_map.get(most_common_label, "Unknown")
+        return most_common_label, archetype_name, session
 
     def cleanup_quiz_session(self, user_id: int):
         """Remove a quiz session after it is fully processed."""

--- a/ironaccord_bot/tests/test_background_quiz_service.py
+++ b/ironaccord_bot/tests/test_background_quiz_service.py
@@ -56,9 +56,10 @@ def test_evaluate_result():
     session.answers = ["B", "B", "A"]
     service.active_quizzes[1] = session
 
-    background, returned_session = service.evaluate_result(1)
+    key, name, returned_session = service.evaluate_result(1)
 
-    assert background == "Beta"
+    assert key == "B"
+    assert name == "Beta"
     assert returned_session is session
     assert 1 in service.active_quizzes
 

--- a/ironaccord_bot/views/background_quiz_view.py
+++ b/ironaccord_bot/views/background_quiz_view.py
@@ -102,23 +102,23 @@ class BackgroundQuizView(discord.ui.View):
             view=None,
         )
 
-        background, session = self.quiz_service.evaluate_result(self.user_id)
-        if not background or not session:
+        archetype_key, archetype_name, session = self.quiz_service.evaluate_result(self.user_id)
+        if not archetype_name or not session:
             await interaction.followup.send("Error evaluating your quiz results.", ephemeral=True)
             self.stop()
             return
 
         welcome_embed = discord.Embed(
-            title=f"Welcome, {background}!",
+            title=f"Welcome, {archetype_name}!",
             description=(
-                f"*{session.background_text[background][:200]}...*\n\n"
+                f"*{session.background_text.get(archetype_key, 'No description found.')[:200]}...*\n\n"
                 "Your path is set. Now, your first trial awaits."
             ),
             color=discord.Color.dark_gold(),
         )
         await interaction.followup.send(embed=welcome_embed, ephemeral=True)
 
-        opening = await self.mission_service.start_mission(self.user_id, background, self.template)
+        opening = await self.mission_service.start_mission(self.user_id, archetype_key, self.template)
         self.quiz_service.cleanup_quiz_session(self.user_id)
 
         if opening:


### PR DESCRIPTION
## Summary
- return archetype key along with name from quiz service
- use the key to look up text and to start missions
- adjust unit test for new return value

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687978a3fa6083279d9fa96da8174e34