### PR TITLE
Implement unified LLM helpers

### DIFF
--- a/ironaccord_bot/services/mission_engine_service.py
+++ b/ironaccord_bot/services/mission_engine_service.py
@@ -7,6 +7,7 @@ from typing import Optional, Dict, Any, TYPE_CHECKING
 from dataclasses import dataclass, field
 
 from ironaccord_bot.utils import json_utils
+from . import ollama_service
 
 if TYPE_CHECKING:
     from ai.ai_agent import AIAgent
@@ -14,6 +15,30 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 MISSIONS_PATH = Path("data/missions")
+
+
+def get_unified_mission_prompt(character, mission, user_choice_text: str) -> str:
+    """Return a single prompt for the unified mission generation flow."""
+    return f"""
+    You are a master storyteller and game designer generating the next step of a quest.
+
+    **Character:** A {character.class_name} named {character.name}
+    **Current Situation:** {mission.state}
+    **Player's Action:** "{user_choice_text}"
+
+    Generate a creative and engaging outcome for this action. Then, provide three new, distinct choices for the player.
+    Your response MUST be ONLY a single, valid JSON object. Do not add any conversational text, explanations, or markdown.
+
+    **JSON Schema:**
+    {{
+      "outcome_text": "A narrative paragraph describing the result of the player's action.",
+      "choices": [
+        {{ "id": 1, "text": "A compelling first choice for the player." }},
+        {{ "id": 2, "text": "A compelling second choice for the player." }},
+        {{ "id": 3, "text": "A compelling third choice for the player." }}
+      ]
+    }}
+    """
 
 
 @dataclass
@@ -171,3 +196,45 @@ class MissionEngineService:
         """Return a mission dictionary using ``background`` and ``template_name``."""
 
         return await self.generate_opening(background, template_name)
+
+
+async def advance_mission_interaction(interaction, user_choice_text: str):
+    """Advance a mission using a single streaming call to the unified LLM."""
+    await interaction.response.send_message("Edraz is considering your choice...", ephemeral=True)
+
+    # Assuming ``character`` and ``mission`` are retrieved elsewhere in the bot
+    character = interaction.client.character_service.get_character(interaction.user.id)
+    mission = interaction.client.mission_service.get_active_mission(interaction.user.id)
+
+    prompt = get_unified_mission_prompt(character, mission, user_choice_text)
+
+    full_text = ""
+    async for chunk in ollama_service.stream_request(prompt, ["llama3:70b-instruct"]):
+        full_text += chunk
+
+    if not full_text:
+        await interaction.edit_original_response(content="My thoughts are clouded. Please try again.")
+        return
+
+    mission_data = json_utils.extract_and_parse_json(full_text)
+    if not mission_data:
+        await interaction.edit_original_response(content="A critical error occurred in my thought process. Please try again.")
+        logger.error("CRITICAL: Primary model failed to produce valid JSON. Response: %s", full_text)
+        return
+
+    outcome = mission_data.get("outcome_text", "An unexpected event occurs.")
+    choices = mission_data.get("choices", [])
+    choice_list = [f"**{chr(65 + i)}.** {choice['text']}" for i, choice in enumerate(choices)]
+    formatted_choices = "\n".join(choice_list)
+    message_content = f"**Scene:** {mission.scene_title}\n\n{outcome}\n\n{formatted_choices}"
+
+    from discord import Button, ButtonStyle, ActionRow
+
+    buttons = [
+        Button(style=ButtonStyle.secondary, label=f"{chr(65 + i)}", custom_id=f"mission_choice:{choice['id']}")
+        for i, choice in enumerate(choices)
+    ]
+    action_row = ActionRow(*buttons)
+
+    await interaction.edit_original_response(content=message_content, components=[action_row])
+    logger.info("Successfully advanced mission for user %s", interaction.user.id)


### PR DESCRIPTION
## Summary
- add unified LLM request helper functions to `OllamaService`
- provide a high‑level prompt and generator for quizzes
- provide a prompt helper and streaming mission advance function

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6879dad68e4c83279e58b6c1f5e04ab1