### PR TITLE
Fix quiz flow and formatting

### DIFF
--- a/ironaccord_bot/cogs/quiz.py
+++ b/ironaccord_bot/cogs/quiz.py
@@ -15,12 +15,34 @@ class QuizCog(commands.Cog):
         self.content_service = QuizContentService()
         self.quiz_service = QuizService(self.content_service)
 
+    async def send_quiz_question(self, interaction: discord.Interaction, user_id: int):
+        """Fetch and send the next quiz question for ``user_id``."""
+        question_data = self.quiz_service.get_next_question_for_user(user_id)
+        if not question_data:
+            await interaction.followup.send("An error occurred with the quiz.", ephemeral=True)
+            return
+
+        formatted_text = (
+            f"**Question {self.quiz_service.active_quizzes[user_id]['question_number']}/5:**\n\n"
+            f"{question_data['text']}\n\n"
+        )
+        button_labels = ["A", "B", "C"]
+        choices = {}
+        for i, (bg, text) in enumerate(question_data["choices"].items()):
+            formatted_text += f"**{button_labels[i]}:** {text}\n"
+            choices[bg] = text
+
+        view = QuizView(self.bot, self.quiz_service, choices)
+
+        if interaction.response.is_done():
+            await interaction.followup.send(formatted_text, view=view, ephemeral=True)
+        else:
+            await interaction.response.send_message(formatted_text, view=view, ephemeral=True)
+
     @app_commands.command(name="startquiz", description="Starts the background sorting quiz.")
     async def startquiz(self, interaction: discord.Interaction):
         self.quiz_service.start_quiz(interaction.user.id)
-        question = self.quiz_service.get_next_question_for_user(interaction.user.id)
-        view = QuizView(self.quiz_service, question["choices"])
-        await interaction.response.send_message(question["text"], view=view, ephemeral=True)
+        await self.send_quiz_question(interaction, user_id=interaction.user.id)
 
 
 async def setup(bot: commands.Bot):

--- a/ironaccord_bot/cogs/start.py
+++ b/ironaccord_bot/cogs/start.py
@@ -44,14 +44,25 @@ class StartCog(commands.Cog):
 
             if question:
                 logger.info(f"Quiz started for user {user_id}. Sending first question.")
-                view = QuizView(self.quiz_service, question["choices"])
+                formatted_text = (
+                    f"**Question {self.quiz_service.active_quizzes[user_id]['question_number']}/5:**\n\n"
+                    f"{question['text']}\n\n"
+                )
+                button_labels = ["A", "B", "C"]
+                choices = {}
+                for i, (bg, text) in enumerate(question["choices"].items()):
+                    formatted_text += f"**{button_labels[i]}:** {text}\n"
+                    choices[bg] = text
+
+                view = QuizView(self.bot, self.quiz_service, choices)
+
                 if ctx.interaction:
                     await ctx.interaction.edit_original_response(
-                        content=question["text"],
+                        content=formatted_text,
                         view=view,
                     )
                 else:
-                    await ctx.send(question["text"], view=view)
+                    await ctx.send(formatted_text, view=view)
             else:
                 logger.error("Quiz content unavailable for user %s", user_id)
                 if ctx.interaction:

--- a/ironaccord_bot/services/quiz_service.py
+++ b/ironaccord_bot/services/quiz_service.py
@@ -33,9 +33,15 @@ class QuizService:
             "choices": {bg: all_choices[bg] for bg in random_backgrounds},
         }
 
-    def record_answer(self, user_id: int, chosen_background: str):
+    def record_answer(self, user_id: int, chosen_background: str) -> bool:
+        """Record a user's answer and advance the quiz.
+
+        Returns ``True`` if the quiz has reached the end of the question list,
+        otherwise ``False``. A missing ``user_id`` results in ``False`` as well.
+        """
         if user_id not in self.active_quizzes:
-            return
+            return False
+
         state = self.active_quizzes[user_id]
         if chosen_background in state["scores"]:
             state["scores"][chosen_background] += 1
