### PR TITLE
Fix quiz key mismatches by slugifying background names

### DIFF
--- a/ironaccord_bot/cogs/start.py
+++ b/ironaccord_bot/cogs/start.py
@@ -2,7 +2,7 @@ import discord
 from discord.ext import commands
 import logging
 
-from .quiz import QuizCog, SimpleQuizView
+from .quiz import QuizCog, SimpleQuizView, slugify
 
 logger = logging.getLogger(__name__)
 
@@ -40,7 +40,7 @@ class StartCog(commands.Cog):
                 raise RuntimeError("QuizCog not loaded")
 
             question = quiz_cog.content_service.get_question_and_choices(1)
-            scores = {c["background"]: 0 for c in question["choices"]}
+            scores = {slugify(c["background"]): 0 for c in question["choices"]}
             quiz_cog.active_quizzes[user_id] = {
                 "question_number": 1,
                 "scores": scores,


### PR DESCRIPTION
## Summary
- normalize background names with `slugify`
- use `slugify` when starting quizzes
- slugify answers before scoring and display friendly name when quiz ends
- import and use `slugify` in `StartCog`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687ad3848c448327ae40a988ffb42529