### PR TITLE
Improve startup and quiz handling

### DIFF
--- a/ironaccord_bot/bot.py
+++ b/ironaccord_bot/bot.py
@@ -27,7 +27,14 @@ STATUS_CHANNEL_ID = 1386506958730690652
 class IronAccordBot(commands.Bot):
     """The main bot class for Iron Accord."""
 
-    def __init__(self, *, command_prefix: str = COMMAND_PREFIX, intents: discord.Intents | None = None, debug_guild_id: int | None = None):
+    def __init__(
+        self,
+        *,
+        rag_service: RAGService | None = None,
+        command_prefix: str = COMMAND_PREFIX,
+        intents: discord.Intents | None = None,
+        debug_guild_id: int | None = None,
+    ):
         if intents is None:
             intents = discord.Intents.default()
             intents.message_content = True
@@ -36,7 +43,7 @@ class IronAccordBot(commands.Bot):
         self.debug_guild_id = debug_guild_id
 
         # --- Services ---
-        self.rag_service = RAGService()
+        self.rag_service = rag_service or RAGService()
         self.player_service = PlayerService()
         self.ai_agent = AIAgent()
         self.ollama_service = OllamaService()

--- a/ironaccord_bot/utils/json_utils.py
+++ b/ironaccord_bot/utils/json_utils.py
@@ -32,3 +32,30 @@ def extract_json_from_string(text: str) -> dict | None:
         logger.error("Extracted string could not be parsed as valid JSON: %s", e)
         logger.debug("Invalid JSON string was: %s", json_str)
         return None
+
+
+def extract_and_parse_json(text: str) -> dict | None:
+    """Return a cleaned JSON object from ``text`` if possible.
+
+    This helper is more tolerant of common LLM mistakes such as surrounding
+    commentary or Markdown code fences. It searches for the first JSON object
+    in ``text`` and attempts to parse it.
+    """
+
+    if not text:
+        logger.error("Extracted string is empty.")
+        return None
+
+    match = re.search(r"\{.*\}", text, re.DOTALL)
+    if not match:
+        logger.error("No JSON object found in the string: %s", text)
+        return None
+
+    json_string = match.group(0)
+
+    try:
+        return json.loads(json_string)
+    except json.JSONDecodeError as e:
+        logger.error("Extracted string could not be parsed as valid JSON: %s", e)
+        logger.debug("Malformed JSON string: %s", json_string)
+        return None


### PR DESCRIPTION
## Summary
- make RAGService initialization non-blocking and add startup logging
- allow `IronAccordBot` to accept an external RAG service
- harden quiz JSON parsing and logging
- add `extract_and_parse_json` helper for lenient JSON cleanup

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6879a6a4ef288327bc44a5cf237be8d3