### PR TITLE
Refactor mission choice display

### DIFF
--- a/ironaccord_bot/tests/test_mission_engine_service.py
+++ b/ironaccord_bot/tests/test_mission_engine_service.py
@@ -1,4 +1,5 @@
 import pytest
+import json
 from services import mission_engine_service as mes
 
 

--- a/ironaccord_bot/tests/test_mission_view.py
+++ b/ironaccord_bot/tests/test_mission_view.py
@@ -35,12 +35,16 @@ class DummyInteraction:
 @pytest.mark.asyncio
 async def test_button_sends_choice():
     service = DummyService()
-    choices = [{"text": "A"}, {"text": "B"}]
+    choices = [
+        {"id": 1, "text": "Option A"},
+        {"id": 2, "text": "Option B"},
+    ]
     view = MissionView(service, 1, "scene", choices)
     interaction = DummyInteraction()
     button = view.children[0]
 
     await button.callback(interaction)
 
-    assert service.choice == "A"
+    assert service.choice == "Option A"
     assert interaction.followup.kwargs is not None
+    assert "**A.** Option A" in view.message_text

--- a/ironaccord_bot/views/background_quiz_view.py
+++ b/ironaccord_bot/views/background_quiz_view.py
@@ -128,7 +128,7 @@ class BackgroundQuizView(discord.ui.View):
                 opening.get("text", ""),
                 opening.get("choices", []),
             )
-            await interaction.followup.send(opening.get("text", ""), view=view, ephemeral=True)
+            await interaction.followup.send(view.message_text, view=view, ephemeral=True)
         else:
             await interaction.followup.send("Failed to start your first mission.", ephemeral=True)
 


### PR DESCRIPTION
## Summary
- show mission choices in the message text
- label buttons A/B/C and keep IDs
- send mission text with formatted choices when starting a mission
- handle messy JSON more robustly
- update unit tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6879d4b24ad883278e5e16f01145ebc7