### PR TITLE
Implement two-step mission LLM flow

### DIFF
--- a/ironaccord_bot/tests/test_mission_engine_service.py
+++ b/ironaccord_bot/tests/test_mission_engine_service.py
@@ -7,14 +7,31 @@ async def test_generate_opening(monkeypatch, tmp_path):
     (tmp_path / "demo.json").write_text('{"title": "Demo"}')
     monkeypatch.setattr(mes, "MISSIONS_PATH", tmp_path)
 
-    async def fake_completion(self, prompt):
-        return '{"text": "intro", "choices": ["a", "b"]}'
+    async def fake_narrative(self, prompt):
+        return "A scene\n1. A\n2. B"
 
-    agent = type('A', (), {'get_completion': fake_completion})()
+    async def fake_gm(self, prompt):
+        return json.dumps({
+            "outcome_text": "intro",
+            "choices": [
+                {"id": 1, "text": "a"},
+                {"id": 2, "text": "b"}
+            ],
+            "status_effect": None
+        })
+
+    agent = type('A', (), {'get_narrative': fake_narrative, 'get_gm_response': fake_gm})()
     svc = mes.MissionEngineService(agent)
     result = await svc.generate_opening("Scout", "demo")
 
-    assert result == {"text": "intro", "choices": ["a", "b"]}
+    assert result == {
+        "text": "intro",
+        "choices": [
+            {"id": 1, "text": "a"},
+            {"id": 2, "text": "b"}
+        ],
+        "status_effect": None
+    }
 
 
 @pytest.mark.asyncio
@@ -22,10 +39,10 @@ async def test_generate_opening_llm_error(monkeypatch, tmp_path):
     (tmp_path / "demo.json").write_text('{"title": "Demo"}')
     monkeypatch.setattr(mes, "MISSIONS_PATH", tmp_path)
 
-    async def fake_completion(self, prompt):
+    async def fake_narrative(self, prompt):
         raise RuntimeError('fail')
 
-    agent = type('A', (), {'get_completion': fake_completion})()
+    agent = type('A', (), {'get_narrative': fake_narrative})()
     svc = mes.MissionEngineService(agent)
     result = await svc.generate_opening("Scout", "demo")
 
@@ -43,16 +60,25 @@ async def test_start_and_advance(monkeypatch, tmp_path):
     (tmp_path / "demo.json").write_text('{"title": "Demo"}')
     monkeypatch.setattr(mes, "MISSIONS_PATH", tmp_path)
 
-    responses = iter([
-        '{"text": "start", "choices": ["a", "b"]}',
-        '{"text": "next", "choices": ["c", "d"]}',
-        '{"text": "done", "status": "complete"}',
+    narratives = iter([
+        "Start scene\n1. A\n2. B",
+        "Next scene\n1. C\n2. D",
+        "Final scene"
     ])
 
-    async def fake_completion(self, prompt):
-        return next(responses)
+    gm_responses = iter([
+        json.dumps({"outcome_text": "start", "choices": [{"id": 1, "text": "a"}, {"id": 2, "text": "b"}]}),
+        json.dumps({"outcome_text": "next", "choices": [{"id": 1, "text": "c"}, {"id": 2, "text": "d"}]}),
+        json.dumps({"outcome_text": "done", "status": "complete"})
+    ])
 
-    agent = type('A', (), {'get_completion': fake_completion})()
+    async def fake_narrative(self, prompt):
+        return next(narratives)
+
+    async def fake_gm(self, prompt):
+        return next(gm_responses)
+
+    agent = type('A', (), {'get_narrative': fake_narrative, 'get_gm_response': fake_gm})()
     svc = mes.MissionEngineService(agent)
     opening = await svc.start_mission(1, "Scout", "demo")
     assert opening["text"] == "start"
@@ -68,19 +94,33 @@ async def test_advance_handles_extra_text(monkeypatch, tmp_path):
     (tmp_path / "demo.json").write_text('{"title": "Demo"}')
     monkeypatch.setattr(mes, "MISSIONS_PATH", tmp_path)
 
-    responses = iter([
-        '{"text": "start", "choices": ["a", "b"]}',
-        'Before JSON {junk} ```json\n{"text": "next", "choices": ["c", "d"]}\n``` After',
+    narratives = iter([
+        "Scene start\n1. A\n2. B",
+        "Messy narrative"
     ])
 
-    async def fake_completion(self, prompt):
-        return next(responses)
+    gm_responses = iter([
+        json.dumps({"outcome_text": "start", "choices": [{"id": 1, "text": "a"}, {"id": 2, "text": "b"}]}),
+        'Before JSON {junk} ```json\n{"outcome_text": "next", "choices": [{"id": 1, "text": "c"}, {"id": 2, "text": "d"}]}\n``` After'
+    ])
 
-    agent = type('A', (), {'get_completion': fake_completion})()
+    async def fake_narrative(self, prompt):
+        return next(narratives)
+
+    async def fake_gm(self, prompt):
+        return next(gm_responses)
+
+    agent = type('A', (), {'get_narrative': fake_narrative, 'get_gm_response': fake_gm})()
     svc = mes.MissionEngineService(agent)
 
     opening = await svc.start_mission(1, "Scout", "demo")
     assert opening["text"] == "start"
 
     nxt = await svc.advance_mission(1, "a")
-    assert nxt == {"text": "next", "choices": ["c", "d"]}
+    assert nxt == {
+        "text": "next",
+        "choices": [
+            {"id": 1, "text": "c"},
+            {"id": 2, "text": "d"}
+        ]
+    }


### PR DESCRIPTION
## Summary
- refactor mission engine prompts for a two-step chain
- add JSON formatting helper for phi3
- update mission advancement to use mixtral then phi3
- adjust mission engine tests for new flow

## Testing
- `pytest -q` *(fails: async def functions are not natively supported)*

------
https://chatgpt.com/codex/tasks/task_e_6879cffe329083278ed1de92294b5e11