### PR TITLE
Add architecture docs and service docstrings

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ This repository houses the Discord bot used for the auto battler experiments alo
 - `ironaccord_bot/tests/stubs/chromadb/` – lightweight stand‑in for the
   [Chromadb](https://github.com/chroma-core/chroma) client so the test suite can
   run without the heavy dependency installed.
+- `docs/ARCHITECTURE.md` – overview of the dual‑LLM architecture used by the bot.
 
 ## Setup
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,0 +1,38 @@
+# Architecture Overview
+
+This document describes the high level structure of the Iron Accord bot and how the dual‑LLM system processes a player's actions. It complements the design details found in [dual_llm_engine.md](dual_llm_engine.md).
+
+## Core Components
+
+- **Discord Cogs & Views** – command handlers and UI elements exposed to players.
+- **Mission Engine & Services** – orchestrates missions, calling out to the LLMs and tracking per–user progress.
+- **Ollama Service** – thin wrapper around the locally hosted LLMs used for narration (`narrator_model`) and fast rules resolution (`gm_model`).
+- **RAG Service & ChromaDB** – optional retrieval component that feeds additional lore snippets into prompts.
+
+## Dual‑LLM Data Flow
+
+```mermaid
+sequenceDiagram
+    participant U as Discord User
+    participant D as Discord Bot
+    participant GM as GM Model
+    participant LW as Lore Weaver Model
+
+    U->>D: Clicks mission choice button
+    D->>GM: Resolve mechanics
+    GM-->>D: JSON outcome
+    D->>LW: Generate narrative with outcome
+    LW-->>D: Narrative text
+    D-->>U: Edited message with new scene and choices
+```
+
+## Setup & Configuration
+
+The bot is configured via environment variables. Copy `.env.example` to `.env` and provide the following values:
+
+- `DISCORD_TOKEN`, `APP_ID`, `DISCORD_GUILD_ID` – Discord application settings.
+- `DB_HOST`, `DB_USER`, `DB_PASSWORD`, `DB_DATABASE` – MySQL connection for persistent data.
+- `OLLAMA_API_URL` – base URL of the local Ollama server.
+- `OLLAMA_NARRATOR_MODEL`, `OLLAMA_GM_MODEL` – model names used for narration and rules logic.
+
+Run `python -m ironaccord_bot.bot` to start the bot after installing dependencies and building the lore database with `python ironaccord_bot/ingest.py`.

--- a/ironaccord_bot/services/mission_engine_service.py
+++ b/ironaccord_bot/services/mission_engine_service.py
@@ -1,4 +1,4 @@
-"""Generate mission openings using player backgrounds and mission templates."""
+"""Mission generation and progression using two local LLM models."""
 
 import json
 import logging
@@ -19,20 +19,42 @@ MISSIONS_PATH = Path("data/missions")
 
 @dataclass
 class MissionSession:
+    """Active mission data tracked per user."""
+
     template: str
     background: str
     history: list[str] = field(default_factory=list)
 
 
 class MissionEngineService:
-    """Combine mission templates with player backgrounds using an LLM."""
+    """Manage mission state and delegate text generation to Ollama models."""
 
     def __init__(self, agent: "AIAgent") -> None:
+        """Create a new engine bound to the provided ``AIAgent``.
+
+        The engine keeps a mapping of active mission sessions keyed by the
+        user's Discord ID so that mission progress can be resumed across
+        interactions.
+
+        Args:
+            agent: The :class:`AIAgent` responsible for contacting the LLMs.
+        """
         self.agent = agent
         self.active_sessions: Dict[int, MissionSession] = {}
 
-    async def _resolve_action_mechanics(self, user_id: int, choice: str) -> Optional[Dict[str, Any]]:
-        """Return a quick mechanical resolution for ``choice``."""
+    async def _resolve_action_mechanics(
+        self, user_id: int, choice: str
+    ) -> Optional[Dict[str, Any]]:
+        """Resolve ``choice`` using the fast rules LLM.
+
+        Args:
+            user_id: Discord ID of the player.
+            choice: The choice text selected by the player.
+
+        Returns:
+            A dictionary describing the mechanical outcome or ``None`` if
+            resolution failed.
+        """
 
         session = self.active_sessions.get(user_id)
         if not session:
@@ -56,7 +78,17 @@ class MissionEngineService:
     async def _generate_narrative_description(
         self, user_id: int, choice: str, mechanics: Dict[str, Any]
     ) -> Optional[str]:
-        """Return a rich narrative for ``choice`` using ``mechanics``."""
+        """Produce narrative text for the player's ``choice``.
+
+        Args:
+            user_id: Discord ID of the player.
+            choice: The original player choice text.
+            mechanics: Parsed mechanics dictionary from the GM model.
+
+        Returns:
+            Narrative description incorporating the mechanical outcome, or
+            ``None`` on failure.
+        """
 
         session = self.active_sessions.get(user_id)
         if not session:
@@ -74,7 +106,15 @@ class MissionEngineService:
         return narrative
 
     def load_template(self, name: str) -> Optional[Dict[str, Any]]:
-        """Load the mission template with the given ``name``."""
+        """Load a mission template from disk.
+
+        Args:
+            name: Base filename of the template without extension.
+
+        Returns:
+            Parsed JSON dictionary if the file exists and is valid, otherwise
+            ``None``.
+        """
         file = MISSIONS_PATH / f"{name}.json"
         if not file.exists():
             return None
@@ -84,8 +124,19 @@ class MissionEngineService:
             logger.error("Failed to load template %s: %s", name, exc, exc_info=True)
             return None
 
-    async def generate_opening(self, background: str, template_name: str) -> Optional[Dict[str, Any]]:
-        """Return a mission opening using ``background`` and ``template_name``."""
+    async def generate_opening(
+        self, background: str, template_name: str
+    ) -> Optional[Dict[str, Any]]:
+        """Create the initial mission scene for the player.
+
+        Args:
+            background: Player background text used for personalization.
+            template_name: The mission template to combine with the background.
+
+        Returns:
+            A dictionary describing the opening scene and available choices, or
+            ``None`` if generation fails.
+        """
 
         template = self.load_template(template_name)
         if template is None:
@@ -123,14 +174,42 @@ class MissionEngineService:
 
         return data
 
-    async def start_mission(self, user_id: int, background: str, template_name: str) -> Optional[Dict[str, Any]]:
+    async def start_mission(
+        self, user_id: int, background: str, template_name: str
+    ) -> Optional[Dict[str, Any]]:
+        """Begin a new mission for ``user_id``.
+
+        Args:
+            user_id: Discord ID of the player starting the mission.
+            background: Background text used to personalize the mission.
+            template_name: Name of the mission template to load.
+
+        Returns:
+            The opening mission dictionary or ``None`` if generation failed.
+        """
+
         opening = await self.generate_opening(background, template_name)
         if opening is None:
             return None
-        self.active_sessions[user_id] = MissionSession(template_name, background, [opening.get("text", "")])
+        self.active_sessions[user_id] = MissionSession(
+            template_name, background, [opening.get("text", "")]
+        )
         return opening
 
-    async def advance_mission(self, user_id: int, choice: str) -> Optional[Dict[str, Any]]:
+    async def advance_mission(
+        self, user_id: int, choice: str
+    ) -> Optional[Dict[str, Any]]:
+        """Advance the mission for ``user_id`` based on ``choice``.
+
+        Args:
+            user_id: Discord ID of the player making the choice.
+            choice: The text of the player's selected option.
+
+        Returns:
+            A mission state dictionary with new text and choices, or ``None`` if
+            advancement fails.
+        """
+
         mechanics = await self._resolve_action_mechanics(user_id, choice)
         if not mechanics:
             return None
@@ -180,15 +259,27 @@ class MissionEngineService:
 
         return result
 
-    async def generate_mission(self, background: str, template_name: str = "missing_person") -> Optional[Dict[str, Any]]:
-        """Return a mission dictionary using ``background`` and ``template_name``."""
+    async def generate_mission(
+        self, background: str, template_name: str = "missing_person"
+    ) -> Optional[Dict[str, Any]]:
+        """Convenience wrapper around :meth:`generate_opening`."""
 
         return await self.generate_opening(background, template_name)
 
 
 async def advance_mission_interaction(interaction, user_choice_text: str):
-    """Advance a mission using a single streaming call to the unified LLM."""
-    await interaction.response.send_message("Edraz is considering your choice...", ephemeral=True)
+    """Handle a Discord interaction to advance a mission.
+
+    This helper performs a single streaming call to the unified LLM stack and
+    updates the original message with the resulting scene and choice buttons.
+
+    Args:
+        interaction: The Discord interaction initiating the advance.
+        user_choice_text: The raw text of the user's selected option.
+    """
+    await interaction.response.send_message(
+        "Edraz is considering your choice...", ephemeral=True
+    )
 
     # Assuming ``character`` and ``mission`` are retrieved elsewhere in the bot
     character = interaction.client.character_service.get_character(interaction.user.id)
@@ -203,28 +294,45 @@ async def advance_mission_interaction(interaction, user_choice_text: str):
         full_text += chunk
 
     if not full_text:
-        await interaction.edit_original_response(content="My thoughts are clouded. Please try again.")
+        await interaction.edit_original_response(
+            content="My thoughts are clouded. Please try again."
+        )
         return
 
     mission_data = json_utils.extract_and_parse_json(full_text)
     if not mission_data:
-        await interaction.edit_original_response(content="A critical error occurred in my thought process. Please try again.")
-        logger.error("CRITICAL: Primary model failed to produce valid JSON. Response: %s", full_text)
+        await interaction.edit_original_response(
+            content="A critical error occurred in my thought process. Please try again."
+        )
+        logger.error(
+            "CRITICAL: Primary model failed to produce valid JSON. Response: %s",
+            full_text,
+        )
         return
 
     outcome = mission_data.get("outcome_text", "An unexpected event occurs.")
     choices = mission_data.get("choices", [])
-    choice_list = [f"**{chr(65 + i)}.** {choice['text']}" for i, choice in enumerate(choices)]
+    choice_list = [
+        f"**{chr(65 + i)}.** {choice['text']}" for i, choice in enumerate(choices)
+    ]
     formatted_choices = "\n".join(choice_list)
-    message_content = f"**Scene:** {mission.scene_title}\n\n{outcome}\n\n{formatted_choices}"
+    message_content = (
+        f"**Scene:** {mission.scene_title}\n\n{outcome}\n\n{formatted_choices}"
+    )
 
     from discord import Button, ButtonStyle, ActionRow
 
     buttons = [
-        Button(style=ButtonStyle.secondary, label=f"{chr(65 + i)}", custom_id=f"mission_choice:{choice['id']}")
+        Button(
+            style=ButtonStyle.secondary,
+            label=f"{chr(65 + i)}",
+            custom_id=f"mission_choice:{choice['id']}",
+        )
         for i, choice in enumerate(choices)
     ]
     action_row = ActionRow(*buttons)
 
-    await interaction.edit_original_response(content=message_content, components=[action_row])
+    await interaction.edit_original_response(
+        content=message_content, components=[action_row]
+    )
     logger.info("Successfully advanced mission for user %s", interaction.user.id)


### PR DESCRIPTION
## Summary
- document the dual LLM architecture in `docs/ARCHITECTURE.md`
- link to the architecture doc from the README
- add detailed docstrings for `OllamaService`, `MissionEngineService` and `RAGService`

## Testing
- `pytest -q` *(fails: NameError in test_mission_view)*

------
https://chatgpt.com/codex/tasks/task_e_687aa451e3b48327b80e2374f33ddbe0