@@ -43,6 +49,9 @@ class QuizService:
             print(
                 f"User {user_id} chose {chosen_background}. Scores: {state['scores']}"
             )
+
+        # The quiz is over once question_number exceeds 5
+        return state["question_number"] > 5
 
     def get_final_result(self, user_id: int):
         if user_id not in self.active_quizzes:

--- a/ironaccord_bot/tests/test_start_cog.py
+++ b/ironaccord_bot/tests/test_start_cog.py
@@ -54,6 +54,7 @@ async def test_start_cog_sends_first_question(monkeypatch):
     interaction = ctx.interaction
     assert interaction.response.args[0].startswith("Edraz is consulting")
     assert interaction.response.kwargs["ephemeral"] is True
-    assert interaction.edited["content"] == "Q1"
+    expected = "**Question 1/5:**\n\nQ1\n\n**A:** A\n**B:** B\n**C:** C\n"
+    assert interaction.edited["content"] == expected
     assert isinstance(interaction.edited["view"], start.QuizView)
 

--- a/ironaccord_bot/views/quiz_view.py
+++ b/ironaccord_bot/views/quiz_view.py
@@ -4,11 +4,12 @@ from ..services.quiz_service import QuizService
 
 
 class QuizButton(discord.ui.Button):
-    def __init__(self, background_name: str, label: str):
+    def __init__(self, label: str, choice_background: str):
+        # The background is stored in the custom_id so we can map it in the callback
         super().__init__(
             label=label,
             style=discord.ButtonStyle.secondary,
-            custom_id=f"quiz_answer_{background_name}",
+            custom_id=f"quiz_answer_{choice_background}",
         )
 
     async def callback(self, interaction: discord.Interaction):
@@ -16,10 +17,11 @@ class QuizButton(discord.ui.Button):
         for item in view.children:
             item.disabled = True
         await interaction.response.edit_message(view=view)
+
         chosen_background = self.custom_id.split("_")[-1]
-        view.quiz_service.record_answer(interaction.user.id, chosen_background)
-        state = view.quiz_service.active_quizzes.get(interaction.user.id)
-        if not state or state["question_number"] > 5:
+        is_over = view.quiz_service.record_answer(interaction.user.id, chosen_background)
+
+        if is_over:
             final_bg = view.quiz_service.get_final_result(interaction.user.id)
             await interaction.followup.send(
                 f"**Diagnostic Complete.**\nYour background is: **{final_bg}**\n\n*Welcome to the Iron Accord.*",
@@ -27,17 +29,18 @@ class QuizButton(discord.ui.Button):
             )
             view.stop()
         else:
-            next_q = view.quiz_service.get_next_question_for_user(interaction.user.id)
-            next_view = QuizView(view.quiz_service, next_q["choices"])
-            await interaction.followup.send(next_q["text"], view=next_view, ephemeral=True)
+            quiz_cog = view.bot.get_cog("QuizCog")
+            if quiz_cog:
+                await quiz_cog.send_quiz_question(interaction, interaction.user.id)
 
 
 class QuizView(discord.ui.View):
-    def __init__(self, quiz_service: QuizService, choices: dict):
+    def __init__(self, bot: discord.Client, quiz_service: QuizService, choices: dict):
         super().__init__(timeout=300)
+        self.bot = bot
         self.quiz_service = quiz_service
+
         button_labels = ["A", "B", "C"]
-        for i, (bg, text) in enumerate(choices.items()):
-            label = f"{button_labels[i]}: {text[:60]}..."
-            self.add_item(QuizButton(background_name=bg, label=label))
+        for i, (background, _text) in enumerate(choices.items()):
+            self.add_item(QuizButton(label=button_labels[i], choice_background=background))
 


### PR DESCRIPTION
## Summary
- ensure quiz ends after five questions
- display options in message text and use A/B/C buttons
- update start command to use new quiz format
- adjust quiz service and tests

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'discord')*

------
https://chatgpt.com/codex/tasks/task_e_687abd0942b483279c16a178d724d711