### PR TITLE
Support prefix alias for start command

### DIFF
--- a/ironaccord_bot/cogs/start.py
+++ b/ironaccord_bot/cogs/start.py
@@ -2,7 +2,6 @@ import discord
 import random
 from pathlib import Path
 from discord.ext import commands
-from discord import app_commands
 import logging
 
 from ironaccord_bot.services.background_quiz_service import BackgroundQuizService
@@ -30,20 +29,26 @@ class StartCog(commands.Cog):
         chosen = random.sample(files, count)
         return {f.stem.replace("_", " ").title(): f.read_text(encoding="utf-8") for f in chosen}
 
-    @app_commands.command(
+    @commands.hybrid_command(
         name="start",
         description="Begin your journey and discover your place in the Iron Accord.",
     )
-    async def start(self, interaction: discord.Interaction):
-        """Kick off the interactive background quiz with a loading message."""
-        user_id = interaction.user.id
-        logger.info(f"User {user_id} started the quiz process.")
-
-        # Send an initial loading message so the user sees immediate feedback
-        await interaction.response.send_message(
-            "Edraz is consulting the archives to build your personalized story...",
-            ephemeral=True,
+    async def start(self, ctx: commands.Context):
+        """Kick off the interactive background quiz via slash or prefix."""
+        user_id = ctx.author.id
+        logger.info(
+            f"User {user_id} started the quiz process via {'slash command' if ctx.interaction else 'prefix command'}."
         )
+
+        if ctx.interaction:
+            await ctx.interaction.response.send_message(
+                "Edraz is consulting the archives to build your personalized story...",
+                ephemeral=True,
+            )
+        else:
+            await ctx.send(
+                "Edraz is consulting the archives to build your personalized story..."
+            )
 
         try:
             backgrounds = self._load_random_backgrounds()
@@ -52,27 +57,38 @@ class StartCog(commands.Cog):
             if session:
                 logger.info(f"Quiz generated for user {user_id}. Sending first question.")
                 view = BackgroundQuizView(self.quiz_service, self.mission_service, user_id)
-                await interaction.edit_original_response(
-                    content=session.get_current_question_text(),
-                    view=view,
-                )
+                if ctx.interaction:
+                    await ctx.interaction.edit_original_response(
+                        content=session.get_current_question_text(),
+                        view=view,
+                    )
+                else:
+                    await ctx.send(session.get_current_question_text(), view=view)
             else:
                 logger.error(f"Failed to generate quiz for user {user_id} after all retries.")
-                await interaction.edit_original_response(
-                    content=(
+                if ctx.interaction:
+                    await ctx.interaction.edit_original_response(
+                        content=(
+                            "There was an error generating the quiz. The archives may be unstable. Please try again later."
+                        ),
+                        view=None,
+                    )
+                else:
+                    await ctx.send(
                         "There was an error generating the quiz. The archives may be unstable. Please try again later."
-                    ),
-                    view=None,
-                )
+                    )
         except Exception as exc:  # pragma: no cover - safety net
             logger.error(
                 f"An unexpected error occurred in the start command for user {user_id}: {exc}",
                 exc_info=True,
             )
-            await interaction.edit_original_response(
-                content="A critical error occurred. Please notify the developers.",
-                view=None,
-            )
+            if ctx.interaction:
+                await ctx.interaction.edit_original_response(
+                    content="A critical error occurred. Please notify the developers.",
+                    view=None,
+                )
+            else:
+                await ctx.send("A critical error occurred. Please notify the developers.")
 
 
 async def setup(bot: commands.Bot):

--- a/run.py
+++ b/run.py
@@ -1,48 +1,27 @@
-import sys
 import os
 import asyncio
+import discord
+from dotenv import load_dotenv
+
+from ironaccord_bot.bot import IronAccordBot
 
 
-def main():
-    """
-    Sets up the system path and directly imports and runs the bot's main function.
-    This is a more forceful approach to bypass environment-specific module resolution issues.
-    """
-    # Get the absolute path of the directory where this script is located (the project root).
-    project_root = os.path.dirname(os.path.abspath(__file__))
+load_dotenv()
 
-    # Add the project root to the system path to allow for package imports.
-    if project_root not in sys.path:
-        sys.path.insert(0, project_root)
-        print(f"[Launcher] Added project root to path: {project_root}")
+# Prefix for traditional commands (e.g. !start)
+COMMAND_PREFIX = os.getenv("COMMAND_PREFIX", "!")
+DISCORD_TOKEN = os.getenv("DISCORD_TOKEN")
+DEBUG_GUILD_ID = int(os.getenv("DEBUG_GUILD_ID", 0)) or None
 
-    # Add the package directory to the system path so top-level imports like
-    # 'from models import ...' resolve correctly when run from this launcher.
-    package_path = os.path.join(project_root, "ironaccord_bot")
-    if package_path not in sys.path:
-        sys.path.insert(0, package_path)
-        print(f"[Launcher] Added package path to path: {package_path}")
 
-    print("[Launcher] Attempting to start the bot directly...")
+async def main() -> None:
+    """Entry point for launching the bot."""
+    intents = discord.Intents.default()
+    intents.message_content = True
 
-    try:
-        # Directly import the function we need from the bot module.
-        # This is a more explicit way of loading the code than runpy.
-        from ironaccord_bot.bot import start_bot
-
-        # Run the bot's main async function.
-        asyncio.run(start_bot())
-
-    except KeyboardInterrupt:
-        print("\n[Launcher] Bot shutdown gracefully.")
-    except ModuleNotFoundError as e:
-        print(f"\n[Launcher] FATAL: A module could not be found: {e}")
-        print("[Launcher] This indicates a persistent pathing problem.")
-        print("[Launcher] Please ensure all dependencies from requirements.txt are installed.")
-        print(f"[Launcher] Current sys.path: {sys.path}")
-    except Exception as e:
-        print(f"\n[Launcher] An unexpected error occurred: {e}")
+    bot = IronAccordBot(command_prefix=COMMAND_PREFIX, intents=intents, debug_guild_id=DEBUG_GUILD_ID)
+    await bot.start(DISCORD_TOKEN)
 
 
 if __name__ == "__main__":
-    main()
+    asyncio.run(main())


### PR DESCRIPTION
## Summary
- add COMMAND_PREFIX env var to `run.py` and pass to bot
- refactor `IronAccordBot` to accept a prefix and optional debug guild
- convert `start` to hybrid command and add prefix support
- update tests for new hybrid command

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_e_6879802092088327b34bbe7db224c085